### PR TITLE
Components Registry Configuration wiki page header made mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ Run `adocPublishToWiki` gradle task
 
 ### Gradle properties
 
-| Name                                     | Description                                               | `asciidoctor` | `adocPublishToWiki` |
-|------------------------------------------|-----------------------------------------------------------|---------------|---------------------|
-| adoc.header                              | Header. Default value: Components Registry Configuration. |               |                     |
-| adoc.glossary-component-link             | Link to Component page in glossary.                       | +             | +                   |
-| adoc.components-registry-link            | Link to Component Registry repository.                    | +             | +                   |
-| adoc.release-management-automation-link  | Link to Release Management Automation page.               | +             | +                   |
-| adoc.escrow-automation-tool-link         | Link to Escrow Automation Tool page.                      | +             | +                   |
-| adoc.service-desk-link                   | Link to Service Desk portal.                              | +             | +                   |
-| adoc.components-registry-validation-link | Link to Component Registry Validation builds.             | +             | +                   |
-| docker.registry                          | Docker registry url.                                      |               | +                   |
-| wiki.url                                 | Confluence url.                                           |               | +                   |
-| wiki.username                            | Confluence user.                                          |               | +                   |
-| wiki.password                            | Confluence user password.                                 |               | +                   |
-| wiki.space-key                           | Confluence space key.                                     |               | +                   |
-| wiki.page-id                             | Confluence page id.                                       |               | +                   |
+| Name                                     | Description                                   | `asciidoctor` | `adocPublishToWiki` |
+|------------------------------------------|-----------------------------------------------|---------------|---------------------|
+| adoc.header                              | Wiki page Header                              | +             | +                   |
+| adoc.glossary-component-link             | Link to Component page in glossary.           | +             | +                   |
+| adoc.components-registry-link            | Link to Component Registry repository.        | +             | +                   |
+| adoc.release-management-automation-link  | Link to Release Management Automation page.   | +             | +                   |
+| adoc.escrow-automation-tool-link         | Link to Escrow Automation Tool page.          | +             | +                   |
+| adoc.service-desk-link                   | Link to Service Desk portal.                  | +             | +                   |
+| adoc.components-registry-validation-link | Link to Component Registry Validation builds. | +             | +                   |
+| docker.registry                          | Docker registry url.                          |               | +                   |
+| wiki.url                                 | Confluence url.                               |               | +                   |
+| wiki.username                            | Confluence user.                              |               | +                   |
+| wiki.password                            | Confluence user password.                     |               | +                   |
+| wiki.space-key                           | Confluence space key.                         |               | +                   |
+| wiki.page-id                             | Confluence page id.                           |               | +                   |
 
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ Run `adocPublishToWiki` gradle task
 
 ### Gradle properties
 
-| Name                                     | Description                                   | `asciidoctor` | `adocPublishToWiki` |
-|------------------------------------------|-----------------------------------------------|---------------|---------------------|
-| adoc.header                              | Wiki page Header                              | +             | +                   |
-| adoc.glossary-component-link             | Link to Component page in glossary.           | +             | +                   |
-| adoc.components-registry-link            | Link to Component Registry repository.        | +             | +                   |
-| adoc.release-management-automation-link  | Link to Release Management Automation page.   | +             | +                   |
-| adoc.escrow-automation-tool-link         | Link to Escrow Automation Tool page.          | +             | +                   |
-| adoc.service-desk-link                   | Link to Service Desk portal.                  | +             | +                   |
-| adoc.components-registry-validation-link | Link to Component Registry Validation builds. | +             | +                   |
-| docker.registry                          | Docker registry url.                          |               | +                   |
-| wiki.url                                 | Confluence url.                               |               | +                   |
-| wiki.username                            | Confluence user.                              |               | +                   |
-| wiki.password                            | Confluence user password.                     |               | +                   |
-| wiki.space-key                           | Confluence space key.                         |               | +                   |
-| wiki.page-id                             | Confluence page id.                           |               | +                   |
+| Name                                     | Description                                               | `asciidoctor` | `adocPublishToWiki` |
+|------------------------------------------|-----------------------------------------------------------|---------------|---------------------|
+| adoc.header                              | Header. Default value: Components Registry Configuration. |               |                     |
+| adoc.glossary-component-link             | Link to Component page in glossary.                       | +             | +                   |
+| adoc.components-registry-link            | Link to Component Registry repository.                    | +             | +                   |
+| adoc.release-management-automation-link  | Link to Release Management Automation page.               | +             | +                   |
+| adoc.escrow-automation-tool-link         | Link to Escrow Automation Tool page.                      | +             | +                   |
+| adoc.service-desk-link                   | Link to Service Desk portal.                              | +             | +                   |
+| adoc.components-registry-validation-link | Link to Component Registry Validation builds.             | +             | +                   |
+| docker.registry                          | Docker registry url.                                      |               | +                   |
+| wiki.url                                 | Confluence url.                                           |               | +                   |
+| wiki.username                            | Confluence user.                                          |               | +                   |
+| wiki.password                            | Confluence user password.                                 |               | +                   |
+| wiki.space-key                           | Confluence space key.                                     |               | +                   |
+| wiki.page-id                             | Confluence page id.                                       |               | +                   |
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,13 @@ plugins {
 }
 
 def adocProperties = [:]
-['header', 'glossary-component-link', 'components-registry-link', 'release-management-automation-link',
+['page-header','header', 'glossary-component-link', 'components-registry-link', 'release-management-automation-link',
  'escrow-automation-tool-link', 'service-desk-link', 'components-registry-validation-link'].each {
     (project.findProperty("adoc.$it") as String)?.with { property -> adocProperties[it] = property }
 }
 
 def checkMandatoryAdocProperties = {
+    println("adoc propertes  = " + adocProperties)
     ['glossary-component-link', 'components-registry-link', 'release-management-automation-link',
      'escrow-automation-tool-link', 'service-desk-link', 'components-registry-validation-link'].each {
         if (adocProperties[it] == null) throw new IllegalArgumentException("`adoc.$it` property must be defined")

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,13 @@ def adocProperties = [:]
     (project.findProperty("adoc.$it") as String)?.with { property -> adocProperties[it] = property }
 }
 
+if (adocProperties['header'] == null) {
+    adocProperties['header'] = 'Components Registry Configuration'
+}
+
 def checkMandatoryAdocProperties = {
     ['glossary-component-link', 'components-registry-link', 'release-management-automation-link',
-     'escrow-automation-tool-link', 'service-desk-link', 'components-registry-validation-link',
-     'header'].each {
+     'escrow-automation-tool-link', 'service-desk-link', 'components-registry-validation-link'].each {
         if (adocProperties[it] == null) throw new IllegalArgumentException("`adoc.$it` property must be defined")
     }
     return

--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,15 @@ plugins {
 }
 
 def adocProperties = [:]
-['page-header','header', 'glossary-component-link', 'components-registry-link', 'release-management-automation-link',
+['header', 'glossary-component-link', 'components-registry-link', 'release-management-automation-link',
  'escrow-automation-tool-link', 'service-desk-link', 'components-registry-validation-link'].each {
     (project.findProperty("adoc.$it") as String)?.with { property -> adocProperties[it] = property }
 }
 
 def checkMandatoryAdocProperties = {
-    println("adoc propertes  = " + adocProperties)
     ['glossary-component-link', 'components-registry-link', 'release-management-automation-link',
-     'escrow-automation-tool-link', 'service-desk-link', 'components-registry-validation-link'].each {
+     'escrow-automation-tool-link', 'service-desk-link', 'components-registry-validation-link',
+     'header'].each {
         if (adocProperties[it] == null) throw new IllegalArgumentException("`adoc.$it` property must be defined")
     }
     return

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,13 +1,6 @@
 :icons: font
-//
-// ifndef::page-header[]
-// :page-header: How to configure Components Registry
-// endif::[]
-
-= {page-header}
+= {header}
 :toc:
-
-Some Text: {page-header}
 
 IMPORTANT: This page is auto-generated!
 

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,11 +1,18 @@
 :icons: font
 
 ifndef::header[]
-:header: Components Registry Configuration
+:header: How to configure Components Registry
 endif::[]
+
+ifndef::page-header[]
+:page-header: How to configure Components Registry
+endif::[]
+
 
 = {header}
 :toc:
+
+== {page-header}
 
 IMPORTANT: This page is auto-generated!
 

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,13 +1,13 @@
 :icons: font
-
-ifndef::page-header[]
-:page-header: How to configure Components Registry
-endif::[]
+//
+// ifndef::page-header[]
+// :page-header: How to configure Components Registry
+// endif::[]
 
 = {page-header}
 :toc:
 
-== {page-header}
+Some Text: {page-header}
 
 IMPORTANT: This page is auto-generated!
 

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -8,8 +8,7 @@ ifndef::page-header[]
 :page-header: How to configure Components Registry
 endif::[]
 
-
-= {header}
+= {page-header}
 :toc:
 
 == {page-header}

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,9 +1,5 @@
 :icons: font
 
-ifndef::header[]
-:header: How to configure Components Registry
-endif::[]
-
 ifndef::page-header[]
 :page-header: How to configure Components Registry
 endif::[]

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,5 +1,9 @@
 :icons: font
+
+ifndef::header[]
 :header: Components Registry Configuration
+endif::[]
+
 = {header}
 :toc:
 


### PR DESCRIPTION
Removed default value for header parameter because it didn't allow to publish page with name that differed from it