### PR TITLE
fix(test): mock AuthServerClient in /migrate-history SpringBootTests

### DIFF
--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepositoryDeleteBySourceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepositoryDeleteBySourceTest.kt
@@ -2,10 +2,12 @@ package org.octopusden.octopus.components.registry.server.repository
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -15,6 +17,10 @@ import java.nio.file.Paths
 @SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
 @ActiveProfiles("common", "test-db")
 class AuditLogRepositoryDeleteBySourceTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
     @Autowired
     private lateinit var auditLogRepository: AuditLogRepository
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepositoryTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/repository/GitHistoryImportStateRepositoryTest.kt
@@ -2,9 +2,11 @@ package org.octopusden.octopus.components.registry.server.repository
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -14,6 +16,10 @@ import java.nio.file.Paths
 @SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
 @ActiveProfiles("common", "test-db")
 class GitHistoryImportStateRepositoryTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
     @Autowired
     private lateinit var repo: GitHistoryImportStateRepository
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryEscrowLoaderFactoryTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryEscrowLoaderFactoryTest.kt
@@ -3,9 +3,11 @@ package org.octopusden.octopus.components.registry.server.service.impl
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -19,6 +21,10 @@ import kotlin.streams.asSequence
 @SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
 @ActiveProfiles("common", "test-db")
 class HistoryEscrowLoaderFactoryTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
     @Autowired
     private lateinit var factory: HistoryEscrowLoaderFactory
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
@@ -14,9 +15,11 @@ import org.octopusden.octopus.components.registry.server.entity.GitHistoryImport
 import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -38,6 +41,10 @@ import kotlin.streams.asSequence
 )
 @ActiveProfiles("common", "test-db")
 class MigrateHistoryIntegrationTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
     @Autowired
     private lateinit var mvc: MockMvc
 
@@ -61,7 +68,7 @@ class MigrateHistoryIntegrationTest {
         // Phase 1: explicit toRef to 1.1 (only c1..c3 in scope).
         val firstBody =
             mvc
-                .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1"))
+                .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1").with(adminJwt()))
                 .andExpect(status().isOk)
                 .andReturn()
                 .response
@@ -77,7 +84,7 @@ class MigrateHistoryIntegrationTest {
 
         // Phase 2: repeat without reset → 409, audit_log unchanged.
         mvc
-            .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1"))
+            .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1").with(adminJwt()))
             .andExpect(status().isConflict)
         val auditAfterRepeat = auditLogRepository.findAll().filter { it.source == "git-history" }
         assertEquals(auditAfterFirst.size, auditAfterRepeat.size)
@@ -86,7 +93,7 @@ class MigrateHistoryIntegrationTest {
         // covers the unparseable commit (c4) and the DELETE of ARCHIVED_TEST_COMPONENT at c5.
         val secondBody =
             mvc
-                .perform(post("/rest/api/4/admin/migrate-history?reset=true"))
+                .perform(post("/rest/api/4/admin/migrate-history?reset=true").with(adminJwt()))
                 .andExpect(status().isOk)
                 .andReturn()
                 .response
@@ -126,7 +133,7 @@ class MigrateHistoryIntegrationTest {
         )
 
         mvc
-            .perform(post("/rest/api/4/admin/migrate-history?reset=true"))
+            .perform(post("/rest/api/4/admin/migrate-history?reset=true").with(adminJwt()))
             .andExpect(status().isConflict)
 
         // Pre-existing IN_PROGRESS row must survive the rejected reset.


### PR DESCRIPTION
## Summary

Fix the five test methods that started failing on `v3` after PR #151
(migrate-history) and PR #150 (Keycloak auth) landed back-to-back. The
new test classes load the full `ComponentRegistryServiceApplication`
context but predate the auth merge and never got the `@MockBean
AuthServerClient` patch — so on `v3` `AuthServerClient.<init>` does live
OIDC discovery against the CI Keycloak's nonexistent `test` realm and
aborts every context with `404 Realm does not exist`.

Apply the existing pattern from `MigrationIntegrationTest`,
`MigrateEndpointTest`, and `AdminControllerV4SecurityTest`:

- `@MockBean AuthServerClient` on each affected test class to
  short-circuit OIDC discovery at bean init.
- `.with(adminJwt())` on every `MigrateHistoryIntegrationTest` call to
  `/rest/api/4/admin/migrate-history` so the class-level
  `@PreAuthorize("@permissionEvaluator.canImport()")` on
  `AdminControllerV4` returns 200/409 instead of 401/403.

Affected:

- `AuditLogRepositoryDeleteBySourceTest`
- `GitHistoryImportStateRepositoryTest`
- `HistoryEscrowLoaderFactoryTest`
- `MigrateHistoryIntegrationTest` (2 methods, 4 endpoint calls)

No production code change.

## Test plan

- [x] `AUTH_SERVER_URL=http://localhost:9999 AUTH_SERVER_REALM=octopus ./gradlew build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test` → BUILD SUCCESSFUL
- [x] All five previously failing test methods green in this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)