### PR TITLE
Fix conflicting Jackson creators in VCSSettingsDTO

### DIFF
--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VCSSettingsDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VCSSettingsDTO.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class VCSSettingsDTO @JsonCreator constructor(
+data class VCSSettingsDTO(
     @JsonProperty("versionControlSystemRoots") val versionControlSystemRoots: List<VersionControlSystemRootDTO> = emptyList(),
     @JsonProperty("externalRegistry") val externalRegistry: String? = null,
 )


### PR DESCRIPTION
Kotlin data classes with all-default constructor parameters can cause Jackson to register two conflicting `@JsonCreator(mode=DEFAULT)` creators: the explicit one on the primary constructor and an implicit no-arg creator that newer versions of jackson-module-kotlin add automatically for all-defaults data classes.

This produces at runtime:
  InvalidDefinitionException: Conflicting property-based creators: already
  had explicit creator [constructor for VCSSettingsDTO (0 args)] ...
  encountered another: [constructor for VCSSettingsDTO (2 args)]

The fix is to drop the redundant `@JsonCreator` annotation. Jackson 2.12+ treats a constructor whose parameters are all annotated with `@JsonProperty` as an implicit properties-based creator, so no explicit annotation is needed. jackson-module-kotlin also handles this pattern correctly without it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal configuration object handling by simplifying JSON deserialization setup, while preserving all existing functionality and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->