### PR TITLE
Fix the handling of the nullable field hotfixVersionFormat

### DIFF
--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentRegistryVersion.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentRegistryVersion.kt
@@ -1,11 +1,13 @@
 package org.octopusden.octopus.components.registry.core.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ComponentRegistryVersion(
     @JsonProperty("type") val type: ComponentVersionType,
     @JsonProperty("version") val version: String,
-    @JsonProperty("jiraVersion") val jiraVersion: String
+    @JsonProperty("jiraVersion") val jiraVersion: String?
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentRegistryVersion.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentRegistryVersion.kt
@@ -1,13 +1,11 @@
 package org.octopusden.octopus.components.registry.core.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ComponentRegistryVersion(
     @JsonProperty("type") val type: ComponentVersionType,
     @JsonProperty("version") val version: String,
-    @JsonProperty("jiraVersion") val jiraVersion: String?
+    @JsonProperty("jiraVersion") val jiraVersion: String
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentVersionFormat.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentVersionFormat.kt
@@ -1,12 +1,14 @@
 package org.octopusden.octopus.components.registry.core.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ComponentVersionFormatDTO @JsonCreator constructor(
         @JsonProperty("majorVersionFormat") val majorVersionFormat: String,
         @JsonProperty("releaseVersionFormat") val releaseVersionFormat: String,
         @JsonProperty("buildVersionFormat") val buildVersionFormat: String,
         @JsonProperty("lineVersionFormat") val lineVersionFormat: String,
-        @JsonProperty("hotfixVersionFormat") val hotfixVersionFormat: String,
+        @JsonProperty("hotfixVersionFormat") val hotfixVersionFormat: String?,
         )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/DetailedComponentVersion.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/DetailedComponentVersion.kt
@@ -1,9 +1,11 @@
 package org.octopusden.octopus.components.registry.core.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class DetailedComponentVersion (
     @JsonProperty("component") val component: String,
     @JsonProperty("minorVersion") val minorVersion: ComponentRegistryVersion,
@@ -11,5 +13,5 @@ data class DetailedComponentVersion (
     @JsonProperty("buildVersion") val buildVersion: ComponentRegistryVersion,
     @JsonProperty("rcVersion") val rcVersion: ComponentRegistryVersion,
     @JsonProperty("releaseVersion") val releaseVersion: ComponentRegistryVersion,
-    @JsonProperty("hotfixVersion") val hotfixVersion: ComponentRegistryVersion
+    @JsonProperty("hotfixVersion") val hotfixVersion: ComponentRegistryVersion?
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VCSSettingsDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VCSSettingsDTO.kt
@@ -8,5 +8,4 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class VCSSettingsDTO @JsonCreator constructor(
     @JsonProperty("versionControlSystemRoots") val versionControlSystemRoots: List<VersionControlSystemRootDTO> = emptyList(),
     @JsonProperty("externalRegistry") val externalRegistry: String? = null,
-    @JsonProperty("hotfixBranch") val hotfixBranch: String? = null,
     )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionControlSystemRootDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionControlSystemRootDTO.kt
@@ -2,9 +2,11 @@ package org.octopusden.octopus.components.registry.core.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class VersionControlSystemRootDTO @JsonCreator constructor(
     @JsonProperty("name") val name: String,
     @JsonProperty("vcsPath") val vcsPath: String,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/JiraComponentVersionToDetailedComponentVersionMapper.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/JiraComponentVersionToDetailedComponentVersionMapper.kt
@@ -44,11 +44,13 @@ class JiraComponentVersionToDetailedComponentVersionMapper(
                 componentVersionFormat.releaseVersionFormat.formatVersion(versionNumericVersionFactory, src.version),
                 src.releaseVersion
             ),
-            ComponentRegistryVersion(
-                ComponentVersionType.HOTFIX,
-                componentVersionFormat.hotfixVersionFormat.formatVersion(versionNumericVersionFactory, src.version),
-                src.hotfixVersion
-            )
+            src.hotfixVersion?.let {
+                ComponentRegistryVersion(
+                    ComponentVersionType.HOTFIX,
+                    componentVersionFormat.hotfixVersionFormat.formatVersion(versionNumericVersionFactory, src.version),
+                    it
+                )
+            } ?: null
         )
     }
 }


### PR DESCRIPTION
В DTO hotfixVersionFormat обязательное, поэтому чтоб это поле всегда возвращать надо его добавлять в Defaults. Само по себе это поле имеет смысл только в случае если задан hotfixBranch, а он задается не всегда, поэтому необходимо сделать поле hotfixVersionFormat nullable. В CRS есть проверка, в случае если задан hotfixBranch то buildVersionFormat должен быть не пустым и hotfixVersionFormat должен начинаться так же как и buildVersionFormat. 