### PR TITLE
Remove legacy parameters

### DIFF
--- a/component-resolver-api/src/main/java/org/octopusden/octopus/escrow/BuildSystem.java
+++ b/component-resolver-api/src/main/java/org/octopusden/octopus/escrow/BuildSystem.java
@@ -7,8 +7,6 @@ public enum BuildSystem {
     GRADLE,
     WHISKEY,
     PROVIDED,
-    ESCROW_NOT_SUPPORTED,
-    ESCROW_PROVIDED_MANUALLY,
     GOLANG,
     IN_CONTAINER
 }

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.octopusden.octopus.components.registry.api.Component
 import org.octopusden.octopus.components.registry.api.SubComponent
+import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
 import org.octopusden.octopus.escrow.BuildSystem
 import org.octopusden.octopus.escrow.MavenArtifactMatcher
 import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
@@ -376,7 +377,8 @@ class EscrowConfigValidator {
     def validateGroupId(EscrowModuleConfig moduleConfig, String module) {
         def groupId = moduleConfig.getGroupIdPattern()
         if (StringUtils.isEmpty(groupId)) {  //TODO!
-            if (moduleConfig.getBuildSystem() != BuildSystem.BS2_0 && moduleConfig.getBuildSystem() != BuildSystem.ESCROW_NOT_SUPPORTED) {
+            def escrowGeneration = moduleConfig.escrow?.getGeneration()?.orElse(null)
+            if (moduleConfig.getBuildSystem() != BuildSystem.BS2_0 && escrowGeneration != EscrowGenerationMode.UNSUPPORTED) {
                 registerError("empty groupId is not allowed in configuration of module $module (type=$moduleConfig.buildSystem)")
             }
         } else {
@@ -390,7 +392,8 @@ class EscrowConfigValidator {
     }
 
     def validateVcsSettings(EscrowModuleConfig moduleConfig, String component) {
-        if (!(moduleConfig.getBuildSystem() in [BuildSystem.ESCROW_PROVIDED_MANUALLY, BuildSystem.ESCROW_NOT_SUPPORTED, BuildSystem.PROVIDED, BuildSystem.WHISKEY]) &&
+        def escrowGeneration = moduleConfig.escrow?.getGeneration()?.orElse(null)
+        if (!(moduleConfig.getBuildSystem() in [BuildSystem.ESCROW_PROVIDED_MANUALLY, BuildSystem.ESCROW_NOT_SUPPORTED, BuildSystem.PROVIDED, BuildSystem.WHISKEY] || escrowGeneration in [EscrowGenerationMode.MANUAL, EscrowGenerationMode.UNSUPPORTED]) &&
                 moduleConfig.getVcsSettings().getVersionControlSystemRoots().isEmpty()) {
             registerError("No VCS roots is configured for component '$component' (type=$moduleConfig.buildSystem)")
             return
@@ -398,7 +401,7 @@ class EscrowConfigValidator {
 
         def vcsRoots = moduleConfig.getVcsSettings().getVersionControlSystemRoots()
         vcsRoots.each { VersionControlSystemRoot vcsRoot ->
-            if (!(moduleConfig.buildSystem == BuildSystem.BS2_0 || moduleConfig.buildSystem == BuildSystem.PROVIDED || moduleConfig.buildSystem == BuildSystem.ESCROW_PROVIDED_MANUALLY) && StringUtils.isEmpty(vcsRoot.vcsPath)) {
+            if (!(moduleConfig.buildSystem == BuildSystem.BS2_0 || moduleConfig.buildSystem == BuildSystem.PROVIDED || escrowGeneration == EscrowGenerationMode.MANUAL) && StringUtils.isEmpty(vcsRoot.vcsPath)) {
                 registerError("empty vcsUrl is not allowed in configuration of component $component (type=$moduleConfig.buildSystem)")
             }
         }

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
@@ -393,7 +393,7 @@ class EscrowConfigValidator {
 
     def validateVcsSettings(EscrowModuleConfig moduleConfig, String component) {
         def escrowGeneration = moduleConfig.escrow?.getGeneration()?.orElse(null)
-        if (!(moduleConfig.getBuildSystem() in [BuildSystem.ESCROW_PROVIDED_MANUALLY, BuildSystem.ESCROW_NOT_SUPPORTED, BuildSystem.PROVIDED, BuildSystem.WHISKEY] || escrowGeneration in [EscrowGenerationMode.MANUAL, EscrowGenerationMode.UNSUPPORTED]) &&
+        if (!(moduleConfig.getBuildSystem() in [BuildSystem.PROVIDED, BuildSystem.WHISKEY] || escrowGeneration in [EscrowGenerationMode.MANUAL, EscrowGenerationMode.UNSUPPORTED]) &&
                 moduleConfig.getVcsSettings().getVersionControlSystemRoots().isEmpty()) {
             registerError("No VCS roots is configured for component '$component' (type=$moduleConfig.buildSystem)")
             return

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
@@ -394,7 +394,7 @@ class EscrowConfigValidator {
     def validateVcsSettings(EscrowModuleConfig moduleConfig, String component) {
         def escrowGeneration = moduleConfig.escrow?.getGeneration()?.orElse(null)
         if (!(moduleConfig.getBuildSystem() in [BuildSystem.PROVIDED, BuildSystem.WHISKEY] || escrowGeneration in [EscrowGenerationMode.MANUAL, EscrowGenerationMode.UNSUPPORTED]) &&
-                moduleConfig.getVcsSettings().getVersionControlSystemRoots().isEmpty()) {
+                moduleConfig.getVcsSettings().getVersionControlSystemRoots().isEmpty() && !moduleConfig.getVcsSettings().notAvailable()) {
             registerError("No VCS roots is configured for component '$component' (type=$moduleConfig.buildSystem)")
             return
         }

--- a/component-resolver-core/src/test/resources/new-vcs/externalRegistryWithVersionRange.groovy
+++ b/component-resolver-core/src/test/resources/new-vcs/externalRegistryWithVersionRange.groovy
@@ -32,7 +32,6 @@ torpedo {
     vcsSettings {
         externalRegistry = "NOT_AVAILABLE"
     }
-    buildSystem = ESCROW_NOT_SUPPORTED
     escrow {
         generation = EscrowGenerationMode.UNSUPPORTED
     }

--- a/component-resolver-core/src/test/resources/new-vcs/externalRegistryWithVersionRange.groovy
+++ b/component-resolver-core/src/test/resources/new-vcs/externalRegistryWithVersionRange.groovy
@@ -1,3 +1,5 @@
+import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
+
 import static org.octopusden.octopus.escrow.BuildSystem.*
 
 Defaults {
@@ -31,6 +33,9 @@ torpedo {
         externalRegistry = "NOT_AVAILABLE"
     }
     buildSystem = ESCROW_NOT_SUPPORTED
+    escrow {
+        generation = EscrowGenerationMode.UNSUPPORTED
+    }
     groupId = "org.octopusden.octopus.torpedo"
     artifactId = "myartifct"
     jira {

--- a/component-resolver-core/src/test/resources/validation/escrow_across_ranges/Components.groovy
+++ b/component-resolver-core/src/test/resources/validation/escrow_across_ranges/Components.groovy
@@ -33,7 +33,6 @@ Component {
         }
     }
     "(,03.51.29.15)" {
-        buildSystem = ESCROW_NOT_SUPPORTED
         escrow {
             generation = EscrowGenerationMode.UNSUPPORTED
         }
@@ -69,7 +68,6 @@ test {
         }
     }
     "(,03.51.29.15)" {
-        buildSystem = ESCROW_NOT_SUPPORTED
         escrow {
             generation = EscrowGenerationMode.UNSUPPORTED
         }

--- a/components-registry-api/src/main/java/org/octopusden/octopus/components/registry/api/enums/BuildSystemType.java
+++ b/components-registry-api/src/main/java/org/octopusden/octopus/components/registry/api/enums/BuildSystemType.java
@@ -6,7 +6,6 @@ public enum BuildSystemType {
     WHISKEY,
     PROVIDED,
     ESCROW_NOT_SUPPORTED,
-    ESCROW_PROVIDED_MANUALLY,
     BS2_0,
     GOLANG,
     IN_CONTAINER

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/BuildSystem.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/BuildSystem.kt
@@ -10,5 +10,4 @@ enum class BuildSystem {
     NOT_SUPPORTED,
     GOLANG,
     IN_CONTAINER,
-    ESCROW_PROVIDED_MANUALLY
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV2.kt
@@ -123,8 +123,6 @@ class ComponentControllerV2(
             org.octopusden.octopus.escrow.BuildSystem.GRADLE -> BuildSystem.GRADLE
             org.octopusden.octopus.escrow.BuildSystem.WHISKEY -> BuildSystem.WHISKEY
             org.octopusden.octopus.escrow.BuildSystem.PROVIDED -> BuildSystem.PROVIDED
-            org.octopusden.octopus.escrow.BuildSystem.ESCROW_NOT_SUPPORTED -> BuildSystem.NOT_SUPPORTED
-            org.octopusden.octopus.escrow.BuildSystem.ESCROW_PROVIDED_MANUALLY -> BuildSystem.ESCROW_PROVIDED_MANUALLY
             org.octopusden.octopus.escrow.BuildSystem.GOLANG -> BuildSystem.GOLANG
             org.octopusden.octopus.escrow.BuildSystem.IN_CONTAINER -> BuildSystem.IN_CONTAINER
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -287,8 +287,6 @@ class ComponentRegistryResolverImpl(
             org.octopusden.octopus.escrow.BuildSystem.GRADLE -> BuildSystem.GRADLE
             org.octopusden.octopus.escrow.BuildSystem.WHISKEY -> BuildSystem.WHISKEY
             org.octopusden.octopus.escrow.BuildSystem.PROVIDED -> BuildSystem.PROVIDED
-            org.octopusden.octopus.escrow.BuildSystem.ESCROW_NOT_SUPPORTED -> BuildSystem.NOT_SUPPORTED
-            org.octopusden.octopus.escrow.BuildSystem.ESCROW_PROVIDED_MANUALLY -> BuildSystem.PROVIDED
             org.octopusden.octopus.escrow.BuildSystem.GOLANG -> BuildSystem.GOLANG
             org.octopusden.octopus.escrow.BuildSystem.IN_CONTAINER -> BuildSystem.IN_CONTAINER
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -50,7 +50,6 @@ class MetricsTest {
                         "GOLANG",
                         "BS2_0",
                         "PROVIDED",
-                        "ESCROW_PROVIDED_MANUALLY",
                         "ECLIPSE_MAVEN",
                         "GRADLE",
                         "IN_CONTAINER"


### PR DESCRIPTION
Replaced legacy escrow constants with EscrowGenerationMode enum.

Removed:
- ESCROW_NOT_SUPPORTED
- ESCROW_PROVIDED_MANUALLY

Updated all usages to:
- EscrowGenerationMode.UNSUPPORTED
- EscrowGenerationMode.MANUAL

## Notice:
Removed deprecated parameters ESCROW_NOT_SUPPORTED and ESCROW_PROVIDED_MANUALLY.
To avoid errors in CR, they must be replaced as follows:

buildSystem = ESCROW_NOT_SUPPORTED →
`escrow {
    generation = EscrowGenerationMode.UNSUPPORTED
}`

ESCROW_PROVIDED_MANUALLY →
`escrow {
    generation = EscrowGenerationMode.MANUAL
}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation expanded to recognize and handle additional escrow generation modes.
  * VCS settings validation updated for better compatibility across those modes.

* **Breaking Changes**
  * Two legacy escrow build-system values are no longer mapped or exposed, which may change reported build-system results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->