### PR TITLE
Support multiple docker images and tag definition

### DIFF
--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -20,6 +20,7 @@ class GroovySlurperConfigValidator {
     public static final String DEPENDENCIES = 'dependencies'
     public static final String SECURITY_GROUPS = 'securityGroups'
     public static final String SECURITY_GROUPS_READ = "read"
+
     private static final String FILE_PATTERN = "file:/.+"
     private static final String PROHIBITED_SYMBOLS = "\\\\\\s:|\\?\\*\"'<>\\+"
     private static final String GAV_PROHIBITED_SYMBOLS = "/$PROHIBITED_SYMBOLS"
@@ -30,17 +31,20 @@ class GroovySlurperConfigValidator {
     public static final Pattern DEB_PATTERN = Pattern.compile("^($DEB_ENTRY_PATTERN)(,($DEB_ENTRY_PATTERN))*\$")
     private static final String RPM_ENTRY_PATTERN = "[^$PROHIBITED_SYMBOLS]+\\.rpm"
     public static final Pattern RPM_PATTERN = Pattern.compile("^($RPM_ENTRY_PATTERN)(,($RPM_ENTRY_PATTERN))*\$")
-    private static final String SG_ENTRY_REGEX = "[\\w-#\\s]+"
-    public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SG_ENTRY_REGEX)(,($SG_ENTRY_REGEX))*\$")
-    public static final Pattern DOCKER_PATTERN = Pattern.compile("^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*\$")
+    private static final String SECURITY_GROUPS_ENTRY_PATTERN = "[\\w-#\\s]+"
+    public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SECURITY_GROUPS_ENTRY_PATTERN)(,($SECURITY_GROUPS_ENTRY_PATTERN))*\$")
+    private static final String DOCKER_IMAGE_PATH_PATTERN = "([a-z0-9]+([_.-][a-z0-9]+)*/)*[a-z0-9]+([_.-][a-z0-9]+)*"
+    private static final String DOCKER_IMAGE_TAG_PATTERN = "\\w[\\w.-]{0,127}"
+    private static final String DOCKER_ENTRY_PATTERN = "$DOCKER_IMAGE_PATH_PATTERN:$DOCKER_IMAGE_TAG_PATTERN"
+    public static final Pattern DOCKER_PATTERN = Pattern.compile("^($DOCKER_ENTRY_PATTERN)(,($DOCKER_ENTRY_PATTERN))*\$")
 
-    public
-    static SUPPORTED_ATTRIBUTES = ['buildSystem', VCS_URL, REPOSITORY_TYPE, 'groupId', 'artifactId',
-                                   TAG, 'versionRange', 'version', 'module',
-                                   'teamcityReleaseConfigId', 'jiraProjectKey', 'jiraMajorVersionFormat', 'jiraReleaseVersionFormat',
-                                   'buildFilePath', 'deprecated', BRANCH,
-                                   'componentDisplayName', 'componentOwner', 'releaseManager', 'securityChampion', 'system',
-                                   'clientCode', 'releasesInDefaultBranch', 'solution', 'parentComponent', 'octopusVersion']
+    public static SUPPORTED_ATTRIBUTES = ['buildSystem', VCS_URL, REPOSITORY_TYPE, 'groupId', 'artifactId',
+                                          TAG, 'versionRange', 'version', 'module',
+                                          'teamcityReleaseConfigId', 'jiraProjectKey', 'jiraMajorVersionFormat', 'jiraReleaseVersionFormat',
+                                          'buildFilePath', 'deprecated', BRANCH,
+                                          'componentDisplayName', 'componentOwner', 'releaseManager', 'securityChampion', 'system',
+                                          'clientCode', 'releasesInDefaultBranch', 'solution', 'parentComponent', 'octopusVersion']
+
     static SUPPORTED_JIRA_ATTRIBUTES = ['projectKey', 'lineVersionFormat', 'majorVersionFormat', 'releaseVersionFormat', 'buildVersionFormat', "displayName", 'technical']
 
     static SUPPORTED_BUILD_ATTRIBUTES = ['dependencies', 'javaVersion', 'mavenVersion', 'gradleVersion', 'requiredProject', 'systemProperties', 'projectVersion', 'requiredTools', 'buildTasks']

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -32,12 +32,11 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
      * Docker pattern should contain only one image name without tag
      */
     void testDockerPattern() {
-        assert DOCKER_PATTERN.matcher("org.octopusden/octopus/image").matches()
-        assert !DOCKER_PATTERN.matcher("org.octopusden/octopus/image:1.0").matches()
-        assert DOCKER_PATTERN.matcher("octopusden/octopus").matches()
-        assert DOCKER_PATTERN.matcher("octopusden.octopus").matches()
-        assert !DOCKER_PATTERN.matcher("octopusden\\octopus").matches()
-        assert !DOCKER_PATTERN.matcher("octopusden/octopus,octopusden/octopus-2").matches()
-        assert !DOCKER_PATTERN.matcher("octopusden/octopus:builder:1.0").matches()
+        assert DOCKER_PATTERN.matcher("org.octopusden/octopus/image:1.0").matches()
+        assert DOCKER_PATTERN.matcher("org.octopusden/octopus/first-image:1.0,org.octopusden/octopus/second-image:1.0").matches()
+        assert !DOCKER_PATTERN.matcher("org.octopusden/octopus/image").matches()
+        assert !DOCKER_PATTERN.matcher("org.octopusden\\octopus/image:1.0").matches()
+        assert !DOCKER_PATTERN.matcher("org.octopusden/octopus:image:1.0").matches()
+        assert !DOCKER_PATTERN.matcher("org.octopusden/octopus/image:.0").matches()
     }
 }

--- a/component-resolver-core/src/test/java/org/octopusden/octopus/escrow/resolvers/DistributionResolverTest.java
+++ b/component-resolver-core/src/test/java/org/octopusden/octopus/escrow/resolvers/DistributionResolverTest.java
@@ -50,7 +50,7 @@ public class DistributionResolverTest {
     void testDockerOfTestComponent() {
         Distribution distribution = distributionResolver.resolveDistribution(ComponentVersion.create("test-component", "1.3.49"));
         assertNotNull(distribution);
-        assertEquals("test-component/image:${version}", distribution.docker());
+        assertEquals("test-component/image:${version}-flavour1,test-component/image:${version}-flavour2", distribution.docker());
     }
 
 }

--- a/component-resolver-core/src/test/java/org/octopusden/octopus/escrow/resolvers/DistributionResolverTest.java
+++ b/component-resolver-core/src/test/java/org/octopusden/octopus/escrow/resolvers/DistributionResolverTest.java
@@ -50,8 +50,7 @@ public class DistributionResolverTest {
     void testDockerOfTestComponent() {
         Distribution distribution = distributionResolver.resolveDistribution(ComponentVersion.create("test-component", "1.3.49"));
         assertNotNull(distribution);
-        String imageName = distribution.docker();
-        assertEquals("test/test-component", imageName);
+        assertEquals("test-component/image:${version}", distribution.docker());
     }
 
 }

--- a/component-resolver-core/src/test/resources/distribution-docker/InfrastructureComponents.groovy
+++ b/component-resolver-core/src/test/resources/distribution-docker/InfrastructureComponents.groovy
@@ -19,7 +19,7 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
     distribution {
         explicit = true
         external = true
-        docker = 'test-component/image:${version}'
+        docker = 'test-component/image:${version}-flavour1,test-component/image:${version}-flavour2'
     }
     "[1.0,1.3)" {
         vcsSettings {

--- a/component-resolver-core/src/test/resources/distribution-docker/InfrastructureComponents.groovy
+++ b/component-resolver-core/src/test/resources/distribution-docker/InfrastructureComponents.groovy
@@ -19,7 +19,7 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
     distribution {
         explicit = true
         external = true
-        docker = "test/test-component"
+        docker = 'test-component/image:${version}'
     }
     "[1.0,1.3)" {
         vcsSettings {


### PR DESCRIPTION
`docker` field in `distribution` section now defines set of docker images coordinates (in format PATH:TAG) separated by comma. SpEL is allowed.

No changes in API/DTO.