### PR TITLE
Resolve clean build version

### DIFF
--- a/component-resolver-core/src/main/java/org/octopusden/octopus/escrow/dto/EscrowExpressionContext.java
+++ b/component-resolver-core/src/main/java/org/octopusden/octopus/escrow/dto/EscrowExpressionContext.java
@@ -26,6 +26,7 @@ public class EscrowExpressionContext {
         this(component, version, fileName, componentVersion -> numericVersionFactory.create(componentVersion));
     }
 
+    //TODO: remove? is it used?
     public String getFileName() {
         return fileName;
     }
@@ -65,4 +66,6 @@ public class EscrowExpressionContext {
     public int getBuild() {
         return versionInfo.getBuildNumber();
     }
+
+    //TODO: support major02, minor02, service02, fix02, fix04, build02, build04 etc. (like in org.octopusden.releng.versions.KotlinVersionFormatter.PREDEFINED_COMPONENT_VARIABLES_LIST)
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -108,15 +108,15 @@ class ComponentRegistryResolverImpl(
     override fun getComponentsDistributionByJiraProject(projectKey: String): Map<String, Distribution> {
         return getJiraComponentVersionRangesByProject(projectKey)
             .groupBy { it.componentName }
-            .mapValues { entry ->
+            .mapValues { (_, versionRange) ->
                 Distribution(
-                    entry.value.any { it.distribution?.explicit() ?: true },
-                    entry.value.any { it.distribution?.external() ?: false },
-                    entry.value.find { it.distribution != null }?.distribution?.GAV(),
-                    entry.value.find { it.distribution != null }?.distribution?.DEB(),
-                    entry.value.find { it.distribution != null }?.distribution?.RPM(),
-                    entry.value.find { it.distribution != null }?.distribution?.docker(),
-                    entry.value.find { it.distribution != null }?.distribution?.securityGroups
+                    versionRange.any { it.distribution?.explicit() ?: true },
+                    versionRange.any { it.distribution?.external() ?: false },
+                    versionRange.find { it.distribution != null }?.distribution?.GAV(),
+                    versionRange.find { it.distribution != null }?.distribution?.DEB(),
+                    versionRange.find { it.distribution != null }?.distribution?.RPM(),
+                    versionRange.find { it.distribution != null }?.distribution?.docker(),
+                    versionRange.find { it.distribution != null }?.distribution?.securityGroups
                         ?: SecurityGroups(null),
                 )
             }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -204,7 +204,7 @@ class ComponentRegistryResolverImpl(
      * Returns single JiraComponentVersion to JiraComponentVersionRange pair found by Component ID and Version
      *
      * @param component Component Id
-     * @param version   Version (having non-strict build/release/major/line format, i.e. having the same number of significant numeric elements)
+     * @param version   Version (having non-strict build/release/major/line format, i.e. having enough of significant numeric elements)
      * @return JiraComponentVersion to JiraComponentVersionRange pair
      */
     private fun getJiraComponentVersionToRangeByComponentAndVersion(

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -92,12 +92,12 @@ Each Component must be configured in corresponding configuration file according 
 
         jira { // Parameters releated to build/release registration in JIRA and generation of client release notes (default for all versions)
             projectKey = <JIRA project key>
-            majorVersionFormat = <format of major version in JIRA> (can be configured using Expression Language)
-            releaseVersionFormat = <format of release version for registration in JIRA> (can be configured using Expression Language)
+            majorVersionFormat = <format of major version in JIRA> (can be configured using Version Formatter)
+            releaseVersionFormat = <format of release version for registration in JIRA> (can be configured using Version Formatter)
 
             component {
                versionPrefix = "prefix in component versioning" // to avoid conflicts between different components' versions and to simplify selection of the component version in the "Fix Version(s)" field of the Jira issue
-               versionFormat = <format of major version in JIRA> (can be configured using Expression Language) 
+               versionFormat = <format of major version in JIRA> (can be configured using Version Formatter)
             }
          }
 
@@ -129,8 +129,8 @@ Each Component must be configured in corresponding configuration file according 
 
         jira { // Parameters releated to build/release registration in JIRA and generation of client release notes (for specific version range)
             projectKey = <JIRA project key>
-            majorVersionFormat = <format of major version in JIRA> (can be configured using Expression Language)
-            releaseVersionFormat = <format of release version for registration in JIRA> (can be configured using Expression Language)
+            majorVersionFormat = <format of major version in JIRA> (can be configured using Version Formatter)
+            releaseVersionFormat = <format of release version for registration in JIRA> (can be configured using Version Formatter)
         }
 
         build { // Parameters related to escrow build (for specific version range)
@@ -156,6 +156,31 @@ Each Component must be configured in corresponding configuration file according 
     }
 }
 ----
+
+=== Version Formatter
+Base version formats like *majorVersionFormat* and *releaseVersionFormat* could be configured using following parameters:
+
+* *$major* - first item of the build version
+* *$major02* - first item of the build version in format %02d
+* *$minor* - second item of the build version
+* *$minor02* - second item of the build version in format %02d
+* *$service* - third item of the build version
+* *$service02* - third item of the build version in format %02d
+* *$fix* - forth item of the build version
+* *$fix02* - forth item of the build version in format %02d
+* *$fix04* - forth item of the build version in format %04d
+* *$build* - fifth item of the build version
+* *$build02* - fifth item of the build version in format %02d
+* *$build04* - fifth item of the build version in format %04d
+
+Jira version format defined by *versionFormat* is extended version of base format that could be configured using following parameters:
+
+* *$versionPrefix* - version prefix
+* *$baseVersionFormat* - base version format
+
+Usually it has value *$versionPrefix-$baseVersionFormat*
+
+WARNING: One should use single-quoted `String` for version formats. Using of double-quoted `GString` may lead to clash with standard Groovy template engine.
 
 === Version ranges
 Different configurations of component depending on version of its release are supported.
@@ -193,27 +218,6 @@ Example:
 branch = 'master|release/$major.$minor'
 ----
 
-=== Expression Language
-The rules of how to calculate major/release version and some other fields by a build version can be configured using Expression Language.
-
-Basic variables are:
-
-* *$component* - component name
-* *$version* - component build version
-
-The component build version is parsed and split into the items which can be referred with following variables:
-
-* *$major* - first item of the build version
-* *$minor* - second item of the build version
-* *$service* - third item of the build version
-* *$fix* - forth item of the build version
-* *$major02* - first item of the build version in format %02d
-* *$minor02* - second item of the build version in format %02d
-* *$service02* - third item of the build version in format %02d
-* *$fix02* - forth item of the build version in format %02d
-
-WARNING: One should use single-quoted `String` with Expression Language statements. Using of double-quoted `GString` may lead to clash with standard Groovy template engine.
-
 === Distribution section
 The distribution section of the component configuration describes how the component is distributed.
 
@@ -224,11 +228,11 @@ Below is the list of available parameters:
 * *GAV* - comma-separated list of MAVEN distribution artifacts
 * *DEB* - comma-separated list of DEBIAN distribution artifacts
 * *RPM* - comma-separated list of RPM distribution artifacts
-* *docker* - name of Docker distribution image(one image per component)(example: 'test/test-component')
+* *docker* - comma-separated list of Docker distribution images
 
-*GAV*, *DEB* and *RPM* parameters can be configured using Expression Language with following variables:
+*GAV*, *DEB*, *RPM* and *docker* parameters can be configured using Expression Language.
 
-WARNING: *GAV* and/or *DEB* and/or *RPM* parameter should be defined for *external* *explicit* component!
+WARNING: At least one of *GAV*, *DEB*, *RPM*, *docker* parameters should be defined for *external* *explicit* component!
 
 ==== MAVEN artifacts configuration
 Each artifact can be either:
@@ -242,3 +246,20 @@ Example:
 ----
 GAV='org.company.newcomponent:artifact:jar,file:///target/application-${version}.exe?artifactId=NewComponent'
 ----
+
+=== Expression Language
+The rules of how to calculate distribution coordinates and some other fields by a build version can be configured using Expression Language.
+
+Available variables are:
+
+* *${component}* - component name
+* *${version}* - component build version
+* *${major}* - first item of the build version
+* *${minor}* - second item of the build version
+* *${service}* - third item of the build version
+* *${fix}* - forth item of the build version
+* *${build}* - fifth item of the build version
+* *${env.<NAME>}* - <NAME> environment variable
+* *${baseDir}* - user.dir system property
+
+WARNING: One should use single-quoted `String` with Expression Language statements. Using of double-quoted `GString` may lead to clash with standard Groovy template engine.

--- a/test-common/src/test/resources/expected-data/versions-api-1-jira-component-version.json
+++ b/test-common/src/test/resources/expected-data/versions-api-1-jira-component-version.json
@@ -1,0 +1,19 @@
+{
+  "name": "versions-api",
+  "version": "1",
+  "component": {
+    "projectKey": "TESTONE",
+    "displayName": "VERSIONS API COMPONENT",
+    "componentVersionFormat": {
+      "majorVersionFormat": "$major",
+      "releaseVersionFormat": "$major.$minor",
+      "buildVersionFormat": "$major.$minor.$service",
+      "lineVersionFormat": "$major"
+    },
+    "componentInfo": {
+      "versionPrefix": "versions-api",
+      "versionFormat": "$versionPrefix.$baseVersionFormat"
+    },
+    "technical": false
+  }
+}

--- a/test-common/src/test/resources/expected-data/versions-api-1.2-jira-component-version.json
+++ b/test-common/src/test/resources/expected-data/versions-api-1.2-jira-component-version.json
@@ -1,0 +1,19 @@
+{
+  "name": "versions-api",
+  "version": "1.2",
+  "component": {
+    "projectKey": "TESTONE",
+    "displayName": "VERSIONS API COMPONENT",
+    "componentVersionFormat": {
+      "majorVersionFormat": "$major",
+      "releaseVersionFormat": "$major.$minor",
+      "buildVersionFormat": "$major.$minor.$service",
+      "lineVersionFormat": "$major"
+    },
+    "componentInfo": {
+      "versionPrefix": "versions-api",
+      "versionFormat": "$versionPrefix.$baseVersionFormat"
+    },
+    "technical": false
+  }
+}

--- a/test-common/src/test/resources/expected-data/versions-api-1.2.3-jira-component-version.json
+++ b/test-common/src/test/resources/expected-data/versions-api-1.2.3-jira-component-version.json
@@ -1,0 +1,19 @@
+{
+  "name": "versions-api",
+  "version": "1.2.3",
+  "component": {
+    "projectKey": "TESTONE",
+    "displayName": "VERSIONS API COMPONENT",
+    "componentVersionFormat": {
+      "majorVersionFormat": "$major",
+      "releaseVersionFormat": "$major.$minor",
+      "buildVersionFormat": "$major.$minor.$service",
+      "lineVersionFormat": "$major"
+    },
+    "componentInfo": {
+      "versionPrefix": "versions-api",
+      "versionFormat": "$versionPrefix.$baseVersionFormat"
+    },
+    "technical": false
+  }
+}

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -271,7 +271,7 @@ abstract class BaseComponentsRegistryServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = [RELEASE_VERSION, RC_VERSION, LINE_VERSION, BUILD_VERSION])
+    @ValueSource(strings = [BUILD_VERSION, JIRA_BUILD_VERSION, LINE_VERSION, JIRA_LINE_VERSION, MINOR_VERSION, JIRA_MINOR_VERSION, RC_VERSION, JIRA_RC_VERSION, JIRA_RELEASE_VERSION, RELEASE_VERSION])
     fun testGetDetailedComponentVersion(version: String) {
         val actualComponentVersion = getDetailedComponentVersion("SUB", version)
         Assertions.assertEquals(DETAILED_COMPONENT_VERSION, actualComponentVersion)
@@ -287,7 +287,7 @@ abstract class BaseComponentsRegistryServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = [BUILD_VERSION, JIRA_BUILD_VERSION, LINE_VERSION, JIRA_LINE_VERSION, MINOR_VERSION, JIRA_MINOR_VERSION, RC_VERSION, JIRA_RC_VERSION])
+    @ValueSource(strings = [BUILD_VERSION, JIRA_BUILD_VERSION, LINE_VERSION, JIRA_LINE_VERSION, MINOR_VERSION, JIRA_MINOR_VERSION, RC_VERSION, JIRA_RC_VERSION, JIRA_RELEASE_VERSION, RELEASE_VERSION])
     fun testGetVCSSettings(version: String) {
         Assertions.assertEquals(VCS_SETTINGS, getVcsSettings("SUB", version))
     }
@@ -433,12 +433,61 @@ abstract class BaseComponentsRegistryServiceTest {
         @JvmStatic
         fun jiraComponentVersions(): Stream<Arguments> {
             return Stream.of(
-                Arguments.of("TESTONE", "1.0", "expected-data/testone-1.0-jira-component-version.json"),
+                Arguments.of(
+                    "TESTONE",
+                    "1.0",
+                    "expected-data/testone-1.0-jira-component-version.json"
+                ),
                 Arguments.of(
                     "versions-api",
                     "versions-api.1.0",
                     "expected-data/versions-api-version-api.1.0-jira-component-version.json"
-                )
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "1",
+                    "expected-data/versions-api-1-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "1.2",
+                    "expected-data/versions-api-1.2-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "versions-api.1.2",
+                    "expected-data/versions-api-1.2-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "1.2_RC",
+                    "expected-data/versions-api-1.2-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "1.2.3",
+                    "expected-data/versions-api-1.2.3-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "1.2-0003",
+                    "expected-data/versions-api-1.2.3-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "prefix-1.2.3-suffix",
+                    "expected-data/versions-api-1.2.3-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "1.2.3.4",
+                    "expected-data/versions-api-1.2.3-jira-component-version.json"
+                ),
+                Arguments.of(
+                    "versions-api",
+                    "prefix-1.2.3.4-suffix",
+                    "expected-data/versions-api-1.2.3-jira-component-version.json"
+                ),
             )
         }
 


### PR DESCRIPTION
Example for monit-unit component:
* versionPrefix = monit-unit
* lineVersionFormat = majorVersionFormat = '$major'
* releaseVersionFormat = buildVersionFormat = '$major.$minor'

jiraComponentVersion.version resolving by component (in rest/api/2/components/${component}/versions/${version}/jira-component for instance):

| Version parameter | Old resolved version | New resolved version |
|-------------------|----------------------|----------------------|
| 1                 | 1                    | 1                    |
| 1.2               | 1.2                  | 1.2                  |
| 1-2               | 1-2                  | 1.2                  |
| 1.2.3             | 1.2.3                | 1.2                  |
| 1.2.3.4           | 1.2.3.4              | 1.2                  |
| 1.02              | 1.02                 | 1.2                  |
| 1_RC              | 1_RC                 | 1                    |
| 1.2_RC            | 1.2_RC               | 1.2                  |
| 1-SNAPSHOT        | 1-SNAPSHOT           | 1                    |
| 1.2-SNAPSHOT      | 1.2-SNAPSHOT         | 1.2                  |
| test-1            | test-1               | 1                    |
| test-1.2          | test-1.2             | 1.2                  |
| monit-unit-1      | 1                    | 1                    |
| monit-unit-1.2    | 1.2                  | 1.2                  |
| monit-unit-1_RC   | monit-unit-1_RC      | 1                    |
| monit-unit-1.2_RC | monit-unit-1.2_RC    | 1.2                  |

jiraComponentVersion.version resolving by project (in rest/api/2/projects/${project}/versions/${version} for instance):

| Version parameter         | Old resolved version | New resolved version |
|---------------------------|----------------------|----------------------|
| 1                         | Error                | Error                |
| 1.2                       | Error                | Error                |
| 1.2.3                     | Error                | Error                |
| monit-unit-1              | 1                    | 1                    |
| monit-unit-1.2            | 1.2                  | 1.2                  |
| monit-unit-1.2.3          | Error                | Error                |
| monit-unit-1_RC           | Error                | Error                |
| monit-unit-1.2_RC         | monit-unit-1.2_RC    | 1.2                  |
| monit-unit-1.2.3_RC       | Error                | Error                |
| monit-unit-1-SNAPSHOT     | Error                | Error                |
| monit-unit-1.2-SNAPSHOT   | Error                | Error                |
| monit-unit-1.2.3-SNAPSHOT | Error                | Error                |