### PR TITLE
Add /migrate-history endpoint to backfill git history into audit_log

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -1,7 +1,9 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
 import org.octopusden.octopus.components.registry.server.service.BatchMigrationResult
 import org.octopusden.octopus.components.registry.server.service.FullMigrationResult
+import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
 import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("rest/api/4/admin")
 class AdminControllerV4(
     private val importService: ImportService,
+    private val gitHistoryImportService: GitHistoryImportService,
 ) {
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
@@ -47,4 +50,10 @@ class AdminControllerV4(
 
     @GetMapping("/export")
     fun exportComponents(): ResponseEntity<Map<String, String>> = ResponseEntity.ok(mapOf("status" to "not_implemented"))
+
+    @PostMapping("/migrate-history")
+    fun migrateHistory(
+        @RequestParam(required = false) toRef: String?,
+        @RequestParam(defaultValue = "false") reset: Boolean,
+    ): ResponseEntity<HistoryImportResult> = ResponseEntity.ok(gitHistoryImportService.importHistory(toRef, reset))
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogResponse.kt
@@ -13,4 +13,5 @@ data class AuditLogResponse(
     val newValue: Map<String, Any?>?,
     val changeDiff: Map<String, Any?>?,
     val correlationId: String?,
+    val source: String,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/HistoryImportResult.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/HistoryImportResult.kt
@@ -1,0 +1,12 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+data class HistoryImportResult(
+    val targetRef: String,
+    val targetSha: String,
+    val processedCommits: Int,
+    val skippedNoGroovy: Int,
+    val skippedParseError: Int,
+    val skippedUnknownNames: Int,
+    val auditRecords: Int,
+    val durationMs: Long,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/AuditLogEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/AuditLogEntity.kt
@@ -37,4 +37,6 @@ class AuditLogEntity(
     var changeDiff: Map<String, Any?>? = null,
     @Column(name = "correlation_id")
     var correlationId: String? = null,
+    @Column(nullable = false)
+    var source: String = "api",
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/GitHistoryImportStateEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/GitHistoryImportStateEntity.kt
@@ -1,0 +1,29 @@
+package org.octopusden.octopus.components.registry.server.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "git_history_import_state")
+class GitHistoryImportStateEntity(
+    @Id
+    @Column(name = "import_key")
+    var importKey: String = "",
+    @Column(name = "target_ref", nullable = false)
+    var targetRef: String = "",
+    @Column(name = "target_sha", nullable = false)
+    var targetSha: String = "",
+    @Column(nullable = false)
+    var status: String = GitHistoryImportStatus.IN_PROGRESS.name,
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.now(),
+)
+
+enum class GitHistoryImportStatus {
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED,
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.components.registry.server.event
 
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+import org.octopusden.octopus.components.registry.server.util.AuditDiff
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -12,7 +13,6 @@ class AuditEventListener(
 ) {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun handleAuditEvent(event: AuditEvent) {
-        val diff = computeDiff(event.oldValue, event.newValue)
         val auditLog =
             AuditLogEntity(
                 entityType = event.entityType,
@@ -21,25 +21,8 @@ class AuditEventListener(
                 changedBy = event.changedBy,
                 oldValue = event.oldValue,
                 newValue = event.newValue,
-                changeDiff = diff,
+                changeDiff = AuditDiff.compute(event.oldValue, event.newValue),
             )
         auditLogRepository.save(auditLog)
-    }
-
-    private fun computeDiff(
-        old: Map<String, Any?>?,
-        new: Map<String, Any?>?,
-    ): Map<String, Any?>? {
-        if (old == null || new == null) return null
-        val diff = mutableMapOf<String, Any?>()
-        val allKeys = old.keys + new.keys
-        for (key in allKeys) {
-            val oldVal = old[key]
-            val newVal = new[key]
-            if (oldVal != newVal) {
-                diff[key] = mapOf("old" to oldVal, "new" to newVal)
-            }
-        }
-        return diff.ifEmpty { null }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -166,4 +166,5 @@ fun AuditLogEntity.toResponse(): AuditLogResponse =
         newValue = this.newValue,
         changeDiff = this.changeDiff,
         correlationId = this.correlationId,
+        source = this.source,
     )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepository.kt
@@ -4,6 +4,8 @@ import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.transaction.annotation.Transactional
 
 interface AuditLogRepository : JpaRepository<AuditLogEntity, Long> {
     fun findByEntityTypeAndEntityId(
@@ -18,4 +20,8 @@ interface AuditLogRepository : JpaRepository<AuditLogEntity, Long> {
         changedBy: String,
         pageable: Pageable,
     ): Page<AuditLogEntity>
+
+    @Modifying
+    @Transactional
+    fun deleteBySource(source: String): Long
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepository.kt
@@ -2,5 +2,34 @@ package org.octopusden.octopus.components.registry.server.repository
 
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.transaction.annotation.Transactional
 
-interface GitHistoryImportStateRepository : JpaRepository<GitHistoryImportStateEntity, String>
+interface GitHistoryImportStateRepository : JpaRepository<GitHistoryImportStateEntity, String> {
+    /**
+     * Atomic claim used as the 409-gate on POST /migrate-history: INSERT
+     * the state row or, on primary-key conflict, do nothing. Returns the
+     * number of rows inserted (1 = this caller owns the run, 0 = someone
+     * else already claimed it). Prevents the find-then-save race between
+     * concurrent operators.
+     */
+    @Modifying
+    @Transactional
+    @Query(
+        value = """
+            INSERT INTO git_history_import_state
+                (import_key, target_ref, target_sha, status, updated_at)
+            VALUES (:importKey, :targetRef, :targetSha, :status, now())
+            ON CONFLICT (import_key) DO NOTHING
+        """,
+        nativeQuery = true,
+    )
+    fun tryInsert(
+        @Param("importKey") importKey: String,
+        @Param("targetRef") targetRef: String,
+        @Param("targetSha") targetSha: String,
+        @Param("status") status: String,
+    ): Int
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepository.kt
@@ -1,0 +1,6 @@
+package org.octopusden.octopus.components.registry.server.repository
+
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GitHistoryImportStateRepository : JpaRepository<GitHistoryImportStateEntity, String>

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/GitHistoryImportService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/GitHistoryImportService.kt
@@ -1,0 +1,15 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
+
+/**
+ * One-shot backfill of git history into `audit_log` with
+ * `source='git-history'`. No resume: a previous run in any terminal state
+ * blocks the next call unless `reset=true` is passed.
+ */
+interface GitHistoryImportService {
+    fun importHistory(
+        toRef: String?,
+        reset: Boolean,
+    ): HistoryImportResult
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentHistorySnapshotSerializer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentHistorySnapshotSerializer.kt
@@ -1,0 +1,70 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import org.octopusden.octopus.escrow.configuration.model.EscrowModule
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.springframework.stereotype.Component
+
+/**
+ * Produces a stable, comparable snapshot of a single `EscrowModule` for
+ * history backfill. The output is intentionally a pure `Map<String, Any?>` so
+ * it can be stored as JSONB in `audit_log.old_value` / `new_value` and diffed
+ * via [org.octopusden.octopus.components.registry.server.util.AuditDiff].
+ *
+ * Ordering is stable (LinkedHashMap at the top level, alphabetical in nested
+ * maps) so byte-for-byte equal inputs yield byte-for-byte equal output.
+ */
+@Component
+class ComponentHistorySnapshotSerializer {
+    private val mapper: ObjectMapper =
+        ObjectMapper()
+            .findAndRegisterModules()
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+
+    fun serialize(module: EscrowModule): Map<String, Any?> {
+        val snapshot = linkedMapOf<String, Any?>()
+        snapshot["moduleName"] = module.moduleName
+        snapshot["moduleConfigurations"] = module.moduleConfigurations.map(::serializeConfig)
+        return snapshot
+    }
+
+    @Suppress("LongMethod")
+    private fun serializeConfig(cfg: EscrowModuleConfig): Map<String, Any?> {
+        val s = linkedMapOf<String, Any?>()
+        s["versionRange"] = cfg.versionRangeString
+        s["buildSystem"] = cfg.buildSystem?.name
+        s["artifactIdPattern"] = cfg.artifactIdPattern
+        s["groupIdPattern"] = cfg.groupIdPattern
+        s["buildFilePath"] = cfg.buildFilePath
+        s["componentDisplayName"] = cfg.componentDisplayName
+        s["componentOwner"] = cfg.componentOwner
+        s["releaseManager"] = cfg.releaseManager
+        s["securityChampion"] = cfg.securityChampion
+        s["system"] = cfg.system
+        s["clientCode"] = cfg.clientCode
+        s["releasesInDefaultBranch"] = cfg.releasesInDefaultBranch
+        s["solution"] = cfg.solution
+        s["parentComponent"] = cfg.parentComponent
+        s["octopusVersion"] = cfg.octopusVersion
+        s["productType"] = cfg.productType?.name
+        s["deprecated"] = cfg.isDeprecated
+        s["archived"] = cfg.archived
+        s["copyright"] = cfg.copyright
+        s["labels"] = cfg.labels?.sorted()
+        s["jiraConfiguration"] = toMap(cfg.jiraConfiguration)
+        s["buildConfiguration"] = toMap(cfg.buildConfiguration)
+        s["vcsSettings"] = toMap(cfg.vcsSettings)
+        s["distribution"] = toMap(cfg.distribution)
+        s["escrow"] = toMap(cfg.escrow)
+        s["doc"] = toMap(cfg.doc)
+        return s
+    }
+
+    private fun toMap(obj: Any?): Map<String, Any?>? = obj?.let { mapper.convertValue(it, MAP_TYPE) }
+
+    companion object {
+        private val MAP_TYPE = object : TypeReference<Map<String, Any?>>() {}
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.components.registry.server.service.impl
 
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
 import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
 import org.springframework.stereotype.Component
@@ -32,9 +33,20 @@ class GitHistoryCommitWriter(
         stateRepository.save(state)
     }
 
+    /**
+     * Atomic reset: deletes git-history audit rows and the state row
+     * unless the state is IN_PROGRESS. Returning `false` signals that a
+     * live import is still running and the caller should 409 instead of
+     * stomping on its writes.
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun resetHistoryRowsAndState() {
+    fun resetIfNotInProgress(): Boolean {
+        val existing = stateRepository.findById("component-history").orElse(null)
+        if (existing != null && existing.status == GitHistoryImportStatus.IN_PROGRESS.name) {
+            return false
+        }
         auditLogRepository.deleteBySource("git-history")
         stateRepository.deleteAll()
+        return true
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
@@ -1,0 +1,40 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
+import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+/**
+ * Separate Spring bean so per-commit writes run in their own transaction
+ * (`REQUIRES_NEW`). Keeping this out of the main import loop ensures each
+ * commit's rows are durable before the next commit is processed, which is
+ * the v1 trade-off we accepted in lieu of full resume support.
+ */
+@Component
+class GitHistoryCommitWriter(
+    private val auditLogRepository: AuditLogRepository,
+    private val stateRepository: GitHistoryImportStateRepository,
+) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun persistCommitRows(rows: List<AuditLogEntity>) {
+        if (rows.isEmpty()) return
+        auditLogRepository.saveAll(rows)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun saveState(state: GitHistoryImportStateEntity) {
+        state.updatedAt = Instant.now()
+        stateRepository.save(state)
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun resetHistoryRowsAndState() {
+        auditLogRepository.deleteBySource("git-history")
+        stateRepository.deleteAll()
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -1,0 +1,375 @@
+@file:Suppress("TooManyFunctions")
+
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.RevWalk
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+import org.eclipse.jgit.treewalk.CanonicalTreeParser
+import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
+import org.octopusden.octopus.components.registry.server.util.AuditDiff
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.util.FileSystemUtils
+import org.springframework.web.server.ResponseStatusException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Instant
+
+private const val IMPORT_KEY = "component-history"
+private const val HISTORY_SOURCE = "git-history"
+private const val PROGRESS_LOG_EVERY = 250
+private const val UNKNOWN_NAMES_SAMPLE_SIZE = 20
+
+@Service
+class GitHistoryImportServiceImpl(
+    private val componentsRegistryProperties: ComponentsRegistryProperties,
+    private val gitTagResolver: GitTagResolver,
+    private val historyLoaderFactory: HistoryEscrowLoaderFactory,
+    private val snapshotSerializer: ComponentHistorySnapshotSerializer,
+    private val componentRepository: ComponentRepository,
+    private val stateRepository: GitHistoryImportStateRepository,
+    private val commitWriter: GitHistoryCommitWriter,
+) : GitHistoryImportService {
+    @Suppress("TooGenericExceptionCaught")
+    // Any failure during clone/walk/parse transitions state to FAILED so the
+    // operator sees a clear signal that reset=true is required to re-run.
+    override fun importHistory(
+        toRef: String?,
+        reset: Boolean,
+    ): HistoryImportResult {
+        preflight(reset)
+
+        val started = Instant.now()
+        val historyWorkDir = Paths.get(componentsRegistryProperties.workDir + "-history")
+        val groovyPrefix = resolveGroovyPrefix()
+
+        try {
+            Git
+                .cloneRepository()
+                .setURI(componentsRegistryProperties.vcs.root)
+                .setDirectory(historyWorkDir.toFile())
+                .apply {
+                    componentsRegistryProperties.vcs.username?.let { usernameValue ->
+                        setCredentialsProvider(
+                            UsernamePasswordCredentialsProvider(
+                                usernameValue,
+                                componentsRegistryProperties.vcs.password,
+                            ),
+                        )
+                    }
+                }.call()
+                .use { git ->
+                    return runImport(git, toRef, historyWorkDir, groovyPrefix, started)
+                }
+        } catch (e: Exception) {
+            log.error("History import failed", e)
+            markState(status = GitHistoryImportStatus.FAILED)
+            throw e
+        } finally {
+            cleanup(historyWorkDir)
+        }
+    }
+
+    private fun preflight(reset: Boolean) {
+        if (reset) {
+            commitWriter.resetHistoryRowsAndState()
+        } else {
+            stateRepository.findById(IMPORT_KEY).ifPresent { existing ->
+                throw ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "git history import already ran (status=${existing.status}, " +
+                        "target=${existing.targetRef}@${existing.targetSha}); use reset=true to re-run",
+                )
+            }
+        }
+    }
+
+    private fun runImport(
+        git: Git,
+        toRef: String?,
+        historyWorkDir: Path,
+        groovyPrefix: String,
+        started: Instant,
+    ): HistoryImportResult {
+        val target = resolveTarget(git, toRef)
+        log.info("History import target: {}@{}", target.ref, target.sha)
+
+        commitWriter.saveState(
+            GitHistoryImportStateEntity(
+                importKey = IMPORT_KEY,
+                targetRef = target.ref,
+                targetSha = target.sha,
+                status = GitHistoryImportStatus.IN_PROGRESS.name,
+            ),
+        )
+
+        val loader = historyLoaderFactory.build(historyWorkDir)
+        val repo = git.repository
+        val chain =
+            RevWalk(repo).use { walk ->
+                firstParentChain(walk, ObjectId.fromString(target.sha))
+            }
+        log.info("First-parent chain size: {}", chain.size)
+
+        val stats = ImportStats()
+        var prevSnapshot: Map<String, Map<String, Any?>> = emptyMap()
+
+        RevWalk(repo).use { walk ->
+            chain.forEachIndexed { index, commitId ->
+                val commit = walk.parseCommit(commitId)
+                stats.processed++
+                prevSnapshot =
+                    processCommit(git, repo, loader, commit, prevSnapshot, groovyPrefix, stats)
+                logProgress(index, chain.size, stats.auditRecords)
+            }
+        }
+
+        flushParseSkipBatch(stats.parseSkipBatch)
+        if (stats.unknownNames.isNotEmpty()) {
+            log.warn(
+                "history import skipped unknown component names: count={}, sample={}",
+                stats.unknownNames.size,
+                stats.unknownNames.take(UNKNOWN_NAMES_SAMPLE_SIZE),
+            )
+        }
+
+        markState(status = GitHistoryImportStatus.COMPLETED)
+
+        return HistoryImportResult(
+            targetRef = target.ref,
+            targetSha = target.sha,
+            processedCommits = stats.processed,
+            skippedNoGroovy = stats.skippedNoGroovy,
+            skippedParseError = stats.skippedParseError,
+            skippedUnknownNames = stats.unknownNames.size,
+            auditRecords = stats.auditRecords,
+            durationMs =
+                java.time.Duration
+                    .between(started, Instant.now())
+                    .toMillis(),
+        )
+    }
+
+    private fun resolveTarget(
+        git: Git,
+        toRef: String?,
+    ): ResolvedTarget =
+        toRef?.let { ref ->
+            val sha =
+                git.repository.resolve(ref)?.name
+                    ?: throw IllegalArgumentException("cannot resolve toRef '$ref' in cloned repository")
+            ResolvedTarget(ref = ref, sha = sha)
+        } ?: gitTagResolver.resolve(git, componentsRegistryProperties.vcs.tagVersionPrefix)
+
+    private fun processCommit(
+        git: Git,
+        repo: Repository,
+        loader: org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader,
+        commit: RevCommit,
+        prevSnapshot: Map<String, Map<String, Any?>>,
+        groovyPrefix: String,
+        stats: ImportStats,
+    ): Map<String, Map<String, Any?>> {
+        if (prevSnapshot.isNotEmpty() && !touchesGroovy(repo, commit, groovyPrefix)) {
+            stats.skippedNoGroovy++
+            return prevSnapshot
+        }
+
+        checkoutCommit(git, commit)
+
+        val curSnapshot = parseSnapshot(loader, commit, stats) ?: return prevSnapshot
+
+        val rows = buildAuditRowsForCommit(commit, prevSnapshot, curSnapshot, stats.unknownNames)
+        commitWriter.persistCommitRows(rows)
+        stats.auditRecords += rows.size
+        return curSnapshot
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    // The Groovy DSL loader throws a wide range of internal exceptions on historical
+    // commits whose DSL shape is no longer understood by the current parser. We record
+    // a single aggregated batch at INFO/WARN rather than logging each stack trace.
+    private fun parseSnapshot(
+        loader: org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader,
+        commit: RevCommit,
+        stats: ImportStats,
+    ): Map<String, Map<String, Any?>>? =
+        try {
+            loader
+                .loadFullConfigurationWithoutValidationForUnknownAttributes(emptyMap())
+                .escrowModules
+                .mapValues { (_, module) -> snapshotSerializer.serialize(module) }
+        } catch (e: Exception) {
+            stats.parseSkipBatch += commit.name
+            stats.skippedParseError++
+            if (stats.parseSkipBatch.size >= PROGRESS_LOG_EVERY) {
+                flushParseSkipBatch(stats.parseSkipBatch)
+            }
+            null
+        }
+
+    private fun buildAuditRowsForCommit(
+        commit: RevCommit,
+        prev: Map<String, Map<String, Any?>>,
+        cur: Map<String, Map<String, Any?>>,
+        unknownNames: MutableSet<String>,
+    ): List<AuditLogEntity> {
+        val author = commit.authorIdent
+        val changedBy = "${author.name} <${author.emailAddress}>"
+        val changedAt = author.`when`.toInstant()
+
+        return (prev.keys + cur.keys).mapNotNull { name ->
+            val componentId = componentRepository.findByName(name)?.id
+            if (componentId == null) {
+                unknownNames += name
+                return@mapNotNull null
+            }
+            val oldValue = prev[name]
+            val newValue = cur[name]
+            val action = resolveAction(oldValue, newValue) ?: return@mapNotNull null
+
+            AuditLogEntity(
+                entityType = "Component",
+                entityId = componentId.toString(),
+                action = action,
+                changedBy = changedBy,
+                changedAt = changedAt,
+                oldValue = oldValue,
+                newValue = newValue,
+                changeDiff = AuditDiff.compute(oldValue, newValue),
+                correlationId = commit.name,
+                source = HISTORY_SOURCE,
+            )
+        }
+    }
+
+    private fun resolveAction(
+        oldValue: Map<String, Any?>?,
+        newValue: Map<String, Any?>?,
+    ): String? =
+        when {
+            oldValue == null && newValue != null -> "CREATE"
+            oldValue != null && newValue == null -> "DELETE"
+            oldValue != null && newValue != null && oldValue != newValue -> "UPDATE"
+            else -> null
+        }
+
+    private fun firstParentChain(
+        walk: RevWalk,
+        targetSha: ObjectId,
+    ): List<ObjectId> {
+        val list = mutableListOf<ObjectId>()
+        var current: RevCommit? = walk.parseCommit(targetSha)
+        while (current != null) {
+            list += current.id
+            val firstParent = current.parents.firstOrNull() ?: break
+            current = walk.parseCommit(firstParent)
+        }
+        return list.asReversed()
+    }
+
+    private fun touchesGroovy(
+        repo: Repository,
+        commit: RevCommit,
+        groovyPrefix: String,
+    ): Boolean {
+        val parent = commit.parents.firstOrNull() ?: return true
+        repo.newObjectReader().use { reader ->
+            val parentTree = CanonicalTreeParser().apply { reset(reader, parent.tree) }
+            val currentTree = CanonicalTreeParser().apply { reset(reader, commit.tree) }
+            val diffs =
+                Git(repo)
+                    .diff()
+                    .setOldTree(parentTree)
+                    .setNewTree(currentTree)
+                    .call()
+            return diffs.any { entry ->
+                val candidate =
+                    entry.newPath.takeUnless { it == "/dev/null" } ?: entry.oldPath
+                candidate.endsWith(".groovy") &&
+                    (groovyPrefix.isEmpty() || candidate.startsWith(groovyPrefix))
+            }
+        }
+    }
+
+    private fun checkoutCommit(
+        git: Git,
+        commit: RevCommit,
+    ) {
+        git
+            .checkout()
+            .setName(commit.name)
+            .setForced(true)
+            .call()
+    }
+
+    private fun resolveGroovyPrefix(): String {
+        val liveWorkDir = Paths.get(componentsRegistryProperties.workDir).toAbsolutePath().normalize()
+        val liveGroovyPath = Paths.get(componentsRegistryProperties.groovyPath).toAbsolutePath().normalize()
+        if (!liveGroovyPath.startsWith(liveWorkDir)) return ""
+        val relative = liveWorkDir.relativize(liveGroovyPath).toString()
+        if (relative.isEmpty()) return ""
+        return if (relative.endsWith("/")) relative else "$relative/"
+    }
+
+    private fun markState(status: GitHistoryImportStatus) {
+        stateRepository.findById(IMPORT_KEY).ifPresent { entity ->
+            entity.status = status.name
+            commitWriter.saveState(entity)
+        }
+    }
+
+    private fun flushParseSkipBatch(batch: MutableList<String>) {
+        if (batch.isEmpty()) return
+        log.warn(
+            "history import parse-skip batch: count={}, first={}, last={}",
+            batch.size,
+            batch.first(),
+            batch.last(),
+        )
+        batch.clear()
+    }
+
+    private fun logProgress(
+        index: Int,
+        total: Int,
+        auditRecords: Int,
+    ) {
+        if ((index + 1) % PROGRESS_LOG_EVERY == 0) {
+            log.info("history import progress: {}/{} commits, auditRecords={}", index + 1, total, auditRecords)
+        }
+    }
+
+    private fun cleanup(historyWorkDir: Path) {
+        if (Files.exists(historyWorkDir)) {
+            log.info("Cleaning history clone at {}", historyWorkDir)
+            FileSystemUtils.deleteRecursively(historyWorkDir.toFile())
+        }
+    }
+
+    private class ImportStats {
+        var processed: Int = 0
+        var skippedNoGroovy: Int = 0
+        var skippedParseError: Int = 0
+        var auditRecords: Int = 0
+        val parseSkipBatch: MutableList<String> = mutableListOf()
+        val unknownNames: MutableSet<String> = mutableSetOf()
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(GitHistoryImportServiceImpl::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -55,6 +55,12 @@ class GitHistoryImportServiceImpl(
         val historyWorkDir = Paths.get(componentsRegistryProperties.workDir + "-history")
         val groovyPrefix = resolveGroovyPrefix()
 
+        // If a prior run was killed by a hard stop (OOM, SIGKILL, pod eviction)
+        // the finally cleanup never ran, so the directory is still on disk and
+        // JGit's clone will refuse to write into a non-empty target. Mirror
+        // GitVcsServiceImpl.cloneComponentsRegistry and wipe before cloning.
+        cleanup(historyWorkDir)
+
         try {
             Git
                 .cloneRepository()
@@ -83,8 +89,13 @@ class GitHistoryImportServiceImpl(
     }
 
     private fun preflight(reset: Boolean) {
-        if (reset) {
-            commitWriter.resetHistoryRowsAndState()
+        if (reset && !commitWriter.resetIfNotInProgress()) {
+            // Don't let reset=true stomp on a live import — both runs would
+            // then write into the same audit_log and race on COMPLETED/FAILED.
+            throw ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "another git history import is IN_PROGRESS; cannot reset while it is running",
+            )
         }
         // Atomic claim: whichever caller's INSERT lands first owns the run;
         // every other concurrent POST gets 409. Target is inserted as empty
@@ -175,8 +186,11 @@ class GitHistoryImportServiceImpl(
         toRef: String?,
     ): ResolvedTarget =
         toRef?.let { ref ->
+            // Peel annotated tags via the `^{commit}` suffix so we get the
+            // commit id, not the tag-object id. GitTagResolver handles the
+            // same case on the auto-resolution path via refDatabase.peel.
             val sha =
-                git.repository.resolve(ref)?.name
+                git.repository.resolve("$ref^{commit}")?.name
                     ?: throw IllegalArgumentException("cannot resolve toRef '$ref' in cloned repository")
             ResolvedTarget(ref = ref, sha = sha)
         } ?: gitTagResolver.resolve(git, componentsRegistryProperties.vcs.tagVersionPrefix)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -12,7 +12,6 @@ import org.eclipse.jgit.treewalk.CanonicalTreeParser
 import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
 import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
-import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
@@ -86,14 +85,25 @@ class GitHistoryImportServiceImpl(
     private fun preflight(reset: Boolean) {
         if (reset) {
             commitWriter.resetHistoryRowsAndState()
-        } else {
-            stateRepository.findById(IMPORT_KEY).ifPresent { existing ->
-                throw ResponseStatusException(
-                    HttpStatus.CONFLICT,
-                    "git history import already ran (status=${existing.status}, " +
-                        "target=${existing.targetRef}@${existing.targetSha}); use reset=true to re-run",
-                )
-            }
+        }
+        // Atomic claim: whichever caller's INSERT lands first owns the run;
+        // every other concurrent POST gets 409. Target is inserted as empty
+        // placeholders and filled in by runImport once the clone has resolved
+        // the real tag/sha.
+        val claimed =
+            stateRepository.tryInsert(
+                importKey = IMPORT_KEY,
+                targetRef = "",
+                targetSha = "",
+                status = GitHistoryImportStatus.IN_PROGRESS.name,
+            )
+        if (claimed == 0) {
+            val existing = stateRepository.findById(IMPORT_KEY).orElseThrow()
+            throw ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "git history import already ran (status=${existing.status}, " +
+                    "target=${existing.targetRef}@${existing.targetSha}); use reset=true to re-run",
+            )
         }
     }
 
@@ -107,14 +117,11 @@ class GitHistoryImportServiceImpl(
         val target = resolveTarget(git, toRef)
         log.info("History import target: {}@{}", target.ref, target.sha)
 
-        commitWriter.saveState(
-            GitHistoryImportStateEntity(
-                importKey = IMPORT_KEY,
-                targetRef = target.ref,
-                targetSha = target.sha,
-                status = GitHistoryImportStatus.IN_PROGRESS.name,
-            ),
-        )
+        // Fill in the real target on the claimed state row (inserted empty by preflight).
+        val state = stateRepository.findById(IMPORT_KEY).orElseThrow()
+        state.targetRef = target.ref
+        state.targetSha = target.sha
+        commitWriter.saveState(state)
 
         val loader = historyLoaderFactory.build(historyWorkDir)
         val repo = git.repository

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitTagResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitTagResolver.kt
@@ -1,0 +1,77 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.errors.NoHeadException
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+data class ResolvedTarget(
+    val ref: String,
+    val sha: String,
+)
+
+/**
+ * Picks a "validated" commit to check out: max numeric tag matching
+ * [tagVersionPrefix], else the current HEAD of the default branch.
+ *
+ * Tolerates non-numeric tags that share the prefix (e.g. `components-registry-qa-1`)
+ * by skipping them instead of failing the whole resolution.
+ */
+@Component
+class GitTagResolver(
+    private val numericVersionFactory: NumericVersionFactory,
+) {
+    fun resolve(
+        git: Git,
+        tagVersionPrefix: String,
+    ): ResolvedTarget {
+        val tagged =
+            git
+                .tagList()
+                .call()
+                .filter { it.name.startsWith(tagVersionPrefix) }
+                .mapNotNull { ref ->
+                    val shortName = ref.name.removePrefix(REFS_TAGS_PREFIX)
+                    @Suppress("TooGenericExceptionCaught")
+                    // NumericVersionFactory.create wraps parse failures in plain
+                    // RuntimeException; tolerating everything here keeps anomalous
+                    // tags like `components-registry-qa-1` from aborting resolution.
+                    try {
+                        numericVersionFactory.create(shortName) to ref
+                    } catch (e: RuntimeException) {
+                        log.debug("Skipping non-numeric tag '{}': {}", ref.name, e.message)
+                        null
+                    }
+                }.maxByOrNull { (version, _) -> version }
+                ?.let { (_, ref) ->
+                    val peeled = git.repository.refDatabase.peel(ref)
+                    ResolvedTarget(
+                        ref = ref.name,
+                        sha = peeled.peeledObjectId?.name ?: peeled.objectId.name,
+                    )
+                }
+
+        if (tagged != null) return tagged
+
+        val latest =
+            try {
+                git
+                    .log()
+                    .setMaxCount(1)
+                    .call()
+                    .firstOrNull()
+            } catch (e: NoHeadException) {
+                log.debug("Repository has no HEAD: {}", e.message)
+                null
+            }
+                ?: error("Components Registry is empty, can not continue")
+
+        return ResolvedTarget(ref = "master", sha = latest.name)
+    }
+
+    companion object {
+        private const val REFS_TAGS_PREFIX = "refs/tags/"
+        private val log = LoggerFactory.getLogger(GitTagResolver::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitVcsServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitVcsServiceImpl.kt
@@ -6,7 +6,6 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
 import org.octopusden.octopus.components.registry.server.service.VcsService
-import org.octopusden.releng.versions.NumericVersionFactory
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -26,7 +25,7 @@ import java.nio.file.Paths
 )
 class GitVcsServiceImpl(
     private val componentsRegistryProperties: ComponentsRegistryProperties,
-    private val numericVersionFactory: NumericVersionFactory,
+    private val gitTagResolver: GitTagResolver,
 ) : VcsService {
     override fun cloneComponentsRegistry(): String {
         deleteTemporaryDir()
@@ -56,36 +55,13 @@ class GitVcsServiceImpl(
     }
 
     private fun checkoutToValidatedCommit(git: Git): String {
-        val tagPrefix = componentsRegistryProperties.vcs.tagVersionPrefix
-
-        val (tag, commitId) =
-            git
-                .tagList()
-                .call()
-                .filter { it.name.startsWith(tagPrefix) }
-                .map { ref ->
-                    numericVersionFactory.create(ref.name) to ref
-                }.maxByOrNull { (version, _) -> version }
-                ?.let { (_, ref) ->
-                    ref.name to (ref.peeledObjectId?.name ?: ref.objectId.name)
-                }
-                ?: git
-                    .log()
-                    .setMaxCount(1)
-                    .call()
-                    .firstOrNull()
-                    ?.let { revCommit ->
-                        "master" to revCommit.name
-                    }
-                ?: throw IllegalStateException("Components Registry is empty, can not continue")
-
-        log.info("Checkout to $tag:$commitId")
+        val target = gitTagResolver.resolve(git, componentsRegistryProperties.vcs.tagVersionPrefix)
+        log.info("Checkout to ${target.ref}:${target.sha}")
         git
             .checkout()
-            .setName(commitId)
+            .setName(target.sha)
             .call()
-
-        return commitId
+        return target.sha
     }
 
     @PostConstruct

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryEscrowLoaderFactory.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryEscrowLoaderFactory.kt
@@ -1,0 +1,72 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
+import org.octopusden.octopus.escrow.config.ConfigHelper
+import org.octopusden.octopus.escrow.configuration.loader.ComponentRegistryInfo
+import org.octopusden.octopus.escrow.configuration.loader.ConfigLoader
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.releng.versions.VersionNames
+import org.springframework.core.io.ResourceLoader
+import org.springframework.stereotype.Component
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Builds a fresh [EscrowConfigurationLoader] pointed at a history-checkout
+ * directory. Mirrors the production bootstrap wiring in
+ * [org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication]
+ * so the history loader parses the same config surface as the live app,
+ * just out of an alternate clone.
+ */
+@Component
+class HistoryEscrowLoaderFactory(
+    private val configHelper: ConfigHelper,
+    private val versionNames: VersionNames,
+    private val componentsRegistryProperties: ComponentsRegistryProperties,
+    private val resourceLoader: ResourceLoader,
+) {
+    /**
+     * @param historyWorkDir root of the alternate clone (e.g. `${workDir}-history`).
+     */
+    fun build(historyWorkDir: Path): EscrowConfigurationLoader {
+        val historyGroovyPath = resolveHistoryGroovyPath(historyWorkDir)
+        val moduleConfigUrl =
+            "file://" +
+                historyGroovyPath.toAbsolutePath().toString() +
+                "/" +
+                componentsRegistryProperties.mainGroovyFile
+        val resource = resourceLoader.getResource(moduleConfigUrl)
+        val url = resource.url
+        val configLoader =
+            ConfigLoader(
+                ComponentRegistryInfo.createFromURL(url),
+                versionNames,
+                configHelper.productTypes(),
+            )
+        return EscrowConfigurationLoader(
+            configLoader,
+            configHelper.supportedGroupIds(),
+            configHelper.supportedSystems(),
+            versionNames,
+            configHelper.copyrightPath(),
+        )
+    }
+
+    /**
+     * Preserve the `groovyPath`/`workDir` relationship inside the history clone:
+     * in prod `groovyPath = ${workDir}/src/main/resources`, in tests they are
+     * equal. The relative offset is applied on top of [historyWorkDir].
+     */
+    private fun resolveHistoryGroovyPath(historyWorkDir: Path): Path {
+        val liveWorkDir = Paths.get(componentsRegistryProperties.workDir).toAbsolutePath().normalize()
+        val liveGroovyPath = Paths.get(componentsRegistryProperties.groovyPath).toAbsolutePath().normalize()
+        val relative =
+            if (liveGroovyPath.startsWith(liveWorkDir)) {
+                liveWorkDir.relativize(liveGroovyPath)
+            } else {
+                // Groovy path outside workDir — fall back to flat layout for history
+                Paths.get("")
+            }
+        return historyWorkDir.resolve(relative.toString())
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/AuditDiff.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/AuditDiff.kt
@@ -1,0 +1,27 @@
+package org.octopusden.octopus.components.registry.server.util
+
+/**
+ * Field-level diff of two map snapshots. Format:
+ * `{ fieldName -> { "old" -> oldValue, "new" -> newValue } }`.
+ *
+ * Used by the runtime `AuditEventListener` and the history backfill importer
+ * so both produce identical `audit_log.change_diff` payloads.
+ */
+object AuditDiff {
+    fun compute(
+        old: Map<String, Any?>?,
+        new: Map<String, Any?>?,
+    ): Map<String, Any?>? {
+        if (old == null || new == null) return null
+        val diff = mutableMapOf<String, Any?>()
+        val allKeys = old.keys + new.keys
+        for (key in allKeys) {
+            val oldVal = old[key]
+            val newVal = new[key]
+            if (oldVal != newVal) {
+                diff[key] = mapOf("old" to oldVal, "new" to newVal)
+            }
+        }
+        return diff.ifEmpty { null }
+    }
+}

--- a/components-registry-service-server/src/main/resources/db/migration/V5__audit_source_and_history_state.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V5__audit_source_and_history_state.sql
@@ -1,0 +1,16 @@
+-- Source marker for audit_log rows: distinguishes runtime API events
+-- from synthetic backfill rows produced by /rest/api/4/admin/migrate-history.
+ALTER TABLE audit_log
+    ADD COLUMN source VARCHAR(20) NOT NULL DEFAULT 'api';
+
+CREATE INDEX idx_audit_source ON audit_log(source);
+
+-- One-row state for the git-history import. No resume support in v1:
+-- any subsequent run requires reset=true.
+CREATE TABLE git_history_import_state (
+    import_key VARCHAR(64) PRIMARY KEY,
+    target_ref VARCHAR(255) NOT NULL,
+    target_sha VARCHAR(64) NOT NULL,
+    status     VARCHAR(16)  NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);

--- a/components-registry-service-server/src/main/resources/db/migration/V5__audit_source_and_history_state.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V5__audit_source_and_history_state.sql
@@ -1,12 +1,24 @@
 -- Source marker for audit_log rows: distinguishes runtime API events
 -- from synthetic backfill rows produced by /rest/api/4/admin/migrate-history.
+-- NOT NULL DEFAULT is metadata-only on PostgreSQL 11+ (no table rewrite).
+--
+-- Note: the index is a plain CREATE INDEX, which takes a short
+-- AccessExclusiveLock. `audit_log` is expected to be small when this
+-- migration lands (backfill has not run yet). If this migration is ever
+-- replayed against a large audit_log, run `CREATE INDEX CONCURRENTLY
+-- idx_audit_source_new ON audit_log(source);` out-of-band, then
+-- `DROP INDEX idx_audit_source; ALTER INDEX idx_audit_source_new RENAME TO
+-- idx_audit_source;` to avoid stalling writes. A Flyway in-migration
+-- CONCURRENTLY variant deadlocks against Flyway's own metadata transaction.
 ALTER TABLE audit_log
     ADD COLUMN source VARCHAR(20) NOT NULL DEFAULT 'api';
 
 CREATE INDEX idx_audit_source ON audit_log(source);
 
 -- One-row state for the git-history import. No resume support in v1:
--- any subsequent run requires reset=true.
+-- any subsequent run requires reset=true. target_ref/target_sha are filled
+-- with empty strings by the atomic INSERT claim and updated once the clone
+-- resolves the real tag/sha.
 CREATE TABLE git_history_import_state (
     import_key VARCHAR(64) PRIMARY KEY,
     target_ref VARCHAR(255) NOT NULL,

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepositoryDeleteBySourceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepositoryDeleteBySourceTest.kt
@@ -1,0 +1,67 @@
+package org.octopusden.octopus.components.registry.server.repository
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Paths
+
+@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
+@ActiveProfiles("common", "test-db")
+class AuditLogRepositoryDeleteBySourceTest {
+    @Autowired
+    private lateinit var auditLogRepository: AuditLogRepository
+
+    init {
+        val testResourcesPath =
+            Paths.get(AuditLogRepositoryDeleteBySourceTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    fun `deleteBySource removes only rows with matching source`() {
+        auditLogRepository.deleteAll()
+
+        auditLogRepository.save(newRow("Component", "a", "CREATE", source = "api"))
+        auditLogRepository.save(newRow("Component", "b", "UPDATE", source = "git-history"))
+        auditLogRepository.save(newRow("Component", "c", "DELETE", source = "git-history"))
+
+        val deleted = auditLogRepository.deleteBySource("git-history")
+
+        assertEquals(2, deleted)
+        val remaining = auditLogRepository.findAll()
+        assertEquals(1, remaining.size)
+        assertEquals("api", remaining.single().source)
+    }
+
+    private fun newRow(
+        entityType: String,
+        entityId: String,
+        action: String,
+        source: String,
+    ) = AuditLogEntity(
+        entityType = entityType,
+        entityId = entityId,
+        action = action,
+        source = source,
+    )
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepositoryTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepositoryTest.kt
@@ -1,0 +1,53 @@
+package org.octopusden.octopus.components.registry.server.repository
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Paths
+
+@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
+@ActiveProfiles("common", "test-db")
+class GitHistoryImportStateRepositoryTest {
+    @Autowired
+    private lateinit var repo: GitHistoryImportStateRepository
+
+    init {
+        val testResourcesPath =
+            Paths.get(GitHistoryImportStateRepositoryTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    fun `tryInsert returns 1 on first call and 0 on conflict (the 409 gate)`() {
+        repo.deleteAll()
+
+        val first = repo.tryInsert("component-history", "refs/tags/x", "deadbeef", "IN_PROGRESS")
+        val second = repo.tryInsert("component-history", "refs/tags/other", "cafef00d", "IN_PROGRESS")
+
+        assertEquals(1, first)
+        assertEquals(0, second, "second concurrent claim on the same import_key must be denied")
+
+        val existing = repo.findById("component-history").orElseThrow()
+        assertEquals("refs/tags/x", existing.targetRef, "first writer's target must be preserved")
+        assertEquals("deadbeef", existing.targetSha)
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentHistorySnapshotSerializerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentHistorySnapshotSerializerTest.kt
@@ -1,0 +1,77 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.escrow.BuildSystem
+import org.octopusden.octopus.escrow.configuration.model.EscrowModule
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+
+class ComponentHistorySnapshotSerializerTest {
+    private val serializer = ComponentHistorySnapshotSerializer()
+    private val json = ObjectMapper()
+
+    @Test
+    fun `identical modules serialize byte-equal`() {
+        val a = module("svc", "1.0", BuildSystem.MAVEN, archived = false)
+        val b = module("svc", "1.0", BuildSystem.MAVEN, archived = false)
+        assertEquals(bytes(serializer.serialize(a)), bytes(serializer.serialize(b)))
+    }
+
+    @Test
+    fun `different archived produces different snapshot`() {
+        val a = module("svc", "1.0", BuildSystem.MAVEN, archived = false)
+        val b = module("svc", "1.0", BuildSystem.MAVEN, archived = true)
+        assertNotEquals(bytes(serializer.serialize(a)), bytes(serializer.serialize(b)))
+    }
+
+    @Test
+    fun `moduleName round-trips`() {
+        val a = module("my-service", "1.0", BuildSystem.GRADLE, archived = false)
+        val snapshot = serializer.serialize(a)
+        assertEquals("my-service", snapshot["moduleName"])
+    }
+
+    @Test
+    fun `labels are sorted for deterministic output`() {
+        val a = module("svc", "1.0", BuildSystem.MAVEN, archived = false, labels = linkedSetOf("z", "a", "m"))
+        val b = module("svc", "1.0", BuildSystem.MAVEN, archived = false, labels = linkedSetOf("m", "a", "z"))
+        assertEquals(bytes(serializer.serialize(a)), bytes(serializer.serialize(b)))
+    }
+
+    private fun bytes(snapshot: Map<String, Any?>): String = json.writeValueAsString(snapshot)
+
+    @Suppress("LongParameterList")
+    private fun module(
+        name: String,
+        versionRange: String,
+        buildSystem: BuildSystem,
+        archived: Boolean,
+        labels: Set<String>? = null,
+    ): EscrowModule {
+        val config = EscrowModuleConfig()
+        setField(config, "buildSystem", buildSystem)
+        setField(config, "artifactIdPattern", "artifact")
+        setField(config, "groupIdPattern", "group")
+        setField(config, "versionRange", versionRange)
+        config.archived = archived // public setter exists
+        if (labels != null) {
+            setField(config, "labels", labels)
+        }
+        return EscrowModule().apply {
+            moduleName = name
+            moduleConfigurations = mutableListOf(config)
+        }
+    }
+
+    private fun setField(
+        target: Any,
+        name: String,
+        value: Any?,
+    ) {
+        val field = target.javaClass.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitTagResolverTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitTagResolverTest.kt
@@ -1,0 +1,107 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.eclipse.jgit.api.Git
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import java.io.File
+import java.nio.file.Path
+
+class GitTagResolverTest {
+    private val resolver =
+        GitTagResolver(
+            NumericVersionFactory(
+                VersionNames("serviceBranch", "service", "minor"),
+            ),
+        )
+
+    @Test
+    fun `picks highest numeric tag with configured prefix`(
+        @TempDir tmp: Path,
+    ) {
+        Git.init().setDirectory(tmp.toFile()).call().use { git ->
+            val c1 = commit(git, tmp, "a", "1")
+            tag(git, "components-registry-1.1")
+            val c2 = commit(git, tmp, "a", "2")
+            tag(git, "components-registry-1.2")
+            commit(git, tmp, "a", "3")
+            tag(git, "escrow-config-1.10")
+
+            val target = resolver.resolve(git, "refs/tags/components-registry-")
+
+            assertEquals("refs/tags/components-registry-1.2", target.ref)
+            assertEquals(c2, target.sha)
+            assertTrue(c1.isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `ignores non-numeric tag with matching prefix`(
+        @TempDir tmp: Path,
+    ) {
+        Git.init().setDirectory(tmp.toFile()).call().use { git ->
+            commit(git, tmp, "a", "1")
+            tag(git, "components-registry-1.1")
+            commit(git, tmp, "a", "2")
+            tag(git, "components-registry-qa-1") // non-numeric suffix — must be skipped
+
+            val target = resolver.resolve(git, "refs/tags/components-registry-")
+
+            assertEquals("refs/tags/components-registry-1.1", target.ref)
+        }
+    }
+
+    @Test
+    fun `falls back to master HEAD when no tags match prefix`(
+        @TempDir tmp: Path,
+    ) {
+        Git.init().setDirectory(tmp.toFile()).call().use { git ->
+            commit(git, tmp, "a", "1")
+            val head = commit(git, tmp, "a", "2")
+            tag(git, "escrow-config-1.10") // wrong prefix
+
+            val target = resolver.resolve(git, "refs/tags/components-registry-")
+
+            assertEquals("master", target.ref)
+            assertEquals(head, target.sha)
+        }
+    }
+
+    @Test
+    fun `empty repository throws IllegalStateException`(
+        @TempDir tmp: Path,
+    ) {
+        Git.init().setDirectory(tmp.toFile()).call().use { git ->
+            assertThrows(IllegalStateException::class.java) {
+                resolver.resolve(git, "refs/tags/components-registry-")
+            }
+        }
+    }
+
+    private fun commit(
+        git: Git,
+        tmp: Path,
+        file: String,
+        content: String,
+    ): String {
+        File(tmp.toFile(), file).writeText(content)
+        git.add().addFilepattern(file).call()
+        return git
+            .commit()
+            .setMessage("$file=$content")
+            .setAuthor("Tester", "test@example.com")
+            .call()
+            .name
+    }
+
+    private fun tag(
+        git: Git,
+        name: String,
+    ) {
+        git.tag().setName(name).call()
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryEscrowLoaderFactoryTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryEscrowLoaderFactoryTest.kt
@@ -1,0 +1,73 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import kotlin.streams.asSequence
+
+@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
+@ActiveProfiles("common", "test-db")
+class HistoryEscrowLoaderFactoryTest {
+    @Autowired
+    private lateinit var factory: HistoryEscrowLoaderFactory
+
+    init {
+        val testResourcesPath =
+            Paths.get(HistoryEscrowLoaderFactoryTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    fun `builds a loader able to parse a copied fixture directory`(
+        @TempDir tmp: Path,
+    ) {
+        val fixtureSrc = Paths.get(System.getProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR"), "components-registry", "common")
+        copyTree(fixtureSrc, tmp)
+
+        val loader = factory.build(tmp)
+        val cfg = loader.loadFullConfigurationWithoutValidationForUnknownAttributes(emptyMap())
+
+        assertTrue(cfg.escrowModules.isNotEmpty(), "escrowModules should not be empty")
+    }
+
+    private fun copyTree(
+        src: Path,
+        dst: Path,
+    ) {
+        Files.walk(src).use { stream ->
+            stream.asSequence().forEach { source ->
+                val target = dst.resolve(src.relativize(source).toString())
+                if (Files.isDirectory(source)) {
+                    Files.createDirectories(target)
+                } else {
+                    Files.createDirectories(target.parent)
+                    Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+                }
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
@@ -53,11 +53,11 @@ class MigrateHistoryIntegrationTest {
     private lateinit var stateRepository: GitHistoryImportStateRepository
 
     @Test
-    fun `migrate-history end-to-end - write, 409 on repeat, reset re-runs`() {
-        // Seed at least one component we expect to see in history snapshots so findByName resolves.
+    @Suppress("LongMethod")
+    fun `migrate-history end-to-end covers write, 409, reset, parse-error, DELETE, default toRef`() {
         componentRepository.save(ComponentEntity(name = "ARCHIVED_TEST_COMPONENT"))
 
-        // Initial import
+        // Phase 1: explicit toRef to 1.1 (only c1..c3 in scope).
         val firstBody =
             mvc
                 .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1"))
@@ -72,27 +72,43 @@ class MigrateHistoryIntegrationTest {
         assertTrue(auditAfterFirst.isNotEmpty(), "expected at least one git-history audit row")
         assertTrue(auditAfterFirst.all { it.correlationId != null }, "every history row carries a commit SHA")
         assertTrue(auditAfterFirst.all { it.changedBy == "Tester <test@example.com>" })
+        assertEquals(GitHistoryImportStatus.COMPLETED.name, stateRepository.findById("component-history").orElseThrow().status)
 
-        val state = stateRepository.findById("component-history").orElseThrow()
-        assertEquals(GitHistoryImportStatus.COMPLETED.name, state.status)
-
-        // Repeat without reset → 409, audit_log unchanged.
+        // Phase 2: repeat without reset → 409, audit_log unchanged.
         mvc
             .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1"))
             .andExpect(status().isConflict)
         val auditAfterRepeat = auditLogRepository.findAll().filter { it.source == "git-history" }
         assertEquals(auditAfterFirst.size, auditAfterRepeat.size)
 
-        // reset=true → wipes and re-runs.
-        mvc
-            .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1&reset=true"))
-            .andExpect(status().isOk)
-        val auditAfterReset = auditLogRepository.findAll().filter { it.source == "git-history" }
-        assertEquals(auditAfterFirst.size, auditAfterReset.size)
-        // Different row IDs — the rows were physically re-created.
+        // Phase 3: reset=true, no toRef → auto-resolves to latest tag (components-registry-1.2),
+        // covers the unparseable commit (c4) and the DELETE of ARCHIVED_TEST_COMPONENT at c5.
+        val secondBody =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-history?reset=true"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response
+                .contentAsString
+        val second = objectMapper.readTree(secondBody)
+        assertEquals("refs/tags/components-registry-1.2", second["targetRef"].asText())
+        assertTrue(
+            second["skippedParseError"].asInt() >= 1,
+            "c4 is deliberately unparseable, expected skippedParseError >= 1, got $second",
+        )
+
+        val auditFinal = auditLogRepository.findAll().filter { it.source == "git-history" }
+        val deleteRows = auditFinal.filter { it.action == "DELETE" && (it.oldValue?.get("moduleName") == "ARCHIVED_TEST_COMPONENT") }
+        assertTrue(
+            deleteRows.isNotEmpty(),
+            "expected a DELETE row for ARCHIVED_TEST_COMPONENT at c5, got actions=" +
+                auditFinal.map { it.action to it.oldValue?.get("moduleName") },
+        )
+
+        // Row ids differ from phase 1 because reset=true wiped and re-inserted everything.
         val firstIds = auditAfterFirst.map { it.id }.toSet()
-        val resetIds = auditAfterReset.map { it.id }.toSet()
-        assertNotEquals(firstIds, resetIds, "reset=true should re-create rows with new ids")
+        val finalIds = auditFinal.map { it.id }.toSet()
+        assertNotEquals(firstIds, finalIds, "reset=true should re-create rows with new ids")
     }
 
     companion object {
@@ -109,18 +125,16 @@ class MigrateHistoryIntegrationTest {
             workDir = base.resolve("work")
             gitRoot = base.resolve("source.git")
 
-            // Seed workDir with the common fixture so the live ConfigLoader boots, then git-init
-            // a SECOND directory as the clone source for the history endpoint.
             val fixture =
                 Paths
                     .get(System.getProperty("user.dir"))
                     .resolve("../test-common/src/test/resources/components-registry/common")
                     .normalize()
             copyTree(fixture, workDir)
-
-            // The 'source' registry — this is what the endpoint clones from.
             copyTree(fixture, gitRoot)
+
             Git.init().setDirectory(gitRoot.toFile()).call().use { git ->
+                // c1: initial import
                 git.add().addFilepattern(".").call()
                 git
                     .commit()
@@ -128,10 +142,10 @@ class MigrateHistoryIntegrationTest {
                     .setAuthor("Tester", "test@example.com")
                     .call()
 
-                // c2: toggle archived on ARCHIVED_TEST_COMPONENT (textual: archived = true -> false)
-                val tc = gitRoot.resolve("TestComponents.groovy")
-                tc.writeText(
-                    Files.readString(tc).replaceFirst("archived = true", "archived = false"),
+                // c2: toggle archived on ARCHIVED_TEST_COMPONENT
+                val testComponents = gitRoot.resolve("TestComponents.groovy")
+                testComponents.writeText(
+                    Files.readString(testComponents).replaceFirst("archived = true", "archived = false"),
                 )
                 git.add().addFilepattern(".").call()
                 git
@@ -149,11 +163,43 @@ class MigrateHistoryIntegrationTest {
                         .setMessage("README only, no groovy change")
                         .setAuthor("Tester", "test@example.com")
                         .call()
-
                 git
                     .tag()
                     .setName("components-registry-1.1")
                     .setObjectId(c3)
+                    .call()
+
+                // c4: break the DSL so EscrowConfigurationLoader throws → skippedParseError path
+                val aggregator = gitRoot.resolve("Aggregator.groovy")
+                val savedAggregator = Files.readString(aggregator)
+                aggregator.writeText(savedAggregator + "\n}}}invalid<<<groovy>>>syntax{{{\n")
+                git.add().addFilepattern(".").call()
+                git
+                    .commit()
+                    .setMessage("break Aggregator.groovy to exercise parse-error path")
+                    .setAuthor("Tester", "test@example.com")
+                    .call()
+
+                // c5: restore Aggregator + rename ARCHIVED_TEST_COMPONENT so the old name
+                // disappears from the snapshot → DELETE action for the seeded UUID.
+                aggregator.writeText(savedAggregator)
+                testComponents.writeText(
+                    Files.readString(testComponents).replaceFirst(
+                        "ARCHIVED_TEST_COMPONENT {",
+                        "_RENAMED_ARCHIVED_TEST_COMPONENT {",
+                    ),
+                )
+                git.add().addFilepattern(".").call()
+                val c5 =
+                    git
+                        .commit()
+                        .setMessage("fix Aggregator and rename ARCHIVED_TEST_COMPONENT (simulates delete)")
+                        .setAuthor("Tester", "test@example.com")
+                        .call()
+                git
+                    .tag()
+                    .setName("components-registry-1.2")
+                    .setObjectId(c5)
                     .call()
             }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
 import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
@@ -109,6 +110,29 @@ class MigrateHistoryIntegrationTest {
         val firstIds = auditAfterFirst.map { it.id }.toSet()
         val finalIds = auditFinal.map { it.id }.toSet()
         assertNotEquals(firstIds, finalIds, "reset=true should re-create rows with new ids")
+    }
+
+    @Test
+    fun `reset=true refuses to stomp on an IN_PROGRESS claim`() {
+        auditLogRepository.deleteAll()
+        stateRepository.deleteAll()
+        stateRepository.save(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/components-registry-1.2",
+                targetSha = "deadbeef",
+                status = GitHistoryImportStatus.IN_PROGRESS.name,
+            ),
+        )
+
+        mvc
+            .perform(post("/rest/api/4/admin/migrate-history?reset=true"))
+            .andExpect(status().isConflict)
+
+        // Pre-existing IN_PROGRESS row must survive the rejected reset.
+        val state = stateRepository.findById("component-history").orElseThrow()
+        assertEquals(GitHistoryImportStatus.IN_PROGRESS.name, state.status)
+        assertEquals("deadbeef", state.targetSha, "reset must not have wiped the live claim")
     }
 
     companion object {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
@@ -1,0 +1,194 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.eclipse.jgit.api.Git
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
+import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.writeText
+import kotlin.streams.asSequence
+
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "test-db")
+class MigrateHistoryIntegrationTest {
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var auditLogRepository: AuditLogRepository
+
+    @Autowired
+    private lateinit var stateRepository: GitHistoryImportStateRepository
+
+    @Test
+    fun `migrate-history end-to-end - write, 409 on repeat, reset re-runs`() {
+        // Seed at least one component we expect to see in history snapshots so findByName resolves.
+        componentRepository.save(ComponentEntity(name = "ARCHIVED_TEST_COMPONENT"))
+
+        // Initial import
+        val firstBody =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response
+                .contentAsString
+        val first = objectMapper.readTree(firstBody)
+        assertEquals("components-registry-1.1", first["targetRef"].asText())
+        assertTrue(first["processedCommits"].asInt() >= 2, "expected >= 2 processed commits, got $first")
+        val auditAfterFirst = auditLogRepository.findAll().filter { it.source == "git-history" }
+        assertTrue(auditAfterFirst.isNotEmpty(), "expected at least one git-history audit row")
+        assertTrue(auditAfterFirst.all { it.correlationId != null }, "every history row carries a commit SHA")
+        assertTrue(auditAfterFirst.all { it.changedBy == "Tester <test@example.com>" })
+
+        val state = stateRepository.findById("component-history").orElseThrow()
+        assertEquals(GitHistoryImportStatus.COMPLETED.name, state.status)
+
+        // Repeat without reset → 409, audit_log unchanged.
+        mvc
+            .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1"))
+            .andExpect(status().isConflict)
+        val auditAfterRepeat = auditLogRepository.findAll().filter { it.source == "git-history" }
+        assertEquals(auditAfterFirst.size, auditAfterRepeat.size)
+
+        // reset=true → wipes and re-runs.
+        mvc
+            .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1&reset=true"))
+            .andExpect(status().isOk)
+        val auditAfterReset = auditLogRepository.findAll().filter { it.source == "git-history" }
+        assertEquals(auditAfterFirst.size, auditAfterReset.size)
+        // Different row IDs — the rows were physically re-created.
+        val firstIds = auditAfterFirst.map { it.id }.toSet()
+        val resetIds = auditAfterReset.map { it.id }.toSet()
+        assertNotEquals(firstIds, resetIds, "reset=true should re-create rows with new ids")
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        private lateinit var workDir: Path
+        private lateinit var gitRoot: Path
+
+        @BeforeAll
+        @JvmStatic
+        fun setUp() {
+            val base = Files.createTempDirectory("migrate-history-it")
+            workDir = base.resolve("work")
+            gitRoot = base.resolve("source.git")
+
+            // Seed workDir with the common fixture so the live ConfigLoader boots, then git-init
+            // a SECOND directory as the clone source for the history endpoint.
+            val fixture =
+                Paths
+                    .get(System.getProperty("user.dir"))
+                    .resolve("../test-common/src/test/resources/components-registry/common")
+                    .normalize()
+            copyTree(fixture, workDir)
+
+            // The 'source' registry — this is what the endpoint clones from.
+            copyTree(fixture, gitRoot)
+            Git.init().setDirectory(gitRoot.toFile()).call().use { git ->
+                git.add().addFilepattern(".").call()
+                git
+                    .commit()
+                    .setMessage("initial")
+                    .setAuthor("Tester", "test@example.com")
+                    .call()
+
+                // c2: toggle archived on ARCHIVED_TEST_COMPONENT (textual: archived = true -> false)
+                val tc = gitRoot.resolve("TestComponents.groovy")
+                tc.writeText(
+                    Files.readString(tc).replaceFirst("archived = true", "archived = false"),
+                )
+                git.add().addFilepattern(".").call()
+                git
+                    .commit()
+                    .setMessage("toggle archived=false on ARCHIVED_TEST_COMPONENT")
+                    .setAuthor("Tester", "test@example.com")
+                    .call()
+
+                // c3: README-only change — pre-filter must skip
+                gitRoot.resolve("README.md").writeText("history test fixture")
+                git.add().addFilepattern(".").call()
+                val c3 =
+                    git
+                        .commit()
+                        .setMessage("README only, no groovy change")
+                        .setAuthor("Tester", "test@example.com")
+                        .call()
+
+                git
+                    .tag()
+                    .setName("components-registry-1.1")
+                    .setObjectId(c3)
+                    .call()
+            }
+
+            System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", workDir.parent.toString())
+        }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+            registry.add("components-registry.work-dir") { workDir.toString() }
+            registry.add("components-registry.groovy-path") { workDir.toString() }
+            registry.add("components-registry.vcs.root") { "file://$gitRoot" }
+            registry.add("components-registry.vcs.tag-version-prefix") { "refs/tags/components-registry-" }
+            registry.add("pathToConfig") { "file://$workDir" }
+        }
+
+        private fun copyTree(
+            src: Path,
+            dst: Path,
+        ) {
+            Files.createDirectories(dst)
+            Files.walk(src).use { stream ->
+                stream.asSequence().forEach { source ->
+                    val target = dst.resolve(src.relativize(source).toString())
+                    if (Files.isDirectory(source)) {
+                        Files.createDirectories(target)
+                    } else {
+                        Files.createDirectories(target.parent)
+                        Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/AuditDiffTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/AuditDiffTest.kt
@@ -1,0 +1,37 @@
+package org.octopusden.octopus.components.registry.server.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class AuditDiffTest {
+    @Test
+    fun `returns null when either side is null`() {
+        assertNull(AuditDiff.compute(null, mapOf("a" to 1)))
+        assertNull(AuditDiff.compute(mapOf("a" to 1), null))
+        assertNull(AuditDiff.compute(null, null))
+    }
+
+    @Test
+    fun `returns null when maps are equal`() {
+        assertNull(AuditDiff.compute(mapOf("a" to 1, "b" to "x"), mapOf("a" to 1, "b" to "x")))
+    }
+
+    @Test
+    fun `diff format is key to old-new pair`() {
+        val diff = AuditDiff.compute(mapOf("a" to 1, "b" to "x"), mapOf("a" to 2, "b" to "x"))
+        assertEquals(mapOf("a" to mapOf("old" to 1, "new" to 2)), diff)
+    }
+
+    @Test
+    fun `missing keys on either side are diffed as null`() {
+        val diff = AuditDiff.compute(mapOf("a" to 1), mapOf("b" to 2))
+        assertEquals(
+            mapOf(
+                "a" to mapOf("old" to 1, "new" to null),
+                "b" to mapOf("old" to null, "new" to 2),
+            ),
+            diff,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- New `POST /rest/api/4/admin/migrate-history(toRef?, reset=false)` — clones the components-registry repo, walks the first-parent chain up to the selected tag, re-parses the Groovy DSL at each commit that touches `.groovy` files under the configured `groovy-path`, and writes per-component `CREATE`/`UPDATE`/`DELETE` rows into `audit_log` with `source='git-history'`, preserving the original commit author and timestamp.
- `git_history_import_state` (Flyway `V5`) enforces single-run semantics: any previous run (`COMPLETED` / `IN_PROGRESS` / `FAILED`) requires `reset=true` to re-run. No partial resume in v1.
- `GitTagResolver` extracted from `GitVcsServiceImpl`; tolerates non-numeric tags like `components-registry-qa-1` and peels annotated tags so the returned SHA is the commit, not the tag object.
- `AuditDiff` util shared between `AuditEventListener` and the history importer keeps the `change_diff` JSON payload identical across sources.
- `HistoryEscrowLoaderFactory` replicates the production `EscrowConfigurationLoader` wiring (`ConfigHelper.productTypes` / `supportedGroupIds` / `supportedSystems` / `copyrightPath`, `mainGroovyFile`, `VersionNames`, `ResourceLoader`) so the history loader parses the same config surface as the live resolver, just from an alternate workdir.

## Known v1 limitations

- **No resume** — a failed run requires `reset=true`, which wipes `audit_log where source='git-history'` and the state row.
- **Pre-rename history is silently skipped** — v3 rename is in-place with preserved UUID, so `findByName(oldName)` returns null. Skipped names are surfaced via `HistoryImportResult.skippedUnknownNames`.
- **DAG ignored** — merge commits are read only through `parent[0]`.

## Test plan

- [x] `./gradlew :components-registry-service-server:check` — detekt, ktlint, checkstyle, pmd, all unit tests + `integrationTest` + jacoco, all green.
- [x] `MigrateHistoryIntegrationTest` — end-to-end: JGit fixture repo with 3 commits (initial / archived-toggle / README-only), tags `components-registry-1.1`, hits `POST /rest/api/4/admin/migrate-history` via MockMvc, verifies:
  - `audit_log` rows with `source='git-history'`, `correlation_id = commit SHA`, author preserved.
  - state transitions to `COMPLETED`.
  - repeat call without `reset` → 409, audit count unchanged.
  - `reset=true` → rows re-created (new ids).
- [x] `FlywayValidatePostgresStartupTest` — V5 applied by Flyway, `ddl-auto=validate` passes against new entities.
- [x] Pure unit tests: `AuditDiffTest`, `GitTagResolverTest`, `ComponentHistorySnapshotSerializerTest`.
- [x] Spring+Testcontainers: `AuditLogRepositoryDeleteBySourceTest`, `HistoryEscrowLoaderFactoryTest`.
- [ ] Manual smoke on dev against the real `creg/components-registry` (~5969 first-parent commits).