### PR TITLE
feat(api): SYS-035 owner filter + SYS-036 audit filter params

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
@@ -1,14 +1,18 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogResponse
 import org.octopusden.octopus.components.registry.server.service.AuditService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
 
 @RestController
 @RequestMapping("rest/api/4/audit")
@@ -23,6 +27,31 @@ class AuditControllerV4(
         pageable: Pageable,
     ): Page<AuditLogResponse> = auditService.getEntityHistory(entityType, entityId, pageable)
 
+    /**
+     * SYS-036 filter params, all independently optional. `from`/`to` are ISO-8601
+     * instants forming a half-open `[from, to)` window over `audit_log.changed_at`.
+     */
     @GetMapping("/recent")
-    fun getRecentChanges(pageable: Pageable): Page<AuditLogResponse> = auditService.getRecentChanges(pageable)
+    fun getRecentChanges(
+        @RequestParam(required = false) entityType: String?,
+        @RequestParam(required = false) entityId: String?,
+        @RequestParam(required = false) changedBy: String?,
+        @RequestParam(required = false) source: String?,
+        @RequestParam(required = false) action: String?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        pageable: Pageable,
+    ): Page<AuditLogResponse> {
+        val filter =
+            AuditLogFilter(
+                entityType = entityType,
+                entityId = entityId,
+                changedBy = changedBy,
+                source = source,
+                action = action,
+                from = from,
+                to = to,
+            )
+        return auditService.getRecentChanges(filter, pageable)
+    }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -66,6 +66,7 @@ class ComponentControllerV4(
         @RequestParam(required = false) productType: String?,
         @RequestParam(required = false) archived: Boolean?,
         @RequestParam(required = false) search: String?,
+        @RequestParam(required = false) owner: String?,
         pageable: Pageable,
     ): Page<ComponentSummaryResponse> {
         val filter =
@@ -74,6 +75,7 @@ class ComponentControllerV4(
                 productType = productType,
                 archived = archived,
                 search = search,
+                owner = owner,
             )
         return componentManagementService.listComponents(filter, pageable)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
@@ -1,0 +1,24 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import java.time.Instant
+
+/**
+ * Filter object for `GET /rest/api/4/audit/recent`. Each field is independently
+ * optional; combinations are ANDed in `AuditServiceImpl`. Empty filter is
+ * equivalent to "all rows, newest first" — preserves the legacy behaviour of
+ * the unfiltered `getRecentChanges` call.
+ *
+ * `from` and `to` form a half-open interval `[from, to)` over `audit_log.changed_at`.
+ * Either bound is independently optional.
+ *
+ * Contract: `SYS-036` in `requirements-common.md`.
+ */
+data class AuditLogFilter(
+    val entityType: String? = null,
+    val entityId: String? = null,
+    val changedBy: String? = null,
+    val source: String? = null,
+    val action: String? = null,
+    val from: Instant? = null,
+    val to: Instant? = null,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentFilter.kt
@@ -5,4 +5,5 @@ data class ComponentFilter(
     val productType: String? = null,
     val archived: Boolean? = null,
     val search: String? = null,
+    val owner: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepository.kt
@@ -4,10 +4,13 @@ import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.transaction.annotation.Transactional
 
-interface AuditLogRepository : JpaRepository<AuditLogEntity, Long> {
+interface AuditLogRepository :
+    JpaRepository<AuditLogEntity, Long>,
+    JpaSpecificationExecutor<AuditLogEntity> {
     fun findByEntityTypeAndEntityId(
         entityType: String,
         entityId: String,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/CurrentUserResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/CurrentUserResolver.kt
@@ -1,0 +1,41 @@
+package org.octopusden.octopus.components.registry.server.security
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves the username for `audit_log.changed_by` from the active Spring Security context.
+ *
+ * Why this is its own helper rather than a one-line `securityService.getCurrentUser()` call:
+ * the cloud-commons `SecurityService` resolves the user via the `UserInfoGrantedAuthoritiesConverter`
+ * chain, which calls Keycloak's userinfo endpoint. That's the right path for fully-blown
+ * production reads (granted roles + groups), but it's overkill for "give me the username"
+ * and it does not work cleanly in MockMvc tests where `AuthServerClient` is `@MockBean`
+ * (the JWT post-processors deliberately bypass the converter — see `SecurityTestHelpers`).
+ *
+ * This resolver reads directly from the JWT in the security context — `preferred_username`
+ * first (Keycloak's canonical username claim), then `sub` as a fallback. If there is no
+ * authenticated user (background jobs, async tasks running outside an HTTP context),
+ * returns `"system"` so `changed_by` is never null in practice. Matches the contract
+ * promised in `docs/db-migration/technical-design.md` §6.4 (Audit changedBy wiring).
+ */
+@Component
+class CurrentUserResolver {
+    fun currentUsername(): String {
+        val auth = SecurityContextHolder.getContext().authentication
+        return when {
+            auth is JwtAuthenticationToken -> {
+                auth.token.getClaimAsString("preferred_username")
+                    ?: auth.name?.takeIf { it.isNotBlank() }
+                    ?: SYSTEM_USER
+            }
+            auth?.name?.isNotBlank() == true -> auth.name
+            else -> SYSTEM_USER
+        }
+    }
+
+    companion object {
+        const val SYSTEM_USER = "system"
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/AuditService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/AuditService.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.service
 
+import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogResponse
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -11,5 +12,8 @@ interface AuditService {
         pageable: Pageable,
     ): Page<AuditLogResponse>
 
-    fun getRecentChanges(pageable: Pageable): Page<AuditLogResponse>
+    fun getRecentChanges(
+        filter: AuditLogFilter,
+        pageable: Pageable,
+    ): Page<AuditLogResponse>
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
@@ -1,13 +1,19 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogResponse
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.octopusden.octopus.components.registry.server.mapper.toResponse
 import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
 import org.octopusden.octopus.components.registry.server.service.AuditService
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 @Service
 @Transactional(readOnly = true)
@@ -23,8 +29,61 @@ class AuditServiceImpl(
             .findByEntityTypeAndEntityId(entityType, entityId, pageable)
             .map { it.toResponse() }
 
-    override fun getRecentChanges(pageable: Pageable): Page<AuditLogResponse> =
+    override fun getRecentChanges(
+        filter: AuditLogFilter,
+        pageable: Pageable,
+    ): Page<AuditLogResponse> =
         auditLogRepository
-            .findAllByOrderByChangedAtDesc(pageable)
+            .findAll(buildSpecification(filter), withDefaultSort(pageable))
             .map { it.toResponse() }
+
+    /**
+     * `audit_log` rows are most useful "newest first" by `changed_at`. The legacy
+     * `findAllByOrderByChangedAtDesc` enforced this in the query name; with the
+     * Specification-based path we apply the same default in the Pageable when the
+     * caller hasn't supplied an explicit sort, so existing clients keep their ordering.
+     */
+    private fun withDefaultSort(pageable: Pageable): Pageable =
+        if (pageable.sort.isUnsorted) {
+            PageRequest.of(pageable.pageNumber, pageable.pageSize, Sort.by(Sort.Direction.DESC, "changedAt"))
+        } else {
+            pageable
+        }
+
+    private fun buildSpecification(filter: AuditLogFilter): Specification<AuditLogEntity> {
+        var spec = Specification.where<AuditLogEntity>(null)
+
+        filter.entityType?.let { entityType ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("entityType"), entityType) })
+        }
+
+        filter.entityId?.let { entityId ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("entityId"), entityId) })
+        }
+
+        filter.changedBy?.let { changedBy ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("changedBy"), changedBy) })
+        }
+
+        filter.source?.let { source ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("source"), source) })
+        }
+
+        filter.action?.let { action ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("action"), action) })
+        }
+
+        filter.from?.let { from ->
+            spec =
+                spec.and(
+                    Specification { root, _, cb -> cb.greaterThanOrEqualTo(root.get<Instant>("changedAt"), from) },
+                )
+        }
+
+        filter.to?.let { to ->
+            spec = spec.and(Specification { root, _, cb -> cb.lessThan(root.get<Instant>("changedAt"), to) })
+        }
+
+        return spec
+    }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -26,6 +26,7 @@ import org.octopusden.octopus.components.registry.server.mapper.toResponse
 import org.octopusden.octopus.components.registry.server.mapper.toSummaryResponse
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.FieldOverrideRepository
+import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
 import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.springframework.context.ApplicationEventPublisher
@@ -44,6 +45,7 @@ class ComponentManagementServiceImpl(
     private val fieldOverrideRepository: FieldOverrideRepository,
     private val sourceRegistry: ComponentSourceRegistry,
     private val applicationEventPublisher: ApplicationEventPublisher,
+    private val currentUserResolver: CurrentUserResolver,
 ) : ComponentManagementService {
     @Suppress("CyclomaticComplexMethod")
     override fun createComponent(request: ComponentCreateRequest): ComponentDetailResponse {
@@ -78,6 +80,7 @@ class ComponentManagementServiceImpl(
                 entityType = "Component",
                 entityId = saved.id.toString(),
                 action = "CREATE",
+                changedBy = currentUserResolver.currentUsername(),
                 newValue =
                     mapOf(
                         "name" to saved.name,
@@ -284,6 +287,7 @@ class ComponentManagementServiceImpl(
                 entityType = "Component",
                 entityId = saved.id.toString(),
                 action = if (isRename) "RENAME" else "UPDATE",
+                changedBy = currentUserResolver.currentUsername(),
                 oldValue = oldValue,
                 newValue = newValue,
             ),
@@ -306,6 +310,7 @@ class ComponentManagementServiceImpl(
                 entityType = "Component",
                 entityId = id.toString(),
                 action = "DELETE",
+                changedBy = currentUserResolver.currentUsername(),
                 oldValue = mapOf("name" to entity.name, "archived" to false),
                 newValue = mapOf("name" to entity.name, "archived" to true),
             ),
@@ -396,6 +401,14 @@ class ComponentManagementServiceImpl(
 
         filter.archived?.let { archived ->
             spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<Boolean>("archived"), archived) })
+        }
+
+        filter.owner?.let { owner ->
+            // Exact match on `componentOwner` (the entity's column for the user-facing
+            // "owner"). Case-sensitive — the values come from `/components/meta/owners`
+            // which returns the canonical strings, so the Portal autocomplete picker
+            // hands back exactly what is in the column.
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("componentOwner"), owner) })
         }
 
         filter.search?.let { search ->

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
@@ -1,0 +1,234 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * SYS-036 — `GET /rest/api/4/audit/recent` accepts optional filter query params so the
+ * Portal `AuditLogPage` can drive its filter sidebar against the server. Without these
+ * params the Portal would have to download every audit page and filter client-side,
+ * which doesn't scale.
+ *
+ * Supported filters (each independently optional, ANDed when combined):
+ *   - `entityType`        — e.g. `COMPONENT`, `FIELD_OVERRIDE`
+ *   - `entityId`          — UUID of a specific entity (for entity-scoped history; identical
+ *                           shape to `GET /audit/{entityType}/{entityId}` but reachable on
+ *                           the same query as user/source/etc. filters)
+ *   - `changedBy`         — username from `audit_log.changed_by`
+ *   - `source`            — `api` | `git-history` | `migration_job`
+ *   - `action`            — `CREATE` | `UPDATE` | `DELETE` | `RENAME` | `ARCHIVE` | …
+ *   - `from`, `to`        — ISO-8601 instants; either or both, half-open `[from, to)`
+ *
+ * Test layer: integration. The `ft-db` profile gives us H2 + auto-migrate; each test
+ * exercises the live `AuditService.getRecentChanges` filters against rows produced by
+ * real component CRUD calls, so the wire shape stays in sync with the implementation.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+class AuditLogFilterTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(AuditLogFilterTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun uniqueName(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    private fun createComponent(name: String): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"name":"$name","displayName":"$name"}"""),
+                ).andExpect(status().isCreated)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun deleteComponent(id: String) {
+        mvc
+            .perform(delete("/rest/api/4/components/$id").with(adminJwt()))
+            .andExpect(status().isNoContent)
+    }
+
+    private fun patchDisplayName(
+        id: String,
+        version: Long,
+        displayName: String,
+    ) {
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"version":$version,"displayName":"$displayName"}"""),
+            ).andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent filtered by entityType returns only matching rows")
+    fun auditRecent_byEntityType_returnsMatching() {
+        val name = uniqueName("sys036_et")
+        val id = createComponent(name)
+        deleteComponent(id) // generates a COMPONENT-scoped audit row even if other types exist
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("entityType", "Component")
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val entityTypes = json["content"].map { it["entityType"].asText() }.toSet()
+        assert(entityTypes.all { it == "Component" }) { "expected only COMPONENT, got $entityTypes" }
+        assert(json["content"].any { it["entityId"].asText() == id }) {
+            "expected to find audit rows for component $id"
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent filtered by entityType + entityId scopes to a single component")
+    fun auditRecent_byEntityTypeAndId_singleComponent() {
+        val name = uniqueName("sys036_eti")
+        val id = createComponent(name)
+        // Need version=0 from the create response. Re-fetch to read it cleanly.
+        val detail =
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val version = objectMapper.readTree(detail)["version"].asLong()
+        patchDisplayName(id, version, "${name}_renamed_display")
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("entityType", "Component")
+                        .param("entityId", id)
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val ids = json["content"].map { it["entityId"].asText() }.toSet()
+        assert(ids == setOf(id)) { "expected only $id, got $ids" }
+        assert(json["content"].size() >= 2) {
+            "expected ≥ 2 audit rows for $id (CREATE + UPDATE), got ${json["content"].size()}"
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent filtered by changedBy returns only that user's rows")
+    fun auditRecent_byChangedBy_returnsMatching() {
+        val name = uniqueName("sys036_user")
+        createComponent(name) // adminJwt → preferred_username "alice"
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("changedBy", "alice")
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val users = json["content"].map { it["changedBy"]?.asText() }.toSet()
+        assert(users.all { it == "alice" }) { "expected only alice, got $users" }
+        assert(users.contains("alice")) { "expected at least one alice row" }
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent filtered by unknown user returns empty page")
+    fun auditRecent_byUnknownUser_empty() {
+        mvc
+            .perform(
+                get("/rest/api/4/audit/recent")
+                    .with(adminJwt())
+                    .param("changedBy", "definitelynotauser_${UUID.randomUUID()}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(0))
+            .andExpect(jsonPath("$.totalElements").value(0))
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent filtered by source='api' excludes git-history rows")
+    fun auditRecent_bySource_excludesOthers() {
+        val name = uniqueName("sys036_src")
+        createComponent(name) // produces source=api rows
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("source", "api")
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val sources = json["content"].map { it["source"].asText() }.toSet()
+        assert(sources.all { it == "api" }) { "expected only api, got $sources" }
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent without filters returns 200 (filters are optional)")
+    fun auditRecent_noFilters_ok() {
+        mvc
+            .perform(get("/rest/api/4/audit/recent").with(adminJwt()))
+            .andExpect(status().isOk)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
@@ -31,12 +31,15 @@ import java.util.UUID
  * which doesn't scale.
  *
  * Supported filters (each independently optional, ANDed when combined):
- *   - `entityType`        — e.g. `COMPONENT`, `FIELD_OVERRIDE`
+ *   - `entityType`        — currently only `Component` (capitalized; the filter is
+ *                           a case-sensitive `cb.equal`). `FieldOverride` and other
+ *                           entity types are reserved for future audit instrumentation.
  *   - `entityId`          — UUID of a specific entity (for entity-scoped history; identical
  *                           shape to `GET /audit/{entityType}/{entityId}` but reachable on
  *                           the same query as user/source/etc. filters)
  *   - `changedBy`         — username from `audit_log.changed_by`
- *   - `source`            — `api` | `git-history` | `migration_job`
+ *   - `source`            — currently only `api` and `git-history`; other values are
+ *                           reserved for future writers
  *   - `action`            — `CREATE` | `UPDATE` | `DELETE` | `RENAME` | `ARCHIVE` | …
  *   - `from`, `to`        — ISO-8601 instants; either or both, half-open `[from, to)`
  *
@@ -110,7 +113,7 @@ class AuditLogFilterTest {
     fun auditRecent_byEntityType_returnsMatching() {
         val name = uniqueName("sys036_et")
         val id = createComponent(name)
-        deleteComponent(id) // generates a COMPONENT-scoped audit row even if other types exist
+        deleteComponent(id) // generates a Component-scoped audit row even if other types exist
 
         val body =
             mvc
@@ -125,7 +128,7 @@ class AuditLogFilterTest {
         val json = objectMapper.readTree(body)
 
         val entityTypes = json["content"].map { it["entityType"].asText() }.toSet()
-        assert(entityTypes.all { it == "Component" }) { "expected only COMPONENT, got $entityTypes" }
+        assert(entityTypes.all { it == "Component" }) { "expected only Component, got $entityTypes" }
         assert(json["content"].any { it["entityId"].asText() == id }) {
             "expected to find audit rows for component $id"
         }
@@ -169,6 +172,12 @@ class AuditLogFilterTest {
     @Test
     @DisplayName("SYS-036 audit/recent filtered by changedBy returns only that user's rows")
     fun auditRecent_byChangedBy_returnsMatching() {
+        // This test depends on CurrentUserResolver wiring (TDD §6.4): every AuditEvent
+        // published by ComponentManagementServiceImpl carries `changedBy =
+        // currentUserResolver.currentUsername()`. Without that wiring, runtime API rows
+        // would write `changed_by = null` and this filter would always return empty.
+        // If a future revert of CurrentUserResolver lands without bisecting this test,
+        // the assertion will fail loudly here rather than silently pass on null rows.
         val name = uniqueName("sys036_user")
         createComponent(name) // adminJwt → preferred_username "alice"
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
+import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -22,6 +24,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.nio.file.Paths
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
@@ -65,6 +69,9 @@ class AuditLogFilterTest {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var auditLogRepository: AuditLogRepository
 
     init {
         val testResourcesPath =
@@ -214,8 +221,16 @@ class AuditLogFilterTest {
     @Test
     @DisplayName("SYS-036 audit/recent filtered by source='api' excludes git-history rows")
     fun auditRecent_bySource_excludesOthers() {
-        val name = uniqueName("sys036_src")
-        createComponent(name) // produces source=api rows
+        // Proof-of-exclusion: seed both an api row (via the live CRUD path) AND a synthetic
+        // git-history row (direct repo write — same path /admin/migrate-history takes), then
+        // assert the source=api filter returns only the api row. If the source predicate were
+        // accidentally removed, this test would fail because the git-history row would leak
+        // through. The earlier shape of this test only checked "all rows are source=api"
+        // which silently passes when the fixture has no git-history rows.
+        val name = uniqueName("sys036_src_api")
+        val apiId = createComponent(name) // source=api row
+        val historyEntityId = "sys036_history_${UUID.randomUUID().toString().take(8)}"
+        seedSyntheticAuditRow(entityId = historyEntityId, source = "git-history")
 
         val body =
             mvc
@@ -223,7 +238,7 @@ class AuditLogFilterTest {
                     get("/rest/api/4/audit/recent")
                         .with(adminJwt())
                         .param("source", "api")
-                        .param("size", "200"),
+                        .param("size", "500"),
                 ).andExpect(status().isOk)
                 .andReturn()
                 .response.contentAsString
@@ -231,6 +246,144 @@ class AuditLogFilterTest {
 
         val sources = json["content"].map { it["source"].asText() }.toSet()
         assert(sources.all { it == "api" }) { "expected only api, got $sources" }
+
+        val entityIds = json["content"].map { it["entityId"].asText() }.toSet()
+        assert(entityIds.contains(apiId)) { "expected the api-sourced row $apiId in the response" }
+        assert(!entityIds.contains(historyEntityId)) {
+            "expected git-history row $historyEntityId to be excluded by source=api"
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent filtered by action returns only matching rows")
+    fun auditRecent_byAction_returnsMatching() {
+        // Generate two rows for the same component: a CREATE and a DELETE. Filtering by
+        // ?action=DELETE should return only the delete row.
+        val name = uniqueName("sys036_act")
+        val id = createComponent(name)
+        deleteComponent(id)
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("action", "DELETE")
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val actions = json["content"].map { it["action"].asText() }.toSet()
+        assert(actions.all { it == "DELETE" }) { "expected only DELETE, got $actions" }
+        assert(json["content"].any { it["entityId"].asText() == id }) {
+            "expected to find the DELETE row for $id"
+        }
+        // Spot-check that the CREATE row from the same component IS reachable on a separate
+        // call — proves we're filtering by action, not just always returning the same set.
+        val createBody =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("action", "CREATE")
+                        .param("entityId", id)
+                        .param("size", "10"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val createActions = objectMapper.readTree(createBody)["content"].map { it["action"].asText() }.toSet()
+        assert(createActions == setOf("CREATE")) { "expected only CREATE for $id, got $createActions" }
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent filtered by half-open [from, to) date window")
+    fun auditRecent_byDateWindow_halfOpen() {
+        // Seed three synthetic rows at controlled timestamps so we can prove half-open
+        // semantics deterministically. Live audit rows always use Instant.now() and we
+        // can't pin those to specific instants without sleeping the test, hence direct repo
+        // writes here. Window: [t1, t2). t0 < t1 < t2 < t3, so:
+        //   - row at t0 → before window, excluded
+        //   - row at t1 → exactly the lower bound, INCLUDED (closed end)
+        //   - row at t2 → exactly the upper bound, EXCLUDED (open end)
+        //   - row at t3 → after window, excluded
+        val anchor = Instant.now().minus(7, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS)
+        val t0 = anchor
+        val t1 = anchor.plus(1, ChronoUnit.HOURS)
+        val t2 = anchor.plus(2, ChronoUnit.HOURS)
+        val t3 = anchor.plus(3, ChronoUnit.HOURS)
+        val tag = "sys036_window_${UUID.randomUUID().toString().take(8)}"
+        val idT0 = "${tag}_t0"
+        val idT1 = "${tag}_t1"
+        val idT2 = "${tag}_t2"
+        val idT3 = "${tag}_t3"
+        seedSyntheticAuditRow(entityId = idT0, changedAt = t0)
+        seedSyntheticAuditRow(entityId = idT1, changedAt = t1)
+        seedSyntheticAuditRow(entityId = idT2, changedAt = t2)
+        seedSyntheticAuditRow(entityId = idT3, changedAt = t3)
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("from", t1.toString())
+                        .param("to", t2.toString())
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+        val ids = json["content"].map { it["entityId"].asText() }.filter { it.startsWith(tag) }.toSet()
+
+        assert(ids == setOf(idT1)) {
+            "expected only [t1] in [from=$t1, to=$t2), got $ids " +
+                "(t0=$idT0 should be excluded as before-window, " +
+                "t2=$idT2 should be excluded as upper-bound-exclusive, " +
+                "t3=$idT3 should be excluded as after-window)"
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-036 audit/recent default sort is changedAt DESC when caller doesn't supply sort=")
+    fun auditRecent_defaultSort_changedAtDesc() {
+        // Seed three rows with controlled, distinct timestamps. With no sort= parameter the
+        // service default-sorts changedAt DESC (AuditServiceImpl.withDefaultSort), so we
+        // expect the response to list our seeded rows in newest-first order.
+        val anchor = Instant.now().minus(30, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS)
+        val tOldest = anchor
+        val tMiddle = anchor.plus(1, ChronoUnit.HOURS)
+        val tNewest = anchor.plus(2, ChronoUnit.HOURS)
+        val tag = "sys036_sort_${UUID.randomUUID().toString().take(8)}"
+        val idOldest = "${tag}_oldest"
+        val idMiddle = "${tag}_middle"
+        val idNewest = "${tag}_newest"
+        // Insert intentionally out of order to make sure ordering comes from the query, not insert order.
+        seedSyntheticAuditRow(entityId = idMiddle, changedAt = tMiddle)
+        seedSyntheticAuditRow(entityId = idOldest, changedAt = tOldest)
+        seedSyntheticAuditRow(entityId = idNewest, changedAt = tNewest)
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("from", tOldest.toString())
+                        .param("to", tNewest.plus(1, ChronoUnit.HOURS).toString())
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+        val orderedIdsForTag =
+            json["content"]
+                .map { it["entityId"].asText() }
+                .filter { it.startsWith(tag) }
+
+        assert(orderedIdsForTag == listOf(idNewest, idMiddle, idOldest)) {
+            "expected DESC order [newest, middle, oldest] for tag $tag, got $orderedIdsForTag"
+        }
     }
 
     @Test
@@ -240,4 +393,29 @@ class AuditLogFilterTest {
             .perform(get("/rest/api/4/audit/recent").with(adminJwt()))
             .andExpect(status().isOk)
     }
+
+    /**
+     * Direct repo write — bypasses the controller path so we can pin source/changedAt to
+     * specific values for tests that need to prove exclusion or ordering. The live CRUD path
+     * always writes source=api and changedAt=Instant.now(), which is fine for the happy-path
+     * tests but not enough to prove the filter predicates are actually applied.
+     */
+    private fun seedSyntheticAuditRow(
+        entityType: String = "Component",
+        entityId: String,
+        action: String = "CREATE",
+        changedBy: String = "system",
+        changedAt: Instant = Instant.now(),
+        source: String = "api",
+    ): AuditLogEntity =
+        auditLogRepository.save(
+            AuditLogEntity(
+                entityType = entityType,
+                entityId = entityId,
+                action = action,
+                changedBy = changedBy,
+                changedAt = changedAt,
+                source = source,
+            ),
+        )
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsOwnerFilterTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsOwnerFilterTest.kt
@@ -127,4 +127,74 @@ class ListComponentsOwnerFilterTest {
     fun listComponents_withoutOwner_ok() {
         mvc.perform(get("/rest/api/4/components").with(viewerJwt())).andExpect(status().isOk)
     }
+
+    @Test
+    @DisplayName("SYS-035 criterion 4: ?owner combines with ?archived via AND")
+    fun listComponents_byOwnerAndArchived_combinesViaAnd() {
+        val owner = uniqueName("alice_and")
+        val activeName = uniqueName("sys035_and_active")
+        val archivedName = uniqueName("sys035_and_archived")
+
+        // Two components for the same owner: one active, one archived.
+        createComponent(activeName, owner)
+        createComponent(archivedName, owner)
+        archiveComponent(archivedName)
+
+        // owner=<owner> AND archived=true → only the archived one
+        val onlyArchivedJson =
+            mvc
+                .perform(
+                    get("/rest/api/4/components")
+                        .with(viewerJwt())
+                        .param("owner", owner)
+                        .param("archived", "true")
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val onlyArchivedNames = objectMapper.readTree(onlyArchivedJson)["content"].map { it["name"].asText() }.toSet()
+        assert(onlyArchivedNames == setOf(archivedName)) {
+            "expected only $archivedName, got $onlyArchivedNames"
+        }
+
+        // owner=<owner> AND archived=false → only the active one
+        val onlyActiveJson =
+            mvc
+                .perform(
+                    get("/rest/api/4/components")
+                        .with(viewerJwt())
+                        .param("owner", owner)
+                        .param("archived", "false")
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val onlyActiveNames = objectMapper.readTree(onlyActiveJson)["content"].map { it["name"].asText() }.toSet()
+        assert(onlyActiveNames == setOf(activeName)) {
+            "expected only $activeName, got $onlyActiveNames"
+        }
+    }
+
+    private fun archiveComponent(name: String) {
+        // Re-fetch to obtain id + version, then PATCH with archived=true. Goes through the
+        // real ComponentControllerV4 PATCH path, so it generates an audit row and increments
+        // @Version — same shape a Portal "Archive" button would use.
+        val detailJson =
+            mvc
+                .perform(get("/rest/api/4/components/$name").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val detail = objectMapper.readTree(detailJson)
+        val id = detail["id"].asText()
+        val version = detail["version"].asLong()
+        mvc
+            .perform(
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                    .patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                    .content("""{"version":$version,"archived":true}"""),
+            ).andExpect(status().isOk)
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsOwnerFilterTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsOwnerFilterTest.kt
@@ -1,0 +1,130 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * SYS-035 — `GET /rest/api/4/components?owner=<username>` filters the component list to
+ * components whose `componentOwner` equals the given value. The Portal `ComponentFilters`
+ * UI surfaces an owner dropdown populated from `/components/meta/owners`; without this
+ * filter param the Portal would have to download all 900+ components to filter
+ * client-side.
+ *
+ * Test layer: integration. The `ft-db` profile gives us H2 + auto-migrate, so each test
+ * creates its own throwaway components (deterministic owner assignments) before
+ * asserting on the filtered list.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+class ListComponentsOwnerFilterTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(ListComponentsOwnerFilterTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun uniqueName(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    private fun createComponent(
+        name: String,
+        owner: String,
+    ) {
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"$name","displayName":"$name","componentOwner":"$owner"}"""),
+            ).andExpect(status().isCreated)
+    }
+
+    @Test
+    @DisplayName("SYS-035 listComponents with ?owner=<username> returns only matching components")
+    fun listComponents_byOwner_returnsMatching() {
+        val mineA = uniqueName("sys035_mine_a")
+        val mineB = uniqueName("sys035_mine_b")
+        val theirs = uniqueName("sys035_theirs")
+        val owner = uniqueName("alice")
+        val otherOwner = uniqueName("bob")
+
+        createComponent(mineA, owner)
+        createComponent(mineB, owner)
+        createComponent(theirs, otherOwner)
+
+        // Use a large page size so the filtered subset fits in a single page even with other
+        // components from earlier tests in the same H2 context.
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/components")
+                        .with(viewerJwt())
+                        .param("owner", owner)
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val names = json["content"].map { it["name"].asText() }.toSet()
+        assert(names.contains(mineA)) { "expected $mineA in $names" }
+        assert(names.contains(mineB)) { "expected $mineB in $names" }
+        assert(!names.contains(theirs)) { "did not expect $theirs in $names (owner=$otherOwner)" }
+    }
+
+    @Test
+    @DisplayName("SYS-035 listComponents with ?owner=<unknown> returns empty page")
+    fun listComponents_byUnknownOwner_returnsEmpty() {
+        val unknownOwner = uniqueName("nobody")
+
+        mvc
+            .perform(
+                get("/rest/api/4/components")
+                    .with(viewerJwt())
+                    .param("owner", unknownOwner),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(0))
+            .andExpect(jsonPath("$.totalElements").value(0))
+    }
+
+    @Test
+    @DisplayName("SYS-035 listComponents without ?owner returns 200 (filter is optional)")
+    fun listComponents_withoutOwner_ok() {
+        mvc.perform(get("/rest/api/4/components").with(viewerJwt())).andExpect(status().isOk)
+    }
+}

--- a/docs/db-migration/functional-spec.md
+++ b/docs/db-migration/functional-spec.md
@@ -135,10 +135,10 @@ All existing search/lookup operations must return identical results from DB:
 ### 4.2 Global Recent Changes
 - **Endpoint**: `GET /rest/api/4/audit/recent`
 - **Input**: Optional filter query params (all independently optional, ANDed when combined; contract `SYS-036`):
-  - `entityType` — e.g. `Component`, `FieldOverride`
+  - `entityType` — currently only `Component` is emitted (case-sensitive; `cb.equal`). `FieldOverride` and other entity types are reserved for future audit instrumentation.
   - `entityId` — UUID of a specific entity (combine with `entityType` for entity-scoped history reachable via the same query as user/source filters)
   - `changedBy` — username from `audit_log.changed_by`
-  - `source` — `api` \| `git-history` \| `migration_job`
+  - `source` — currently only `api` and `git-history` are emitted. Other values are reserved for future writers.
   - `action` — `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `ARCHIVE`
   - `from`, `to` — ISO-8601 instants forming a half-open `[from, to)` window over `audit_log.changed_at`
 - **Output**: Paginated feed of audit rows newest-first (default sort `changedAt DESC`; caller-supplied `sort=` overrides)

--- a/docs/db-migration/functional-spec.md
+++ b/docs/db-migration/functional-spec.md
@@ -8,7 +8,7 @@
 ## 1. Component Management
 
 ### 1.1 List Components
-- **Input**: Optional filters — system, clientCode, productType, archived, search (name/displayName)
+- **Input**: Optional filters — `productType`, `archived`, `search` (name/displayName), `owner` (exact match on `componentOwner`, `SYS-035`). `system` is currently rejected with 400 (see ADR/TDD on JPA Criteria + `text[]` limitations); `clientCode` is reserved for future.
 - **Output**: Paginated list of components with summary info
 - **Sorting**: By name (default), system, productType, updatedAt
 - **Pagination**: Page number + page size (default 20, max 100)
@@ -133,9 +133,16 @@ All existing search/lookup operations must return identical results from DB:
 - **Each entry**: action, changedBy, changedAt, oldValue (JSONB), newValue (JSONB), changeDiff (JSONB)
 
 ### 4.2 Global Recent Changes
-- **Input**: Optional filters — user, date range, entity type, action type
-- **Output**: Paginated feed of all recent changes across all entities
-- **Default**: Last 7 days, page size 50
+- **Endpoint**: `GET /rest/api/4/audit/recent`
+- **Input**: Optional filter query params (all independently optional, ANDed when combined; contract `SYS-036`):
+  - `entityType` — e.g. `Component`, `FieldOverride`
+  - `entityId` — UUID of a specific entity (combine with `entityType` for entity-scoped history reachable via the same query as user/source filters)
+  - `changedBy` — username from `audit_log.changed_by`
+  - `source` — `api` \| `git-history` \| `migration_job`
+  - `action` — `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `ARCHIVE`
+  - `from`, `to` — ISO-8601 instants forming a half-open `[from, to)` window over `audit_log.changed_at`
+- **Output**: Paginated feed of audit rows newest-first (default sort `changedAt DESC`; caller-supplied `sort=` overrides)
+- **Page size**: Spring Data `Pageable`; defaults to the global `spring.data.web.pageable.default-page-size`
 
 ### 4.3 Change Diff
 - **Format**: JSON object showing only changed fields

--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -1039,9 +1039,9 @@ The Portal `ComponentFilters` UI offers an owner dropdown populated from `/compo
 1. `GET /rest/api/4/components?owner=alice` returns HTTP 200 and the `content` array contains only components whose `componentOwner == "alice"`.
 2. `GET /rest/api/4/components?owner=<unknown>` returns HTTP 200 with an empty `content` array and `totalElements == 0`.
 3. `GET /rest/api/4/components` without the `owner` param returns HTTP 200 with the full list (the parameter is optional).
-4. `owner` combines with existing filters (`system`, `productType`, `archived`, `search`) via AND.
+4. `owner` combines with the other supported filters (`productType`, `archived`, `search`) via AND. (`system` is currently rejected with HTTP 400 — see `ComponentManagementServiceImpl.buildSpecification` — and is therefore not part of this combination.)
 
-**Test method:** `ListComponentsOwnerFilterTest` — three test methods covering criteria 1, 2, 3 against the live `WebSecurityConfig` chain on the `ft-db` profile.
+**Test method:** `ListComponentsOwnerFilterTest` — four test methods covering criteria 1, 2, 3, 4 against the live `WebSecurityConfig` chain on the `ft-db` profile.
 
 **Out of scope:**
 - Multi-owner / OR semantics (a single value per call; combine with other filters or paginate).
@@ -1062,10 +1062,10 @@ The Portal `AuditLogPage` filter sidebar drives a server-side query — without 
 Supported filters:
 | Param | Type | Notes |
 |---|---|---|
-| `entityType` | string | e.g. `COMPONENT`, `FIELD_OVERRIDE` |
+| `entityType` | string | Currently only `Component` is emitted (capitalized — `cb.equal` is case-sensitive). `FieldOverride` and other entity types are reserved for future audit instrumentation; field-override CRUD does not publish `AuditEvent` yet. |
 | `entityId` | string | usually a UUID; combine with `entityType` for entity-scoped history reachable in the same query as user/source filters |
-| `changedBy` | string | username from `audit_log.changed_by` |
-| `source` | string | `api` \| `git-history` \| `migration_job` |
+| `changedBy` | string | username from `audit_log.changed_by`. For runtime API events the value is resolved by `CurrentUserResolver` (see TDD §6.4); for git-history backfill rows it is the git author signature. |
+| `source` | string | Currently only `api` (default for runtime events) and `git-history` (backfill from `/admin/migrate-history`) are emitted. Other values are reserved for future writers. |
 | `action` | string | `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `ARCHIVE` \| … |
 | `from`, `to` | ISO-8601 instant | half-open `[from, to)` over `audit_log.changed_at`; either or both optional |
 
@@ -1074,9 +1074,9 @@ Supported filters:
 - DB contains audit rows produced by either runtime API events (`source = 'api'`) or backfill from `/admin/migrate-history` (`source = 'git-history'`).
 
 **Acceptance criteria:**
-1. `GET /audit/recent?entityType=COMPONENT` returns only rows with `entityType == "COMPONENT"`.
-2. `GET /audit/recent?entityType=COMPONENT&entityId=<uuid>` returns only rows for that single component (CREATE + any UPDATE/RENAME/DELETE).
-3. `GET /audit/recent?changedBy=alice` returns only rows with `changedBy == "alice"`.
+1. `GET /audit/recent?entityType=Component` returns only rows with `entityType == "Component"`.
+2. `GET /audit/recent?entityType=Component&entityId=<uuid>` returns only rows for that single component (CREATE + any UPDATE/RENAME/DELETE).
+3. `GET /audit/recent?changedBy=alice` returns only rows with `changedBy == "alice"`. Depends on `CurrentUserResolver` populating `audit_log.changed_by` (TDD §6.4) — without that wiring, runtime API rows would have `changed_by = null` and the filter would always be empty.
 4. `GET /audit/recent?changedBy=<unknown>` returns HTTP 200 with empty `content` and `totalElements == 0`.
 5. `GET /audit/recent?source=api` returns only rows with `source == "api"`; rows with `source == "git-history"` are excluded.
 6. `GET /audit/recent` without any filter param returns the full audit log newest-first (legacy contract preserved).

--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -44,6 +44,8 @@
 | SYS-032 | ComponentSourceRegistry reads reflect cross-pod DB changes on every call | High | integration-test | ✅ Tested |
 | SYS-033 | GET /rest/api/4/info returns build name and version, anonymous access | Medium | integration-test | ✅ Tested |
 | SYS-034 | GET /auth/me returns current user (username, roles, groups), authenticated | Medium | integration-test | ❌ Not tested |
+| SYS-035 | GET /components?owner=&lt;username&gt; filters by componentOwner exact match | High | integration-test | ✅ Tested |
+| SYS-036 | GET /audit/recent accepts entityType/entityId/changedBy/source/action/from/to filter params | High | integration-test | ✅ Tested |
 
 ---
 
@@ -1017,3 +1019,72 @@ The Portal needs to render the signed-in user (username, roles) in the header/ad
 **Out of scope:**
 - Modifying user data (this is read-only).
 - Custom claims beyond what cloud-commons `User` exposes.
+
+---
+
+### SYS-035: GET /components?owner=&lt;username&gt; filters by componentOwner exact match
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Description:**
+The Portal `ComponentFilters` UI offers an owner dropdown populated from `/components/meta/owners`. Without a server-side `owner` filter the SPA would have to download the entire components list (~900 rows) on every owner-filter change, defeating server-side pagination. This requirement adds an `owner` query parameter to `GET /rest/api/4/components` that filters rows whose `componentOwner` equals the supplied value (exact, case-sensitive — values come from the same `/meta/owners` source the autocomplete uses).
+
+**Preconditions:**
+- DB contains components with various `componentOwner` values (or none).
+- Caller authenticated with `ACCESS_COMPONENTS` (anonymous is acceptable for reads on v4).
+
+**Acceptance criteria:**
+1. `GET /rest/api/4/components?owner=alice` returns HTTP 200 and the `content` array contains only components whose `componentOwner == "alice"`.
+2. `GET /rest/api/4/components?owner=<unknown>` returns HTTP 200 with an empty `content` array and `totalElements == 0`.
+3. `GET /rest/api/4/components` without the `owner` param returns HTTP 200 with the full list (the parameter is optional).
+4. `owner` combines with existing filters (`system`, `productType`, `archived`, `search`) via AND.
+
+**Test method:** `ListComponentsOwnerFilterTest` — three test methods covering criteria 1, 2, 3 against the live `WebSecurityConfig` chain on the `ft-db` profile.
+
+**Out of scope:**
+- Multi-owner / OR semantics (a single value per call; combine with other filters or paginate).
+- Substring or fuzzy match on owner (the autocomplete passes the exact value; substring would defeat the DB index).
+- Owner aliases / SSO username mapping — accept whatever the DB has.
+
+---
+
+### SYS-036: GET /audit/recent accepts filter params
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Description:**
+The Portal `AuditLogPage` filter sidebar drives a server-side query — without filter params on `/audit/recent` the SPA would have to page through the full audit log to apply filters client-side, which doesn't scale beyond a few hundred rows. This requirement adds a set of independently-optional filter query params to `GET /rest/api/4/audit/recent`. Combinations are ANDed; an empty filter is equivalent to "all rows, newest first" (preserves the legacy unfiltered behaviour).
+
+Supported filters:
+| Param | Type | Notes |
+|---|---|---|
+| `entityType` | string | e.g. `COMPONENT`, `FIELD_OVERRIDE` |
+| `entityId` | string | usually a UUID; combine with `entityType` for entity-scoped history reachable in the same query as user/source filters |
+| `changedBy` | string | username from `audit_log.changed_by` |
+| `source` | string | `api` \| `git-history` \| `migration_job` |
+| `action` | string | `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `ARCHIVE` \| … |
+| `from`, `to` | ISO-8601 instant | half-open `[from, to)` over `audit_log.changed_at`; either or both optional |
+
+**Preconditions:**
+- Caller authenticated with `ACCESS_AUDIT`.
+- DB contains audit rows produced by either runtime API events (`source = 'api'`) or backfill from `/admin/migrate-history` (`source = 'git-history'`).
+
+**Acceptance criteria:**
+1. `GET /audit/recent?entityType=COMPONENT` returns only rows with `entityType == "COMPONENT"`.
+2. `GET /audit/recent?entityType=COMPONENT&entityId=<uuid>` returns only rows for that single component (CREATE + any UPDATE/RENAME/DELETE).
+3. `GET /audit/recent?changedBy=alice` returns only rows with `changedBy == "alice"`.
+4. `GET /audit/recent?changedBy=<unknown>` returns HTTP 200 with empty `content` and `totalElements == 0`.
+5. `GET /audit/recent?source=api` returns only rows with `source == "api"`; rows with `source == "git-history"` are excluded.
+6. `GET /audit/recent` without any filter param returns the full audit log newest-first (legacy contract preserved).
+7. Default sort when caller has not supplied `sort=`: `changedAt DESC`. Caller-supplied `sort=` overrides.
+
+**Test method:** `AuditLogFilterTest` — six test methods covering criteria 1–6 against live `AuditService.getRecentChanges` Specification on the `ft-db` profile.
+
+**Out of scope:**
+- Free-text search inside `oldValue` / `newValue` / `changeDiff` JSON.
+- OR-combining values inside a single param (e.g. `source=api,git-history` — pass them as separate calls or use a different endpoint when needed).
+- Pagination metadata changes — Spring Data `Pageable` + `Page<>` shape unchanged.

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -284,10 +284,12 @@ GET    /rest/api/4/audit/recent
   Response: Page<AuditEntry>, default sort changedAt DESC
   Auth:     ACCESS_AUDIT
   Filters:  Optional query params (independent, ANDed when combined; SYS-036):
-              entityType   — e.g. "Component", "FieldOverride"
+              entityType   — currently only "Component" (case-sensitive); other
+                             types reserved for future audit instrumentation
               entityId     — UUID; combine with entityType for entity-scoped history
-              changedBy    — username from audit_log.changed_by
-              source       — "api" | "git-history" | "migration_job"
+              changedBy    — username from audit_log.changed_by (CurrentUserResolver)
+              source       — currently only "api" or "git-history"; other values
+                             reserved for future writers
               action       — "CREATE" | "UPDATE" | "DELETE" | "RENAME" | "ARCHIVE"
               from, to     — ISO-8601 instants; half-open [from, to) on changed_at
   Note:     `audit_log.changed_by` is populated from CurrentUserResolver

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -244,6 +244,14 @@ PATCH  /rest/api/4/components/{id}
 DELETE /rest/api/4/components/{id}
   Behavior: Sets archived=true (soft delete)
   Auth:     DELETE_COMPONENTS
+
+GET    /rest/api/4/components?productType=&archived=&search=&owner=
+  Response: Page<ComponentSummaryResponse>
+  Auth:     ACCESS_COMPONENTS
+  Filters:  productType, archived, search (name/displayName, ILIKE), owner (exact
+            componentOwner). All independently optional, ANDed when combined.
+            `system` is currently rejected with 400 (JPA Criteria + text[] gap).
+  Contract: SYS-035 pins the owner filter (case-sensitive exact match).
 ```
 
 #### Field Version Overrides
@@ -269,12 +277,23 @@ GET    /rest/api/4/components/{id}/field-overrides
 #### Audit
 ```
 GET    /rest/api/4/audit/{entityType}/{entityId}?page=0&size=20
-  Response: Page<AuditEntry> { action, changedBy, changedAt, oldValue, newValue, diff }
+  Response: Page<AuditEntry> { action, changedBy, changedAt, oldValue, newValue, diff, source }
   Auth:     ACCESS_AUDIT
 
-GET    /rest/api/4/audit/recent?page=0&size=50
-  Response: Page<AuditEntry>
+GET    /rest/api/4/audit/recent
+  Response: Page<AuditEntry>, default sort changedAt DESC
   Auth:     ACCESS_AUDIT
+  Filters:  Optional query params (independent, ANDed when combined; SYS-036):
+              entityType   — e.g. "Component", "FieldOverride"
+              entityId     — UUID; combine with entityType for entity-scoped history
+              changedBy    — username from audit_log.changed_by
+              source       — "api" | "git-history" | "migration_job"
+              action       — "CREATE" | "UPDATE" | "DELETE" | "RENAME" | "ARCHIVE"
+              from, to     — ISO-8601 instants; half-open [from, to) on changed_at
+  Note:     `audit_log.changed_by` is populated from CurrentUserResolver
+            (preferred_username from the authenticated JWT, fallback "system" for
+            background jobs). Fixes the gap where API-driven audit rows used to
+            store NULL.
 ```
 
 #### Admin
@@ -421,7 +440,12 @@ Per-component ownership (`componentOwner`, `releaseManager`) is a deferred layer
 
 ### 6.4 Audit `changedBy` wiring
 
-Every `applicationEventPublisher.publishEvent(AuditEvent(...))` call site reads the username from `SecurityService.getCurrentUser().username` (cloud-commons), with a fallback of `"system"` for events triggered outside an authenticated context (e.g. background jobs). The fallback path is exercised by `/admin/migrate-history` rows, which still want a non-null `changed_by` for audit consistency.
+Every `applicationEventPublisher.publishEvent(AuditEvent(...))` call site sets `changedBy = currentUserResolver.currentUsername()`. `CurrentUserResolver` reads the active Spring Security context:
+- `JwtAuthenticationToken` → `preferred_username` claim (Keycloak's canonical username), falling back to `auth.name` (JWT subject);
+- non-JWT `Authentication` (rare) → `auth.name`;
+- no authenticated context (background jobs, async tasks outside an HTTP thread) → `"system"`.
+
+The fallback path is exercised by code paths that don't carry a request context. `/admin/migrate-history` is a special case: it sets `changedBy` from the git author signature (`"Name <email>"`) rather than from `CurrentUserResolver`, because the historical event was originally authored by that git committer — see `GitHistoryImportServiceImpl`. SYS-036 acceptance criterion 3 (filter by `changedBy`) depends on this wiring being in place; tests live under `AuditLogFilterTest`.
 
 ### 6.5 Backward Compatibility
 - v1/v2/v3 endpoints: **permit all** (existing 7+ Feign client consumers don't send JWT).


### PR DESCRIPTION
## Why

Backend support for two Portal P1 (B7.1) UX gaps that the existing `GET /components` and `GET /audit/recent` contracts couldn't service:

1. **Owner-based filtering on the components list** — Portal `ComponentFilters` UI plans an owner dropdown populated from `/components/meta/owners`. Without a server-side filter, the SPA would have to download the full ~900-component list and filter client-side on every owner change.
2. **Filter params on the audit feed** — Portal `AuditLogPage` plans a filter sidebar by entity, user, source, action, date range. Without query params, the SPA would have to page through the entire audit log.

Both arrived in the same PR because the audit filter exposes a `changedBy` filter, which depends on `audit_log.changed_by` actually being populated for runtime API events. That wiring was missing — runtime audit rows had `changed_by = null` (only git-history backfill rows had a value). This PR closes that gap as well.

All landed test-first (TDD red → green).

## What changes

### `SYS-035` — owner filter on `GET /components`

- **Test (red):** `ListComponentsOwnerFilterTest` exercises `?owner=alice`, `?owner=<unknown>`, and the no-filter baseline against `ft-db` H2.
- **Impl (green):**
  - `ComponentFilter` gains `owner: String?`.
  - `ComponentControllerV4.listComponents` accepts a new `owner` `@RequestParam`.
  - `ComponentManagementServiceImpl.buildSpecification` adds an exact-match clause on `componentOwner` (case-sensitive — values come from `/components/meta/owners` so the autocomplete hands back canonical strings).

### `SYS-036` — filter params on `GET /audit/recent`

- **Test (red):** `AuditLogFilterTest` covers `entityType`, `entityType + entityId`, `changedBy` (positive + unknown-user), `source=api`, no-filter baseline. Six methods, `ft-db` H2 profile.
- **Impl (green):**
  - New `AuditLogFilter` DTO: `entityType`, `entityId`, `changedBy`, `source`, `action`, `from`, `to`. Half-open `[from, to)` window over `changed_at`.
  - `AuditLogRepository` extends `JpaSpecificationExecutor`.
  - `AuditServiceImpl.getRecentChanges` builds a Specification from the filter; default-sorts `changedAt DESC` when the caller hasn't supplied `sort=`, preserving the legacy unfiltered behaviour.
  - `AuditControllerV4.getRecentChanges` accepts the new params; `from`/`to` bind via `@DateTimeFormat(iso = ISO.DATE_TIME)`.

### Audit `changedBy` wiring (gap exposed by SYS-036)

- **New** `CurrentUserResolver` (`security/CurrentUserResolver.kt`): a small `@Component` that reads the active Spring Security context. Reads `preferred_username` from the JWT (Keycloak's canonical username claim), falls back to `auth.name` (JWT subject), then to `"system"` for background contexts.
  - Deliberately bypasses cloud-commons `SecurityService.getCurrentUser()` because the latter hits Keycloak `/userinfo` on every call (overkill for audit) and is broken in MockMvc tests where `@MockBean AuthServerClient` short-circuits the converter chain.
- `ComponentManagementServiceImpl` injects `CurrentUserResolver` and sets `changedBy = currentUserResolver.currentUsername()` at all three `AuditEvent` publish sites (CREATE, UPDATE/RENAME, DELETE).
- `/admin/migrate-history` is **unchanged**: it still uses git author info for `changedBy` because that's the historically correct attribution.

### Spec docs

- `requirements-common.md` — `SYS-035` + `SYS-036` acceptance criteria with live test method names; both summary-table rows ✅ Tested.
- `functional-spec.md` §1.1 lists the new owner filter; §4.2 documents the full `SYS-036` query-param table and the default sort.
- `technical-design.md` §5.2 adds the `GET /components` contract block with filter params and the `GET /audit/recent` block with the same; §6.4 (Audit `changedBy` wiring) rewritten to point at `CurrentUserResolver`.

## Test plan

- [x] `ListComponentsOwnerFilterTest` (3 tests) — TDD red → green.
- [x] `AuditLogFilterTest` (6 tests) — TDD red → green.
- [x] Adjacent tests touching the same code paths still pass: `ComponentRenameTest`, `ListComponentsSystemFilterTest`, `ComponentControllerV4LookupFallbackTest`, `ComponentSourceRegistryMultiPodTest`, `AuditDiffTest`.
- [x] `qualityStatic` (detekt + ktlint + Checkstyle + PMD) passes.
- [ ] Full-suite tests requiring Docker / testcontainers: skipped in my environment (Docker not running). Will need CI confirmation.

## Companion work

This PR unblocks Portal P1 tasks **7.1.1 (owner filter)** and **7.1.3 (audit log filtering)** in `octopus-components-management-portal`. Portal `feature/ui-p1` will land on top of this once it's merged. The four Portal P1 tasks that don't depend on this PR (per-component history, rename, parentComponent, optimistic-locking UX) can proceed in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)