### PR TITLE
External registry resolved to null in case of version range

### DIFF
--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -441,7 +441,9 @@ class EscrowConfigurationLoader {
             List<VersionControlSystemRoot> componentRoots = replaceDefaults(componentDefaultConfiguration?.vcsSettingsWrapper,
                     [:], defaultVCSRoot, defaultVCSRoot?.isFullyConfigured() ? [defaultVCSRoot] : [])
 
-            return new VCSSettingsWrapper(vcsSettings: VCSSettings.create(componentRoots),
+            return new VCSSettingsWrapper(vcsSettings:
+                    VCSSettings.create(
+                            componentDefaultConfiguration?.vcsSettingsWrapper?.vcsSettings?.externalRegistry, componentRoots),
                     defaultVCSSettings: defaultVCSRoot,
                     vscRootName2ParametersFromDefaultsMap: [:])
         }

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/RepositoryResolverTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/RepositoryResolverTest.groovy
@@ -134,6 +134,12 @@ class RepositoryResolverTest {
         assert "dwh" == component.vcsSettings.externalRegistry
     }
 
+    @Test
+    void testExternalRegistryWithVersionRange() {
+        ReleaseInfo component = withConfigResolver("new-vcs/externalRegistryWithVersionRange").resolveRelease(create("torpedo", "1.0"))
+        assert component.vcsSettings.externalRegistry() : "$component.vcsSettings for version should have external registry"
+        assert component.vcsSettings.notAvailable() : "$component.vcsSettings for version should have external registry"
+    }
 
     @Test
     void testDefaultTag() {

--- a/component-resolver-core/src/test/resources/new-vcs/externalRegistryWithVersionRange.groovy
+++ b/component-resolver-core/src/test/resources/new-vcs/externalRegistryWithVersionRange.groovy
@@ -1,0 +1,41 @@
+import static org.octopusden.octopus.escrow.BuildSystem.*
+
+Defaults {
+    buildSystem = MAVEN
+    tag = '$module-$version';
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    jira {
+        majorVersionFormat = '$major.$minor'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+    build {
+        requiredTools = "BuildEnv"
+        javaVersion = "1.8"
+        mavenVersion = "3.6.3"
+        gradleVersion = "LATEST"
+    }
+    distribution {
+        explicit = false
+        external = true
+    }
+}
+
+torpedo {
+    componentOwner = "streltsov"
+    vcsSettings {
+        externalRegistry = "NOT_AVAILABLE"
+    }
+    buildSystem = ESCROW_NOT_SUPPORTED
+    groupId = "org.octopusden.octopus.torpedo"
+    artifactId = "myartifct"
+    jira {
+        projectKey = "PRJ"
+    }
+    "(,1.2.3)" {
+    }
+}


### PR DESCRIPTION
externalRegistry is resolved to null for the following configurations:


```
"some-component" {
    vcsSettings {
        externalRegistry = "NOT_AVAILABLE"
    }
    "(,1.2.3)" {
    }
}
```