### PR TITLE
#74 find a component by docker + #82 docker tag format 

### DIFF
--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -119,14 +119,16 @@ class EscrowConfigurationLoader {
 
     static Distribution recalculateDockerWithVersion(Distribution distribution, String version) {
         if (distribution == null || distribution.docker() == null) {
-            return null
+            return distribution
         }
+
+        println "Distribution in : ${distribution}"
 
         def docker = distribution.docker()
 
         // -- DOCKER -- to be removed
         if (docker.contains("\${version}")) {
-            docker = docker.replaceAll("\${version}", version)
+            docker = docker.replaceAll("${version}", version)
         } else {
             docker = docker.split(',').collect {img ->
                 def parts = img.split(":")
@@ -136,15 +138,16 @@ class EscrowConfigurationLoader {
             }.join(",")
         }
 
-        return Distribution(
-                explicit: distribution.explicit(),
-                external: distribution.external(),
-                GAV: distribution.GAV(),
-                DEB: distribution.DEB(),
-                RPM: distribution.RPM(),
-                docker: docker,
-                securityGroups: new SecurityGroups(distribution.securityGroups?.read)
+        return new Distribution(
+                distribution.explicit(),
+                distribution.external(),
+                distribution.GAV(),
+                distribution.DEB(),
+                distribution.RPM(),
+                docker,
+                new SecurityGroups(distribution.securityGroups?.read)
         )
+
     }
 
     EscrowConfiguration loadFullConfiguration(Map<String, String> params) {

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -111,20 +111,21 @@ class EscrowConfigurationLoader {
         def config = modules[0]
         def escrowModuleConfig = config.clone()
         def postProcessor = new ModelConfigPostProcessor(ComponentVersion.create(componentKey, componentVersion), escrowConfiguration.versionNames)
-        escrowModuleConfig.distribution = recalculateDockerWithVersion(postProcessor.resolveDistribution(config.distribution), componentVersion)
+        escrowModuleConfig.distribution = calculateDistribution(postProcessor.resolveDistribution(config.distribution), componentVersion)
 
         escrowModuleConfig.jiraConfiguration = postProcessor.resolveJiraConfiguration(config.jiraConfiguration)
         escrowModuleConfig
     }
 
-    static Distribution recalculateDockerWithVersion(Distribution distribution, String version) {
+    static Distribution calculateDistribution(Distribution distribution, String version) {
         if (distribution == null || distribution.docker() == null) {
             return distribution
         }
 
         def docker = distribution.docker()
 
-        // -- DOCKER -- to be removed
+        // TODO -- DOCKER -- to be removed
+        // the only "else" block will remain
         if (docker.contains("\${version}")) {
             docker = docker.replaceAll("\\\$\\{version}", version)
         } else {

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -122,8 +122,6 @@ class EscrowConfigurationLoader {
             return distribution
         }
 
-        println "Distribution in : ${distribution}"
-
         def docker = distribution.docker()
 
         // -- DOCKER -- to be removed

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -130,25 +130,24 @@ class EscrowConfigurationLoader {
         def jiraComponentVersionFormatter = new JiraComponentVersionFormatter(versionNames)
         def numericVersion = new NumericVersionFactory(versionNames).create(version)
 
-        def formatters = [
-                jiraComponentVersionFormatter.&matchesBuildVersionFormat,
-                jiraComponentVersionFormatter.&matchesReleaseVersionFormat,
-                jiraComponentVersionFormatter.&matchesMajorVersionFormat,
-                jiraComponentVersionFormatter.&matchesLineVersionFormat,
-                jiraComponentVersionFormatter.&matchesHotfixVersionFormat
-        ]
-        def formatStr= [
-                component.componentVersionFormat.buildVersionFormat,
-                component.componentVersionFormat.releaseVersionFormat,
-                component.componentVersionFormat.majorVersionFormat,
-                component.componentVersionFormat.lineVersionFormat,
-                component.componentVersionFormat.hotfixVersionFormat
+        def formats = [
+
+                // todo - order must be changed
+                // it should be from more many component to less many component
+                // Hot fix - build - release - major - line
+                // see the issue #87
+
+                [jiraComponentVersionFormatter.&matchesBuildVersionFormat, component.componentVersionFormat.buildVersionFormat],
+                [jiraComponentVersionFormatter.&matchesReleaseVersionFormat, component.componentVersionFormat.releaseVersionFormat],
+                [jiraComponentVersionFormatter.&matchesMajorVersionFormat, component.componentVersionFormat.majorVersionFormat],
+                [jiraComponentVersionFormatter.&matchesLineVersionFormat, component.componentVersionFormat.lineVersionFormat],
+                [jiraComponentVersionFormatter.&matchesHotfixVersionFormat, component.componentVersionFormat.hotfixVersionFormat]
         ]
 
-        for (int i = 0; i < formatters.size(); i++) {
-            if (formatters[i](component, version, strict)) {
-                if (formatStr[i] != null) {
-                    return numericVersion.formatVersion(formatStr[i])
+        for (def format in formats) {
+            if (format[0](component, version, strict)) {
+                if (format[1] != null) {
+                    return numericVersion.formatVersion(format[1])
                 }
             }
         }

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -126,7 +126,7 @@ class EscrowConfigurationLoader {
 
         // -- DOCKER -- to be removed
         if (docker.contains("\${version}")) {
-            docker = docker.replaceAll("${version}", version)
+            docker = docker.replaceAll("\\\$\\{version}", version)
         } else {
             docker = docker.split(',').collect {img ->
                 def parts = img.split(":")

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -111,7 +111,12 @@ class EscrowConfigurationLoader {
         }
         def config = modules[0]
 
-        def normalizedVersion = normalizeVersion(componentVersion, config.jiraConfiguration, escrowConfiguration.versionNames, false) ?: componentVersion
+        def normalizedVersion = normalizeVersion(componentVersion, config.jiraConfiguration, escrowConfiguration.versionNames, false)
+        if (normalizedVersion == null) {
+            LOG.warn("Version of component {}:{} is incorrect", componentKey, componentVersion)
+            return null
+        }
+
         def escrowModuleConfig = config.clone()
         def postProcessor = new ModelConfigPostProcessor(ComponentVersion.create(componentKey, normalizedVersion), escrowConfiguration.versionNames)
         escrowModuleConfig.distribution = calculateDistribution(postProcessor.resolveDistribution(config.distribution), normalizedVersion)
@@ -123,7 +128,7 @@ class EscrowConfigurationLoader {
     static String normalizeVersion(String version, JiraComponent component, VersionNames versionNames,
                                    boolean strict) {
 
-        if (component?.getComponentInfo()?.getVersionFormat() == null) {
+        if (component?.componentVersionFormat == null) {
             return null
         }
 

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -248,22 +248,12 @@ class GroovySlurperConfigValidator {
         validateValueByPattern(distributionSection, "DEB", DEB_PATTERN, expressionContext)
         validateValueByPattern(distributionSection, "RPM", RPM_PATTERN, expressionContext)
 
-
+        // -- DOCKER -- to be changed
         validateValueByPattern(distributionSection, "docker", DOCKER_PATTERN_OLD, expressionContext)
         validateNoExpressionInImageName(distributionSection)
 
         if (distributionSection.containsKey(SECURITY_GROUPS)) {
             validateSecurityGroupsParameters(distributionSection, SECURITY_GROUPS, moduleName)
-        }
-    }
-
-    private void validateValueDocker(Map distributionSection, EscrowExpressionContext expressionContext) {
-        String key = "docker"
-        if (distributionSection.containsKey(key)) {
-            def value = distributionSection.get(key) as String
-
-            // -- DOCKER -- to be changed
-            validateValueByPattern(distributionSection, "docker", DOCKER_PATTERN_OLD, expressionContext)
         }
     }
 

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -34,9 +34,16 @@ class GroovySlurperConfigValidator {
     private static final String SECURITY_GROUPS_ENTRY_PATTERN = "[\\w-#\\s]+"
     public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SECURITY_GROUPS_ENTRY_PATTERN)(,($SECURITY_GROUPS_ENTRY_PATTERN))*\$")
     private static final String DOCKER_IMAGE_PATH_PATTERN = "([a-z0-9]+([_.-][a-z0-9]+)*/)*[a-z0-9]+([_.-][a-z0-9]+)*"
-    private static final String DOCKER_IMAGE_TAG_PATTERN = "\\w[\\w.-]{0,127}"
-    private static final String DOCKER_ENTRY_PATTERN = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN)?"
-    public static final Pattern DOCKER_PATTERN = Pattern.compile("^($DOCKER_ENTRY_PATTERN)(,($DOCKER_ENTRY_PATTERN))*\$")
+
+    private static final String DOCKER_IMAGE_TAG_PATTERN_NEW = "[a-zA-Z0-9]{1,127}"
+    private static final String DOCKER_ENTRY_PATTERN_NEW = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN_NEW)?"
+    public static final Pattern DOCKER_PATTERN_NEW = Pattern.compile("^($DOCKER_ENTRY_PATTERN_NEW)(,($DOCKER_ENTRY_PATTERN_NEW))*\$")
+
+    // -- DOCKER -- to be removed
+    private static final String DOCKER_IMAGE_TAG_PATTERN_OLD = "\\w[\\w.-]{0,127}"
+    private static final String DOCKER_ENTRY_PATTERN_OLD = "$DOCKER_IMAGE_PATH_PATTERN:$DOCKER_IMAGE_TAG_PATTERN_OLD"
+    public static final Pattern DOCKER_PATTERN_OLD = Pattern.compile("^($DOCKER_ENTRY_PATTERN_OLD)(,($DOCKER_ENTRY_PATTERN_OLD))*\$")
+    // -- DOCKER -- to be removed
 
     public static SUPPORTED_ATTRIBUTES = ['buildSystem', VCS_URL, REPOSITORY_TYPE, 'groupId', 'artifactId',
                                           TAG, 'versionRange', 'version', 'module',
@@ -241,13 +248,22 @@ class GroovySlurperConfigValidator {
         validateValueByPattern(distributionSection, "DEB", DEB_PATTERN, expressionContext)
         validateValueByPattern(distributionSection, "RPM", RPM_PATTERN, expressionContext)
 
-        // to change in phase 2
-        validateValueByPattern(distributionSection, "docker", DOCKER_PATTERN, expressionContext)
-        // to change in phase 2
+        validateValueDocker(distributionSection, expressionContext)
+
         validateNoExpressionInImageName(distributionSection)
 
         if (distributionSection.containsKey(SECURITY_GROUPS)) {
             validateSecurityGroupsParameters(distributionSection, SECURITY_GROUPS, moduleName)
+        }
+    }
+
+    static void validateValueDocker(Map distributionSection, EscrowExpressionContext expressionContext) {
+        String key = "docker"
+        if (distributionSection.containsKey(key)) {
+            def value = distributionSection.get(key) as String
+            def oldStyleMode = value.contains('$')
+            // -- DOCKER -- to be changed
+            validateValueByPattern(distributionSection, "docker", oldStyleMode ? DOCKER_PATTERN_OLD : DOCKER_PATTERN_NEW, expressionContext)
         }
     }
 

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -35,7 +35,7 @@ class GroovySlurperConfigValidator {
     public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SECURITY_GROUPS_ENTRY_PATTERN)(,($SECURITY_GROUPS_ENTRY_PATTERN))*\$")
     private static final String DOCKER_IMAGE_PATH_PATTERN = "([a-z0-9]+([_.-][a-z0-9]+)*/)*[a-z0-9]+([_.-][a-z0-9]+)*"
     private static final String DOCKER_IMAGE_TAG_PATTERN = "\\w[\\w.-]{0,127}"
-    private static final String DOCKER_ENTRY_PATTERN = "$DOCKER_IMAGE_PATH_PATTERN:$DOCKER_IMAGE_TAG_PATTERN"
+    private static final String DOCKER_ENTRY_PATTERN = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN)?"
     public static final Pattern DOCKER_PATTERN = Pattern.compile("^($DOCKER_ENTRY_PATTERN)(,($DOCKER_ENTRY_PATTERN))*\$")
 
     public static SUPPORTED_ATTRIBUTES = ['buildSystem', VCS_URL, REPOSITORY_TYPE, 'groupId', 'artifactId',
@@ -240,7 +240,10 @@ class GroovySlurperConfigValidator {
         validateValueByPattern(distributionSection, "GAV", GAV_PATTERN, expressionContext)
         validateValueByPattern(distributionSection, "DEB", DEB_PATTERN, expressionContext)
         validateValueByPattern(distributionSection, "RPM", RPM_PATTERN, expressionContext)
+
+        // to change in phase 2
         validateValueByPattern(distributionSection, "docker", DOCKER_PATTERN, expressionContext)
+        // to change in phase 2
         validateNoExpressionInImageName(distributionSection)
 
         if (distributionSection.containsKey(SECURITY_GROUPS)) {

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -257,7 +257,7 @@ class GroovySlurperConfigValidator {
         }
     }
 
-    static void validateValueDocker(Map distributionSection, EscrowExpressionContext expressionContext) {
+    private void validateValueDocker(Map distributionSection, EscrowExpressionContext expressionContext) {
         String key = "docker"
         if (distributionSection.containsKey(key)) {
             def value = distributionSection.get(key) as String

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -35,15 +35,15 @@ class GroovySlurperConfigValidator {
     public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SECURITY_GROUPS_ENTRY_PATTERN)(,($SECURITY_GROUPS_ENTRY_PATTERN))*\$")
     private static final String DOCKER_IMAGE_PATH_PATTERN = "([a-z0-9]+([_.-][a-z0-9]+)*/)*[a-z0-9]+([_.-][a-z0-9]+)*"
 
-    public static final String DOCKER_IMAGE_TAG_PATTERN_NEW = "[a-zA-Z][a-zA-Z0-9]*"
-    private static final String DOCKER_ENTRY_PATTERN_NEW = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN_NEW)?"
+    public static final String DOCKER_IMAGE_TAG_SUFFIX_PATTERN_NEW = "[a-zA-Z][a-zA-Z0-9]*"
+    private static final String DOCKER_ENTRY_PATTERN_NEW = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_SUFFIX_PATTERN_NEW)?"
     public static final Pattern DOCKER_PATTERN_NEW = Pattern.compile("^($DOCKER_ENTRY_PATTERN_NEW)(,($DOCKER_ENTRY_PATTERN_NEW))*\$")
 
-    // -- DOCKER -- to be removed
-    private static final String DOCKER_IMAGE_TAG_PATTERN_OLD = "\\w[\\w.-]{0,64}"
-    private static final String DOCKER_ENTRY_PATTERN_OLD = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN_OLD)?"
+    // TODO -- DOCKER -- to be removed
+    private static final String DOCKER_IMAGE_TAG_SUFFIX_PATTERN_OLD = "\\w[\\w.-]{0,64}"
+    private static final String DOCKER_ENTRY_PATTERN_OLD = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_SUFFIX_PATTERN_OLD)?"
     public static final Pattern DOCKER_PATTERN_OLD = Pattern.compile("^($DOCKER_ENTRY_PATTERN_OLD)(,($DOCKER_ENTRY_PATTERN_OLD))*\$")
-    // -- DOCKER -- to be removed
+    // TODO -- DOCKER -- to be removed
 
     public static SUPPORTED_ATTRIBUTES = ['buildSystem', VCS_URL, REPOSITORY_TYPE, 'groupId', 'artifactId',
                                           TAG, 'versionRange', 'version', 'module',
@@ -248,7 +248,7 @@ class GroovySlurperConfigValidator {
         validateValueByPattern(distributionSection, "DEB", DEB_PATTERN, expressionContext)
         validateValueByPattern(distributionSection, "RPM", RPM_PATTERN, expressionContext)
 
-        // -- DOCKER -- to be changed
+        // TODO -- DOCKER -- to be changed
         validateValueByPattern(distributionSection, "docker", DOCKER_PATTERN_OLD, expressionContext)
         validateNoExpressionInImageName(distributionSection)
 

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -35,7 +35,7 @@ class GroovySlurperConfigValidator {
     public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SECURITY_GROUPS_ENTRY_PATTERN)(,($SECURITY_GROUPS_ENTRY_PATTERN))*\$")
     private static final String DOCKER_IMAGE_PATH_PATTERN = "([a-z0-9]+([_.-][a-z0-9]+)*/)*[a-z0-9]+([_.-][a-z0-9]+)*"
 
-    private static final String DOCKER_IMAGE_TAG_PATTERN_NEW = "[a-zA-Z0-9]+"
+    public static final String DOCKER_IMAGE_TAG_PATTERN_NEW = "[a-zA-Z][a-zA-Z0-9]*"
     private static final String DOCKER_ENTRY_PATTERN_NEW = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN_NEW)?"
     public static final Pattern DOCKER_PATTERN_NEW = Pattern.compile("^($DOCKER_ENTRY_PATTERN_NEW)(,($DOCKER_ENTRY_PATTERN_NEW))*\$")
 

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -35,7 +35,9 @@ class GroovySlurperConfigValidator {
     public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SECURITY_GROUPS_ENTRY_PATTERN)(,($SECURITY_GROUPS_ENTRY_PATTERN))*\$")
     private static final String DOCKER_IMAGE_PATH_PATTERN = "([a-z0-9]+([_.-][a-z0-9]+)*/)*[a-z0-9]+([_.-][a-z0-9]+)*"
 
-    public static final String DOCKER_IMAGE_TAG_SUFFIX_PATTERN_NEW = "[a-zA-Z][a-zA-Z0-9]*"
+    private static final String SUFFIX_PART_NEW = "[a-zA-Z][a-zA-Z0-9]*"
+    private static final String DOCKER_IMAGE_TAG_SUFFIX_PATTERN_NEW = "$SUFFIX_PART_NEW([_.-]$SUFFIX_PART_NEW)*"
+
     private static final String DOCKER_ENTRY_PATTERN_NEW = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_SUFFIX_PATTERN_NEW)?"
     public static final Pattern DOCKER_PATTERN_NEW = Pattern.compile("^($DOCKER_ENTRY_PATTERN_NEW)(,($DOCKER_ENTRY_PATTERN_NEW))*\$")
 

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -35,13 +35,13 @@ class GroovySlurperConfigValidator {
     public static final Pattern SECURITY_GROUPS_PATTERN = Pattern.compile("^($SECURITY_GROUPS_ENTRY_PATTERN)(,($SECURITY_GROUPS_ENTRY_PATTERN))*\$")
     private static final String DOCKER_IMAGE_PATH_PATTERN = "([a-z0-9]+([_.-][a-z0-9]+)*/)*[a-z0-9]+([_.-][a-z0-9]+)*"
 
-    private static final String DOCKER_IMAGE_TAG_PATTERN_NEW = "[a-zA-Z0-9]{1,127}"
+    private static final String DOCKER_IMAGE_TAG_PATTERN_NEW = "[a-zA-Z0-9]+"
     private static final String DOCKER_ENTRY_PATTERN_NEW = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN_NEW)?"
     public static final Pattern DOCKER_PATTERN_NEW = Pattern.compile("^($DOCKER_ENTRY_PATTERN_NEW)(,($DOCKER_ENTRY_PATTERN_NEW))*\$")
 
     // -- DOCKER -- to be removed
-    private static final String DOCKER_IMAGE_TAG_PATTERN_OLD = "\\w[\\w.-]{0,127}"
-    private static final String DOCKER_ENTRY_PATTERN_OLD = "$DOCKER_IMAGE_PATH_PATTERN:$DOCKER_IMAGE_TAG_PATTERN_OLD"
+    private static final String DOCKER_IMAGE_TAG_PATTERN_OLD = "\\w[\\w.-]{0,64}"
+    private static final String DOCKER_ENTRY_PATTERN_OLD = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_PATTERN_OLD)?"
     public static final Pattern DOCKER_PATTERN_OLD = Pattern.compile("^($DOCKER_ENTRY_PATTERN_OLD)(,($DOCKER_ENTRY_PATTERN_OLD))*\$")
     // -- DOCKER -- to be removed
 
@@ -248,8 +248,8 @@ class GroovySlurperConfigValidator {
         validateValueByPattern(distributionSection, "DEB", DEB_PATTERN, expressionContext)
         validateValueByPattern(distributionSection, "RPM", RPM_PATTERN, expressionContext)
 
-        validateValueDocker(distributionSection, expressionContext)
 
+        validateValueByPattern(distributionSection, "docker", DOCKER_PATTERN_OLD, expressionContext)
         validateNoExpressionInImageName(distributionSection)
 
         if (distributionSection.containsKey(SECURITY_GROUPS)) {
@@ -261,9 +261,9 @@ class GroovySlurperConfigValidator {
         String key = "docker"
         if (distributionSection.containsKey(key)) {
             def value = distributionSection.get(key) as String
-            def oldStyleMode = value.contains('$')
+
             // -- DOCKER -- to be changed
-            validateValueByPattern(distributionSection, "docker", oldStyleMode ? DOCKER_PATTERN_OLD : DOCKER_PATTERN_NEW, expressionContext)
+            validateValueByPattern(distributionSection, "docker", DOCKER_PATTERN_OLD, expressionContext)
         }
     }
 

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -6,7 +6,7 @@ import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurp
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_PATTERN_NEW
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.GAV_PATTERN
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.RPM_PATTERN
-// -- DOCKER -- to be removed
+// TODO -- DOCKER -- to be removed
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_PATTERN_OLD
 
 class GroovySlurperConfigValidatorTest extends GroovyTestCase {
@@ -49,7 +49,7 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
         assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus:image:t10").matches()
         assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:").matches()
 
-        // -- DOCKER -- to be removed
+        // TODO -- DOCKER -- to be removed
         assert DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/image:1.0").matches()
         assert DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/first-image:1.0,org.octopusden/octopus/second-image:1.0").matches()
         assert !DOCKER_PATTERN_OLD.matcher("org.octopusden\\octopus/image:1.0").matches()

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -36,7 +36,7 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
     void testDockerPattern() {
         assert DOCKER_PATTERN.matcher("org.octopusden/octopus/image:1.0").matches()
         assert DOCKER_PATTERN.matcher("org.octopusden/octopus/first-image:1.0,org.octopusden/octopus/second-image:1.0").matches()
-        assert !DOCKER_PATTERN.matcher("org.octopusden/octopus/image").matches()
+        assert DOCKER_PATTERN.matcher("org.octopusden/octopus/image").matches()
         assert !DOCKER_PATTERN.matcher("org.octopusden\\octopus/image:1.0").matches()
         assert !DOCKER_PATTERN.matcher("org.octopusden/octopus:image:1.0").matches()
         assert !DOCKER_PATTERN.matcher("org.octopusden/octopus/image:.0").matches()

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -52,7 +52,6 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
         // -- DOCKER -- to be removed
         assert DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/image:1.0").matches()
         assert DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/first-image:1.0,org.octopusden/octopus/second-image:1.0").matches()
-        assert !DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/image").matches()
         assert !DOCKER_PATTERN_OLD.matcher("org.octopusden\\octopus/image:1.0").matches()
         assert !DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus:image:1.0").matches()
         assert !DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/image:.0").matches()
@@ -77,6 +76,7 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
         correctDockerStrings.forEach {
             def correct = new ConfigSlurper().parse(it)
             def validator = new GroovySlurperConfigValidator(verNames)
+            println "correct: ${correct}"
             validator.validateDistributionSection(correct, verNames, "testModule", "testConfig")
             assert !validator.hasErrors()
         }

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -76,7 +76,6 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
         correctDockerStrings.forEach {
             def correct = new ConfigSlurper().parse(it)
             def validator = new GroovySlurperConfigValidator(verNames)
-            println "correct: ${correct}"
             validator.validateDistributionSection(correct, verNames, "testModule", "testConfig")
             assert !validator.hasErrors()
         }

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -3,9 +3,11 @@ package org.octopusden.octopus.escrow.configuration.validation
 import org.octopusden.releng.versions.VersionNames
 
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DEB_PATTERN
+import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_PATTERN_NEW
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.GAV_PATTERN
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.RPM_PATTERN
-import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_PATTERN
+// -- DOCKER -- to be removed
+import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_PATTERN_OLD
 
 class GroovySlurperConfigValidatorTest extends GroovyTestCase {
 
@@ -34,12 +36,27 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
      * Docker pattern should contain only one image name without tag
      */
     void testDockerPattern() {
-        assert DOCKER_PATTERN.matcher("org.octopusden/octopus/image:1.0").matches()
-        assert DOCKER_PATTERN.matcher("org.octopusden/octopus/first-image:1.0,org.octopusden/octopus/second-image:1.0").matches()
-        assert DOCKER_PATTERN.matcher("org.octopusden/octopus/image").matches()
-        assert !DOCKER_PATTERN.matcher("org.octopusden\\octopus/image:1.0").matches()
-        assert !DOCKER_PATTERN.matcher("org.octopusden/octopus:image:1.0").matches()
-        assert !DOCKER_PATTERN.matcher("org.octopusden/octopus/image:.0").matches()
+        assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image").matches()
+        assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:arm64").matches()
+        assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image,org.octopusden/octopus/image:arm64").matches()
+        assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/first-image:amd64,org.octopusden/octopus/second-image:amd64").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/first-image:-amd64").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/first-image:1.1-amd64").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:\${version}").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:\${version}-jdk1").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/first-image:1.0,org.octopusden/octopus/second-image:1.0").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden\\octopus/image:t10").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus:image:t10").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:").matches()
+
+        // -- DOCKER -- to be removed
+        assert DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/image:1.0").matches()
+        assert DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/first-image:1.0,org.octopusden/octopus/second-image:1.0").matches()
+        assert !DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/image").matches()
+        assert !DOCKER_PATTERN_OLD.matcher("org.octopusden\\octopus/image:1.0").matches()
+        assert !DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus:image:1.0").matches()
+        assert !DOCKER_PATTERN_OLD.matcher("org.octopusden/octopus/image:.0").matches()
+
     }
 
 

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -40,6 +40,11 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
         assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:arm64").matches()
         assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image,org.octopusden/octopus/image:arm64").matches()
         assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/first-image:amd64,org.octopusden/octopus/second-image:amd64").matches()
+
+        assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:arm64-r2.d2").matches()
+        assert DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image,org.octopusden/octopus/image:arm64,org.octopusden/octopus/image:arm64-r2_d2").matches()
+        assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:arm64-v2.1").matches()
+
         assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/first-image:-amd64").matches()
         assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/first-image:1.1-amd64").matches()
         assert !DOCKER_PATTERN_NEW.matcher("org.octopusden/octopus/image:\${version}").matches()

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/JiraParametersResolverTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/JiraParametersResolverTest.groovy
@@ -125,7 +125,7 @@ class JiraParametersResolverTest extends GroovyTestCase {
         IJiraParametersResolver jiraParametersResolver = createJiraParametersResolverFromConfig("componentConfig.groovy")
         def version = ComponentVersion.create("component", "0.1");
         def versionBad = ComponentVersion.create("component1", "0.1")
-        def sysVersion = ComponentVersion.create("commoncomponent", "12")
+        def sysVersion = ComponentVersion.create("commoncomponent", "12.1")
         def sysWrongVersion = ComponentVersion.create("commoncomponent", "1")
         def componentVersion = ComponentVersion.create("sms_component", "5")
 

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/ReleaseInfoResolverTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/ReleaseInfoResolverTest.groovy
@@ -64,8 +64,8 @@ class ReleaseInfoResolverTest {
     @Test
     void testReleaseInfoResolverDebRpm() {
         def resolver = getResolver("/deb-rpm/Aggregator.groovy")
-        def releaseInfo3 = resolver.resolveRelease(ComponentVersion.create("logcomp", "3.0"))
-        def releaseInfo4 = resolver.resolveRelease(ComponentVersion.create("logcomp", "4.0"))
+        def releaseInfo3 = resolver.resolveRelease(ComponentVersion.create("logcomp", "3.0.1"))
+        def releaseInfo4 = resolver.resolveRelease(ComponentVersion.create("logcomp", "4.0.1"))
         assertEquals('org.octopusden.octopus.logcomp:logcomp', releaseInfo3.distribution.GAV())
         assertEquals('logcomp_${version}-1_amd64.deb', releaseInfo3.distribution.DEB())
         assertNull(releaseInfo3.distribution.RPM())

--- a/component-resolver-core/src/test/java/org/octopusden/octopus/escrow/resolvers/DistributionResolverTest.java
+++ b/component-resolver-core/src/test/java/org/octopusden/octopus/escrow/resolvers/DistributionResolverTest.java
@@ -50,7 +50,7 @@ public class DistributionResolverTest {
     void testDockerOfTestComponent() {
         Distribution distribution = distributionResolver.resolveDistribution(ComponentVersion.create("test-component", "1.3.49"));
         assertNotNull(distribution);
-        assertEquals("test-component/image:${version}-flavour1,test-component/image:${version}-flavour2", distribution.docker());
+        assertEquals("test-component/image:1.3.49-flavour1,test-component/image:1.3.49-flavour2", distribution.docker());
     }
 
 }

--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceClient.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceClient.kt
@@ -41,7 +41,7 @@ interface ComponentsRegistryServiceClient {
 
     @RequestLine("POST rest/api/3/components/find-by-docker-images")
     @Headers("Content-Type: application/json")
-    fun findComponentsByDockerImages(images: Set<Image>): Map<String, ComponentImage>
+    fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage>
 
     @RequestLine("GET /rest/api/1/components/{componentKey}")
     @Throws(NotFoundException::class)

--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceClient.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceClient.kt
@@ -25,6 +25,8 @@ import feign.Headers
 import feign.Param
 import feign.QueryMap
 import feign.RequestLine
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
+import org.octopusden.octopus.components.registry.core.dto.Image
 
 interface ComponentsRegistryServiceClient {
     /**
@@ -36,6 +38,10 @@ interface ComponentsRegistryServiceClient {
     @RequestLine("POST rest/api/3/components/find-by-artifacts")
     @Headers("Content-Type: application/json")
     fun findArtifactComponentsByArtifacts(artifacts: Set<ArtifactDependency>): ArtifactComponentsDTO
+
+    @RequestLine("POST rest/api/3/components/find-by-docker-images")
+    @Headers("Content-Type: application/json")
+    fun findComponentsByDockerImages(images: Set<Image>): Map<String, ComponentImage>
 
     @RequestLine("GET /rest/api/1/components/{componentKey}")
     @Throws(NotFoundException::class)

--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/impl/ClassicComponentsRegistryServiceClient.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/impl/ClassicComponentsRegistryServiceClient.kt
@@ -15,7 +15,9 @@ import org.octopusden.octopus.components.registry.client.ComponentsRegistryServi
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentArtifactConfigurationDTO
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.DistributionDTO
+import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionDTO
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionRangeDTO
 import org.octopusden.octopus.components.registry.core.dto.ServiceStatusDTO
@@ -39,6 +41,9 @@ class ClassicComponentsRegistryServiceClient(
 
     override fun findArtifactComponentsByArtifacts(artifacts: Set<ArtifactDependency>) =
         client.findArtifactComponentsByArtifacts(artifacts)
+
+    override fun findComponentsByDockerImages(images: Set<Image>): Map<String, ComponentImage> =
+        client.findComponentsByDockerImages(images)
 
     override fun getById(componentKey: String) = client.getById(componentKey)
 

--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/impl/ClassicComponentsRegistryServiceClient.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/impl/ClassicComponentsRegistryServiceClient.kt
@@ -42,7 +42,7 @@ class ClassicComponentsRegistryServiceClient(
     override fun findArtifactComponentsByArtifacts(artifacts: Set<ArtifactDependency>) =
         client.findArtifactComponentsByArtifacts(artifacts)
 
-    override fun findComponentsByDockerImages(images: Set<Image>): Map<String, ComponentImage> =
+    override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> =
         client.findComponentsByDockerImages(images)
 
     override fun getById(componentKey: String) = client.getById(componentKey)

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -199,8 +199,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             )
         )
         assertEquals(2, components.size)
-        assert(components.any { it.image.name == "test-docker-1" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_1" && it.componentVersion == "0.1" })
-        assert(components.any { it.image.name == "test/versions-api" && it.componentId == "TESTONE" && it.componentVersion == "10.1" })
+        assert(components.any { it.image.name == "test-docker-1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1" && it.version == "0.1" })
+        assert(components.any { it.image.name == "test/versions-api" && it.component == "TESTONE" && it.version == "10.1" })
         assert(components.none { it.image.name == "not-found" })
     }
 
@@ -213,8 +213,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             )
         )
         assertEquals(1, components.size)
-        assert(components.none { it.image.name == "test-docker-first" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_2" && it.componentVersion == "1.0.5" })
-        assert(components.any { it.image.name == "test-docker-second" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_2" && it.componentVersion == "1.0.5" })
+        assert(components.none { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
 
         components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
@@ -223,8 +223,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             )
         )
         assertEquals(1, components.size)
-        assert(components.any { it.image.name == "test-docker-first" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_2" && it.componentVersion == "0.0.5" })
-        assert(components.none { it.image.name == "test-docker-second" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_2" && it.componentVersion == "0.0.5" })
+        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+        assert(components.none { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
 
         components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
@@ -234,9 +234,9 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             )
         )
         assertEquals(3, components.size)
-        assert(components.any { it.image.name == "test-docker-first" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_2" && it.componentVersion == "0.0.5" })
-        assert(components.any { it.image.name == "test-docker-second" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_2" && it.componentVersion == "1.0.5" })
-        assert(components.any { it.image.name == "test-docker-third" && it.componentId == "TEST_COMPONENT_WITH_DOCKER_2" && it.componentVersion == "2.0.5" })
+        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+        assert(components.any { it.image.name == "test-docker-third" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "2.0.5" })
 
     }
 

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -256,9 +256,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             )
         )
         assertEquals(2, components.size)
-        System.out.println(components)
         assert(components.any { it.image.name == "test-docker-1_1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_1" && it.version == "0.1" })
-        assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.2.3" })
+        assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.2-3" })
         assert(components.none { it.image.name == "not-found" })
     }
 

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -226,7 +226,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         var components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
                 Image("test-docker-first", "1.0.5"),
-                Image("test-docker-second", "1.0.5")
+                Image("test-docker-second", "1.0.5-amd64"),
             )
         )
         assertEquals(1, components.size)
@@ -246,8 +246,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
                 Image("test-docker-first", "0.0.5"),
-                Image("test-docker-second", "1.0.5"),
-                Image("test-docker-third", "2.0.5")
+                Image("test-docker-second", "1.0.5-amd64"),
+                Image("test-docker-third", "2.0.5-arm64")
             )
         )
         assertEquals(3, components.size)

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -213,7 +213,6 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
                 Image("not-found", "0.1")
             )
         )
-        println(components)
         assertEquals(2, components.size)
         assert(components.any { it.image.name == "test-docker-1_1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_1" && it.version == "0.1" })
         assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.1.2" })

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -236,18 +236,33 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     }
 
+
+    @Test
+    fun findComponentsByDockerImagesNormalizeVersion() {
+
+        var components =
+            componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-3", "10.1-amd64")))
+        assertEquals(1, components.size)
+        assert(components.any { it.image.name == "test-docker-3" && it.component == "TEST_COMPONENT_WITH_DOCKER_3" && it.version == "10.1" })
+
+
+    }
+
+
+
     @Test
     fun findComponentsByDockerImagesNewStyle() {
         val components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
                 Image("test-docker-1_1", "0.1"),
-                Image("test-docker-1_2", "0.1.1.2-jdk11"),
+                Image("test-docker-1_2", "0.1-2.3-jdk11"),
                 Image("not-found", "0.1")
             )
         )
+        System.out.println("components = $components")
         assertEquals(2, components.size)
         assert(components.any { it.image.name == "test-docker-1_1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_1" && it.version == "0.1" })
-        assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.1.2" })
+        assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.2.3" })
         assert(components.none { it.image.name == "not-found" })
     }
 

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -251,7 +251,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         val components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
                 Image("test-docker-1_1", "0.1"),
-                Image("test-docker-1_2", "0.1.2-3-jdk11"),
+                Image("test-docker-1_2", "0.1-2-3-jdk11"),
                 Image("not-found", "0.1")
             )
         )

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -121,7 +121,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     @Test
     fun testGetAllComponents() {
-        assertEquals(45, componentsRegistryClient.getAllComponents().components.size)
+        assertEquals(46, componentsRegistryClient.getAllComponents().components.size)
         assertEquals(
             3,
             componentsRegistryClient.getAllComponents("ssh://hg@mercurial/technical", null).components.size
@@ -135,8 +135,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             ).components.size
         )
         assertEquals(4, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC")).components.size)
-        assertEquals(41, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
-        assertEquals(45, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
+        assertEquals(42, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
+        assertEquals(46, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
     }
 
     @Test
@@ -255,7 +255,6 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
                 Image("not-found", "0.1")
             )
         )
-        System.out.println("components = $components")
         assertEquals(2, components.size)
         assert(components.any { it.image.name == "test-docker-1_1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_1" && it.version == "0.1" })
         assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.2.3" })
@@ -299,5 +298,11 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     }
 
+    @Test
+    fun dockerImagesVersionResolver() {
+        assertEquals(getDistribution("TEST_COMPONENT_WITH_DOCKER_4", "1.2.3").docker, "test-docker-4:1.2.3-amd64")
+        assertEquals(getDistribution("TEST_COMPONENT_WITH_DOCKER_2", "1.2.3").docker, "test-docker-second:1.2.3-amd64")
+        assertEquals(getDistribution("TEST_COMPONENT_WITH_DOCKER_5", "7.6.5").docker, "test-docker-5:7.6.5-amd64,test-docker-5:7.6.5-arm64")
+    }
 
 }

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -256,6 +256,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             )
         )
         assertEquals(2, components.size)
+        System.out.println(components)
         assert(components.any { it.image.name == "test-docker-1_1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_1" && it.version == "0.1" })
         assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.2.3" })
         assert(components.none { it.image.name == "not-found" })

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -189,56 +189,56 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         )
     }
 
-    @Test
-    fun findComponentsByDockerImages() {
-        val components = componentsRegistryClient.findComponentsByDockerImages(
-            setOf(
-                Image("test/versions-api", "10.1"),
-                Image("test-docker-1", "0.1"),
-                Image("not-found", "0.1")
-            )
-        )
-        assertEquals(2, components.size)
-        assert(components.any { it.image.name == "test-docker-1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1" && it.version == "0.1" })
-        assert(components.any { it.image.name == "test/versions-api" && it.component == "TESTONE" && it.version == "10.1" })
-        assert(components.none { it.image.name == "not-found" })
-    }
-
-    @Test
-    fun findComponentsByDockerImagesWithRanges() {
-        var components = componentsRegistryClient.findComponentsByDockerImages(
-            setOf(
-                Image("test-docker-first", "1.0.5"),
-                Image("test-docker-second", "1.0.5")
-            )
-        )
-        assertEquals(1, components.size)
-        assert(components.none { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
-        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
-
-        components = componentsRegistryClient.findComponentsByDockerImages(
-            setOf(
-                Image("test-docker-first", "0.0.5"),
-                Image("test-docker-second", "0.0.5")
-            )
-        )
-        assertEquals(1, components.size)
-        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
-        assert(components.none { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
-
-        components = componentsRegistryClient.findComponentsByDockerImages(
-            setOf(
-                Image("test-docker-first", "0.0.5"),
-                Image("test-docker-second", "1.0.5"),
-                Image("test-docker-third", "2.0.5")
-            )
-        )
-        assertEquals(3, components.size)
-        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
-        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
-        assert(components.any { it.image.name == "test-docker-third" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "2.0.5" })
-
-    }
+//    @Test
+//    fun findComponentsByDockerImages() {
+//        val components = componentsRegistryClient.findComponentsByDockerImages(
+//            setOf(
+//                Image("test/versions-api", "10.1"),
+//                Image("test-docker-1", "0.1"),
+//                Image("not-found", "0.1")
+//            )
+//        )
+//        assertEquals(2, components.size)
+//        assert(components.any { it.image.name == "test-docker-1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1" && it.version == "0.1" })
+//        assert(components.any { it.image.name == "test/versions-api" && it.component == "TESTONE" && it.version == "10.1" })
+//        assert(components.none { it.image.name == "not-found" })
+//    }
+//
+//    @Test
+//    fun findComponentsByDockerImagesWithRanges() {
+//        var components = componentsRegistryClient.findComponentsByDockerImages(
+//            setOf(
+//                Image("test-docker-first", "1.0.5"),
+//                Image("test-docker-second", "1.0.5")
+//            )
+//        )
+//        assertEquals(1, components.size)
+//        assert(components.none { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+//        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+//
+//        components = componentsRegistryClient.findComponentsByDockerImages(
+//            setOf(
+//                Image("test-docker-first", "0.0.5"),
+//                Image("test-docker-second", "0.0.5")
+//            )
+//        )
+//        assertEquals(1, components.size)
+//        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+//        assert(components.none { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+//
+//        components = componentsRegistryClient.findComponentsByDockerImages(
+//            setOf(
+//                Image("test-docker-first", "0.0.5"),
+//                Image("test-docker-second", "1.0.5"),
+//                Image("test-docker-third", "2.0.5")
+//            )
+//        )
+//        assertEquals(3, components.size)
+//        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+//        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+//        assert(components.any { it.image.name == "test-docker-third" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "2.0.5" })
+//
+//    }
 
 
 }

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -122,7 +122,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     @Test
     fun testGetAllComponents() {
-        assertEquals(41, componentsRegistryClient.getAllComponents().components.size)
+        assertEquals(43, componentsRegistryClient.getAllComponents().components.size)
         assertEquals(
             3,
             componentsRegistryClient.getAllComponents("ssh://hg@mercurial/technical", null).components.size
@@ -136,8 +136,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             ).components.size
         )
         assertEquals(4, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC")).components.size)
-        assertEquals(37, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
-        assertEquals(41, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
+        assertEquals(39, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
+        assertEquals(43, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
     }
 
     @Test

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -31,6 +31,7 @@ import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.Date
+import kotlin.math.log
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
@@ -189,56 +190,72 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         )
     }
 
-//    @Test
-//    fun findComponentsByDockerImages() {
-//        val components = componentsRegistryClient.findComponentsByDockerImages(
-//            setOf(
-//                Image("test/versions-api", "10.1"),
-//                Image("test-docker-1", "0.1"),
-//                Image("not-found", "0.1")
-//            )
-//        )
-//        assertEquals(2, components.size)
-//        assert(components.any { it.image.name == "test-docker-1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1" && it.version == "0.1" })
-//        assert(components.any { it.image.name == "test/versions-api" && it.component == "TESTONE" && it.version == "10.1" })
-//        assert(components.none { it.image.name == "not-found" })
-//    }
-//
-//    @Test
-//    fun findComponentsByDockerImagesWithRanges() {
-//        var components = componentsRegistryClient.findComponentsByDockerImages(
-//            setOf(
-//                Image("test-docker-first", "1.0.5"),
-//                Image("test-docker-second", "1.0.5")
-//            )
-//        )
-//        assertEquals(1, components.size)
-//        assert(components.none { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
-//        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
-//
-//        components = componentsRegistryClient.findComponentsByDockerImages(
-//            setOf(
-//                Image("test-docker-first", "0.0.5"),
-//                Image("test-docker-second", "0.0.5")
-//            )
-//        )
-//        assertEquals(1, components.size)
-//        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
-//        assert(components.none { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
-//
-//        components = componentsRegistryClient.findComponentsByDockerImages(
-//            setOf(
-//                Image("test-docker-first", "0.0.5"),
-//                Image("test-docker-second", "1.0.5"),
-//                Image("test-docker-third", "2.0.5")
-//            )
-//        )
-//        assertEquals(3, components.size)
-//        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
-//        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
-//        assert(components.any { it.image.name == "test-docker-third" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "2.0.5" })
-//
-//    }
+    @Test
+    fun findComponentsByDockerImagesOldStyle() {
+        val components = componentsRegistryClient.findComponentsByDockerImages(
+            setOf(
+                Image("test/versions-api", "10.1"),
+                Image("test-docker-1", "0.1"),
+                Image("not-found", "0.1")
+            )
+        )
+        assertEquals(2, components.size)
+        assert(components.any { it.image.name == "test-docker-1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1" && it.version == "0.1" })
+        assert(components.any { it.image.name == "test/versions-api" && it.component == "TESTONE" && it.version == "10.1" })
+        assert(components.none { it.image.name == "not-found" })
+    }
+    @Test
+    fun findComponentsByDockerImagesNewStyle() {
+        val components = componentsRegistryClient.findComponentsByDockerImages(
+            setOf(
+                Image("test-docker-1_1", "0.1"),
+                Image("test-docker-1_2", "0.1.1.2-jdk11"),
+                Image("not-found", "0.1")
+            )
+        )
+        println(components)
+        assertEquals(2, components.size)
+        assert(components.any { it.image.name == "test-docker-1_1" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_1" && it.version == "0.1" })
+        assert(components.any { it.image.name == "test-docker-1_2" && it.component == "TEST_COMPONENT_WITH_DOCKER_1_2" && it.version == "0.1.1.2" })
+        assert(components.none { it.image.name == "not-found" })
+    }
+
+
+    @Test
+    fun findComponentsByDockerImagesWithRanges() {
+        var components = componentsRegistryClient.findComponentsByDockerImages(
+            setOf(
+                Image("test-docker-first", "1.0.5"),
+                Image("test-docker-second", "1.0.5")
+            )
+        )
+        assertEquals(1, components.size)
+        assert(components.none { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+
+        components = componentsRegistryClient.findComponentsByDockerImages(
+            setOf(
+                Image("test-docker-first", "0.0.5"),
+                Image("test-docker-second", "0.0.5")
+            )
+        )
+        assertEquals(1, components.size)
+        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+        assert(components.none { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+
+        components = componentsRegistryClient.findComponentsByDockerImages(
+            setOf(
+                Image("test-docker-first", "0.0.5"),
+                Image("test-docker-second", "1.0.5"),
+                Image("test-docker-third", "2.0.5")
+            )
+        )
+        assertEquals(3, components.size)
+        assert(components.any { it.image.name == "test-docker-first" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "0.0.5" })
+        assert(components.any { it.image.name == "test-docker-second" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "1.0.5" })
+        assert(components.any { it.image.name == "test-docker-third" && it.component == "TEST_COMPONENT_WITH_DOCKER_2" && it.version == "2.0.5" })
+
+    }
 
 
 }

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -251,7 +251,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         val components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
                 Image("test-docker-1_1", "0.1"),
-                Image("test-docker-1_2", "0.1-2-3-jdk11"),
+                Image("test-docker-1_2", "0.1.2-3-jdk11"),
                 Image("not-found", "0.1")
             )
         )

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -31,7 +31,6 @@ import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.Date
-import kotlin.math.log
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
@@ -122,7 +121,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     @Test
     fun testGetAllComponents() {
-        assertEquals(43, componentsRegistryClient.getAllComponents().components.size)
+        assertEquals(45, componentsRegistryClient.getAllComponents().components.size)
         assertEquals(
             3,
             componentsRegistryClient.getAllComponents("ssh://hg@mercurial/technical", null).components.size
@@ -136,8 +135,8 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
             ).components.size
         )
         assertEquals(4, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC")).components.size)
-        assertEquals(39, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
-        assertEquals(43, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
+        assertEquals(41, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
+        assertEquals(45, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
     }
 
     @Test
@@ -204,6 +203,39 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         assert(components.any { it.image.name == "test/versions-api" && it.component == "TESTONE" && it.version == "10.1" })
         assert(components.none { it.image.name == "not-found" })
     }
+
+
+    @Test
+    fun findComponentsByDockerImagesOldStyle2() {
+
+        var components =
+            componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-3", "10.1-amd64")))
+        assertEquals(1, components.size)
+        assert(components.any { it.image.name == "test-docker-3" && it.component == "TEST_COMPONENT_WITH_DOCKER_3" && it.version == "10.1" })
+
+        components = componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-4", "0.1.345")))
+        assertEquals(1, components.size)
+        assert(components.any { it.image.name == "test-docker-4" && it.component == "TEST_COMPONENT_WITH_DOCKER_4" && it.version == "0.1.345" })
+
+        components = componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-4", "1.2.345")))
+        assertEquals(0, components.size)
+
+        components =
+            componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-4", "1.2.345-arm64")))
+        assertEquals(0, components.size)
+
+        components =
+            componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-4", "1.2.345-amd64")))
+        assertEquals(1, components.size)
+        assert(components.any { it.image.name == "test-docker-4" && it.component == "TEST_COMPONENT_WITH_DOCKER_4" && it.version == "1.2.345" })
+
+        components =
+            componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-4", "2.34.567-arm64")))
+        assertEquals(1, components.size)
+        assert(components.any { it.image.name == "test-docker-4" && it.component == "TEST_COMPONENT_WITH_DOCKER_4" && it.version == "2.34.567" })
+
+    }
+
     @Test
     fun findComponentsByDockerImagesNewStyle() {
         val components = componentsRegistryClient.findComponentsByDockerImages(

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -251,7 +251,7 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         val components = componentsRegistryClient.findComponentsByDockerImages(
             setOf(
                 Image("test-docker-1_1", "0.1"),
-                Image("test-docker-1_2", "0.1-2.3-jdk11"),
+                Image("test-docker-1_2", "0.1.2-3-jdk11"),
                 Image("not-found", "0.1")
             )
         )

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -239,15 +239,11 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     @Test
     fun findComponentsByDockerImagesNormalizeVersion() {
-
         var components =
             componentsRegistryClient.findComponentsByDockerImages(setOf(Image("test-docker-3", "10.1-amd64")))
         assertEquals(1, components.size)
         assert(components.any { it.image.name == "test-docker-3" && it.component == "TEST_COMPONENT_WITH_DOCKER_3" && it.version == "10.1" })
-
-
     }
-
 
 
     @Test

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ComponentImage @JsonCreator constructor(
-    @JsonProperty val componentId: String,
-    @JsonProperty val componentVersion: String,
-    @JsonProperty val image: Image
+    @JsonProperty("componentId") val componentId: String,
+    @JsonProperty("componentVersion") val componentVersion: String,
+    @JsonProperty("image") val image: Image
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
@@ -1,0 +1,12 @@
+package org.octopusden.octopus.components.registry.core.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ComponentImage @JsonCreator constructor(
+    @JsonProperty val componentId: String,
+    @JsonProperty val componentVersion: String,
+    @JsonProperty val image: Image
+)

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ComponentImage @JsonCreator constructor(
-    @JsonProperty("componentId") val componentId: String,
-    @JsonProperty("componentVersion") val componentVersion: String,
+    @JsonProperty("component") val component: String,
+    @JsonProperty("version") val version: String,
     @JsonProperty("image") val image: Image
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/Image.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/Image.kt
@@ -1,0 +1,11 @@
+package org.octopusden.octopus.components.registry.core.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Image @JsonCreator constructor(
+    @JsonProperty val name: String,
+    @JsonProperty val tag: String
+)

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/Image.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/Image.kt
@@ -6,6 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Image @JsonCreator constructor(
-    @JsonProperty val name: String,
-    @JsonProperty val tag: String
+    @JsonProperty("name") val name: String,
+    @JsonProperty("tag") val tag: String
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/BaseComponentController.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/BaseComponentController.kt
@@ -87,7 +87,6 @@ abstract class BaseComponentController<T : Component> {
         getDistribution(component)
 
     @GetMapping("{component}/versions/{version}/distribution")
-    // todo - recalc docker with component
     fun getComponentVersionDistribution(
         @PathVariable("component") component: String,
         @PathVariable("version") version: String

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/BaseComponentController.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/BaseComponentController.kt
@@ -26,6 +26,8 @@ abstract class BaseComponentController<T : Component> {
     protected abstract val createComponentFunc: (escrowModule: EscrowModule) -> T
 
     @GetMapping
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun getAllComponents(
         @RequestParam("vcs-path", required = false) vcsPath: String?,
         @RequestParam("build-system", required = false) buildSystem: BuildSystem?,
@@ -70,6 +72,8 @@ abstract class BaseComponentController<T : Component> {
     }
 
     @GetMapping("{component}")
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun getComponentById(@PathVariable("component") component: String): T {
         val escrowModule = componentRegistryResolver.getComponentById(component)
             ?: throw NotFoundException("Component id $component is not found")
@@ -77,10 +81,13 @@ abstract class BaseComponentController<T : Component> {
     }
 
     @GetMapping("{component}/distribution")
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun getComponentDistribution(@PathVariable("component") component: String): DistributionDTO =
         getDistribution(component)
 
     @GetMapping("{component}/versions/{version}/distribution")
+    // todo - recalc docker with component
     fun getComponentVersionDistribution(
         @PathVariable("component") component: String,
         @PathVariable("version") version: String

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CommonControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CommonControllerV2.kt
@@ -24,6 +24,8 @@ class CommonControllerV2(
         ConfigHelper(this.environment)
 
     @GetMapping("jira-component-version-ranges", produces = [MediaType.APPLICATION_JSON_VALUE])
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun getAllJiraComponentVersionRanges(): Set<JiraComponentVersionRangeDTO> {
         return componentRegistryResolver.getAllJiraComponentVersionRanges()
             .map { it.toDTO() }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV2.kt
@@ -43,6 +43,7 @@ class ComponentControllerV2(
         "{component}/versions/{version}",
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
+    // todo - recalc docker with component
     fun getDetailedComponent(
         @PathVariable("component") component: String,
         @PathVariable("version") version: String
@@ -206,6 +207,7 @@ class ComponentControllerV2(
     }
 
     @PostMapping("find-by-artifact")
+    // todo - recalc docker with component
     fun findComponentByArtifact(@RequestBody artifact: ArtifactDependency): VersionedComponent =
         componentRegistryResolver.findComponentByArtifact(artifact)
 
@@ -214,6 +216,7 @@ class ComponentControllerV2(
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
+    // todo - recalc docker with component
     fun findComponentByArtifact(@RequestBody artifacts: Collection<ArtifactDependency>): Collection<VersionedComponent> =
         componentRegistryResolver.findComponentsByArtifact(artifacts.toSet())
             .values

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV2.kt
@@ -43,7 +43,6 @@ class ComponentControllerV2(
         "{component}/versions/{version}",
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    // todo - recalc docker with component
     fun getDetailedComponent(
         @PathVariable("component") component: String,
         @PathVariable("version") version: String
@@ -207,7 +206,8 @@ class ComponentControllerV2(
     }
 
     @PostMapping("find-by-artifact")
-    // todo - recalc docker with component
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun findComponentByArtifact(@RequestBody artifact: ArtifactDependency): VersionedComponent =
         componentRegistryResolver.findComponentByArtifact(artifact)
 
@@ -216,7 +216,8 @@ class ComponentControllerV2(
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    // todo - recalc docker with component
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun findComponentByArtifact(@RequestBody artifacts: Collection<ArtifactDependency>): Collection<VersionedComponent> =
         componentRegistryResolver.findComponentsByArtifact(artifacts.toSet())
             .values

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV3.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV3.kt
@@ -24,6 +24,9 @@ class ComponentControllerV3(
      * Get all components.
      */
     @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
+
     fun getAllComponents(): Collection<ComponentV3> {
         return componentRegistryResolver.getComponents().map { escrowModule ->
             //TODO Check/Discuss if display name and owner should be in escrowModule (not versioned part of Component)
@@ -48,6 +51,7 @@ class ComponentControllerV3(
             .entries
             .map { (artifact, component) -> ArtifactComponentDTO(artifact, component) }
             .toSet()
+        // todo - recalc docker with component
         return ArtifactComponentsDTO(artifactComponents)
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV3.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV3.kt
@@ -3,8 +3,10 @@ package org.octopusden.octopus.components.registry.server.controller
 import org.octopusden.octopus.components.registry.core.dto.ArtifactComponentDTO
 import org.octopusden.octopus.components.registry.core.dto.ArtifactComponentsDTO
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.ComponentV2
 import org.octopusden.octopus.components.registry.core.dto.ComponentV3
+import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -48,4 +50,15 @@ class ComponentControllerV3(
             .toSet()
         return ArtifactComponentsDTO(artifactComponents)
     }
+
+    @PostMapping(
+        "find-by-docker-images",
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun findComponentsByDockerImages(@RequestBody images: Set<Image>): Map<String, ComponentImage> {
+        return componentRegistryResolver.findComponentsByDockerImages(images)
+    }
+
+
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV3.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV3.kt
@@ -56,7 +56,7 @@ class ComponentControllerV3(
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    fun findComponentsByDockerImages(@RequestBody images: Set<Image>): Map<String, ComponentImage> {
+    fun findComponentsByDockerImages(@RequestBody images: Set<Image>): Set<ComponentImage> {
         return componentRegistryResolver.findComponentsByDockerImages(images)
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ProjectControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ProjectControllerV2.kt
@@ -33,6 +33,8 @@ class ProjectControllerV2(
     }
 
     @GetMapping("{projectKey}/jira-component-version-ranges", produces = [MediaType.APPLICATION_JSON_VALUE])
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun getJiraComponentVersionRangesByProject(@PathVariable("projectKey") projectKey: String): Set<JiraComponentVersionRangeDTO> {
         LOG.info("Get Jira Component Version Ranges: '$projectKey'")
         return componentRegistryResolver.getJiraComponentVersionRangesByProject(projectKey)
@@ -41,6 +43,8 @@ class ProjectControllerV2(
     }
 
     @GetMapping("{projectKey}/component-distributions", produces = [MediaType.APPLICATION_JSON_VALUE])
+    // todo - consider removing the whole endpoint or just version specific fields, like docker,
+    //  because version is not provided in this context
     fun getComponentsDistributionByJiraProject(@PathVariable("projectKey") projectKey: String): Map<String, DistributionDTO> {
         LOG.info("Get distributions: '$projectKey'")
         return componentRegistryResolver.getComponentsDistributionByJiraProject(projectKey)
@@ -56,6 +60,7 @@ class ProjectControllerV2(
     }
 
     @GetMapping("{projectKey}/versions/{version}/distribution", produces = [MediaType.APPLICATION_JSON_VALUE])
+    // todo - recalc docker with component
     fun getDistributionForProject(@PathVariable("projectKey") projectKey: String,
                                   @PathVariable("version") version: String): DistributionDTO {
         LOG.info("Get distribution: '$projectKey:$version'")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
@@ -24,8 +24,6 @@ interface ComponentRegistryResolver {
 
     fun getResolvedComponentDefinition(id: String, version: String): EscrowModuleConfig?
 
-    fun getResolvedComponentDefinitionByImage(id: String, tagWithVersion: String): EscrowModuleConfig?
-
     fun getJiraComponentVersion(component: String, version: String): JiraComponentVersion
 
     fun getJiraComponentVersions(component: String, versions: List<String>): Map<String, JiraComponentVersion>

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
@@ -24,6 +24,8 @@ interface ComponentRegistryResolver {
 
     fun getResolvedComponentDefinition(id: String, version: String): EscrowModuleConfig?
 
+    fun getResolvedComponentDefinitionByImage(id: String, tagWithVersion: String): EscrowModuleConfig?
+
     fun getJiraComponentVersion(component: String, version: String): JiraComponentVersion
 
     fun getJiraComponentVersions(component: String, versions: List<String>): Map<String, JiraComponentVersion>

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
@@ -54,6 +54,6 @@ interface ComponentRegistryResolver {
 
     fun getComponentsCountByBuildSystem(): EnumMap<BuildSystem, Int>
 
-    fun findComponentsByDockerImages(images: Set<Image>): Map<String, ComponentImage>
+    fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage>
 
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentRegistryResolver.kt
@@ -2,6 +2,8 @@ package org.octopusden.octopus.components.registry.server.service
 
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
+import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
 import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
 import org.octopusden.octopus.escrow.configuration.model.EscrowModule
@@ -51,5 +53,7 @@ interface ComponentRegistryResolver {
     fun getDependencyMapping(): Map<String, String>
 
     fun getComponentsCountByBuildSystem(): EnumMap<BuildSystem, Int>
+
+    fun findComponentsByDockerImages(images: Set<Image>): Map<String, ComponentImage>
 
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -237,10 +237,9 @@ class ComponentRegistryResolverImpl(
         if (ecl?.distribution?.docker() != null) {
             val dockerString = ecl.distribution?.docker() ?: return null
             if (imageName in dockerStringToList(dockerString)) {
-                // remove this later
                 val declToCheck = imageName + (tagSuffix?.let { ":$it" } ?: "")
                 if (dockerString.split(',')
-                        // change this later
+                        // -- DOCKER -- to be removed
                         .map {
                             it.replace("\${version}-", "").replace("\${version}", "").removeSuffix(":")
                         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -85,7 +85,7 @@ class ComponentRegistryResolverImpl(
         return EscrowConfigurationLoader.getEscrowModuleConfig(configuration, ComponentVersion.create(id, version))
     }
 
-    private fun reconstructVersionString(imageTag : String): String {
+    private fun reconstructVersionString(imageTag : String, compId: String): String {
         val numericVersionFactory = NumericVersionFactory(versionNames)
         val version = numericVersionFactory.create(imageTag)
         val originalDelimiters = imageTag.filter { it == '.' || it == '-' || it == '_' }
@@ -96,6 +96,9 @@ class ComponentRegistryResolverImpl(
                 versionString += (originalDelimiters.getOrNull(i) ?: originalDelimiters.firstOrNull() ?: ".")
             }
         }
+
+        // normalize version for particular component
+
         return versionString
     }
 
@@ -224,7 +227,7 @@ class ComponentRegistryResolverImpl(
     }
 
     private fun findConfigurationByImage(imageName: String, imageTag: String, compId: String): ComponentImage? {
-        val versionString = reconstructVersionString(imageTag)
+        val versionString = reconstructVersionString(imageTag, compId)
         val tagSuffix = extractSuffix(versionString, imageTag)
         val ecl = EscrowConfigurationLoader.getEscrowModuleConfig(
             configuration,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -227,6 +227,11 @@ class ComponentRegistryResolverImpl(
     }
 
     private fun findConfigurationByImage(imageName: String, imageTag: String, compId: String): ComponentImage? {
+
+        val a2 = getJiraComponentVersionToRangeByComponentAndVersion(compId, imageTag)
+        print("*** *** *** ***")
+        print(a2)
+
         val versionString = reconstructVersionString(imageTag)
         val tagSuffix = extractSuffix(versionString, imageTag)
         val ecl = EscrowConfigurationLoader.getEscrowModuleConfig(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -85,7 +85,7 @@ class ComponentRegistryResolverImpl(
         return EscrowConfigurationLoader.getEscrowModuleConfig(configuration, ComponentVersion.create(id, version))
     }
 
-    private fun reconstructVersionString(imageTag : String, compId: String): String {
+    private fun reconstructVersionString(imageTag : String): String {
         val numericVersionFactory = NumericVersionFactory(versionNames)
         val version = numericVersionFactory.create(imageTag)
         val originalDelimiters = imageTag.filter { it == '.' || it == '-' || it == '_' }
@@ -227,16 +227,15 @@ class ComponentRegistryResolverImpl(
     }
 
     private fun findConfigurationByImage(imageName: String, imageTag: String, compId: String): ComponentImage? {
-        val versionString = reconstructVersionString(imageTag, compId)
+        val versionString = reconstructVersionString(imageTag)
         val tagSuffix = extractSuffix(versionString, imageTag)
         val ecl = EscrowConfigurationLoader.getEscrowModuleConfig(
             configuration,
             ComponentVersion.create(compId, versionString)
         )
 
-
         if (ecl?.distribution?.docker() != null) {
-            var dockerString = ecl.distribution?.docker() ?: return null
+            val dockerString = ecl.distribution?.docker() ?: return null
             if (imageName in dockerStringToList(dockerString)) {
                 // remove this later
                 val declToCheck = imageName + (tagSuffix?.let { ":$it" } ?: "")
@@ -276,7 +275,7 @@ class ComponentRegistryResolverImpl(
     }
 
     private fun EscrowModule.getBuildSystem(): BuildSystem {
-        return moduleConfigurations.firstOrNull()?.let { it.buildSystem.toDTO() }
+        return moduleConfigurations.firstOrNull()?.buildSystem?.toDTO()
             ?: throw IllegalStateException("No module configurations available")
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -234,14 +234,15 @@ class ComponentRegistryResolverImpl(
             val tagSuffix = extractSuffix(versionString, imageTag)
             val ecl = EscrowConfigurationLoader.getEscrowModuleConfig(configuration, ComponentVersion.create(compId, versionString))
 
-            println("tag $imageTag was reconstructed to version $versionString and suffix $tagSuffix")
 
             if (ecl?.distribution?.docker() != null) {
                 val dockerString = ecl.distribution?.docker() ?: return null
                 // add check for tag suffix if any vs dockerString
-
                 if ( imageName in dockerStringToList(dockerString) ) {
-                    return ComponentImage(compId, versionString, Image(imageName, imageTag))
+                    val declToCheck = imageName + (tagSuffix?.let { ":$it" } ?: "")
+                    if (dockerString.split(',').contains(declToCheck)) {
+                        return ComponentImage(compId, versionString, Image(imageName, imageTag))
+                    }
                 }
             }
             return null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -367,12 +367,16 @@ class ComponentRegistryResolverImpl(
                 "",
             )
 
-            component.distribution?.docker?.let { docker ->
-                component.distribution = component.distribution.copy(
-                    docker = recalculateDockerWithVersion(docker, component.version)
+            val distribution = component.distribution
+            if (distribution != null && distribution.docker != null) {
+                val updatedDistribution = distribution.copy(
+                    docker = recalculateDockerWithVersion(distribution.docker!!, component.version)
                 )
+                component.distribution = updatedDistribution
             }
+
             component
+
         }
 
     private fun loadDependencyMapping() {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -44,6 +44,8 @@ import javax.annotation.Resource
 import kotlin.io.path.exists
 import kotlin.io.path.inputStream
 import kotlin.io.path.isRegularFile
+import kotlin.system.measureTimeMillis
+
 
 @Service
 @EnableConfigurationProperties(ComponentsRegistryProperties::class)
@@ -300,7 +302,10 @@ class ComponentRegistryResolverImpl(
 
     private fun loadImageToComponentMap() {
         LOG.info("Update dockerImageMapping")
-        imageToComponentMap = buildImageToComponentMap()
+        val timeTaken = measureTimeMillis {
+            imageToComponentMap = buildImageToComponentMap()
+        }
+        LOG.info("Time taken to build imageToComponentMap: {} ms", timeTaken)
     }
 
     private val buildSystemMetrics = ConcurrentHashMap<BuildSystem, Int>()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -16,6 +16,7 @@ import org.octopusden.octopus.components.registry.server.util.formatVersion
 import org.octopusden.octopus.escrow.ModelConfigPostProcessor
 import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
 import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader.calculateDistribution
 import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader.normalizeVersion
 import org.octopusden.octopus.escrow.configuration.model.EscrowConfiguration
 import org.octopusden.octopus.escrow.configuration.model.EscrowModule
@@ -148,8 +149,11 @@ class ComponentRegistryResolverImpl(
         ).resolveVariables(jiraComponentVersionRange.vcsSettings)
     }
 
-    override fun getDistributionForProject(projectKey: String, version: String): Distribution =
-        getJiraComponentVersionToRangeByProjectAndVersion(projectKey, version).second.distribution
+    override fun getDistributionForProject(projectKey: String, version: String): Distribution {
+        LOG.info("Get distribution for project: {} version: {}", projectKey, version)
+        val found = getJiraComponentVersionToRangeByProjectAndVersion(projectKey, version)
+        return calculateDistribution(found.second.distribution, found.first.version)
+    }
 
     override fun getAllJiraComponentVersionRanges() =
         jiraParametersResolver.componentConfig.projectKeyToJiraComponentVersionRangeMap.values.flatten().toSet()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -232,11 +232,11 @@ class ComponentRegistryResolverImpl(
         if (ecl?.distribution?.docker() != null) {
             val dockerString = ecl.distribution?.docker() ?: return null
             if (imageName in dockerStringToList(dockerString)) {
-                val declToCheck = imageName + (tagSuffix?.let { ":$it" } ?: "")
+                val declToCheck = imageName + ":$versionString" + (tagSuffix?.let { "-$it" } ?: "")
                 if (dockerString.split(',')
                         // -- DOCKER -- to be removed
                         .map {
-                            it.replace("\${version}-", "").replace("\${version}", "").removeSuffix(":")
+                            it.replace("\${version}-", versionString + "-").replace("\${version}", versionString).removeSuffix(":")
                         }
                         .contains(declToCheck)) {
                     return ComponentImage(compId, versionString, Image(imageName, imageTag))

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -105,18 +105,6 @@ class ComponentRegistryResolverImpl(
             ?.groups?.get("tag")?.value
     }
 
-    fun recalculateDockerWithVersion(docker: String, version: String): String {
-        return if ("\${version}" in docker) {
-            // -- DOCKER -- to be removed
-            docker.replace("\${version}", version)
-        } else {
-            docker.split(",").joinToString(",") { img ->
-                val (base, suffix) = img.split(":").let { it[0] to it.getOrNull(1)?.let { "-$it" }.orEmpty() }
-                "$base:$version$suffix"
-            }
-        }
-    }
-
     override fun getJiraComponentVersion(component: String, version: String) =
         getJiraComponentVersionToRangeByComponentAndVersion(component, version).first
 
@@ -360,23 +348,12 @@ class ComponentRegistryResolverImpl(
                 null
             )
         )?.let { resolvedComponent ->
-            val component = VersionedComponent(
+            VersionedComponent(
                 resolvedComponent.componentName,
                 null,
                 resolvedComponent.version,
-                "",
+                ""
             )
-
-            val distribution = component.distribution
-            if (distribution != null && distribution.docker != null) {
-                val updatedDistribution = distribution.copy(
-                    docker = recalculateDockerWithVersion(distribution.docker!!, component.version)
-                )
-                component.distribution = updatedDistribution
-            }
-
-            component
-
         }
 
     private fun loadDependencyMapping() {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -215,8 +215,7 @@ class ComponentRegistryResolverImpl(
             configuration,
             ComponentVersion.create(compId, versionString)
         )?.distribution?.let {
-            val normalizedTag = versionString + imageTag.substring(versionString.length)
-            if (it.docker()?.split(',')?.contains("$imageName:$normalizedTag") == true) {
+            if (it.docker()?.split(',')?.contains("$imageName:$imageTag") == true) {
                 ComponentImage(compId, versionString, Image(imageName, imageTag))
             } else null
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -39,7 +39,6 @@ import java.nio.file.Paths
 import java.util.EnumMap
 import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.annotation.PostConstruct
 import javax.annotation.Resource
 import kotlin.io.path.exists

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -20,7 +20,7 @@ import org.octopusden.octopus.escrow.configuration.model.EscrowConfiguration
 import org.octopusden.octopus.escrow.configuration.model.EscrowModule
 import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
 import org.octopusden.octopus.escrow.configuration.validation.EscrowConfigValidator
-import org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_IMAGE_TAG_PATTERN_NEW
+import org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_IMAGE_TAG_SUFFIX_PATTERN_NEW
 import org.octopusden.octopus.escrow.dto.ComponentArtifactConfiguration
 import org.octopusden.octopus.escrow.model.Distribution
 import org.octopusden.octopus.escrow.model.SecurityGroups
@@ -100,7 +100,7 @@ class ComponentRegistryResolverImpl(
     }
 
     private fun extractSuffix(versionString: String, tagWithVersion: String): String? {
-        return Regex("(?<tag>${DOCKER_IMAGE_TAG_PATTERN_NEW})$")
+        return Regex("(?<tag>${DOCKER_IMAGE_TAG_SUFFIX_PATTERN_NEW})$")
             .find(tagWithVersion)
             ?.groups?.get("tag")?.value
     }
@@ -234,7 +234,7 @@ class ComponentRegistryResolverImpl(
             if (imageName in dockerStringToList(dockerString)) {
                 val declToCheck = imageName + ":$versionString" + (tagSuffix?.let { "-$it" } ?: "")
                 if (dockerString.split(',')
-                        // -- DOCKER -- to be removed
+                        // TODO -- DOCKER -- to be removed
                         .map {
                             it.replace("\${version}-", versionString + "-").replace("\${version}", versionString).removeSuffix(":")
                         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -227,16 +227,12 @@ class ComponentRegistryResolverImpl(
             ComponentVersion.create(compId, versionString)
         )
 
-        System.out.println("1 - " + versionString)
         versionString = normalizeVersion(versionString, ecl)
-        System.out.println("2 - " + versionString)
 
         if (ecl?.distribution?.docker() != null) {
             val dockerString = ecl.distribution?.docker() ?: return null
             if (imageName in dockerStringToList(dockerString)) {
                 val declToCheck = imageName + (tagSuffix?.let { ":$it" } ?: "")
-                System.out.println("declToCheck - " + declToCheck)
-                System.out.println("dockerString - " + dockerString)
                 if (dockerString.split(',')
                         // -- DOCKER -- to be removed
                         .map {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -20,6 +20,7 @@ import org.octopusden.octopus.escrow.configuration.model.EscrowConfiguration
 import org.octopusden.octopus.escrow.configuration.model.EscrowModule
 import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
 import org.octopusden.octopus.escrow.configuration.validation.EscrowConfigValidator
+import org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_IMAGE_TAG_PATTERN_NEW
 import org.octopusden.octopus.escrow.dto.ComponentArtifactConfiguration
 import org.octopusden.octopus.escrow.model.Distribution
 import org.octopusden.octopus.escrow.model.SecurityGroups
@@ -99,13 +100,9 @@ class ComponentRegistryResolverImpl(
     }
 
     private fun extractSuffix(versionString: String, tagWithVersion: String): String? {
-        return if (tagWithVersion.startsWith(versionString)) {
-            val suffix = tagWithVersion.removePrefix(versionString)
-                .removePrefix(".").removePrefix("-").removePrefix("_")
-            suffix.ifEmpty { null }
-        } else {
-            null
-        }
+        return Regex("(?<tag>${DOCKER_IMAGE_TAG_PATTERN_NEW})$")
+            .find(tagWithVersion)
+            ?.groups?.get("tag")?.value
     }
 
     override fun getJiraComponentVersion(component: String, version: String) =
@@ -230,12 +227,16 @@ class ComponentRegistryResolverImpl(
             ComponentVersion.create(compId, versionString)
         )
 
+        System.out.println("1 - " + versionString)
         versionString = normalizeVersion(versionString, ecl)
+        System.out.println("2 - " + versionString)
 
         if (ecl?.distribution?.docker() != null) {
             val dockerString = ecl.distribution?.docker() ?: return null
             if (imageName in dockerStringToList(dockerString)) {
                 val declToCheck = imageName + (tagSuffix?.let { ":$it" } ?: "")
+                System.out.println("declToCheck - " + declToCheck)
+                System.out.println("dockerString - " + dockerString)
                 if (dockerString.split(',')
                         // -- DOCKER -- to be removed
                         .map {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -45,7 +45,6 @@ import kotlin.io.path.exists
 import kotlin.io.path.inputStream
 import kotlin.io.path.isRegularFile
 import kotlin.system.measureTimeMillis
-import kotlin.text.replace
 
 
 @Service
@@ -217,24 +216,24 @@ class ComponentRegistryResolverImpl(
         }
     }
 
-    private fun dockerStringToList(dockerString: String): List<String> {
-        return dockerString.split(",").map { it.substringBefore(":") }
-    }
-
     private fun buildImageToComponentMap(): Map<String, String> {
         val dockerImageName2ComponentMap = mutableMapOf<String, String>()
         val timeTaken = measureTimeMillis {
             getComponents().forEach { comp ->
                 comp.moduleConfigurations.forEach { moduleConfig ->
                     moduleConfig.distribution?.docker()?.let { dockersString ->
-                        dockerStringToList(dockersString).forEach { dockerImgName ->
+                        dockersString.split(",").map { it.substringBefore(":") }.forEach { dockerImgName ->
                             dockerImageName2ComponentMap[dockerImgName] = comp.moduleName
                         }
                     }
                 }
             }
         }
-        LOG.info("Time taken to buildImageToComponentMap {} ms, read {} images", timeTaken, dockerImageName2ComponentMap.size)
+        LOG.info(
+            "Time taken to buildImageToComponentMap {} ms, read {} images",
+            timeTaken,
+            dockerImageName2ComponentMap.size
+        )
 
         return dockerImageName2ComponentMap
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -306,6 +306,7 @@ class ComponentRegistryResolverImpl(
             imageToComponentMap = buildImageToComponentMap()
         }
         LOG.info("Time taken to build imageToComponentMap: {} ms", timeTaken)
+        LOG.info("Read {} docker images", imageToComponentMap.size)
     }
 
     private val buildSystemMetrics = ConcurrentHashMap<BuildSystem, Int>()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -86,6 +86,11 @@ class ComponentRegistryResolverImpl(
         return EscrowConfigurationLoader.getEscrowModuleConfig(configuration, ComponentVersion.create(id, version))
     }
 
+    override fun getResolvedComponentDefinitionByImage(id: String, tagWithVersion: String): EscrowModuleConfig? {
+        // to implement
+        return null
+    }
+
     override fun getJiraComponentVersion(component: String, version: String) =
         getJiraComponentVersionToRangeByComponentAndVersion(component, version).first
 
@@ -207,8 +212,9 @@ class ComponentRegistryResolverImpl(
         }
     }
 
-    private fun findConfigurationByImage(imageName: String, version: String, compId: String): EscrowModuleConfig? {
-        val emc = getResolvedComponentDefinition(compId, version) ?: return null
+    private fun findConfigurationByImage(imageName: String, tagWithVersion: String, compId: String): EscrowModuleConfig? {
+
+        val emc = getResolvedComponentDefinitionByImage(compId, tagWithVersion) ?: return null
         val dockerString = emc.distribution?.docker() ?: return null
         return emc.takeIf { imageName in dockerStringToList(dockerString) }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -195,10 +195,10 @@ class ComponentRegistryResolverImpl(
         dockerCacheLock.readLock().lock()
         return try {
             val imageNames = images.map { it.name }.toSet()
-            imageToComponentMap.filterKeys(imageNames::contains).mapNotNull { (imgName, componentId) ->
+            imageToComponentMap.filterKeys(imageNames::contains).mapNotNull { (imgName, component) ->
                 images.find { it.name == imgName }?.let { requiredImage ->
-                    findConfigurationByImage(imgName, requiredImage.tag, componentId)?.let {
-                        ComponentImage(componentId, requiredImage.tag, Image(imgName, requiredImage.tag))
+                    findConfigurationByImage(imgName, requiredImage.tag, component)?.let {
+                        ComponentImage(component, requiredImage.tag, Image(imgName, requiredImage.tag))
                     }
                 }
             }.toSet()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -45,6 +45,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.inputStream
 import kotlin.io.path.isRegularFile
 import kotlin.system.measureTimeMillis
+import kotlin.text.replace
 
 
 @Service
@@ -238,11 +239,12 @@ class ComponentRegistryResolverImpl(
                 val declToCheck = imageName + (tagSuffix?.let { ":$it" } ?: "")
                 if (dockerString.split(',')
                         // change this later
-                        .map { it.removeSuffix("\${version}").removeSuffix(":") }
+                        .map {
+                            it.replace("\${version}-", "").replace("\${version}", "").removeSuffix(":")
+                        }
                         .contains(declToCheck)) {
                     return ComponentImage(compId, versionString, Image(imageName, imageTag))
                 }
-
             }
         }
         return null

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -334,7 +334,7 @@ class ComponentsRegistryServiceControllerTest : BaseComponentsRegistryServiceTes
         expectedComponent.releasesInDefaultBranch = false
         expectedComponent.solution = true
 
-        Assertions.assertEquals(45, components.components.size)
+        Assertions.assertEquals(46, components.components.size)
         Assertions.assertTrue(expectedComponent in components.components) {
             components.components.toString()
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -334,7 +334,7 @@ class ComponentsRegistryServiceControllerTest : BaseComponentsRegistryServiceTes
         expectedComponent.releasesInDefaultBranch = false
         expectedComponent.solution = true
 
-        Assertions.assertEquals(41, components.components.size)
+        Assertions.assertEquals(43, components.components.size)
         Assertions.assertTrue(expectedComponent in components.components) {
             components.components.toString()
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -334,7 +334,7 @@ class ComponentsRegistryServiceControllerTest : BaseComponentsRegistryServiceTes
         expectedComponent.releasesInDefaultBranch = false
         expectedComponent.solution = true
 
-        Assertions.assertEquals(39, components.components.size)
+        Assertions.assertEquals(41, components.components.size)
         Assertions.assertTrue(expectedComponent in components.components) {
             components.components.toString()
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -334,7 +334,7 @@ class ComponentsRegistryServiceControllerTest : BaseComponentsRegistryServiceTes
         expectedComponent.releasesInDefaultBranch = false
         expectedComponent.solution = true
 
-        Assertions.assertEquals(43, components.components.size)
+        Assertions.assertEquals(45, components.components.size)
         Assertions.assertTrue(expectedComponent in components.components) {
             components.components.toString()
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -38,7 +38,7 @@ class MetricsTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(45.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(46.0))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -38,7 +38,7 @@ class MetricsTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(41.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(43.0))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -38,7 +38,7 @@ class MetricsTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(39.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(41.0))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -38,7 +38,7 @@ class MetricsTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(43.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(45.0))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -249,9 +249,9 @@ Below is the list of available parameters:
 * *GAV* - comma-separated list of MAVEN artifact coordinates
 * *DEB* - comma-separated list of DEBIAN artifact coordinates
 * *RPM* - comma-separated list of RPM artifact coordinates
-* *docker* - comma-separated list of Docker image coordinates
+* *docker* - comma-separated list of Docker image coordinates where image tag implicitly starts with a component version and optionally ends with a specified suffix (e.g. `:arm64` after evaluation with version  `:1.2.3` will become `:1.2.3-arm64`)
 
-*GAV*, *DEB*, *RPM* and *docker* parameters can be configured using Expression Language.
+*GAV*, *DEB*, and *RPM* parameters can be configured using Expression Language.
 
 WARNING: At least one of *GAV*, *DEB*, *RPM*, *docker* parameters should be defined for *external* *explicit* component!
 

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -887,6 +887,29 @@ TEST_COMPONENT4 {
     }
 }
 
+"TEST_COMPONENT_WITH_DOCKER_1_1" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.docker"
+    distribution {
+        explicit = false
+        external = true
+        docker = 'test-docker-1_1'
+    }
+}
+
+"TEST_COMPONENT_WITH_DOCKER_1_2" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.docker"
+    distribution {
+        explicit = false
+        external = true
+        docker = 'test-docker-1_2:jdk1.1'
+    }
+}
+
+
+
+
 "TEST_COMPONENT_WITH_DOCKER_2" {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -921,21 +921,18 @@ TEST_COMPONENT4 {
 
     "(,1.0.0]" {
         distribution {
-            docker = 'test-docker-first:${version}'
+            docker = 'test-docker-first'
         }
     }
 
     "(1.0.0, 2.0.0)" {
         distribution {
-            docker = 'test-docker-second:${version}'
+            docker = 'test-docker-second:amd64'
         }
     }
     "(2.0.0,)" {
         distribution {
-            docker = 'test-docker-third:${version}'
+            docker = 'test-docker-third:arm64'
         }
     }
-
-
-
 }

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -907,9 +907,6 @@ TEST_COMPONENT4 {
     }
 }
 
-
-
-
 "TEST_COMPONENT_WITH_DOCKER_2" {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
@@ -936,3 +933,41 @@ TEST_COMPONENT4 {
         }
     }
 }
+
+"TEST_COMPONENT_WITH_DOCKER_3" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.docker"
+    distribution {
+        explicit = false
+        external = true
+        docker = 'test-docker-3:${version}-amd64'
+    }
+}
+
+"TEST_COMPONENT_WITH_DOCKER_4" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.docker"
+
+    distribution {
+        explicit = false
+        external = true
+    }
+
+    "(,1.0.0]" {
+        distribution {
+            docker = 'test-docker-4:${version}'
+        }
+    }
+
+    "(1.0.0, 2.0.0)" {
+        distribution {
+            docker = 'test-docker-4:${version}-amd64'
+        }
+    }
+    "(2.0.0,)" {
+        distribution {
+            docker = 'test-docker-4:${version}-arm64'
+        }
+    }
+}
+

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -901,7 +901,7 @@ TEST_COMPONENT4 {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
     jira {
-        projectKey = "TEST"
+        projectKey = "TEST-D"
     }
     distribution {
         explicit = false

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -903,7 +903,7 @@ TEST_COMPONENT4 {
     distribution {
         explicit = false
         external = true
-        docker = 'test-docker-1_2:jdk1.1'
+        docker = 'test-docker-1_2:jdk11'
     }
 }
 

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -974,3 +974,12 @@ TEST_COMPONENT4 {
     }
 }
 
+"TEST_COMPONENT_WITH_DOCKER_5" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.docker"
+    distribution {
+        explicit = false
+        external = true
+        docker = 'test-docker-5:amd64,test-docker-5:arm64'
+    }
+}

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -880,6 +880,9 @@ TEST_COMPONENT4 {
 "TEST_COMPONENT_WITH_DOCKER_1" {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
+    jira {
+        projectKey = "TEST_DOCKER"
+    }
     distribution {
         explicit = false
         external = true
@@ -890,6 +893,9 @@ TEST_COMPONENT4 {
 "TEST_COMPONENT_WITH_DOCKER_1_1" {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
+    jira {
+        projectKey = "TEST_DOCKER"
+    }
     distribution {
         explicit = false
         external = true
@@ -913,6 +919,10 @@ TEST_COMPONENT4 {
 "TEST_COMPONENT_WITH_DOCKER_2" {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
+
+    jira {
+        projectKey = "TEST_DOCKER"
+    }
 
     distribution {
         explicit = false
@@ -954,6 +964,10 @@ TEST_COMPONENT4 {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
 
+    jira {
+        projectKey = "TEST_DOCKER"
+    }
+
     distribution {
         explicit = false
         external = true
@@ -978,6 +992,11 @@ TEST_COMPONENT4 {
 }
 
 "TEST_COMPONENT_WITH_DOCKER_5" {
+
+    jira {
+        projectKey = "TEST_DOCKER"
+    }
+
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
     distribution {

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -875,3 +875,44 @@ TEST_COMPONENT4 {
     artifactId = "test-golang"
     buildSystem = GOLANG
 }
+
+
+"TEST_COMPONENT_WITH_DOCKER_1" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.docker"
+    distribution {
+        explicit = false
+        external = true
+        docker = 'test-docker-1:${version}'
+    }
+}
+
+"TEST_COMPONENT_WITH_DOCKER_2" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.docker"
+
+    distribution {
+        explicit = false
+        external = true
+    }
+
+    "(,1.0.0]" {
+        distribution {
+            docker = 'test-docker-first:${version}'
+        }
+    }
+
+    "(1.0.0, 2.0.0)" {
+        distribution {
+            docker = 'test-docker-second:${version}'
+        }
+    }
+    "(2.0.0,)" {
+        distribution {
+            docker = 'test-docker-third:${version}'
+        }
+    }
+
+
+
+}

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -937,6 +937,9 @@ TEST_COMPONENT4 {
 "TEST_COMPONENT_WITH_DOCKER_3" {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
+    jira {
+        projectKey = "TEST"
+    }
     distribution {
         explicit = false
         external = true

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -900,6 +900,9 @@ TEST_COMPONENT4 {
 "TEST_COMPONENT_WITH_DOCKER_1_2" {
     componentOwner = "user9"
     groupId = "org.octopusden.octopus.test.docker"
+    jira {
+        projectKey = "TEST"
+    }
     distribution {
         explicit = false
         external = true

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1578,5 +1578,34 @@
       "versionControlSystemRoots": [],
       "externalRegistry": null
     }
+  },
+  {
+    "componentName": "TEST_COMPONENT_WITH_DOCKER_1_2",
+    "versionRange": "(,0),[0,)",
+    "component": {
+      "projectKey": "TEST",
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major.$minor",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "hotfixVersionFormat": "$major.$minor.$service-$fix.$build",
+        "lineVersionFormat": "$major"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat",
+        "technical": false
+      },
+      "distribution": {
+        "explicit": false,
+        "external": true,
+        "securityGroups": {
+          "read": [
+            "vfiler1-default#group"
+          ]
+        },
+        "docker": "docker=test-docker-1_2:jdk11"
+      }
+    }
   }
 ]

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1590,21 +1590,21 @@
         "buildVersionFormat": "$major.$minor.$service-$fix",
         "hotfixVersionFormat": "$major.$minor.$service-$fix.$build",
         "lineVersionFormat": "$major"
-      },
-      "componentInfo": {
-        "versionPrefix": "",
-        "versionFormat": "$versionPrefix-$baseVersionFormat",
-      },
-      "distribution": {
-        "explicit": false,
-        "external": true,
-        "securityGroups": {
-          "read": [
-            "vfiler1-default#group"
-          ]
-        },
-        "docker": "docker=test-docker-1_2:jdk11"
       }
+    },
+    "componentInfo": {
+      "versionPrefix": "",
+      "versionFormat": "$versionPrefix-$baseVersionFormat"
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      },
+      "docker": "docker=test-docker-1_2:jdk11"
     }
   }
 ]

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1594,7 +1594,6 @@
       "componentInfo": {
         "versionPrefix": "",
         "versionFormat": "$versionPrefix-$baseVersionFormat",
-        "technical": false
       },
       "distribution": {
         "explicit": false,

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1610,5 +1610,141 @@
       "versionControlSystemRoots": [],
       "externalRegistry": null
     }
+  },
+  {
+    "componentName": "TEST_COMPONENT_WITH_DOCKER_4",
+    "versionRange": "(,1.0.0]",
+    "component": {
+      "projectKey": "TEST_DOCKER",
+      "displayName": null,
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major.$minor",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": "$major.$minor.$service-$fix.$build"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      },
+      "docker": "test-docker-4:${version}"
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
+  },
+  {
+    "componentName": "TEST_COMPONENT_WITH_DOCKER_4",
+    "versionRange": "(1.0.0, 2.0.0)",
+    "component": {
+      "projectKey": "TEST_DOCKER",
+      "displayName": null,
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major.$minor",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": "$major.$minor.$service-$fix.$build"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      },
+      "docker": "test-docker-4:${version}-amd64"
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
+  },
+  {
+    "componentName": "TEST_COMPONENT_WITH_DOCKER_4",
+    "versionRange": "(2.0.0,)",
+    "component": {
+      "projectKey": "TEST_DOCKER",
+      "displayName": null,
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major.$minor",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": "$major.$minor.$service-$fix.$build"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      },
+      "docker": "test-docker-4:${version}-arm64"
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
+  },
+  {
+    "componentName": "TEST_COMPONENT_WITH_DOCKER_5",
+    "versionRange": "(,0),[0,)",
+    "component": {
+      "projectKey": "TEST_DOCKER",
+      "displayName": null,
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major.$minor",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": "$major.$minor.$service-$fix.$build"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      },
+      "docker": "test-docker-5:amd64,test-docker-5:arm64"
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
   }
 ]

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1583,7 +1583,7 @@
     "componentName": "TEST_COMPONENT_WITH_DOCKER_1_2",
     "versionRange": "(,0),[0,)",
     "component": {
-      "projectKey": "TEST",
+      "projectKey": "TEST-D",
       "componentVersionFormat": {
         "majorVersionFormat": "$major.$minor",
         "releaseVersionFormat": "$major.$minor.$service",

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1604,7 +1604,7 @@
           "vfiler1-default#group"
         ]
       },
-      "docker": "docker=test-docker-1_2:jdk11"
+      "docker": "test-docker-1_2:jdk11"
     },
     "vcsSettings": {
       "versionControlSystemRoots": [],

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1605,6 +1605,10 @@
         ]
       },
       "docker": "docker=test-docker-1_2:jdk11"
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
     }
   }
 ]

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -1590,11 +1590,11 @@
         "buildVersionFormat": "$major.$minor.$service-$fix",
         "hotfixVersionFormat": "$major.$minor.$service-$fix.$build",
         "lineVersionFormat": "$major"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
       }
-    },
-    "componentInfo": {
-      "versionPrefix": "",
-      "versionFormat": "$versionPrefix-$baseVersionFormat"
     },
     "distribution": {
       "explicit": false,

--- a/test-common/src/test/resources/expected-data/testone-1.0-distribution.json
+++ b/test-common/src/test/resources/expected-data/testone-1.0-distribution.json
@@ -2,7 +2,7 @@
   "explicit": false,
   "external": false,
   "GAV": "org.octopusden.octopus.test:versions-api:jar",
-  "docker": "test/versions-api",
+  "docker": "test/versions-api:1.0",
   "securityGroups": {
     "read": [
       "vfiler1-default#group"

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -129,6 +129,17 @@ abstract class BaseComponentsRegistryServiceTest {
         val actual = getAllJiraComponentVersionRanges().stream()
             .sorted { o1, o2 -> (o1.componentName + o1.versionRange).compareTo(o2.componentName + o2.versionRange)}
             .collect(Collectors.toList())
+
+
+        for (i in expected) {
+            println("expected: $i")
+        }
+
+        for (i in actual) {
+            println("actual: $i")
+        }
+
+
         Assertions.assertTrue(expected.containsAll(actual))
         Assertions.assertTrue(actual.containsAll(expected))
         Assertions.assertIterableEquals(expected, actual)

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -247,7 +247,7 @@ abstract class BaseComponentsRegistryServiceTest {
             false,
             "org.octopusden.octopus.test:versions-api:jar",
             securityGroups = SecurityGroupsDTO(listOf("vfiler1-default#group")),
-            docker = "test/versions-api"
+            docker = "test/versions-api:1"
         )
         expectedComponent.releaseManager = "user"
         expectedComponent.securityChampion = "user"

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -129,23 +129,6 @@ abstract class BaseComponentsRegistryServiceTest {
         val actual = getAllJiraComponentVersionRanges().stream()
             .sorted { o1, o2 -> (o1.componentName + o1.versionRange).compareTo(o2.componentName + o2.versionRange)}
             .collect(Collectors.toList())
-
-
-        for (i in expected) {
-            println("expected: $i")
-        }
-
-        for (i in actual) {
-            println("actual: $i")
-        }
-
-
-        val missingInActual = expected - actual
-        val extraInActual = actual - expected
-
-        println("Missing in actual: $missingInActual")
-        println("Extra in actual: $extraInActual")
-
         Assertions.assertTrue(expected.containsAll(actual))
         Assertions.assertTrue(actual.containsAll(expected))
         Assertions.assertIterableEquals(expected, actual)

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -140,6 +140,12 @@ abstract class BaseComponentsRegistryServiceTest {
         }
 
 
+        val missingInActual = expected - actual
+        val extraInActual = actual - expected
+
+        println("Missing in actual: $missingInActual")
+        println("Extra in actual: $extraInActual")
+
         Assertions.assertTrue(expected.containsAll(actual))
         Assertions.assertTrue(actual.containsAll(expected))
         Assertions.assertIterableEquals(expected, actual)


### PR DESCRIPTION
There are two tasks implemented here - #74 and #82
The current solution is compatible with both forms of the CR/docker distribution - the legacy one, like `docker = 'test-docker-1:${version}'`, and the new one, like `docker = 'test-docker-second:amd64'`. After deployment, the CR should be converted to the new format. Then another small edit should be made to disable and prohibit the old form.

Suffix must starts with letter 