### PR TITLE
feat(info): /rest/api/4/info for footer + MIG-024 security regression

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
@@ -72,6 +72,11 @@ class WebSecurityConfig(
                     // requests pass method-security too.
                     .requestMatchers(HttpMethod.GET, "/rest/api/4/components/**", "/rest/api/4/config/**")
                     .permitAll()
+                    // SYS-033: anonymous build-info for the portal footer. Public on
+                    // purpose so the footer renders before login and so the portal
+                    // gateway does not have to special-case auth for /info.
+                    .requestMatchers(HttpMethod.GET, "/rest/api/4/info")
+                    .permitAll()
                     // v4 writes + admin + audit — authenticated + method-level @PreAuthorize.
                     .requestMatchers("/rest/api/4/**")
                     .authenticated()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/InfoControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/InfoControllerV4.kt
@@ -1,0 +1,20 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.springframework.boot.info.BuildProperties
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("rest/api/4")
+class InfoControllerV4(
+    private val buildProperties: BuildProperties,
+) {
+    @GetMapping("/info")
+    fun info(): InfoResponse = InfoResponse(name = buildProperties.name, version = buildProperties.version)
+
+    data class InfoResponse(
+        val name: String,
+        val version: String,
+    )
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -1,0 +1,102 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.service.BatchMigrationResult
+import org.octopusden.octopus.components.registry.server.service.FullMigrationResult
+import org.octopusden.octopus.components.registry.server.service.ImportService
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Path
+import java.nio.file.Paths
+
+// MIG-024: pin both gates that protect POST /rest/api/4/admin/migrate:
+//   - URL-level requestMatchers("/rest/api/4/**").authenticated() in
+//     WebSecurityConfig → 401 for anonymous callers.
+//   - Class-level @PreAuthorize("@permissionEvaluator.canImport()") on
+//     AdminControllerV4 → 403 for authenticated callers without IMPORT_DATA.
+//
+// ImportService is mocked so the positive path does not actually run a
+// migration in the test context. Slice tests (@WebMvcTest) wouldn't load
+// the real WebSecurityConfig, so the only meaningful regression test is
+// a full @SpringBootTest.
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "test")
+class AdminControllerV4SecurityTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @MockBean
+    private lateinit var importService: ImportService
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Test
+    @DisplayName("MIG-024: POST /admin/migrate without JWT returns 401 and does not invoke ImportService")
+    fun `MIG-024 anonymous POST migrate returns 401 and does not run migration`() {
+        mvc
+            .perform(post("/rest/api/4/admin/migrate"))
+            .andExpect(status().isUnauthorized)
+
+        verify(importService, never()).migrate()
+    }
+
+    @Test
+    @DisplayName("MIG-024: POST /admin/migrate with non-IMPORT_DATA JWT returns 403 and does not invoke ImportService")
+    fun `MIG-024 editor JWT POST migrate returns 403 and does not run migration`() {
+        mvc
+            .perform(post("/rest/api/4/admin/migrate").with(editorJwt()))
+            .andExpect(status().isForbidden)
+
+        verify(importService, never()).migrate()
+    }
+
+    @Test
+    @DisplayName("MIG-024: POST /admin/migrate with IMPORT_DATA JWT returns 200 and invokes ImportService.migrate exactly once")
+    fun `MIG-024 admin JWT POST migrate returns 200 and runs migration once`() {
+        `when`(importService.migrate()).thenReturn(EMPTY_MIGRATION_RESULT)
+
+        mvc
+            .perform(post("/rest/api/4/admin/migrate").with(adminJwt()))
+            .andExpect(status().isOk)
+
+        verify(importService, times(1)).migrate()
+    }
+
+    companion object {
+        private val EMPTY_MIGRATION_RESULT =
+            FullMigrationResult(
+                defaults = emptyMap(),
+                components = BatchMigrationResult(total = 0, migrated = 0, failed = 0, skipped = 0, results = emptyList()),
+            )
+
+        @JvmStatic
+        @BeforeAll
+        fun configureTestDataDir() {
+            val resourcesPath: Path =
+                Paths.get(AdminControllerV4SecurityTest::class.java.getResource("/expected-data")!!.toURI()).parent
+            System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", resourcesPath.toString())
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/InfoControllerV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/InfoControllerV4Test.kt
@@ -1,0 +1,95 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.info.BuildProperties
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Properties
+
+/**
+ * SYS-033: `/rest/api/4/info` exposes the build name and version anonymously
+ * so the portal footer can render "Components Registry by F1 team
+ * (portal X · service Y)" before the user has authenticated. Both layers of
+ * the security chain (URL matcher in WebSecurityConfig + class-level
+ * @PreAuthorize on other v4 controllers) are exercised through the full
+ * SpringBootTest context — `@WebMvcTest` would not load the real
+ * WebSecurityConfig and would silently pass even if the endpoint were
+ * implicitly authenticated.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@Import(InfoControllerV4Test.TestBuildPropertiesConfig::class)
+@ActiveProfiles("common", "test")
+class InfoControllerV4Test {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Test
+    @DisplayName("SYS-033: GET /rest/api/4/info returns 200 with name and version, anonymous access")
+    fun `SYS-033 anonymous GET info returns build name and version`() {
+        mvc
+            .perform(get("/rest/api/4/info"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.name").value(EXPECTED_NAME))
+            .andExpect(jsonPath("$.version").value(EXPECTED_VERSION))
+    }
+
+    @TestConfiguration
+    class TestBuildPropertiesConfig {
+        // BuildProperties is a final class but has a public Properties-based
+        // constructor — preferred over a Mockito mock (which would need
+        // mockito-inline) and over relying on the production
+        // META-INF/build-info.properties (which only exists in the bootJar,
+        // not on the test classpath).
+        @Bean
+        fun buildProperties(): BuildProperties {
+            val props = Properties()
+            props.setProperty("name", EXPECTED_NAME)
+            props.setProperty("version", EXPECTED_VERSION)
+            return BuildProperties(props)
+        }
+    }
+
+    companion object {
+        private const val EXPECTED_NAME = "components-registry-service"
+        private const val EXPECTED_VERSION = "3.0.42"
+
+        // application-common.yml resolves work-dir from this property; without
+        // it set the @SpringBootTest context fails to start with a
+        // PropertyPlaceholderHelper IllegalArgumentException long before the
+        // controller is even reached. Pattern lifted verbatim from MetricsTest.
+        @JvmStatic
+        @BeforeAll
+        fun configureTestDataDir() {
+            val resourcesPath: Path =
+                Paths.get(InfoControllerV4Test::class.java.getResource("/expected-data")!!.toURI()).parent
+            System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", resourcesPath.toString())
+        }
+    }
+}

--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -42,6 +42,7 @@
 | SYS-030 | DistributionEntity round-trips groupId-only GAV without `:null` suffix | High | unit-test | ✅ Tested |
 | SYS-031 | DistributionEntity round-trips multi-image docker coordinates verbatim | High | unit-test | ✅ Tested |
 | SYS-032 | ComponentSourceRegistry reads reflect cross-pod DB changes on every call | High | integration-test | ✅ Tested |
+| SYS-033 | GET /rest/api/4/info returns build name and version, anonymous access | Medium | integration-test | ✅ Tested |
 
 ---
 
@@ -953,3 +954,39 @@ through the shared `ComponentSourceRepository`.
 - Designing the cluster-aware L2 cache for later performance work.
 - In-flight writes and isolation semantics (covered by ordinary JPA
   transaction / optimistic-lock mechanics).
+
+---
+
+### SYS-033: GET /rest/api/4/info returns build name and version, anonymous access
+
+**Priority:** Medium
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Description:**
+The portal footer needs to display the running CRS service version next to the
+portal version (DMS-style "Components Registry by F1 team (portal X · service
+Y)"). The portal proxies `/rest/**` to CRS, but the SecurityConfig on both
+sides currently authenticates everything under `/rest/api/4/**`. To keep the
+footer working before the user has logged in (and to avoid 401-noise in logs),
+expose `/rest/api/4/info` anonymously on CRS, sourcing the values from
+Spring Boot's `BuildProperties` bean (`springBoot { buildInfo() }` is already
+enabled in the server module).
+
+**Preconditions:**
+- `META-INF/build-info.properties` is generated at build time (already wired
+  via `springBoot.buildInfo()`).
+
+**Acceptance criteria:**
+1. `GET /rest/api/4/info` without an `Authorization` header returns HTTP 200.
+2. Response body is `application/json` containing fields `name` (string) and
+   `version` (string).
+3. The returned `version` matches `BuildProperties.getVersion()`.
+4. The endpoint is reachable through `WebSecurityConfig` without a valid JWT
+   (i.e. the path is added to `permitAll()` and not just to a slice test).
+
+**Test method:** `InfoControllerV4Test.SYS-033 anonymous GET info returns build name and version` (full `@SpringBootTest` MockMvc — exercises the real `WebSecurityConfig` chain).
+
+**Out of scope:**
+- Caching or rate-limiting the endpoint (single read per page load is fine).
+- Returning git SHA or build timestamp — only `name`/`version` for the footer.

--- a/docs/db-migration/requirements-migration.md
+++ b/docs/db-migration/requirements-migration.md
@@ -33,6 +33,7 @@
 | MIG-021 | Version-range-only component inherits buildSystem from defaults | High | integration-test | ✅ Tested |
 | MIG-022 | Migration preserves build-tools endpoint behavior | High | integration-test | ✅ Tested |
 | MIG-023 | DB artifact resolution preserves version-specific matches for shared group IDs | High | unit-test, integration-test | ✅ Tested |
+| MIG-024 | POST /rest/api/4/admin/migrate enforces IMPORT_DATA permission | High | integration-test | ✅ Tested |
 
 ---
 
@@ -621,3 +622,49 @@ instead of falling back to a generic component-level artifact pattern.
 3. After migration, DB-backed artifact lookup is identical to Git-backed artifact lookup for the same request
 
 **Test method:** `DatabaseComponentRegistryResolverTest.MIG-023 DB resolver prefers version-specific artifact over generic match`; `MigrationIntegrationTest.MIG-023 version-specific artifact mapping parity`
+
+---
+
+### MIG-024: POST /rest/api/4/admin/migrate enforces IMPORT_DATA permission
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Description:**
+The portal exposes a "Run migration" button on the `/admin` page (visible only
+when an authenticated user has the `IMPORT_DATA` permission and has explicitly
+enabled "Admin mode" in the footer). The button POSTs to
+`/rest/api/4/admin/migrate`. UI gates are UX hints — the authoritative gate is
+on CRS:
+
+- The class-level `@PreAuthorize("@permissionEvaluator.canImport()")` on
+  `AdminControllerV4`.
+- The network-level matcher
+  `.requestMatchers("/rest/api/4/**").authenticated()` in `WebSecurityConfig`.
+
+This requirement pins both gates with an explicit security regression test so
+that future refactors of the controller or security chain cannot silently
+expose the migration endpoint.
+
+**Preconditions:**
+- `octopus-security-common` `BasePermissionEvaluator` maps `ROLE_ADMIN` to the
+  `IMPORT_DATA` permission via `application.yml` (existing config).
+
+**Acceptance criteria:**
+1. `POST /rest/api/4/admin/migrate` without an `Authorization` header returns
+   HTTP 401 with the JSON envelope produced by `jsonAuthenticationEntryPoint`.
+2. `POST /rest/api/4/admin/migrate` with a valid JWT whose authorities do NOT
+   include `IMPORT_DATA` returns HTTP 403 with the JSON envelope produced by
+   `jsonAccessDeniedHandler`. `ImportService.migrate()` is not invoked.
+3. `POST /rest/api/4/admin/migrate` with a valid JWT whose authorities include
+   `IMPORT_DATA` returns HTTP 200 with a `FullMigrationResult` body, and
+   `ImportService.migrate()` is invoked exactly once.
+
+**Test method:** `AdminControllerV4SecurityTest.MIG-024 anonymous POST migrate returns 401`; `AdminControllerV4SecurityTest.MIG-024 editor JWT POST migrate returns 403`; `AdminControllerV4SecurityTest.MIG-024 admin JWT POST migrate returns 200 and runs migration once`.
+
+**Out of scope:**
+- Frontend disabled-button / Admin-mode-toggle behavior (covered by Vitest
+  RTL on the portal).
+- The actual content of `FullMigrationResult` (covered by existing
+  `MigrationIntegrationTest`).


### PR DESCRIPTION
## Summary

Two related changes for the upcoming portal Admin-Migration UI work:

- **SYS-033** (`385b48f`) — `InfoControllerV4` exposes anonymous build name + version at `GET /rest/api/4/info`, sourced from Spring Boot's `BuildProperties`. The portal footer (separate PR on octopus-components-management-portal) reads this through the gateway to render `Components Registry by F1 team (portal X · service Y)` before login. Path is added to `permitAll()` in `WebSecurityConfig`. Full-context `@SpringBootTest` test exercises the real security chain (a `@WebMvcTest` slice would silently pass even if the endpoint stayed authenticated).
- **MIG-024** (`38b2149`) — `AdminControllerV4SecurityTest` pins both auth gates on `POST /rest/api/4/admin/migrate`: URL-level `requestMatchers("/rest/api/4/**").authenticated()` (401 anonymous) and class-level `@PreAuthorize("@permissionEvaluator.canImport()")` (403 without `IMPORT_DATA`, 200 with). `ImportService` is `@MockBean`-ed so the positive path doesn't actually run a migration in the test context. This is the authoritative gate referenced by the portal "Run migration" UX gate.

Requirements added: `SYS-033` (`docs/db-migration/requirements-common.md`), `MIG-024` (`docs/db-migration/requirements-migration.md`), both ✅ Tested.

## Test plan

- [x] `:components-registry-service-server:test` green (full `@SpringBootTest` with real `WebSecurityConfig`)
- [x] Full `./gradlew build` green locally (with docker/oc/automation:test environmentally excluded — those need CI infra)
- [ ] Verify CI green
- [ ] Manual smoke (after merge): `curl -s http://localhost:4567/rest/api/4/info` returns `{"name":"...","version":"..."}` without auth header
- [ ] Manual smoke: `POST /rest/api/4/admin/migrate` without JWT → 401; with viewer JWT → 403; with admin JWT → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)