### PR TITLE
Disable mandatory vcsUrl validation in CRS for components with extern…

### DIFF
--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/EscrowConfigValidator.groovy
@@ -391,7 +391,7 @@ class EscrowConfigValidator {
 
     def validateVcsSettings(EscrowModuleConfig moduleConfig, String component) {
         if (!(moduleConfig.getBuildSystem() in [BuildSystem.ESCROW_PROVIDED_MANUALLY, BuildSystem.ESCROW_NOT_SUPPORTED, BuildSystem.PROVIDED, BuildSystem.WHISKEY]) &&
-                moduleConfig.getVcsSettings().getVersionControlSystemRoots().isEmpty()) {
+                moduleConfig.getVcsSettings().getVersionControlSystemRoots().isEmpty() && !moduleConfig.getVcsSettings().notAvailable()) {
             registerError("No VCS roots is configured for component '$component' (type=$moduleConfig.buildSystem)")
             return
         }

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/EscrowConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/EscrowConfigValidatorTest.groovy
@@ -1,0 +1,68 @@
+package org.octopusden.octopus.escrow.configuration.validation
+
+import org.junit.Test
+import org.octopusden.octopus.escrow.BuildSystem
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.octopusden.octopus.escrow.configuration.model.ValidationConfig
+import org.octopusden.octopus.escrow.model.VCSSettings
+import org.octopusden.releng.versions.VersionNames
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class EscrowConfigValidatorTest {
+
+    private static final VersionNames VERSION_NAMES = new VersionNames("serviceCBranch", "serviceC", "minorC")
+
+    private static EscrowConfigValidator newValidator() {
+        new EscrowConfigValidator(
+                ["org.octopusden"],
+                ["CLASSIC"],
+                VERSION_NAMES,
+                null,
+                new ValidationConfig()
+        )
+    }
+
+    @Test
+    void validateVcsSettingsRegistersErrorWhenVcsRootsEmptyAndBuildSystemRequiresThem() {
+        def validator = newValidator()
+        def moduleConfig = new EscrowModuleConfig(
+                buildSystem: BuildSystem.MAVEN,
+                vcsSettings: VCSSettings.createEmpty()
+        )
+
+        validator.validateVcsSettings(moduleConfig, "my-component")
+
+        assertTrue(validator.errors.any {
+            it.contains("No VCS roots is configured for component 'my-component'") &&
+                    it.contains("type=MAVEN")
+        })
+    }
+
+    @Test
+    void validateVcsSettingsSkipsVcsRootsCheckForProvidedBuildSystem() {
+        def validator = newValidator()
+        def moduleConfig = new EscrowModuleConfig(
+                buildSystem: BuildSystem.PROVIDED,
+                vcsSettings: VCSSettings.createEmpty()
+        )
+
+        validator.validateVcsSettings(moduleConfig, "provided-component")
+
+        assertFalse(validator.errors.any { it.contains("No VCS roots is configured") })
+    }
+
+    @Test
+    void validateVcsSettingsSkipsVcsRootsCheckWhenVcsMarkedNotAvailable() {
+        def validator = newValidator()
+        def moduleConfig = new EscrowModuleConfig(
+                buildSystem: BuildSystem.GRADLE,
+                vcsSettings: VCSSettings.create("NOT_AVAILABLE")
+        )
+
+        validator.validateVcsSettings(moduleConfig, "no-vcs-component")
+
+        assertFalse(validator.errors.any { it.contains("No VCS roots is configured") })
+    }
+}


### PR DESCRIPTION
…alRegistry='NOT_AVAILABLE'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VCS configuration validation now skips errors when VCS settings are explicitly marked unavailable, preventing false-positive validation failures.
* **Tests**
  * Added tests covering VCS validation behavior across build types to ensure correct handling of empty or unavailable VCS settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->