### PR TITLE
Retry on 503 Service Unavailable in ClassicComponentsRegistryServiceClient

### DIFF
--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoder.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoder.kt
@@ -12,6 +12,13 @@ class ComponentsRegistryServiceErrorDecoder(val objectMapper: ObjectMapper) : Er
 
     override fun decode(methodKey: String?, response: Response?): Exception {
         if (isRetryable(response)) {
+            // Let super parse Retry-After header first; reuse the RetryableException it builds
+            // (which carries the parsed retry timestamp). If super returns a plain FeignException
+            // (no Retry-After header present), synthesize our own with null retryAfter.
+            val superException = super.decode(methodKey, response)
+            if (superException is RetryableException) {
+                return superException
+            }
             return RetryableException(
                 response!!.status(),
                 response.reason() ?: "Service Unavailable",

--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoder.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoder.kt
@@ -5,11 +5,21 @@ import org.octopusden.octopus.components.registry.core.dto.ErrorResponse
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.core.exceptions.RepositoryNotPreparedException
 import feign.Response
+import feign.RetryableException
 import feign.codec.ErrorDecoder
 
 class ComponentsRegistryServiceErrorDecoder(val objectMapper: ObjectMapper) : ErrorDecoder.Default() {
 
     override fun decode(methodKey: String?, response: Response?): Exception {
+        if (isRetryable(response)) {
+            return RetryableException(
+                response!!.status(),
+                response.reason() ?: "Service Unavailable",
+                response.request().httpMethod(),
+                null as java.util.Date?,
+                response.request()
+            )
+        }
         return getErrorResponse(response)
                 ?.let {
                     val status = response?.status()!!
@@ -39,5 +49,8 @@ class ComponentsRegistryServiceErrorDecoder(val objectMapper: ObjectMapper) : Er
                 404 to { errorResponse: ErrorResponse -> NotFoundException(errorResponse.errorMessage) },
                 425 to { errorResponse: ErrorResponse -> RepositoryNotPreparedException(errorResponse.errorMessage) }
         )
+        private val retryableStatusCodes = setOf(503)
     }
+
+    private fun isRetryable(response: Response?) = response?.status() in retryableStatusCodes
 }

--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/impl/ClassicComponentsRegistryServiceClient.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/impl/ClassicComponentsRegistryServiceClient.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import feign.Feign
 import feign.Logger
+import feign.Retryer
 import feign.Param
 import feign.Response
 import feign.httpclient.ApacheHttpClient
@@ -145,6 +146,7 @@ class ClassicComponentsRegistryServiceClient(
             .errorDecoder(ComponentsRegistryServiceErrorDecoder(objectMapper))
             .encoder(JacksonEncoder())
             .decoder(JacksonDecoder())
+            .retryer(Retryer.Default(100, 1000, 5))
             .logger(Slf4jLogger(ComponentsRegistryServiceClient::class.java))
             .logLevel(Logger.Level.FULL)
             .target(ComponentsRegistryServiceClient::class.java, apiUrl)

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoderTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoderTest.kt
@@ -1,0 +1,55 @@
+package org.octopusden.octopus.components.registry.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import feign.Request
+import feign.RequestTemplate
+import feign.Response
+import feign.RetryableException
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+
+class ComponentsRegistryServiceErrorDecoderTest {
+
+    private val decoder = ComponentsRegistryServiceErrorDecoder(ObjectMapper())
+
+    private fun stubResponse(status: Int, reason: String = "", body: String? = null): Response {
+        val request = Request.create(
+            Request.HttpMethod.GET,
+            "http://localhost/test",
+            emptyMap(),
+            null,
+            RequestTemplate()
+        )
+        val builder = Response.builder()
+            .status(status)
+            .reason(reason)
+            .request(request)
+            .headers(emptyMap())
+        if (body != null) {
+            builder.body(body, Charsets.UTF_8)
+            builder.headers(mapOf("content-type" to listOf("application/json")))
+        }
+        return builder.build()
+    }
+
+    @Test
+    fun `503 returns RetryableException`() {
+        val ex = decoder.decode("test#method", stubResponse(503, "Service Unavailable"))
+        assertTrue(ex is RetryableException) { "Expected RetryableException for 503, got ${ex::class.simpleName}" }
+    }
+
+    @Test
+    fun `404 with json body returns NotFoundException`() {
+        val body = """{"errorMessage":"not found"}"""
+        val ex = decoder.decode("test#method", stubResponse(404, "Not Found", body))
+        assertTrue(ex is NotFoundException) { "Expected NotFoundException for 404, got ${ex::class.simpleName}" }
+    }
+
+    @Test
+    fun `500 returns generic FeignException`() {
+        val ex = decoder.decode("test#method", stubResponse(500, "Internal Server Error"))
+        assertTrue(ex is feign.FeignException) { "Expected FeignException for 500, got ${ex::class.simpleName}" }
+        assertTrue(ex !is RetryableException) { "500 should not be retryable" }
+    }
+}

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoderTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceErrorDecoderTest.kt
@@ -5,6 +5,8 @@ import feign.Request
 import feign.RequestTemplate
 import feign.Response
 import feign.RetryableException
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
@@ -34,9 +36,32 @@ class ComponentsRegistryServiceErrorDecoderTest {
     }
 
     @Test
-    fun `503 returns RetryableException`() {
+    fun `503 without Retry-After returns RetryableException`() {
         val ex = decoder.decode("test#method", stubResponse(503, "Service Unavailable"))
         assertTrue(ex is RetryableException) { "Expected RetryableException for 503, got ${ex::class.simpleName}" }
+        // synthesized by us — no cause
+        assertNull(ex.cause)
+    }
+
+    @Test
+    fun `503 with Retry-After header preserves retry timestamp`() {
+        val request = Request.create(
+            Request.HttpMethod.GET,
+            "http://localhost/test",
+            emptyMap(),
+            null,
+            RequestTemplate()
+        )
+        val response = Response.builder()
+            .status(503)
+            .reason("Service Unavailable")
+            .request(request)
+            .headers(mapOf("Retry-After" to listOf("5")))
+            .build()
+        val ex = decoder.decode("test#method", response) as RetryableException
+        // Verify the exception came from super.decode() (which parses Retry-After),
+        // not a freshly synthesized one: super.decode() includes the cause FeignException.
+        assertNotNull(ex.cause, "RetryableException from super.decode() should carry the cause FeignException")
     }
 
     @Test

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/RetryOn503Test.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/RetryOn503Test.kt
@@ -1,0 +1,72 @@
+package org.octopusden.octopus.components.registry.client
+
+import com.sun.net.httpserver.HttpServer
+import feign.RetryableException
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClient
+import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClientUrlProvider
+
+class RetryOn503Test {
+
+    private lateinit var server: HttpServer
+    private lateinit var client: ComponentsRegistryServiceClient
+    private val callCount = AtomicInteger(0)
+
+    @BeforeEach
+    fun setup() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        server.start()
+        val port = server.address.port
+        client = ClassicComponentsRegistryServiceClient(
+            object : ClassicComponentsRegistryServiceClientUrlProvider {
+                override fun getApiUrl() = "http://localhost:$port"
+            }
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        server.stop(0)
+        callCount.set(0)
+    }
+
+    private fun stubServiceStatus(failTimes: Int) {
+        val body = """{"cacheUpdatedAt":0,"serviceMode":"FS","versionControlRevision":"abc"}"""
+        server.createContext("/rest/api/2/components-registry/service/status") { exchange ->
+            val attempt = callCount.incrementAndGet()
+            if (attempt <= failTimes) {
+                exchange.sendResponseHeaders(503, -1)
+            } else {
+                val bytes = body.toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, bytes.size.toLong())
+                exchange.responseBody.use { it.write(bytes) }
+            }
+            exchange.close()
+        }
+    }
+
+    @Test
+    fun `succeeds after two 503s`() {
+        stubServiceStatus(failTimes = 2)
+        val status = client.getServiceStatus()
+        assertEquals(3, callCount.get(), "Should have taken 3 attempts (2 retries + 1 success)")
+        assertEquals("FS", status.serviceMode.name)
+    }
+
+    @Test
+    fun `fails with RetryableException when all retries exhausted`() {
+        stubServiceStatus(failTimes = Int.MAX_VALUE)
+        assertThrows(RetryableException::class.java) {
+            client.getServiceStatus()
+        }
+        // Retryer.Default(100, 1000, 5): attempt starts at 1, throws when attempt >= 5 → 5 total HTTP calls
+        assertEquals(5, callCount.get(), "Should have tried 5 times (1 initial + 4 retries)")
+    }
+}


### PR DESCRIPTION
## Problem

Functional tests on OKD fail intermittently with:

```
feign.FeignException$ServiceUnavailable: [503 Service Unavailable] during [GET] to
[...] [ComponentsRegistryServiceClient#getDetailedComponent(String,String)]
```

The components-registry pod on OKD returns 503 transiently during startup or under load.

## Root cause

1. `ComponentsRegistryServiceErrorDecoder` falls through to `super.decode()` for 503, producing a plain `FeignException` — not a `RetryableException`, so Feign never retries.
2. `ClassicComponentsRegistryServiceClient` does not configure a `Retryer`, so the default `NEVER_RETRY` is used.

## Fix

- **`ComponentsRegistryServiceErrorDecoder`**: return `RetryableException` for 503 responses.
- **`ClassicComponentsRegistryServiceClient`**: add `Retryer.Default(100ms, 1s, 5 attempts)` to the Feign builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for service unavailability by implementing automatic retry logic. The system now gracefully recovers from temporary service interruptions with configurable retry intervals and attempt limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->