### PR TITLE
feat(migrate-history): async job + cross-job gate + phase indicator + force-reset

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
@@ -32,6 +32,16 @@ import org.springframework.context.annotation.Profile
 @Configuration
 @Profile("dev-fault-injection")
 class FaultInjectionConfig {
+    init {
+        // Startup log — critical that operators can spot "fault injection
+        // active" in pod boot logs. ERROR level so it surfaces in
+        // alert/monitoring pipelines that filter on ERROR-only.
+        log.error(
+            "[fault-injection] dev-fault-injection profile is ACTIVE. " +
+                "If you see this in a production deployment, the wrong profile is set — " +
+                "investigate spring.profiles.active and the matching property gates immediately.",
+        )
+    }
     /**
      * Wraps the real [ImportService], throwing once `migrateDefaults()` is
      * called (so the SPA observes phase=DEFAULTS first, then a FAILED
@@ -66,7 +76,7 @@ class FaultInjectionConfig {
             // knows the path was hit, then bomb. A pure throw without delegation
             // would also work but makes the failure feel synthetic.
             delegate.migrateDefaults()
-            log.warn("[fault-injection] throwing IllegalStateException after migrateDefaults")
+            log.error("[fault-injection] throwing IllegalStateException after migrateDefaults")
             throw IllegalStateException(
                 "fault-injection: migration.fault-injection.fail-after-defaults=true",
             )
@@ -81,7 +91,7 @@ class FaultInjectionConfig {
             reset: Boolean,
             listener: HistoryImportProgressListener,
         ): HistoryImportResult {
-            log.warn("[fault-injection] throwing IllegalStateException from importHistory before walk")
+            log.error("[fault-injection] throwing IllegalStateException from importHistory before walk")
             // We could delegate part-way, but we don't actually want to leave
             // partial DB state — the underlying impl already marks FAILED on
             // throw via its outer try/catch, that's what we want to exercise.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
@@ -42,6 +42,7 @@ class FaultInjectionConfig {
                 "investigate spring.profiles.active and the matching property gates immediately.",
         )
     }
+
     /**
      * Wraps the real [ImportService], throwing once `migrateDefaults()` is
      * called (so the SPA observes phase=DEFAULTS first, then a FAILED
@@ -65,8 +66,7 @@ class FaultInjectionConfig {
     @Bean
     @Primary
     @ConditionalOnProperty("migration.fault-injection.fail-history-after-clone", havingValue = "true")
-    fun faultyHistoryImportService(real: GitHistoryImportServiceImpl): GitHistoryImportService =
-        FaultInjectingHistoryImportService(real)
+    fun faultyHistoryImportService(real: GitHistoryImportServiceImpl): GitHistoryImportService = FaultInjectingHistoryImportService(real)
 
     private class FaultInjectingImportService(
         private val delegate: ImportService,
@@ -77,9 +77,7 @@ class FaultInjectionConfig {
             // would also work but makes the failure feel synthetic.
             delegate.migrateDefaults()
             log.error("[fault-injection] throwing IllegalStateException after migrateDefaults")
-            throw IllegalStateException(
-                "fault-injection: migration.fault-injection.fail-after-defaults=true",
-            )
+            error("fault-injection: migration.fault-injection.fail-after-defaults=true")
         }
     }
 
@@ -95,7 +93,7 @@ class FaultInjectionConfig {
             // We could delegate part-way, but we don't actually want to leave
             // partial DB state — the underlying impl already marks FAILED on
             // throw via its outer try/catch, that's what we want to exercise.
-            throw IllegalStateException(
+            error(
                 "fault-injection: migration.fault-injection.fail-history-after-clone=true",
             )
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
@@ -1,0 +1,97 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
+import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
+import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
+import org.octopusden.octopus.components.registry.server.service.ImportService
+import org.octopusden.octopus.components.registry.server.service.impl.GitHistoryImportServiceImpl
+import org.octopusden.octopus.components.registry.server.service.impl.ImportServiceImpl
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+/**
+ * Test-only fault injection. Loaded ONLY when both gates fire:
+ *   - Spring profile `dev-fault-injection` is active (the @Profile annotation
+ *     means the @Configuration class is not even instantiated otherwise);
+ *   - the matching @ConditionalOnProperty is set to "true".
+ *
+ * Two gates instead of one because a stray JVM property without the profile
+ * activation should NOT trigger fault injection — defense-in-depth against an
+ * accidentally-set env var becoming a production kill switch. Operators must
+ * explicitly opt into both layers.
+ *
+ * Used by Verification 5/5a in the plan: drives the SPA into the FAILED
+ * destructive-block UX so the Retry flow can be validated end-to-end without
+ * killing pods (which would only exercise the loss-of-state path, see
+ * Verification 7).
+ */
+@Configuration
+@Profile("dev-fault-injection")
+class FaultInjectionConfig {
+    /**
+     * Wraps the real [ImportService], throwing once `migrateDefaults()` is
+     * called (so the SPA observes phase=DEFAULTS first, then a FAILED
+     * transition with a recognisable errorMessage). All other methods
+     * delegate.
+     */
+    @Bean
+    @Primary
+    @ConditionalOnProperty("migration.fault-injection.fail-after-defaults", havingValue = "true")
+    fun faultyImportService(real: ImportServiceImpl): ImportService = FaultInjectingImportService(real)
+
+    /**
+     * Wraps the real [GitHistoryImportService], throwing inside `importHistory`
+     * after the clone+resolve phase (the listener gets a single
+     * `totalCommits` event before the throw, so the SPA briefly sees the
+     * total before the FAILED transition). State row in
+     * `git_history_import_state` is left as IN_PROGRESS by the underlying
+     * impl's `markState(FAILED)` — exact same path a real-world failure
+     * takes. Verification 5b uses this to test Force-reset.
+     */
+    @Bean
+    @Primary
+    @ConditionalOnProperty("migration.fault-injection.fail-history-after-clone", havingValue = "true")
+    fun faultyHistoryImportService(real: GitHistoryImportServiceImpl): GitHistoryImportService =
+        FaultInjectingHistoryImportService(real)
+
+    private class FaultInjectingImportService(
+        private val delegate: ImportService,
+    ) : ImportService by delegate {
+        override fun migrateDefaults(): Map<String, Any?> {
+            // Run once for real so the operator sees the existing log lines and
+            // knows the path was hit, then bomb. A pure throw without delegation
+            // would also work but makes the failure feel synthetic.
+            delegate.migrateDefaults()
+            log.warn("[fault-injection] throwing IllegalStateException after migrateDefaults")
+            throw IllegalStateException(
+                "fault-injection: migration.fault-injection.fail-after-defaults=true",
+            )
+        }
+    }
+
+    private class FaultInjectingHistoryImportService(
+        private val delegate: GitHistoryImportService,
+    ) : GitHistoryImportService {
+        override fun importHistory(
+            toRef: String?,
+            reset: Boolean,
+            listener: HistoryImportProgressListener,
+        ): HistoryImportResult {
+            log.warn("[fault-injection] throwing IllegalStateException from importHistory before walk")
+            // We could delegate part-way, but we don't actually want to leave
+            // partial DB state — the underlying impl already marks FAILED on
+            // throw via its outer try/catch, that's what we want to exercise.
+            throw IllegalStateException(
+                "fault-injection: migration.fault-injection.fail-history-after-clone=true",
+            )
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(FaultInjectionConfig::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/FaultInjectionConfig.kt
@@ -55,13 +55,13 @@ class FaultInjectionConfig {
     fun faultyImportService(real: ImportServiceImpl): ImportService = FaultInjectingImportService(real)
 
     /**
-     * Wraps the real [GitHistoryImportService], throwing inside `importHistory`
-     * after the clone+resolve phase (the listener gets a single
-     * `totalCommits` event before the throw, so the SPA briefly sees the
-     * total before the FAILED transition). State row in
-     * `git_history_import_state` is left as IN_PROGRESS by the underlying
-     * impl's `markState(FAILED)` — exact same path a real-world failure
-     * takes. Verification 5b uses this to test Force-reset.
+     * Wraps the real [GitHistoryImportService], throwing immediately at the
+     * start of `importHistory` without delegating. No progress events are
+     * emitted — the throw happens before the clone+resolve phase, so the
+     * SPA goes straight from RUNNING to FAILED with no totalCommits update.
+     * The underlying impl's `markState(FAILED)` path handles state row
+     * cleanup, which is the same path a real-world failure takes.
+     * Verification 5b uses this to test Force-reset.
      */
     @Bean
     @Primary

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -3,20 +3,16 @@ package org.octopusden.octopus.components.registry.server.controller
 import org.octopusden.octopus.components.registry.server.dto.v4.HistoryMigrationJobResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationConflictResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationJobResponse
-import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
-import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
 import org.octopusden.octopus.components.registry.server.service.BatchMigrationResult
+import org.octopusden.octopus.components.registry.server.service.ForceResetOutcome
 import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
 import org.octopusden.octopus.components.registry.server.service.ImportService
-import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
-import org.octopusden.octopus.components.registry.server.service.impl.GitHistoryCommitWriter
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -27,8 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.time.Duration
-import java.time.Instant
 
 @RestController
 @RequestMapping("rest/api/4/admin")
@@ -38,8 +32,6 @@ class AdminControllerV4(
     private val importService: ImportService,
     private val migrationJobService: MigrationJobService,
     private val historyMigrationJobService: HistoryMigrationJobService,
-    private val historyCommitWriter: GitHistoryCommitWriter,
-    private val historyStateRepository: GitHistoryImportStateRepository,
 ) {
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
@@ -132,124 +124,28 @@ class AdminControllerV4(
 
     /**
      * Destructive: deletes the git_history_import_state row AND all audit_log
-     * rows with source='git-history'. Used to recover from stale IN_PROGRESS
-     * claims left by a prior pod restart, or to bootstrap a re-import on a
-     * stuck COMPLETED row when reset=true is also blocked.
-     *
-     * Two layers of guard against multi-pod corruption (P1 review fix):
-     *
-     * 1. **In-pod gate** — refused with 409 if a history migration is
-     *    currently RUNNING in *this* pod. Defense-in-depth against a curl
-     *    call racing the Run flow.
-     * 2. **Cross-pod staleness gate** — refused with 409 if the DB row is
-     *    IN_PROGRESS with a fresh `updatedAt` (< STALE_IN_PROGRESS_THRESHOLD).
-     *    A live import in *another* pod would have a recent updatedAt; this
-     *    catches the cross-pod overlap that the in-pod gate cannot. Operators
-     *    who explicitly need to interrupt a fresh live import can override
-     *    with `?ack-multipod-risk=true` — that's an audit-loud opt-in, not a
-     *    silent default.
-     *
-     * Always logs the destructive action before performing it so operators
-     * have an audit trail even when the DB row gets wiped. Idempotent on
-     * an empty DB (returns 204 even when nothing was deleted).
+     * rows with source='git-history'. Guards and audit logging are handled by
+     * [HistoryMigrationJobService.forceReset]; this method maps the outcome to
+     * HTTP. Returns 204 on success (idempotent — same response when the DB was
+     * already empty), 409 with a [MigrationConflictResponse] body when any guard
+     * blocks the wipe.
      */
     @PostMapping("/migrate-history/force-reset")
     fun forceResetHistory(
         @RequestParam(name = "ack-multipod-risk", defaultValue = "false") ackMultipodRisk: Boolean,
-    ): ResponseEntity<Any> {
-        // Guard 1: same-pod active job.
-        val active = historyMigrationJobService.current()
-        if (active?.state == JobState.RUNNING) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                MigrationConflictResponse(
-                    code = "history-migration-running",
-                    message =
-                        "Cannot force-reset while history migration is RUNNING (jobId=${active.id}). " +
-                            "Wait for it to finish or restart the pod.",
-                    activeKind = MigrationLifecycleGate.JobKind.HISTORY.name,
-                    activeJobId = active.id,
-                ),
-            )
-        }
-
-        // Guard 2: cross-pod staleness. Inspect the DB row directly (NOT via
-        // current() — that one synthesizes a JobState rather than exposing
-        // updatedAt).
-        val row = historyStateRepository.findById(IMPORT_KEY).orElse(null)
-        if (row != null &&
-            row.status == GitHistoryImportStatus.IN_PROGRESS.name &&
-            !ackMultipodRisk
-        ) {
-            val age = Duration.between(row.updatedAt, Instant.now())
-            if (age < STALE_IN_PROGRESS_THRESHOLD) {
-                // INFO not WARN: this is the *successful* defense path —
-                // the gate worked, no operator needs to be paged. The WARN
-                // is reserved for the override case below where a live
-                // import in another pod might be about to lose data.
-                LOG.info(
-                    "Refusing force-reset: IN_PROGRESS row updated {} ago (threshold={}). " +
-                        "Likely a live import in another pod. Override with ack-multipod-risk=true if you accept the data-corruption risk.",
-                    age,
-                    STALE_IN_PROGRESS_THRESHOLD,
-                )
-                return ResponseEntity.status(HttpStatus.CONFLICT).body(
+    ): ResponseEntity<Any> =
+        when (val outcome = historyMigrationJobService.forceReset(ackMultipodRisk)) {
+            is ForceResetOutcome.Cleared -> ResponseEntity.noContent().build()
+            is ForceResetOutcome.Blocked ->
+                ResponseEntity.status(HttpStatus.CONFLICT).body(
                     MigrationConflictResponse(
-                        code = "history-import-likely-live-elsewhere",
-                        message =
-                            "Refusing force-reset: the IN_PROGRESS claim was updated ${age.toSeconds()}s ago, " +
-                                "below the ${STALE_IN_PROGRESS_THRESHOLD.toMinutes()}-minute staleness threshold. " +
-                                "A live import in another pod is likely. " +
-                                "If you understand the multi-pod risk and want to proceed anyway, " +
-                                "POST again with ?ack-multipod-risk=true.",
-                        activeKind = MigrationLifecycleGate.JobKind.HISTORY.name,
-                        // Owned by another pod — we can't read its in-memory job id from here.
-                        activeJobId = null,
+                        code = outcome.code,
+                        message = outcome.message,
+                        activeKind = outcome.activeKind,
+                        activeJobId = outcome.activeJobId,
                     ),
                 )
-            }
         }
-
-        // P1 review fix: TOCTOU between Guard 1 (in-memory state) and Guard 2
-        // (DB row read). Window is microseconds — between an external
-        // startAsync's state.compareAndSet and its preflight tryInsert.
-        // Re-check the in-memory state after the row read so a freshly-claimed
-        // job in this same pod can't slip past both guards. Cheap defensive
-        // re-read; if it picks up a RUNNING job, treat it like Guard 1.
-        val activeAfterRowRead = historyMigrationJobService.current()
-        if (activeAfterRowRead?.state == JobState.RUNNING) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                MigrationConflictResponse(
-                    code = "history-migration-running",
-                    message =
-                        "Cannot force-reset while history migration is RUNNING (jobId=${activeAfterRowRead.id}). " +
-                            "Wait for it to finish or restart the pod.",
-                    activeKind = MigrationLifecycleGate.JobKind.HISTORY.name,
-                    activeJobId = activeAfterRowRead.id,
-                ),
-            )
-        }
-
-        // Audit-loud destructive action: log before the wipe so the pre-state
-        // survives the operation in the log stream. ack-multipod-risk=true is
-        // logged at WARN to make the override visible in alert pipelines.
-        if (row != null) {
-            val msg =
-                "FORCE-RESET: deleting git_history_import_state " +
-                    "(target=${row.targetRef}@${row.targetSha}, status=${row.status}, " +
-                    "updatedAt=${row.updatedAt}) and all audit_log rows with source='git-history'."
-            // ack-multipod-risk overrides the staleness check, which means the
-            // operator just told us "I accept potential data corruption."
-            // ERROR level so alert pipelines that filter on ERROR-only catch
-            // this — same reasoning as FaultInjectionConfig's startup banner.
-            if (ackMultipodRisk) LOG.error("$msg [ack-multipod-risk=true overriding staleness check]") else LOG.info(msg)
-        } else {
-            LOG.info("FORCE-RESET: no state row to delete (idempotent no-op on empty DB)")
-        }
-
-        historyCommitWriter.forceReset()
-        historyMigrationJobService.clearInMemory()
-        return ResponseEntity.noContent().build()
-    }
 
     /**
      * Map cross-kind gate conflicts to a structured 409. Same-kind 409 is
@@ -271,24 +167,5 @@ class AdminControllerV4(
                 activeJobId = e.active.jobId,
             ),
         )
-    }
-
-    companion object {
-        private val LOG = LoggerFactory.getLogger(AdminControllerV4::class.java)
-
-        /**
-         * Threshold for considering an IN_PROGRESS DB row "stale enough that no
-         * one in any pod is actively writing to it." Conservative: a real
-         * import keeps `updated_at` fresh via the per-50-commits heartbeat
-         * call from `GitHistoryImportServiceImpl.runImport`. If we haven't
-         * seen a write in 30 minutes, the original pod is almost certainly
-         * gone.
-         *
-         * Operators who genuinely need to interrupt a fresh live import can
-         * bypass with `?ack-multipod-risk=true` — explicit acknowledgement
-         * that data corruption is acceptable.
-         */
-        private val STALE_IN_PROGRESS_THRESHOLD: Duration = Duration.ofMinutes(30)
-        private const val IMPORT_KEY = "component-history"
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -1,17 +1,23 @@
 package org.octopusden.octopus.components.registry.server.controller
 
-import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryMigrationJobResponse
+import org.octopusden.octopus.components.registry.server.dto.v4.MigrationConflictResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationJobResponse
 import org.octopusden.octopus.components.registry.server.service.BatchMigrationResult
-import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
+import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
 import org.octopusden.octopus.components.registry.server.service.ImportService
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
+import org.octopusden.octopus.components.registry.server.service.impl.GitHistoryCommitWriter
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -24,8 +30,9 @@ import org.springframework.web.bind.annotation.RestController
 @PreAuthorize("@permissionEvaluator.canImport()")
 class AdminControllerV4(
     private val importService: ImportService,
-    private val gitHistoryImportService: GitHistoryImportService,
     private val migrationJobService: MigrationJobService,
+    private val historyMigrationJobService: HistoryMigrationJobService,
+    private val historyCommitWriter: GitHistoryCommitWriter,
 ) {
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
@@ -55,7 +62,11 @@ class AdminControllerV4(
      * the existing job's state — the SPA "attaches" to the in-flight job rather
      * than spawning a duplicate. Either way, callers can poll
      * `GET /admin/migrate/job` to watch progress and pick up the final
-     * [MigrationJobResponse.result] once `state == COMPLETED`.
+     * result once `state == COMPLETED`.
+     *
+     * If the OTHER migration kind (history) is currently RUNNING, the service
+     * throws [MigrationConflictException] which the handler below maps to a
+     * 409 with [MigrationConflictResponse] body.
      */
     @PostMapping("/migrate")
     fun migrate(): ResponseEntity<MigrationJobResponse> {
@@ -66,9 +77,7 @@ class AdminControllerV4(
 
     /**
      * Returns the latest known [MigrationJobResponse], or 404 if no migration has been started
-     * since the pod came up. While the job is RUNNING, response carries `currentComponent`
-     * and per-component counters that the SPA renders as a progress bar; once
-     * `state == COMPLETED`, `result` is populated with the full [FullMigrationResult].
+     * since the pod came up.
      */
     @GetMapping("/migrate/job")
     fun getMigrateJob(): ResponseEntity<MigrationJobResponse> {
@@ -82,9 +91,87 @@ class AdminControllerV4(
     @GetMapping("/export")
     fun exportComponents(): ResponseEntity<Map<String, String>> = ResponseEntity.ok(mapOf("status" to "not_implemented"))
 
+    /**
+     * Async git-history backfill. Mirrors POST /migrate for components:
+     * 202 on a freshly-started job, 409 with an attach-able job body on a
+     * same-kind retry (poll /migrate-history/job for live state).
+     *
+     * `toRef` defaults to the auto-resolved tag matching the configured prefix;
+     * `reset=true` is required to re-run on top of an existing terminal
+     * git_history_import_state row.
+     */
     @PostMapping("/migrate-history")
     fun migrateHistory(
         @RequestParam(required = false) toRef: String?,
         @RequestParam(defaultValue = "false") reset: Boolean,
-    ): ResponseEntity<HistoryImportResult> = ResponseEntity.ok(gitHistoryImportService.importHistory(toRef, reset))
+    ): ResponseEntity<HistoryMigrationJobResponse> {
+        val outcome = historyMigrationJobService.startAsync(toRef, reset)
+        val httpStatus = if (outcome.isNewlyStarted) HttpStatus.ACCEPTED else HttpStatus.CONFLICT
+        return ResponseEntity.status(httpStatus).body(HistoryMigrationJobResponse.from(outcome.state))
+    }
+
+    /**
+     * Returns the latest known history-migration job — including a state
+     * synthesized from `git_history_import_state` if no in-memory job is
+     * active in this pod (so the SPA sees prior-pod outcomes after restart
+     * and surfaces the right action — see HistoryMigrationJobServiceImpl A7.1).
+     * 404 only when there is neither in-memory state nor a DB row.
+     */
+    @GetMapping("/migrate-history/job")
+    fun getHistoryMigrateJob(): ResponseEntity<HistoryMigrationJobResponse> {
+        val state = historyMigrationJobService.current() ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(HistoryMigrationJobResponse.from(state))
+    }
+
+    /**
+     * Destructive: deletes the git_history_import_state row AND all audit_log
+     * rows with source='git-history'. Used to recover from stale IN_PROGRESS
+     * claims left by a prior pod restart, or to bootstrap a re-import on a
+     * stuck COMPLETED row when reset=true is also blocked.
+     *
+     * Refused with 409 if a history migration is currently RUNNING in this
+     * pod — defense-in-depth against a direct curl call racing the Run flow.
+     * Idempotent on an empty DB (returns 204).
+     */
+    @PostMapping("/migrate-history/force-reset")
+    fun forceResetHistory(): ResponseEntity<Any> {
+        val active = historyMigrationJobService.current()
+        if (active?.state == JobState.RUNNING) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                MigrationConflictResponse(
+                    code = "history-migration-running",
+                    message =
+                        "Cannot force-reset while history migration is RUNNING (jobId=${active.id}). " +
+                            "Wait for it to finish or restart the pod.",
+                    activeKind = MigrationLifecycleGate.JobKind.HISTORY.name,
+                    activeJobId = active.id,
+                ),
+            )
+        }
+        historyCommitWriter.forceReset()
+        historyMigrationJobService.clearInMemory()
+        return ResponseEntity.noContent().build()
+    }
+
+    /**
+     * Map cross-kind gate conflicts to a structured 409. Same-kind 409 is
+     * NOT routed here — it returns from startAsync as `isNewlyStarted=false`
+     * with the existing job state body so the SPA can attach.
+     */
+    @ExceptionHandler(MigrationConflictException::class)
+    fun handleCrossKindConflict(e: MigrationConflictException): ResponseEntity<MigrationConflictResponse> {
+        val code =
+            when (e.active.kind) {
+                MigrationLifecycleGate.JobKind.COMPONENTS -> "components-migration-running"
+                MigrationLifecycleGate.JobKind.HISTORY -> "history-migration-running"
+            }
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(
+            MigrationConflictResponse(
+                code = code,
+                message = e.message ?: "Cross-kind migration conflict",
+                activeKind = e.active.kind.name,
+                activeJobId = e.active.jobId,
+            ),
+        )
+    }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -9,13 +9,18 @@ import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
 import org.octopusden.octopus.components.registry.server.service.impl.GitHistoryCommitWriter
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import java.time.Duration
+import java.time.Instant
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
@@ -33,7 +38,25 @@ class AdminControllerV4(
     private val migrationJobService: MigrationJobService,
     private val historyMigrationJobService: HistoryMigrationJobService,
     private val historyCommitWriter: GitHistoryCommitWriter,
+    private val historyStateRepository: GitHistoryImportStateRepository,
 ) {
+    companion object {
+        private val LOG = LoggerFactory.getLogger(AdminControllerV4::class.java)
+
+        /**
+         * Threshold for considering an IN_PROGRESS DB row "stale enough that no
+         * one in any pod is actively writing to it." Conservative: a real
+         * import takes minutes and writes update the state row's `updated_at`
+         * implicitly via JPA on every commit batch. If we haven't seen a
+         * write in 30 minutes, the original pod is almost certainly gone.
+         *
+         * Operators who genuinely need to interrupt a fresh live import can
+         * bypass with `?ack-multipod-risk=true` — explicit acknowledgement
+         * that data corruption is acceptable.
+         */
+        private val STALE_IN_PROGRESS_THRESHOLD: Duration = Duration.ofMinutes(30)
+        private const val IMPORT_KEY = "component-history"
+    }
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
         @PathVariable name: String,
@@ -129,12 +152,28 @@ class AdminControllerV4(
      * claims left by a prior pod restart, or to bootstrap a re-import on a
      * stuck COMPLETED row when reset=true is also blocked.
      *
-     * Refused with 409 if a history migration is currently RUNNING in this
-     * pod — defense-in-depth against a direct curl call racing the Run flow.
-     * Idempotent on an empty DB (returns 204).
+     * Two layers of guard against multi-pod corruption (P1 review fix):
+     *
+     * 1. **In-pod gate** — refused with 409 if a history migration is
+     *    currently RUNNING in *this* pod. Defense-in-depth against a curl
+     *    call racing the Run flow.
+     * 2. **Cross-pod staleness gate** — refused with 409 if the DB row is
+     *    IN_PROGRESS with a fresh `updatedAt` (< STALE_IN_PROGRESS_THRESHOLD).
+     *    A live import in *another* pod would have a recent updatedAt; this
+     *    catches the cross-pod overlap that the in-pod gate cannot. Operators
+     *    who explicitly need to interrupt a fresh live import can override
+     *    with `?ack-multipod-risk=true` — that's an audit-loud opt-in, not a
+     *    silent default.
+     *
+     * Always logs the destructive action before performing it so operators
+     * have an audit trail even when the DB row gets wiped. Idempotent on
+     * an empty DB (returns 204 even when nothing was deleted).
      */
     @PostMapping("/migrate-history/force-reset")
-    fun forceResetHistory(): ResponseEntity<Any> {
+    fun forceResetHistory(
+        @RequestParam(name = "ack-multipod-risk", defaultValue = "false") ackMultipodRisk: Boolean,
+    ): ResponseEntity<Any> {
+        // Guard 1: same-pod active job.
         val active = historyMigrationJobService.current()
         if (active?.state == JobState.RUNNING) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(
@@ -148,6 +187,52 @@ class AdminControllerV4(
                 ),
             )
         }
+
+        // Guard 2: cross-pod staleness. Inspect the DB row directly (NOT via
+        // current() — that one synthesizes a JobState rather than exposing
+        // updatedAt).
+        val row = historyStateRepository.findById(IMPORT_KEY).orElse(null)
+        if (row != null &&
+            row.status == GitHistoryImportStatus.IN_PROGRESS.name &&
+            !ackMultipodRisk
+        ) {
+            val age = Duration.between(row.updatedAt, Instant.now())
+            if (age < STALE_IN_PROGRESS_THRESHOLD) {
+                LOG.warn(
+                    "Refusing force-reset: IN_PROGRESS row updated {} ago (threshold={}). " +
+                        "Likely a live import in another pod. Override with ack-multipod-risk=true if you accept the data-corruption risk.",
+                    age,
+                    STALE_IN_PROGRESS_THRESHOLD,
+                )
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                    MigrationConflictResponse(
+                        code = "history-import-likely-live-elsewhere",
+                        message =
+                            "Refusing force-reset: the IN_PROGRESS claim was updated ${age.toSeconds()}s ago, " +
+                                "below the ${STALE_IN_PROGRESS_THRESHOLD.toMinutes()}-minute staleness threshold. " +
+                                "A live import in another pod is likely. " +
+                                "If you understand the multi-pod risk and want to proceed anyway, " +
+                                "POST again with ?ack-multipod-risk=true.",
+                        activeKind = MigrationLifecycleGate.JobKind.HISTORY.name,
+                        activeJobId = "(unknown — owned by another pod)",
+                    ),
+                )
+            }
+        }
+
+        // Audit-loud destructive action: log before the wipe so the pre-state
+        // survives the operation in the log stream. ack-multipod-risk=true is
+        // logged at WARN to make the override visible in alert pipelines.
+        if (row != null) {
+            val msg =
+                "FORCE-RESET: deleting git_history_import_state " +
+                    "(target=${row.targetRef}@${row.targetSha}, status=${row.status}, " +
+                    "updatedAt=${row.updatedAt}) and all audit_log rows with source='git-history'."
+            if (ackMultipodRisk) LOG.warn("$msg [ack-multipod-risk=true overriding staleness check]") else LOG.info(msg)
+        } else {
+            LOG.info("FORCE-RESET: no state row to delete (idempotent no-op on empty DB)")
+        }
+
         historyCommitWriter.forceReset()
         historyMigrationJobService.clearInMemory()
         return ResponseEntity.noContent().build()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -3,14 +3,14 @@ package org.octopusden.octopus.components.registry.server.controller
 import org.octopusden.octopus.components.registry.server.dto.v4.HistoryMigrationJobResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationConflictResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationJobResponse
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
 import org.octopusden.octopus.components.registry.server.service.BatchMigrationResult
 import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
 import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
-import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
-import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
@@ -19,8 +19,6 @@ import org.octopusden.octopus.components.registry.server.service.impl.GitHistory
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import java.time.Duration
-import java.time.Instant
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,10 +27,13 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
+import java.time.Instant
 
 @RestController
 @RequestMapping("rest/api/4/admin")
 @PreAuthorize("@permissionEvaluator.canImport()")
+@Suppress("TooManyFunctions") // Each migration / import endpoint is its own method; consistent with ComponentControllerV4.
 class AdminControllerV4(
     private val importService: ImportService,
     private val migrationJobService: MigrationJobService,
@@ -40,23 +41,6 @@ class AdminControllerV4(
     private val historyCommitWriter: GitHistoryCommitWriter,
     private val historyStateRepository: GitHistoryImportStateRepository,
 ) {
-    companion object {
-        private val LOG = LoggerFactory.getLogger(AdminControllerV4::class.java)
-
-        /**
-         * Threshold for considering an IN_PROGRESS DB row "stale enough that no
-         * one in any pod is actively writing to it." Conservative: a real
-         * import takes minutes and writes update the state row's `updated_at`
-         * implicitly via JPA on every commit batch. If we haven't seen a
-         * write in 30 minutes, the original pod is almost certainly gone.
-         *
-         * Operators who genuinely need to interrupt a fresh live import can
-         * bypass with `?ack-multipod-risk=true` — explicit acknowledgement
-         * that data corruption is acceptable.
-         */
-        private val STALE_IN_PROGRESS_THRESHOLD: Duration = Duration.ofMinutes(30)
-        private const val IMPORT_KEY = "component-history"
-    }
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
         @PathVariable name: String,
@@ -267,5 +251,24 @@ class AdminControllerV4(
                 activeJobId = e.active.jobId,
             ),
         )
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(AdminControllerV4::class.java)
+
+        /**
+         * Threshold for considering an IN_PROGRESS DB row "stale enough that no
+         * one in any pod is actively writing to it." Conservative: a real
+         * import keeps `updated_at` fresh via the per-50-commits heartbeat
+         * call from `GitHistoryImportServiceImpl.runImport`. If we haven't
+         * seen a write in 30 minutes, the original pod is almost certainly
+         * gone.
+         *
+         * Operators who genuinely need to interrupt a fresh live import can
+         * bypass with `?ack-multipod-risk=true` — explicit acknowledgement
+         * that data corruption is acceptable.
+         */
+        private val STALE_IN_PROGRESS_THRESHOLD: Duration = Duration.ofMinutes(30)
+        private const val IMPORT_KEY = "component-history"
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -209,6 +209,26 @@ class AdminControllerV4(
             }
         }
 
+        // P1 review fix: TOCTOU between Guard 1 (in-memory state) and Guard 2
+        // (DB row read). Window is microseconds — between an external
+        // startAsync's state.compareAndSet and its preflight tryInsert.
+        // Re-check the in-memory state after the row read so a freshly-claimed
+        // job in this same pod can't slip past both guards. Cheap defensive
+        // re-read; if it picks up a RUNNING job, treat it like Guard 1.
+        val activeAfterRowRead = historyMigrationJobService.current()
+        if (activeAfterRowRead?.state == JobState.RUNNING) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                MigrationConflictResponse(
+                    code = "history-migration-running",
+                    message =
+                        "Cannot force-reset while history migration is RUNNING (jobId=${activeAfterRowRead.id}). " +
+                            "Wait for it to finish or restart the pod.",
+                    activeKind = MigrationLifecycleGate.JobKind.HISTORY.name,
+                    activeJobId = activeAfterRowRead.id,
+                ),
+            )
+        }
+
         // Audit-loud destructive action: log before the wipe so the pre-state
         // survives the operation in the log stream. ack-multipod-risk=true is
         // logged at WARN to make the override visible in alert pipelines.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -198,7 +198,11 @@ class AdminControllerV4(
         ) {
             val age = Duration.between(row.updatedAt, Instant.now())
             if (age < STALE_IN_PROGRESS_THRESHOLD) {
-                LOG.warn(
+                // INFO not WARN: this is the *successful* defense path —
+                // the gate worked, no operator needs to be paged. The WARN
+                // is reserved for the override case below where a live
+                // import in another pod might be about to lose data.
+                LOG.info(
                     "Refusing force-reset: IN_PROGRESS row updated {} ago (threshold={}). " +
                         "Likely a live import in another pod. Override with ack-multipod-risk=true if you accept the data-corruption risk.",
                     age,
@@ -214,7 +218,8 @@ class AdminControllerV4(
                                 "If you understand the multi-pod risk and want to proceed anyway, " +
                                 "POST again with ?ack-multipod-risk=true.",
                         activeKind = MigrationLifecycleGate.JobKind.HISTORY.name,
-                        activeJobId = "(unknown — owned by another pod)",
+                        // Owned by another pod — we can't read its in-memory job id from here.
+                        activeJobId = null,
                     ),
                 )
             }
@@ -228,7 +233,11 @@ class AdminControllerV4(
                 "FORCE-RESET: deleting git_history_import_state " +
                     "(target=${row.targetRef}@${row.targetSha}, status=${row.status}, " +
                     "updatedAt=${row.updatedAt}) and all audit_log rows with source='git-history'."
-            if (ackMultipodRisk) LOG.warn("$msg [ack-multipod-risk=true overriding staleness check]") else LOG.info(msg)
+            // ack-multipod-risk overrides the staleness check, which means the
+            // operator just told us "I accept potential data corruption."
+            // ERROR level so alert pipelines that filter on ERROR-only catch
+            // this — same reasoning as FaultInjectionConfig's startup banner.
+            if (ackMultipodRisk) LOG.error("$msg [ack-multipod-risk=true overriding staleness check]") else LOG.info(msg)
         } else {
             LOG.info("FORCE-RESET: no state row to delete (idempotent no-op on empty DB)")
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/HistoryMigrationJobResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/HistoryMigrationJobResponse.kt
@@ -1,0 +1,49 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobState
+import org.octopusden.octopus.components.registry.server.service.JobState
+import java.time.Instant
+
+/**
+ * Wire shape for `POST /admin/migrate-history` and `GET /admin/migrate-history/job`.
+ *
+ * Mirrors [MigrationJobResponse] for the components flow. `result` is populated
+ * only after the job reaches [JobState.COMPLETED]; while RUNNING the SPA leans
+ * on `processedCommits/totalCommits` + `currentSha` for progress rendering.
+ */
+data class HistoryMigrationJobResponse(
+    val id: String,
+    val state: JobState,
+    val startedAt: Instant,
+    val finishedAt: Instant?,
+    val totalCommits: Int,
+    val processedCommits: Int,
+    val auditRecords: Int,
+    val skippedNoGroovy: Int,
+    val skippedParseError: Int,
+    val skippedUnknownNames: Int,
+    val currentSha: String?,
+    val targetRef: String?,
+    val errorMessage: String?,
+    val result: HistoryImportResult?,
+) {
+    companion object {
+        fun from(state: HistoryMigrationJobState): HistoryMigrationJobResponse =
+            HistoryMigrationJobResponse(
+                id = state.id,
+                state = state.state,
+                startedAt = state.startedAt,
+                finishedAt = state.finishedAt,
+                totalCommits = state.totalCommits,
+                processedCommits = state.processedCommits,
+                auditRecords = state.auditRecords,
+                skippedNoGroovy = state.skippedNoGroovy,
+                skippedParseError = state.skippedParseError,
+                skippedUnknownNames = state.skippedUnknownNames,
+                currentSha = state.currentSha,
+                targetRef = state.targetRef,
+                errorMessage = state.errorMessage,
+                result = state.result,
+            )
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/HistoryMigrationJobResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/HistoryMigrationJobResponse.kt
@@ -26,6 +26,21 @@ data class HistoryMigrationJobResponse(
     val targetRef: String?,
     val errorMessage: String?,
     val result: HistoryImportResult?,
+    /**
+     * SPA action hint: 'RETRY' | 'FORCE_RESET' | null. Replaces the
+     * previous "match `errorMessage.includes('marked IN_PROGRESS')`"
+     * substring contract — the new field is a positive discriminator,
+     * stable across wording changes.
+     */
+    val recoveryAction: String?,
+    /**
+     * Discriminator for unambiguous 409 branching on the SPA. Always
+     * `"job"` for this shape; the cross-kind 409 envelope sets
+     * `"conflict"`. Without an explicit discriminator the SPA had to
+     * branch on the *absence* of fields, which silently corrupts on
+     * future contract drift.
+     */
+    val kind: String = "job",
 ) {
     companion object {
         fun from(state: HistoryMigrationJobState): HistoryMigrationJobResponse =
@@ -44,6 +59,7 @@ data class HistoryMigrationJobResponse(
                 targetRef = state.targetRef,
                 errorMessage = state.errorMessage,
                 result = state.result,
+                recoveryAction = state.recoveryAction?.name,
             )
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationConflictResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationConflictResponse.kt
@@ -18,7 +18,16 @@ data class MigrationConflictResponse(
     val code: String,
     val message: String,
     val activeKind: String,
-    val activeJobId: String,
+    /**
+     * Active job id when known (same-pod conflict, gate-tracked active job).
+     * Null when the controller can't determine the id — currently the
+     * cross-pod staleness path (`history-import-likely-live-elsewhere`)
+     * where the row is owned by a different pod and the in-memory gate
+     * has no reference to it. Previous form `"(unknown — owned by another pod)"`
+     * stuffed human prose into a field whose other paths are real UUIDs;
+     * downstream log scrapers / metrics had to special-case the parens.
+     */
+    val activeJobId: String?,
     /**
      * Discriminator. Always `"conflict"` for this shape — counterpart to
      * `kind = "job"` on MigrationJobResponse / HistoryMigrationJobResponse.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationConflictResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationConflictResponse.kt
@@ -19,4 +19,11 @@ data class MigrationConflictResponse(
     val message: String,
     val activeKind: String,
     val activeJobId: String,
+    /**
+     * Discriminator. Always `"conflict"` for this shape — counterpart to
+     * `kind = "job"` on MigrationJobResponse / HistoryMigrationJobResponse.
+     * The SPA branches on this directly instead of inferring from the
+     * presence/absence of fields, which is brittle under contract drift.
+     */
+    val kind: String = "conflict",
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationConflictResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationConflictResponse.kt
@@ -1,0 +1,22 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+/**
+ * 409 Conflict body returned when one migration kind is rejected because the
+ * other kind currently holds the lifecycle gate.
+ *
+ * Distinct from the existing ErrorResponse so the SPA can switch on `code` to
+ * decide UX:
+ *  - "components-migration-running" — render destructive block ("Components
+ *    migration is currently running. Wait for it to finish.")
+ *  - "history-migration-running" — same with "History migration is..."
+ *
+ * The same-kind 409 (a second components POST while one is RUNNING) does NOT
+ * use this shape — it returns a full MigrationJobResponse so the SPA can
+ * "attach" to the in-flight job. Cross-kind has no equivalent attach path.
+ */
+data class MigrationConflictResponse(
+    val code: String,
+    val message: String,
+    val activeKind: String,
+    val activeJobId: String,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationJobResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationJobResponse.kt
@@ -25,6 +25,14 @@ data class MigrationJobResponse(
     val currentComponent: String?,
     val errorMessage: String?,
     val result: FullMigrationResult?,
+    /**
+     * Sub-phase ("DEFAULTS" | "COMPONENTS"). Serialized as the enum name (a
+     * String, not the enum itself) so client/server are not coupled through
+     * Jackson's enum (de)serialization conventions. Older SPA builds simply
+     * ignore this field; older CRS builds simply omit it from the JSON, and
+     * the SPA falls back to a generic "Running…" label.
+     */
+    val phase: String?,
 ) {
     companion object {
         fun from(state: MigrationJobState): MigrationJobResponse =
@@ -40,6 +48,7 @@ data class MigrationJobResponse(
                 currentComponent = state.currentComponent,
                 errorMessage = state.errorMessage,
                 result = state.result,
+                phase = state.phase?.name,
             )
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationJobResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/MigrationJobResponse.kt
@@ -33,6 +33,14 @@ data class MigrationJobResponse(
      * the SPA falls back to a generic "Running…" label.
      */
     val phase: String?,
+    /**
+     * Discriminator for unambiguous 409 branching on the SPA. Always
+     * `"job"` for this shape; the cross-kind 409 envelope sets
+     * `"conflict"`. Without an explicit discriminator the SPA had to
+     * branch on the *absence* of fields, which silently corrupts on
+     * future contract drift.
+     */
+    val kind: String = "job",
 ) {
     companion object {
         fun from(state: MigrationJobState): MigrationJobResponse =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/GitHistoryImportService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/GitHistoryImportService.kt
@@ -8,8 +8,56 @@ import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportRes
  * blocks the next call unless `reset=true` is passed.
  */
 interface GitHistoryImportService {
+    /**
+     * Run an import without progress reporting. Equivalent to passing
+     * [HistoryImportProgressListener.NOOP] to the overload below.
+     */
     fun importHistory(
         toRef: String?,
         reset: Boolean,
+    ): HistoryImportResult = importHistory(toRef, reset, HistoryImportProgressListener.NOOP)
+
+    /**
+     * Run an import and feed live progress events to [listener] — one event
+     * before the per-commit loop starts (so the SPA learns `totalCommits`
+     * without waiting for the first commit), one per commit (so the bar
+     * advances smoothly), and one final event before return (clears
+     * `currentSha` so the SPA stops showing a stale "Processing commit X").
+     *
+     * Listener exceptions are caught and logged but do not abort the import —
+     * progress reporting is observability, not control flow.
+     */
+    fun importHistory(
+        toRef: String?,
+        reset: Boolean,
+        listener: HistoryImportProgressListener,
     ): HistoryImportResult
 }
+
+/**
+ * Progress sink for [GitHistoryImportService.importHistory]. Drives the SPA's
+ * History migration progress bar.
+ */
+fun interface HistoryImportProgressListener {
+    fun onProgress(event: HistoryImportProgressEvent)
+
+    companion object {
+        val NOOP: HistoryImportProgressListener = HistoryImportProgressListener { }
+    }
+}
+
+data class HistoryImportProgressEvent(
+    /** Total commits in the first-parent chain. Known after RevWalk; 0 only at the very first emission moment. */
+    val totalCommits: Int,
+    /** Commits processed so far (post-loop iteration); starts at 0, ends at totalCommits. */
+    val processedCommits: Int,
+    /** audit_log rows written so far. Climbs cumulatively as commits are persisted. */
+    val auditRecords: Int,
+    val skippedNoGroovy: Int,
+    val skippedParseError: Int,
+    val skippedUnknownNames: Int,
+    /** Short SHA of the commit currently being processed; null at boundaries. */
+    val currentSha: String?,
+    /** Resolved target ref the import is walking toward. */
+    val targetRef: String,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
@@ -60,6 +60,26 @@ data class StartHistoryMigrationResult(
     val isNewlyStarted: Boolean,
 )
 
+/**
+ * Outcome of [HistoryMigrationJobService.forceReset].
+ *
+ * Using a sealed type (rather than throwing) so the service layer can express
+ * all outcomes without coupling the controller to implementation details:
+ *  - [Cleared] → 204 No Content; DB row + audit rows wiped (or already empty).
+ *  - [Blocked] → 409 Conflict; controller maps [code]/[message]/[activeKind]/[activeJobId]
+ *    to a [org.octopusden.octopus.components.registry.server.dto.v4.MigrationConflictResponse].
+ */
+sealed interface ForceResetOutcome {
+    data object Cleared : ForceResetOutcome
+
+    data class Blocked(
+        val code: String,
+        val message: String,
+        val activeKind: String,
+        val activeJobId: String?,
+    ) : ForceResetOutcome
+}
+
 interface HistoryMigrationJobService {
     /**
      * Mirror of [MigrationJobService.startAsync] for history. Same idempotency
@@ -85,9 +105,30 @@ interface HistoryMigrationJobService {
     fun current(): HistoryMigrationJobState?
 
     /**
-     * Drop the in-memory state. Called from the force-reset flow (A7.2) so the
-     * synthesized DB-backed state doesn't keep showing "restored from previous
-     * pod" once the operator has explicitly wiped it.
+     * Drop the in-memory state. Called externally when an operator-level
+     * action (e.g. a test helper) needs to reset the slot without going
+     * through the full guard logic. Ignored (with a WARN log) if a job is
+     * currently RUNNING — callers that need to clear a live job should use
+     * [forceReset] instead.
      */
     fun clearInMemory()
+
+    /**
+     * Destructive recovery endpoint (POST /admin/migrate-history/force-reset).
+     *
+     * Applies two guards before wiping:
+     *  1. In-pod gate — refused with [ForceResetOutcome.Blocked] if a history
+     *     migration is currently RUNNING in this pod.
+     *  2. Cross-pod staleness — refused if the DB row is IN_PROGRESS with a
+     *     fresh `updatedAt` (< STALE_IN_PROGRESS_THRESHOLD), unless
+     *     `ackMultipodRisk=true` overrides.
+     *
+     * After both guards pass it calls the underlying commit writer to wipe the
+     * state row + all audit_log rows with source='git-history', then clears
+     * the in-memory slot.
+     *
+     * Returns [ForceResetOutcome.Cleared] (idempotent) when the DB was already
+     * empty, so the controller can always answer 204 on success.
+     */
+    fun forceReset(ackMultipodRisk: Boolean): ForceResetOutcome
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
@@ -14,6 +14,20 @@ import java.time.Instant
  * state lives only for the duration of the running pod; on restart, the DB row
  * is the source of truth and the impl synthesizes a state from it (see A7.1).
  */
+/**
+ * Recovery hint for a non-running history-migration state. Drives the SPA's
+ * action button mode. Replaces the previous "match `errorMessage.includes('marked
+ * IN_PROGRESS')`" substring contract that was silently coupled across two repos.
+ *
+ * - `RETRY` — terminal-but-recoverable: COMPLETED or normal FAILED row. The SPA
+ *   shows "Retry (reset state)" and POSTs with `reset=true`.
+ * - `FORCE_RESET` — stuck IN_PROGRESS row (left by a previous pod that crashed
+ *   or restarted mid-import). SPA shows "Force reset" + disabled "Retry".
+ *
+ * `null` for RUNNING jobs and on idle (no claim, no previous run).
+ */
+enum class HistoryRecoveryAction { RETRY, FORCE_RESET }
+
 data class HistoryMigrationJobState(
     val id: String,
     val state: JobState,
@@ -32,6 +46,8 @@ data class HistoryMigrationJobState(
     val targetRef: String?,
     val errorMessage: String?,
     val result: HistoryImportResult?,
+    /** See [HistoryRecoveryAction]. Null while RUNNING or for an idle service. */
+    val recoveryAction: HistoryRecoveryAction? = null,
 )
 
 data class StartHistoryMigrationResult(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
@@ -23,10 +23,15 @@ import java.time.Instant
  *   shows "Retry (reset state)" and POSTs with `reset=true`.
  * - `FORCE_RESET` — stuck IN_PROGRESS row (left by a previous pod that crashed
  *   or restarted mid-import). SPA shows "Force reset" + disabled "Retry".
+ * - `UNKNOWN` — the backend has a state row it can't classify (e.g. a future
+ *   status enum value rolled out via DB without a code change). The SPA shows
+ *   the errorMessage with NO action buttons enabled — defense against
+ *   confidently telling the operator "Force reset" or "Retry" against a
+ *   state we don't actually understand.
  *
  * `null` for RUNNING jobs and on idle (no claim, no previous run).
  */
-enum class HistoryRecoveryAction { RETRY, FORCE_RESET }
+enum class HistoryRecoveryAction { RETRY, FORCE_RESET, UNKNOWN }
 
 data class HistoryMigrationJobState(
     val id: String,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
@@ -1,0 +1,72 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
+import java.time.Instant
+
+/**
+ * Server-side state of a long-running POST /rest/api/4/admin/migrate-history run.
+ *
+ * Mirrors [MigrationJobState] for components, with history-specific counters
+ * (`processedCommits/totalCommits`, `auditRecords`, etc.) instead of per-component.
+ *
+ * Unlike the components job, history has a table-backed claim
+ * (`git_history_import_state`) that persists across pod restarts. The in-memory
+ * state lives only for the duration of the running pod; on restart, the DB row
+ * is the source of truth and the impl synthesizes a state from it (see A7.1).
+ */
+data class HistoryMigrationJobState(
+    val id: String,
+    val state: JobState,
+    val startedAt: Instant,
+    val finishedAt: Instant?,
+    /** Total commits in the first-parent chain. Known once RevWalk finishes; 0 before that. */
+    val totalCommits: Int,
+    val processedCommits: Int,
+    val auditRecords: Int,
+    val skippedNoGroovy: Int,
+    val skippedParseError: Int,
+    val skippedUnknownNames: Int,
+    /** Short SHA of the commit currently being processed; null at boundaries. */
+    val currentSha: String?,
+    /** Resolved target ref (e.g. "refs/tags/components-registry-1.2"); null until resolved. */
+    val targetRef: String?,
+    val errorMessage: String?,
+    val result: HistoryImportResult?,
+)
+
+data class StartHistoryMigrationResult(
+    val state: HistoryMigrationJobState,
+    val isNewlyStarted: Boolean,
+)
+
+interface HistoryMigrationJobService {
+    /**
+     * Mirror of [MigrationJobService.startAsync] for history. Same idempotency
+     * contract: a second startAsync while one is RUNNING attaches; same
+     * cross-job semantics through [MigrationLifecycleGate].
+     *
+     * `toRef` and `reset` are passed through to the underlying
+     * [GitHistoryImportService.importHistory]:
+     *  - `toRef` defaults to the auto-resolved tag matching the configured prefix;
+     *  - `reset=true` is required to re-run on top of a terminal `git_history_import_state` row.
+     */
+    fun startAsync(
+        toRef: String?,
+        reset: Boolean,
+    ): StartHistoryMigrationResult
+
+    /**
+     * Latest known job state. Falls back to a [HistoryMigrationJobState] synthesized
+     * from `git_history_import_state` if no in-memory job exists (so the SPA sees
+     * COMPLETED / FAILED / restored-FAILED state after a pod restart and can
+     * surface the right action — see A7.1).
+     */
+    fun current(): HistoryMigrationJobState?
+
+    /**
+     * Drop the in-memory state. Called from the force-reset flow (A7.2) so the
+     * synthesized DB-backed state doesn't keep showing "restored from previous
+     * pod" once the operator has explicitly wiped it.
+     */
+    fun clearInMemory()
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
@@ -4,17 +4,6 @@ import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportRes
 import java.time.Instant
 
 /**
- * Server-side state of a long-running POST /rest/api/4/admin/migrate-history run.
- *
- * Mirrors [MigrationJobState] for components, with history-specific counters
- * (`processedCommits/totalCommits`, `auditRecords`, etc.) instead of per-component.
- *
- * Unlike the components job, history has a table-backed claim
- * (`git_history_import_state`) that persists across pod restarts. The in-memory
- * state lives only for the duration of the running pod; on restart, the DB row
- * is the source of truth and the impl synthesizes a state from it (see A7.1).
- */
-/**
  * Recovery hint for a non-running history-migration state. Drives the SPA's
  * action button mode. Replaces the previous "match `errorMessage.includes('marked
  * IN_PROGRESS')`" substring contract that was silently coupled across two repos.
@@ -33,6 +22,17 @@ import java.time.Instant
  */
 enum class HistoryRecoveryAction { RETRY, FORCE_RESET, UNKNOWN }
 
+/**
+ * Server-side state of a long-running POST /rest/api/4/admin/migrate-history run.
+ *
+ * Mirrors [MigrationJobState] for components, with history-specific counters
+ * (`processedCommits/totalCommits`, `auditRecords`, etc.) instead of per-component.
+ *
+ * Unlike the components job, history has a table-backed claim
+ * (`git_history_import_state`) that persists across pod restarts. The in-memory
+ * state lives only for the duration of the running pod; on restart, the DB row
+ * is the source of truth and the impl synthesizes a state from it (see A7.1).
+ */
 data class HistoryMigrationJobState(
     val id: String,
     val state: JobState,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationJobService.kt
@@ -31,9 +31,30 @@ data class MigrationJobState(
     val currentComponent: String?,
     val errorMessage: String?,
     val result: FullMigrationResult?,
+    /**
+     * Sub-phase the migration is currently in. Lets the SPA render an
+     * informative label ("Loading defaults from Git…", "Resolving components
+     * from Git…") during the early window before the per-component progress
+     * listener has fired its first event — that window can take many seconds
+     * on a cold git clone, and a frozen "Running…" with `total=0` was the
+     * original UX complaint that motivated this field.
+     *
+     * `null` only on terminal states (COMPLETED / FAILED) where no phase is
+     * active. While RUNNING this is always set.
+     */
+    val phase: MigrationPhase? = null,
 )
 
 enum class JobState { RUNNING, COMPLETED, FAILED }
+
+/**
+ * Phases of `ImportService.migrate(progress)` exposed to the SPA so it can
+ * render meaningful text while progress counters are still zero. Closed enum
+ * — DEFAULTS happens before any per-component event, COMPONENTS while the
+ * loop is iterating. There is no DONE / COMPLETED phase: terminal job state
+ * lives in [JobState], and `phase` is cleared to null on transition.
+ */
+enum class MigrationPhase { DEFAULTS, COMPONENTS }
 
 /** Outcome of [MigrationJobService.startAsync]. */
 data class StartMigrationResult(
@@ -82,3 +103,19 @@ data class MigrationProgressEvent(
     val skipped: Int,
     val total: Int,
 )
+
+/**
+ * Thrown by either job service's startAsync when [MigrationLifecycleGate] reports
+ * a *cross-kind* conflict (this caller is COMPONENTS, but HISTORY holds the gate,
+ * or vice versa). Same-kind conflicts are NOT exceptions — they resolve to the
+ * existing [StartMigrationResult] with `isNewlyStarted=false` so the caller can
+ * attach to the in-flight job. Cross-kind has no equivalent attach path: the
+ * caller wanted a different operation and there is nothing useful to attach to.
+ *
+ * The controller layer maps this to HTTP 409 with a structured error body
+ * carrying [activeKind] / [activeJobId] so the SPA can render a clear message
+ * ("History migration is currently running. Wait for it to finish.").
+ */
+class MigrationConflictException(
+    val active: MigrationLifecycleGate.ActiveJob,
+) : RuntimeException("Cross-kind migration conflict: ${active.kind} job ${active.jobId} is already running")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationLifecycleGate.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationLifecycleGate.kt
@@ -1,0 +1,65 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Cross-job concurrency gate shared by [MigrationJobService] (components) and
+ * [HistoryMigrationJobService] — only one of the two may be RUNNING at a time.
+ *
+ * Why this exists separately from each service's own AtomicReference: each job
+ * service has its own slot for the response shape ("what is the current
+ * components job?") but neither knows about the other. Without a shared gate
+ * both would happily start in parallel — the SPA would render two RUNNING
+ * jobs, both backed by importers writing to the same DB tables. The
+ * single-thread `migrationExecutor` doesn't help: ThreadPoolTaskExecutor with
+ * `queueCapacity > 0` queues the second submit instead of rejecting it, so
+ * both `startAsync()` calls return 202 with RUNNING and the second job just
+ * starts later.
+ *
+ * Single-pod scope. If CRS is ever deployed with `replicas > 1` (or rolling
+ * update with overlap), each pod owns its own gate and concurrent migrations
+ * become possible again. That is also true of the existing components-only
+ * gate in [MigrationJobServiceImpl]; making it DB-backed is a followup.
+ */
+@Component
+class MigrationLifecycleGate {
+    enum class JobKind { COMPONENTS, HISTORY }
+
+    data class ActiveJob(val kind: JobKind, val jobId: String)
+
+    private val active = AtomicReference<ActiveJob?>(null)
+
+    /**
+     * CAS-loop claim. Returns null when this caller now owns the gate; returns
+     * the existing [ActiveJob] (any kind) when something else owns it.
+     *
+     * Loop matters: a naive `compareAndSet(null, candidate); return active.get()`
+     * has a race where the holder release()s between the failed CAS and the
+     * subsequent get(), so the second caller sees null and thinks it claimed
+     * the gate without ever installing itself. A third caller can then claim
+     * the now-null slot, and both proceed believing they hold the gate. The
+     * loop guarantees we either observe a live owner (returned as conflict) or
+     * win our own CAS on a confirmed-null slot.
+     */
+    fun tryClaim(kind: JobKind, jobId: String): ActiveJob? {
+        val candidate = ActiveJob(kind, jobId)
+        while (true) {
+            val current = active.get()
+            if (current != null) return current
+            if (active.compareAndSet(null, candidate)) return null
+        }
+    }
+
+    /**
+     * Release the slot iff [jobId] is the current owner. Idempotent — safe to
+     * call from multiple finally blocks; safe to call after a stale jobId has
+     * been replaced by a newer claim.
+     */
+    fun release(jobId: String) {
+        active.updateAndGet { current -> if (current?.jobId == jobId) null else current }
+    }
+
+    /** Snapshot of the active claim, or null if the gate is free. */
+    fun current(): ActiveJob? = active.get()
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationLifecycleGate.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationLifecycleGate.kt
@@ -26,7 +26,10 @@ import java.util.concurrent.atomic.AtomicReference
 class MigrationLifecycleGate {
     enum class JobKind { COMPONENTS, HISTORY }
 
-    data class ActiveJob(val kind: JobKind, val jobId: String)
+    data class ActiveJob(
+        val kind: JobKind,
+        val jobId: String,
+    )
 
     private val active = AtomicReference<ActiveJob?>(null)
 
@@ -42,7 +45,10 @@ class MigrationLifecycleGate {
      * loop guarantees we either observe a live owner (returned as conflict) or
      * win our own CAS on a confirmed-null slot.
      */
-    fun tryClaim(kind: JobKind, jobId: String): ActiveJob? {
+    fun tryClaim(
+        kind: JobKind,
+        jobId: String,
+    ): ActiveJob? {
         val candidate = ActiveJob(kind, jobId)
         while (true) {
             val current = active.get()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
@@ -20,7 +20,7 @@ import java.time.Instant
 class GitHistoryCommitWriter(
     private val auditLogRepository: AuditLogRepository,
     private val stateRepository: GitHistoryImportStateRepository,
-) {
+) : HistoryForceResetter {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun persistCommitRows(rows: List<AuditLogEntity>) {
         if (rows.isEmpty()) return
@@ -49,7 +49,7 @@ class GitHistoryCommitWriter(
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun touchHeartbeat() {
-        val row = stateRepository.findById("component-history").orElse(null) ?: return
+        val row = stateRepository.findById(HISTORY_IMPORT_KEY).orElse(null) ?: return
         row.updatedAt = Instant.now()
         stateRepository.save(row)
     }
@@ -62,7 +62,7 @@ class GitHistoryCommitWriter(
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun resetIfNotInProgress(): Boolean {
-        val existing = stateRepository.findById("component-history").orElse(null)
+        val existing = stateRepository.findById(HISTORY_IMPORT_KEY).orElse(null)
         if (existing != null && existing.status == GitHistoryImportStatus.IN_PROGRESS.name) {
             return false
         }
@@ -85,7 +85,7 @@ class GitHistoryCommitWriter(
      * duplicates. The force-reset confirm dialog spells this out.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun forceReset() {
+    override fun forceReset() {
         auditLogRepository.deleteBySource("git-history")
         stateRepository.deleteAll()
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
@@ -49,4 +49,23 @@ class GitHistoryCommitWriter(
         stateRepository.deleteAll()
         return true
     }
+
+    /**
+     * Unconditional wipe used by POST /admin/migrate-history/force-reset (A7.2).
+     * Differs from [resetIfNotInProgress] in that it bypasses the IN_PROGRESS
+     * guard — the controller is responsible for refusing this when an
+     * in-memory job is RUNNING in the current pod. Idempotent: a no-op on an
+     * empty DB returns normally so the endpoint can answer 204 either way.
+     *
+     * The destructive scope (state row + ALL git-history audit_log rows) is
+     * load-bearing: the alternative — clearing only the state row — would
+     * leak partial audit_log rows from an interrupted import, and the next
+     * Run-without-reset would write fresh history on top of them, producing
+     * duplicates. The force-reset confirm dialog spells this out.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun forceReset() {
+        auditLogRepository.deleteBySource("git-history")
+        stateRepository.deleteAll()
+    }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
@@ -34,6 +34,27 @@ class GitHistoryCommitWriter(
     }
 
     /**
+     * Refresh `updated_at` on the IN_PROGRESS row without touching anything
+     * else. Used as a liveness heartbeat by `runImport`'s chain loop so the
+     * force-reset multi-pod-staleness check can distinguish "live import in
+     * another pod" from "orphan claim from a crashed pod".
+     *
+     * Without this, `updated_at` would only flip at start (preflight insert
+     * + targetSha fill) and at terminal markState — a long legitimate
+     * import would appear stale to a force-reset operator after the
+     * STALE_IN_PROGRESS_THRESHOLD elapsed.
+     *
+     * REQUIRES_NEW so the heartbeat write is committed even if the outer
+     * chain loop's transaction (none currently, but defensive) rolled back.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun touchHeartbeat() {
+        val row = stateRepository.findById("component-history").orElse(null) ?: return
+        row.updatedAt = Instant.now()
+        stateRepository.save(row)
+    }
+
+    /**
      * Atomic reset: deletes git-history audit rows and the state row
      * unless the state is IN_PROGRESS. Returning `false` signals that a
      * live import is still running and the caller should 409 instead of

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -36,18 +36,22 @@ private const val UNKNOWN_NAMES_SAMPLE_SIZE = 20
 private const val SHORT_SHA_LENGTH = 7
 
 /**
- * How often to refresh `git_history_import_state.updated_at` from inside the
- * chain loop. Used by the force-reset multi-pod-staleness check to distinguish
- * "live import in another pod" from "orphan claim". Cadence chosen to be:
- *   - frequent enough that a healthy import never sneaks past the
- *     STALE_IN_PROGRESS_THRESHOLD (controller-side, 30 minutes); even on a
- *     pathologically slow per-commit cost of 2 seconds, every-50 commits
- *     puts the heartbeat at <2 minutes.
- *   - infrequent enough that the heartbeat doesn't contend with persistCommitRows
- *     for DB write capacity. 50 is a round number well below the 250-commit
- *     log cadence already established in this file.
+ * Min interval between `git_history_import_state.updated_at` refreshes from
+ * inside the chain loop. Used by the force-reset multi-pod-staleness check
+ * to distinguish "live import in another pod" from "orphan claim".
+ *
+ * Wall-clock based, not commit-count based — the count-based variant
+ * (every 50 commits) silently failed two corner cases:
+ *   1. A chain with <50 commits where heartbeat never fires.
+ *   2. A pathologically slow per-commit step (Groovy DSL parsing on a huge
+ *      escrow tree) where 50 commits could take longer than the 30-min
+ *      controller threshold.
+ *
+ * 5-minute interval keeps a healthy import comfortably under the 30-minute
+ * STALE_IN_PROGRESS_THRESHOLD even with one heartbeat write per interval,
+ * and is well below any commit-loop processing cost worth caring about.
  */
-private const val HEARTBEAT_EVERY = 50
+private val HEARTBEAT_INTERVAL: java.time.Duration = java.time.Duration.ofMinutes(5)
 
 @Service
 class GitHistoryImportServiceImpl(
@@ -163,6 +167,9 @@ class GitHistoryImportServiceImpl(
 
         val stats = ImportStats()
         var prevSnapshot: Map<String, Map<String, Any?>> = emptyMap()
+        // Wall-clock-based heartbeat — see HEARTBEAT_INTERVAL for the rationale
+        // (commit-count was vulnerable to small chains and slow first commits).
+        var lastHeartbeat = Instant.now()
 
         // Emission #1: pre-loop. The SPA needs `totalCommits` ASAP so its progress
         // bar can switch from indeterminate to determinate. Without this, the bar
@@ -188,10 +195,12 @@ class GitHistoryImportServiceImpl(
                     totalCommits = chain.size,
                 )
                 // Liveness heartbeat: refresh updated_at on the state row so a
-                // concurrent force-reset call in another pod sees this import
-                // as live, not stale. See HEARTBEAT_EVERY for the cadence
-                // rationale.
-                if ((index + 1) % HEARTBEAT_EVERY == 0) {
+                // concurrent force-reset call in another pod sees this import as
+                // live, not stale. Wall-clock based so a slow per-commit cost
+                // doesn't sneak past the controller's STALE_IN_PROGRESS_THRESHOLD.
+                val now = Instant.now()
+                if (java.time.Duration.between(lastHeartbeat, now) >= HEARTBEAT_INTERVAL) {
+                    lastHeartbeat = now
                     runCatching { commitWriter.touchHeartbeat() }
                         .onFailure { log.warn("Heartbeat write failed at commit $index: ${it.message}") }
                 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -29,7 +29,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Instant
 
-private const val IMPORT_KEY = "component-history"
 private const val HISTORY_SOURCE = "git-history"
 private const val PROGRESS_LOG_EVERY = 250
 private const val UNKNOWN_NAMES_SAMPLE_SIZE = 20
@@ -125,13 +124,13 @@ class GitHistoryImportServiceImpl(
         // the real tag/sha.
         val claimed =
             stateRepository.tryInsert(
-                importKey = IMPORT_KEY,
+                importKey = HISTORY_IMPORT_KEY,
                 targetRef = "",
                 targetSha = "",
                 status = GitHistoryImportStatus.IN_PROGRESS.name,
             )
         if (claimed == 0) {
-            val existing = stateRepository.findById(IMPORT_KEY).orElseThrow()
+            val existing = stateRepository.findById(HISTORY_IMPORT_KEY).orElseThrow()
             throw ResponseStatusException(
                 HttpStatus.CONFLICT,
                 "git history import already ran (status=${existing.status}, " +
@@ -152,7 +151,7 @@ class GitHistoryImportServiceImpl(
         log.info("History import target: {}@{}", target.ref, target.sha)
 
         // Fill in the real target on the claimed state row (inserted empty by preflight).
-        val state = stateRepository.findById(IMPORT_KEY).orElseThrow()
+        val state = stateRepository.findById(HISTORY_IMPORT_KEY).orElseThrow()
         state.targetRef = target.ref
         state.targetSha = target.sha
         commitWriter.saveState(state)
@@ -201,8 +200,12 @@ class GitHistoryImportServiceImpl(
                 val now = Instant.now()
                 if (java.time.Duration.between(lastHeartbeat, now) >= HEARTBEAT_INTERVAL) {
                     lastHeartbeat = now
-                    runCatching { commitWriter.touchHeartbeat() }
-                        .onFailure { log.warn("Heartbeat write failed at commit $index: ${it.message}") }
+                    @Suppress("TooGenericExceptionCaught") // intentional: don't abort the import on a transient DB hiccup
+                    try {
+                        commitWriter.touchHeartbeat()
+                    } catch (e: Exception) {
+                        log.warn("Heartbeat write failed at commit $index: ${e.message}")
+                    }
                 }
             }
         }
@@ -435,7 +438,7 @@ class GitHistoryImportServiceImpl(
     }
 
     private fun markState(status: GitHistoryImportStatus) {
-        stateRepository.findById(IMPORT_KEY).ifPresent { entity ->
+        stateRepository.findById(HISTORY_IMPORT_KEY).ifPresent { entity ->
             entity.status = status.name
             commitWriter.saveState(entity)
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -16,6 +16,8 @@ import org.octopusden.octopus.components.registry.server.entity.GitHistoryImport
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
 import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
+import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressEvent
+import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
 import org.octopusden.octopus.components.registry.server.util.AuditDiff
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -31,6 +33,7 @@ private const val IMPORT_KEY = "component-history"
 private const val HISTORY_SOURCE = "git-history"
 private const val PROGRESS_LOG_EVERY = 250
 private const val UNKNOWN_NAMES_SAMPLE_SIZE = 20
+private const val SHORT_SHA_LENGTH = 7
 
 @Service
 class GitHistoryImportServiceImpl(
@@ -48,6 +51,7 @@ class GitHistoryImportServiceImpl(
     override fun importHistory(
         toRef: String?,
         reset: Boolean,
+        listener: HistoryImportProgressListener,
     ): HistoryImportResult {
         preflight(reset)
 
@@ -77,7 +81,7 @@ class GitHistoryImportServiceImpl(
                     }
                 }.call()
                 .use { git ->
-                    return runImport(git, toRef, historyWorkDir, groovyPrefix, started)
+                    return runImport(git, toRef, historyWorkDir, groovyPrefix, started, listener)
                 }
         } catch (e: Exception) {
             log.error("History import failed", e)
@@ -124,6 +128,7 @@ class GitHistoryImportServiceImpl(
         historyWorkDir: Path,
         groovyPrefix: String,
         started: Instant,
+        listener: HistoryImportProgressListener,
     ): HistoryImportResult {
         val target = resolveTarget(git, toRef)
         log.info("History import target: {}@{}", target.ref, target.sha)
@@ -145,6 +150,12 @@ class GitHistoryImportServiceImpl(
         val stats = ImportStats()
         var prevSnapshot: Map<String, Map<String, Any?>> = emptyMap()
 
+        // Emission #1: pre-loop. The SPA needs `totalCommits` ASAP so its progress
+        // bar can switch from indeterminate to determinate. Without this, the bar
+        // would stay indeterminate (totalCommits=0) until the first per-commit
+        // event below, which on a large chain can be tens of seconds.
+        emitProgress(listener, stats, target.ref, currentSha = null, totalCommits = chain.size)
+
         RevWalk(repo).use { walk ->
             chain.forEachIndexed { index, commitId ->
                 val commit = walk.parseCommit(commitId)
@@ -152,6 +163,16 @@ class GitHistoryImportServiceImpl(
                 prevSnapshot =
                     processCommit(git, repo, loader, commit, prevSnapshot, groovyPrefix, stats)
                 logProgress(index, chain.size, stats.auditRecords)
+                // Emission #2: per-commit. One event per processed commit gives the
+                // SPA a smooth animation. The existing logProgress logs only every
+                // 250 commits — appropriate for log volume but too coarse for UX.
+                emitProgress(
+                    listener,
+                    stats,
+                    target.ref,
+                    currentSha = commit.name.take(SHORT_SHA_LENGTH),
+                    totalCommits = chain.size,
+                )
             }
         }
 
@@ -166,6 +187,11 @@ class GitHistoryImportServiceImpl(
 
         markState(status = GitHistoryImportStatus.COMPLETED)
 
+        // Emission #3: pre-return. Clears `currentSha` so the SPA stops showing a
+        // stale "Processing commit X" between the last loop tick and the COMPLETED
+        // transition.
+        emitProgress(listener, stats, target.ref, currentSha = null, totalCommits = chain.size)
+
         return HistoryImportResult(
             targetRef = target.ref,
             targetSha = target.sha,
@@ -179,6 +205,37 @@ class GitHistoryImportServiceImpl(
                     .between(started, Instant.now())
                     .toMillis(),
         )
+    }
+
+    /**
+     * Throwable-catching emit so a misbehaving listener can't poison the import
+     * loop. Progress reporting is observability, not control flow — if it
+     * throws, the migration carries on without it.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun emitProgress(
+        listener: HistoryImportProgressListener,
+        stats: ImportStats,
+        targetRef: String,
+        currentSha: String?,
+        totalCommits: Int,
+    ) {
+        try {
+            listener.onProgress(
+                HistoryImportProgressEvent(
+                    totalCommits = totalCommits,
+                    processedCommits = stats.processed,
+                    auditRecords = stats.auditRecords,
+                    skippedNoGroovy = stats.skippedNoGroovy,
+                    skippedParseError = stats.skippedParseError,
+                    skippedUnknownNames = stats.unknownNames.size,
+                    currentSha = currentSha,
+                    targetRef = targetRef,
+                ),
+            )
+        } catch (e: Throwable) {
+            log.warn("History import progress listener threw at sha={}: {}", currentSha, e.message)
+        }
     }
 
     private fun resolveTarget(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -35,6 +35,20 @@ private const val PROGRESS_LOG_EVERY = 250
 private const val UNKNOWN_NAMES_SAMPLE_SIZE = 20
 private const val SHORT_SHA_LENGTH = 7
 
+/**
+ * How often to refresh `git_history_import_state.updated_at` from inside the
+ * chain loop. Used by the force-reset multi-pod-staleness check to distinguish
+ * "live import in another pod" from "orphan claim". Cadence chosen to be:
+ *   - frequent enough that a healthy import never sneaks past the
+ *     STALE_IN_PROGRESS_THRESHOLD (controller-side, 30 minutes); even on a
+ *     pathologically slow per-commit cost of 2 seconds, every-50 commits
+ *     puts the heartbeat at <2 minutes.
+ *   - infrequent enough that the heartbeat doesn't contend with persistCommitRows
+ *     for DB write capacity. 50 is a round number well below the 250-commit
+ *     log cadence already established in this file.
+ */
+private const val HEARTBEAT_EVERY = 50
+
 @Service
 class GitHistoryImportServiceImpl(
     private val componentsRegistryProperties: ComponentsRegistryProperties,
@@ -173,6 +187,14 @@ class GitHistoryImportServiceImpl(
                     currentSha = commit.name.take(SHORT_SHA_LENGTH),
                     totalCommits = chain.size,
                 )
+                // Liveness heartbeat: refresh updated_at on the state row so a
+                // concurrent force-reset call in another pod sees this import
+                // as live, not stale. See HEARTBEAT_EVERY for the cadence
+                // rationale.
+                if ((index + 1) % HEARTBEAT_EVERY == 0) {
+                    runCatching { commitWriter.touchHeartbeat() }
+                        .onFailure { log.warn("Heartbeat write failed at commit $index: ${it.message}") }
+                }
             }
         }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryForceResetter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryForceResetter.kt
@@ -1,0 +1,17 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+/**
+ * Narrow interface for the single destructive operation extracted from
+ * [GitHistoryCommitWriter] so that [HistoryMigrationJobServiceImpl] can depend on
+ * this contract without pulling in the full commit-writer bean (and its
+ * `AuditLogRepository` dep) into unit tests.
+ *
+ * Only [GitHistoryCommitWriter] implements this in production. Tests use a lambda stub.
+ */
+fun interface HistoryForceResetter {
+    /**
+     * Unconditional wipe: deletes all `audit_log` rows with `source='git-history'`
+     * and the `git_history_import_state` row. Idempotent on an empty DB.
+     */
+    fun forceReset()
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryImportConstants.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryImportConstants.kt
@@ -1,0 +1,16 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.time.Duration
+
+/** Primary key used in `git_history_import_state` for the single component-history row. */
+internal const val HISTORY_IMPORT_KEY = "component-history"
+
+/**
+ * If an IN_PROGRESS row was last touched more than this long ago, it is considered stale
+ * (the owning pod almost certainly crashed). The force-reset staleness check uses this.
+ *
+ * A real import keeps `updated_at` fresh via the per-[HEARTBEAT_INTERVAL] heartbeat from
+ * [GitHistoryImportServiceImpl]. 30 minutes is conservative: even a single-commit import
+ * that takes 29 minutes would still keep the row fresh.
+ */
+internal val STALE_IN_PROGRESS_THRESHOLD: Duration = Duration.ofMinutes(30)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -44,6 +44,8 @@ class HistoryMigrationJobServiceImpl(
 ) : HistoryMigrationJobService {
     private val state = AtomicReference<HistoryMigrationJobState?>()
 
+    // See MigrationJobServiceImpl.startAsync — same CAS-retry shape, same suppression rationale.
+    @Suppress("LoopWithTooManyJumpStatements")
     override fun startAsync(
         toRef: String?,
         reset: Boolean,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -44,76 +44,106 @@ class HistoryMigrationJobServiceImpl(
 ) : HistoryMigrationJobService {
     private val state = AtomicReference<HistoryMigrationJobState?>()
 
-    // See MigrationJobServiceImpl.startAsync — same CAS-retry shape, same suppression rationale.
-    @Suppress("LoopWithTooManyJumpStatements")
+    /** Mirror of [MigrationJobServiceImpl.ClaimAttempt] for the history flow. */
+    private sealed interface ClaimAttempt {
+        data class Attached(
+            val state: HistoryMigrationJobState,
+        ) : ClaimAttempt
+
+        data class CrossKindConflict(
+            val active: MigrationLifecycleGate.ActiveJob,
+        ) : ClaimAttempt
+
+        data object Retry : ClaimAttempt
+
+        data class Claimed(
+            val candidate: HistoryMigrationJobState,
+        ) : ClaimAttempt
+    }
+
     override fun startAsync(
         toRef: String?,
         reset: Boolean,
     ): StartHistoryMigrationResult {
-        // Same ordering as MigrationJobServiceImpl.startAsync — see comments there.
-        // Same-kind 409 first (so we don't read nullable state in cross-kind branch),
-        // then cross-kind gate, then publish state, then submit.
         while (true) {
-            val existing = state.get()
-            if (existing?.state == JobState.RUNNING) {
-                return StartHistoryMigrationResult(existing, isNewlyStarted = false)
+            when (val attempt = tryClaim()) {
+                is ClaimAttempt.Attached -> return StartHistoryMigrationResult(attempt.state, isNewlyStarted = false)
+                is ClaimAttempt.CrossKindConflict -> throw MigrationConflictException(attempt.active)
+                is ClaimAttempt.Claimed -> {
+                    submitToExecutor(attempt.candidate, toRef, reset)
+                    return StartHistoryMigrationResult(state.get() ?: attempt.candidate, isNewlyStarted = true)
+                }
+                ClaimAttempt.Retry -> Unit
             }
+        }
+    }
 
-            val candidate =
-                HistoryMigrationJobState(
-                    id = UUID.randomUUID().toString(),
-                    state = JobState.RUNNING,
-                    startedAt = Instant.now(),
-                    finishedAt = null,
-                    totalCommits = 0,
-                    processedCommits = 0,
-                    auditRecords = 0,
-                    skippedNoGroovy = 0,
-                    skippedParseError = 0,
-                    skippedUnknownNames = 0,
-                    currentSha = null,
-                    targetRef = null,
-                    errorMessage = null,
-                    result = null,
-                )
+    /** See [MigrationJobServiceImpl.tryClaim] — same CAS-retry shape, same ordering rationale. */
+    private fun tryClaim(): ClaimAttempt {
+        val existing = state.get()
+        if (existing?.state == JobState.RUNNING) {
+            return ClaimAttempt.Attached(existing)
+        }
 
-            val gateConflict = lifecycleGate.tryClaim(JobKind.HISTORY, candidate.id)
-            if (gateConflict != null) {
-                when (gateConflict.kind) {
-                    JobKind.HISTORY -> continue
-                    JobKind.COMPONENTS -> throw MigrationConflictException(gateConflict)
+        val candidate =
+            HistoryMigrationJobState(
+                id = UUID.randomUUID().toString(),
+                state = JobState.RUNNING,
+                startedAt = Instant.now(),
+                finishedAt = null,
+                totalCommits = 0,
+                processedCommits = 0,
+                auditRecords = 0,
+                skippedNoGroovy = 0,
+                skippedParseError = 0,
+                skippedUnknownNames = 0,
+                currentSha = null,
+                targetRef = null,
+                errorMessage = null,
+                result = null,
+            )
+
+        val gateConflict = lifecycleGate.tryClaim(JobKind.HISTORY, candidate.id)
+        if (gateConflict != null) {
+            return when (gateConflict.kind) {
+                JobKind.HISTORY -> ClaimAttempt.Retry
+                JobKind.COMPONENTS -> ClaimAttempt.CrossKindConflict(gateConflict)
+            }
+        }
+
+        if (!state.compareAndSet(existing, candidate)) {
+            lifecycleGate.release(candidate.id)
+            return ClaimAttempt.Retry
+        }
+        return ClaimAttempt.Claimed(candidate)
+    }
+
+    @Suppress("TooGenericExceptionCaught") // Throwable so executor rejection ALWAYS unwinds the slot.
+    private fun submitToExecutor(
+        candidate: HistoryMigrationJobState,
+        toRef: String?,
+        reset: Boolean,
+    ) {
+        LOG.info("Starting history migration job {} (toRef={}, reset={})", candidate.id, toRef, reset)
+        try {
+            executor.execute { runHistoryMigration(candidate.id, toRef, reset) }
+        } catch (rejected: Throwable) {
+            LOG.error("Failed to submit history migration job {} to executor", candidate.id, rejected)
+            lifecycleGate.release(candidate.id)
+            state.updateAndGet { current ->
+                if (current?.id != candidate.id) {
+                    current
+                } else {
+                    current.copy(
+                        state = JobState.FAILED,
+                        finishedAt = Instant.now(),
+                        errorMessage =
+                            "Failed to submit history migration: ${rejected.message ?: rejected::class.java.simpleName}",
+                        recoveryAction = HistoryRecoveryAction.RETRY,
+                    )
                 }
             }
-
-            if (!state.compareAndSet(existing, candidate)) {
-                lifecycleGate.release(candidate.id)
-                continue
-            }
-
-            LOG.info("Starting history migration job {} (toRef={}, reset={})", candidate.id, toRef, reset)
-            try {
-                executor.execute { runHistoryMigration(candidate.id, toRef, reset) }
-            } catch (
-                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
-            ) {
-                LOG.error("Failed to submit history migration job {} to executor", candidate.id, rejected)
-                lifecycleGate.release(candidate.id)
-                state.updateAndGet { current ->
-                    if (current?.id != candidate.id) {
-                        current
-                    } else {
-                        current.copy(
-                            state = JobState.FAILED,
-                            finishedAt = Instant.now(),
-                            errorMessage =
-                                "Failed to submit history migration: ${rejected.message ?: rejected::class.java.simpleName}",
-                            recoveryAction = HistoryRecoveryAction.RETRY,
-                        )
-                    }
-                }
-                throw rejected
-            }
-            return StartHistoryMigrationResult(state.get() ?: candidate, isNewlyStarted = true)
+            throw rejected
         }
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -1,0 +1,267 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
+import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
+import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
+import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobState
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
+import org.octopusden.octopus.components.registry.server.service.StartHistoryMigrationResult
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.task.TaskExecutor
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+private const val IMPORT_KEY = "component-history"
+
+/**
+ * In-memory async wrapper around [GitHistoryImportService.importHistory]. Mirrors
+ * [MigrationJobServiceImpl] for the components flow — same gate integration, same
+ * CAS-then-publish ordering, same finally-release.
+ *
+ * Difference from components: history has a table-backed claim
+ * (`git_history_import_state`) that survives pod restarts. The in-memory state
+ * is what the SPA sees while a job is RUNNING in this pod; after the pod
+ * restarts the in-memory ref is empty but the DB row is still there, and
+ * [current] synthesizes a state from it so the SPA can render the right action
+ * (Retry on COMPLETED/FAILED, Force-reset on stale IN_PROGRESS — see A7.1).
+ */
+@Service
+class HistoryMigrationJobServiceImpl(
+    private val gitHistoryImportService: GitHistoryImportService,
+    private val stateRepository: GitHistoryImportStateRepository,
+    @Qualifier("migrationExecutor") private val executor: TaskExecutor,
+    private val lifecycleGate: MigrationLifecycleGate,
+) : HistoryMigrationJobService {
+    private val state = AtomicReference<HistoryMigrationJobState?>()
+
+    override fun startAsync(
+        toRef: String?,
+        reset: Boolean,
+    ): StartHistoryMigrationResult {
+        // Same ordering as MigrationJobServiceImpl.startAsync — see comments there.
+        // Same-kind 409 first (so we don't read nullable state in cross-kind branch),
+        // then cross-kind gate, then publish state, then submit.
+        while (true) {
+            val existing = state.get()
+            if (existing?.state == JobState.RUNNING) {
+                return StartHistoryMigrationResult(existing, isNewlyStarted = false)
+            }
+
+            val candidate =
+                HistoryMigrationJobState(
+                    id = UUID.randomUUID().toString(),
+                    state = JobState.RUNNING,
+                    startedAt = Instant.now(),
+                    finishedAt = null,
+                    totalCommits = 0,
+                    processedCommits = 0,
+                    auditRecords = 0,
+                    skippedNoGroovy = 0,
+                    skippedParseError = 0,
+                    skippedUnknownNames = 0,
+                    currentSha = null,
+                    targetRef = null,
+                    errorMessage = null,
+                    result = null,
+                )
+
+            val gateConflict = lifecycleGate.tryClaim(JobKind.HISTORY, candidate.id)
+            if (gateConflict != null) {
+                when (gateConflict.kind) {
+                    JobKind.HISTORY -> continue
+                    JobKind.COMPONENTS -> throw MigrationConflictException(gateConflict)
+                }
+            }
+
+            if (!state.compareAndSet(existing, candidate)) {
+                lifecycleGate.release(candidate.id)
+                continue
+            }
+
+            LOG.info("Starting history migration job {} (toRef={}, reset={})", candidate.id, toRef, reset)
+            try {
+                executor.execute { runHistoryMigration(candidate.id, toRef, reset) }
+            } catch (
+                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
+            ) {
+                LOG.error("Failed to submit history migration job {} to executor", candidate.id, rejected)
+                lifecycleGate.release(candidate.id)
+                state.updateAndGet { current ->
+                    if (current?.id != candidate.id) {
+                        current
+                    } else {
+                        current.copy(
+                            state = JobState.FAILED,
+                            finishedAt = Instant.now(),
+                            errorMessage =
+                                "Failed to submit history migration: ${rejected.message ?: rejected::class.java.simpleName}",
+                        )
+                    }
+                }
+                throw rejected
+            }
+            return StartHistoryMigrationResult(state.get() ?: candidate, isNewlyStarted = true)
+        }
+    }
+
+    /**
+     * In-memory state if a job is currently / recently active in THIS pod,
+     * otherwise a [HistoryMigrationJobState] synthesized from the DB row so
+     * the SPA can see prior-pod outcomes.
+     *
+     * IN_PROGRESS DB rows are surfaced as FAILED-with-explainer (NOT auto-FAILED
+     * in the row itself) so a multi-pod overlap doesn't have one pod marking
+     * another's live import as failed. The operator decides whether to
+     * Force-reset.
+     */
+    override fun current(): HistoryMigrationJobState? {
+        state.get()?.let { return it }
+        val row = stateRepository.findById(IMPORT_KEY).orElse(null) ?: return null
+        return synthesizeFromDb(row)
+    }
+
+    override fun clearInMemory() {
+        state.set(null)
+    }
+
+    private fun runHistoryMigration(
+        jobId: String,
+        toRef: String?,
+        reset: Boolean,
+    ) {
+        try {
+            val result = gitHistoryImportService.importHistory(toRef, reset, progressListener(jobId))
+            state.updateAndGet { current ->
+                if (current?.id != jobId) {
+                    current
+                } else {
+                    current.copy(
+                        state = JobState.COMPLETED,
+                        finishedAt = Instant.now(),
+                        currentSha = null,
+                        targetRef = result.targetRef,
+                        totalCommits = result.processedCommits,
+                        processedCommits = result.processedCommits,
+                        auditRecords = result.auditRecords,
+                        skippedNoGroovy = result.skippedNoGroovy,
+                        skippedParseError = result.skippedParseError,
+                        skippedUnknownNames = result.skippedUnknownNames,
+                        result = result,
+                    )
+                }
+            }
+            LOG.info(
+                "History migration job {} COMPLETED: {} commits processed, {} audit rows, {} ms",
+                jobId,
+                result.processedCommits,
+                result.auditRecords,
+                result.durationMs,
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Throwable,
+        ) {
+            LOG.error("History migration job {} FAILED", jobId, e)
+            state.updateAndGet { current ->
+                if (current?.id != jobId) {
+                    current
+                } else {
+                    current.copy(
+                        state = JobState.FAILED,
+                        finishedAt = Instant.now(),
+                        currentSha = null,
+                        errorMessage = e.message ?: e::class.java.simpleName,
+                    )
+                }
+            }
+        } finally {
+            lifecycleGate.release(jobId)
+        }
+    }
+
+    private fun progressListener(jobId: String): HistoryImportProgressListener =
+        HistoryImportProgressListener { event ->
+            state.updateAndGet { current ->
+                if (current?.id != jobId) {
+                    current
+                } else {
+                    current.copy(
+                        totalCommits = event.totalCommits,
+                        processedCommits = event.processedCommits,
+                        auditRecords = event.auditRecords,
+                        skippedNoGroovy = event.skippedNoGroovy,
+                        skippedParseError = event.skippedParseError,
+                        skippedUnknownNames = event.skippedUnknownNames,
+                        currentSha = event.currentSha,
+                        targetRef = event.targetRef,
+                    )
+                }
+            }
+        }
+
+    private fun synthesizeFromDb(row: GitHistoryImportStateEntity): HistoryMigrationJobState {
+        val syntheticId = "restored-${row.updatedAt.toEpochMilli()}"
+        val targetRef = row.targetRef.takeIf { it.isNotEmpty() }
+        return when (row.status) {
+            GitHistoryImportStatus.COMPLETED.name ->
+                emptyJobState(syntheticId, JobState.COMPLETED, row.updatedAt, targetRef, errorMessage = null)
+            GitHistoryImportStatus.FAILED.name ->
+                emptyJobState(
+                    syntheticId,
+                    JobState.FAILED,
+                    row.updatedAt,
+                    targetRef,
+                    errorMessage = "Previous run failed (details unavailable). Use Retry to re-run.",
+                )
+            GitHistoryImportStatus.IN_PROGRESS.name ->
+                emptyJobState(
+                    syntheticId,
+                    JobState.FAILED,
+                    row.updatedAt,
+                    targetRef,
+                    errorMessage =
+                        "Previous run is marked IN_PROGRESS but no job is active in this pod " +
+                            "(probably interrupted by pod restart). Use Force reset to clear the claim, " +
+                            "then Retry. WARNING: if another CRS pod is currently running this import, " +
+                            "force-reset will corrupt its data.",
+                )
+            else -> emptyJobState(syntheticId, JobState.FAILED, row.updatedAt, targetRef, errorMessage = "Unknown status: ${row.status}")
+        }
+    }
+
+    private fun emptyJobState(
+        id: String,
+        state: JobState,
+        updatedAt: Instant,
+        targetRef: String?,
+        errorMessage: String?,
+    ): HistoryMigrationJobState =
+        HistoryMigrationJobState(
+            id = id,
+            state = state,
+            startedAt = updatedAt,
+            finishedAt = updatedAt,
+            totalCommits = 0,
+            processedCommits = 0,
+            auditRecords = 0,
+            skippedNoGroovy = 0,
+            skippedParseError = 0,
+            skippedUnknownNames = 0,
+            currentSha = null,
+            targetRef = targetRef,
+            errorMessage = errorMessage,
+            result = null,
+        )
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(HistoryMigrationJobServiceImpl::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.service.impl
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.octopusden.octopus.components.registry.server.service.ForceResetOutcome
 import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
 import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
 import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
@@ -17,11 +18,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.task.TaskExecutor
 import org.springframework.stereotype.Service
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
-
-private const val IMPORT_KEY = "component-history"
 
 /**
  * In-memory async wrapper around [GitHistoryImportService.importHistory]. Mirrors
@@ -41,6 +41,7 @@ class HistoryMigrationJobServiceImpl(
     private val stateRepository: GitHistoryImportStateRepository,
     @Qualifier("migrationExecutor") private val executor: TaskExecutor,
     private val lifecycleGate: MigrationLifecycleGate,
+    private val forceResetter: HistoryForceResetter,
 ) : HistoryMigrationJobService {
     private val state = AtomicReference<HistoryMigrationJobState?>()
 
@@ -159,12 +160,109 @@ class HistoryMigrationJobServiceImpl(
      */
     override fun current(): HistoryMigrationJobState? {
         state.get()?.let { return it }
-        val row = stateRepository.findById(IMPORT_KEY).orElse(null) ?: return null
+        val row = stateRepository.findById(HISTORY_IMPORT_KEY).orElse(null) ?: return null
         return synthesizeFromDb(row)
     }
 
     override fun clearInMemory() {
+        val current = state.get()
+        if (current?.state == JobState.RUNNING) {
+            LOG.warn(
+                "clearInMemory() called while job {} is RUNNING — ignored. " +
+                    "Call forceReset() or wait for the job to complete first.",
+                current.id,
+            )
+            return
+        }
         state.set(null)
+    }
+
+    /**
+     * Guards → wipe → return outcome. See [HistoryMigrationJobService.forceReset].
+     *
+     * Guard ordering mirrors [AdminControllerV4.forceResetHistory] before refactor:
+     *  1. In-pod RUNNING check (in-memory read, no DB).
+     *  2. DB staleness check (DB read + age compare).
+     *  3. TOCTOU re-read: re-check in-memory state after DB read to catch a
+     *     concurrent [startAsync] that claimed the gate between Guards 1 and 2.
+     */
+    override fun forceReset(ackMultipodRisk: Boolean): ForceResetOutcome {
+        // Guard 1: same-pod active job.
+        val active = state.get()
+        if (active?.state == JobState.RUNNING) {
+            return ForceResetOutcome.Blocked(
+                code = "history-migration-running",
+                message =
+                    "Cannot force-reset while history migration is RUNNING (jobId=${active.id}). " +
+                        "Wait for it to finish or restart the pod.",
+                activeKind = JobKind.HISTORY.name,
+                activeJobId = active.id,
+            )
+        }
+
+        // Guard 2: cross-pod staleness. Inspect the DB row directly so a live import
+        // in another pod (with a fresh updatedAt) is detected.
+        val row = stateRepository.findById(HISTORY_IMPORT_KEY).orElse(null)
+        if (row != null &&
+            row.status == GitHistoryImportStatus.IN_PROGRESS.name &&
+            !ackMultipodRisk
+        ) {
+            val age = Duration.between(row.updatedAt, Instant.now())
+            if (age < STALE_IN_PROGRESS_THRESHOLD) {
+                LOG.info(
+                    "Refusing force-reset: IN_PROGRESS row updated {} ago (threshold={}). " +
+                        "Likely a live import in another pod. Override with ack-multipod-risk=true if you accept the data-corruption risk.",
+                    age,
+                    STALE_IN_PROGRESS_THRESHOLD,
+                )
+                return ForceResetOutcome.Blocked(
+                    code = "history-import-likely-live-elsewhere",
+                    message =
+                        "Refusing force-reset: the IN_PROGRESS claim was updated ${age.toSeconds()}s ago, " +
+                            "below the ${STALE_IN_PROGRESS_THRESHOLD.toMinutes()}-minute staleness threshold. " +
+                            "A live import in another pod is likely. " +
+                            "If you understand the multi-pod risk and want to proceed anyway, " +
+                            "POST again with ?ack-multipod-risk=true.",
+                    activeKind = JobKind.HISTORY.name,
+                    activeJobId = null,
+                )
+            }
+        }
+
+        // TOCTOU re-read: re-check in-memory state after the DB row read. The window
+        // between Guard 1 and this point is at most one DB round-trip wide. A concurrent
+        // startAsync that slipped past Guard 1 (it hadn't claimed the gate yet) and has
+        // since published its state will be caught here.
+        val activeAfterRowRead = state.get()
+        if (activeAfterRowRead?.state == JobState.RUNNING) {
+            return ForceResetOutcome.Blocked(
+                code = "history-migration-running",
+                message =
+                    "Cannot force-reset while history migration is RUNNING (jobId=${activeAfterRowRead.id}). " +
+                        "Wait for it to finish or restart the pod.",
+                activeKind = JobKind.HISTORY.name,
+                activeJobId = activeAfterRowRead.id,
+            )
+        }
+
+        // Audit-loud destructive action: log before the wipe so the pre-state survives
+        // in the log stream. ackMultipodRisk override logged at ERROR so alert pipelines
+        // that filter on ERROR-only catch it.
+        if (row != null) {
+            val msg =
+                "FORCE-RESET: deleting git_history_import_state " +
+                    "(target=${row.targetRef}@${row.targetSha}, status=${row.status}, " +
+                    "updatedAt=${row.updatedAt}) and all audit_log rows with source='git-history'."
+            if (ackMultipodRisk) LOG.error("$msg [ack-multipod-risk=true overriding staleness check]") else LOG.info(msg)
+        } else {
+            LOG.info("FORCE-RESET: no state row to delete (idempotent no-op on empty DB)")
+        }
+
+        forceResetter.forceReset()
+        // Bypass the clearInMemory() RUNNING guard — we already verified there is no
+        // RUNNING job above (Guards 1, 3). Direct set avoids the redundant re-check.
+        state.set(null)
+        return ForceResetOutcome.Cleared
     }
 
     private fun runHistoryMigration(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -7,6 +7,7 @@ import org.octopusden.octopus.components.registry.server.service.GitHistoryImpor
 import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
 import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
 import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobState
+import org.octopusden.octopus.components.registry.server.service.HistoryRecoveryAction
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
@@ -104,6 +105,7 @@ class HistoryMigrationJobServiceImpl(
                             finishedAt = Instant.now(),
                             errorMessage =
                                 "Failed to submit history migration: ${rejected.message ?: rejected::class.java.simpleName}",
+                            recoveryAction = HistoryRecoveryAction.RETRY,
                         )
                     }
                 }
@@ -156,6 +158,9 @@ class HistoryMigrationJobServiceImpl(
                         skippedParseError = result.skippedParseError,
                         skippedUnknownNames = result.skippedUnknownNames,
                         result = result,
+                        // Operator can re-run the import on top of a COMPLETED row
+                        // via reset=true; SPA shows "Retry (reset state)".
+                        recoveryAction = HistoryRecoveryAction.RETRY,
                     )
                 }
             }
@@ -179,6 +184,11 @@ class HistoryMigrationJobServiceImpl(
                         finishedAt = Instant.now(),
                         currentSha = null,
                         errorMessage = e.message ?: e::class.java.simpleName,
+                        // FAILED in-memory paths are recoverable with reset=true
+                        // (the underlying preflight will clear the FAILED row
+                        // before re-claiming). FORCE_RESET is reserved for the
+                        // synthesized stuck-IN_PROGRESS DB-fallback case only.
+                        recoveryAction = HistoryRecoveryAction.RETRY,
                     )
                 }
             }
@@ -208,41 +218,70 @@ class HistoryMigrationJobServiceImpl(
         }
 
     private fun synthesizeFromDb(row: GitHistoryImportStateEntity): HistoryMigrationJobState {
-        val syntheticId = "restored-${row.updatedAt.toEpochMilli()}"
         val targetRef = row.targetRef.takeIf { it.isNotEmpty() }
+        // Synthetic id includes status + targetSha + updatedAt millis. Status
+        // makes the id distinguishable across the COMPLETED→re-claimed→FAILED
+        // sequence in the same pod-restart window; targetSha disambiguates
+        // imports against different refs; updatedAt covers the rare
+        // same-content same-ref case. The previous "restored-${epochMillis}"
+        // form could collide on identical updatedAt (multiple sequential
+        // restarts against the unchanged row), causing downstream consumers
+        // that key on `id` to miss state transitions.
+        val shaPart = row.targetSha.takeIf { it.isNotEmpty() } ?: "no-sha"
+        val syntheticId = "restored:${row.status.lowercase()}:$shaPart:${row.updatedAt.toEpochMilli()}"
         return when (row.status) {
             GitHistoryImportStatus.COMPLETED.name ->
-                emptyJobState(syntheticId, JobState.COMPLETED, row.updatedAt, targetRef, errorMessage = null)
+                synthesizedJobState(
+                    syntheticId,
+                    JobState.COMPLETED,
+                    row.updatedAt,
+                    targetRef,
+                    errorMessage = null,
+                    recoveryAction = HistoryRecoveryAction.RETRY,
+                )
             GitHistoryImportStatus.FAILED.name ->
-                emptyJobState(
+                synthesizedJobState(
                     syntheticId,
                     JobState.FAILED,
                     row.updatedAt,
                     targetRef,
                     errorMessage = "Previous run failed (details unavailable). Use Retry to re-run.",
+                    recoveryAction = HistoryRecoveryAction.RETRY,
                 )
             GitHistoryImportStatus.IN_PROGRESS.name ->
-                emptyJobState(
+                synthesizedJobState(
                     syntheticId,
                     JobState.FAILED,
                     row.updatedAt,
                     targetRef,
+                    // Human-readable explainer; the SPA does NOT match on this
+                    // string anymore — it branches on `recoveryAction == FORCE_RESET`.
                     errorMessage =
-                        "Previous run is marked IN_PROGRESS but no job is active in this pod " +
-                            "(probably interrupted by pod restart). Use Force reset to clear the claim, " +
+                        "Previous run is stuck in IN_PROGRESS state with no active job in this pod " +
+                            "(probably interrupted by a pod restart). Use Force reset to clear the claim, " +
                             "then Retry. WARNING: if another CRS pod is currently running this import, " +
                             "force-reset will corrupt its data.",
+                    recoveryAction = HistoryRecoveryAction.FORCE_RESET,
                 )
-            else -> emptyJobState(syntheticId, JobState.FAILED, row.updatedAt, targetRef, errorMessage = "Unknown status: ${row.status}")
+            else ->
+                synthesizedJobState(
+                    syntheticId,
+                    JobState.FAILED,
+                    row.updatedAt,
+                    targetRef,
+                    errorMessage = "Unknown status: ${row.status}",
+                    recoveryAction = HistoryRecoveryAction.FORCE_RESET,
+                )
         }
     }
 
-    private fun emptyJobState(
+    private fun synthesizedJobState(
         id: String,
         state: JobState,
         updatedAt: Instant,
         targetRef: String?,
         errorMessage: String?,
+        recoveryAction: HistoryRecoveryAction?,
     ): HistoryMigrationJobState =
         HistoryMigrationJobState(
             id = id,
@@ -259,6 +298,7 @@ class HistoryMigrationJobServiceImpl(
             targetRef = targetRef,
             errorMessage = errorMessage,
             result = null,
+            recoveryAction = recoveryAction,
         )
 
     companion object {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -269,8 +269,11 @@ class HistoryMigrationJobServiceImpl(
                     JobState.FAILED,
                     row.updatedAt,
                     targetRef,
-                    errorMessage = "Unknown status: ${row.status}",
-                    recoveryAction = HistoryRecoveryAction.FORCE_RESET,
+                    errorMessage = "Unknown status: ${row.status}. Contact operations.",
+                    // Don't confidently route an unknown DB status to FORCE_RESET —
+                    // we don't actually know if a force-reset is the right move.
+                    // SPA renders the message and disables both action buttons.
+                    recoveryAction = HistoryRecoveryAction.UNKNOWN,
                 )
         }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
@@ -1,9 +1,14 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.service.FullMigrationResult
 import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
 import org.octopusden.octopus.components.registry.server.service.MigrationJobState
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
+import org.octopusden.octopus.components.registry.server.service.MigrationPhase
 import org.octopusden.octopus.components.registry.server.service.MigrationProgressListener
 import org.octopusden.octopus.components.registry.server.service.StartMigrationResult
 import org.slf4j.LoggerFactory
@@ -24,26 +29,41 @@ import java.util.concurrent.atomic.AtomicReference
  * every component on restart. So we trade resilience for code we can read in one
  * sitting.
  *
- * The single-thread [TaskExecutor] is the ground truth for "no two migrations at
- * once": even if the AtomicReference CAS were buggy, the executor's queue serializes
- * runs. The CAS exists for the *response*: we want the second `POST /admin/migrate`
- * to return 409 immediately rather than queue a duplicate run that would only fail
- * later with "already migrated".
+ * Concurrency model:
+ *  - Same-kind 409 (a second components POST while one is RUNNING) is decided by
+ *    reading the local AtomicReference. The SPA "attaches" to the in-flight job
+ *    rather than spawning a duplicate.
+ *  - Cross-kind serialization (a components POST while history is RUNNING) is
+ *    decided by [MigrationLifecycleGate] — a shared bean both this service and
+ *    HistoryMigrationJobService consult before claiming. ThreadPoolTaskExecutor
+ *    on its own does NOT serialize cross-service: it queues the second submit,
+ *    so without the gate both `startAsync` calls would return 202 and the SPA
+ *    would render two RUNNING jobs.
  */
 @Service
 class MigrationJobServiceImpl(
     private val importService: ImportService,
     @Qualifier("migrationExecutor") private val executor: TaskExecutor,
+    private val lifecycleGate: MigrationLifecycleGate,
 ) : MigrationJobService {
     private val state = AtomicReference<MigrationJobState?>()
 
     override fun startAsync(): StartMigrationResult {
-        // CAS loop: claim the slot ONLY if no RUNNING job is currently in it.
+        // Order of operations is load-bearing:
+        //   1. same-kind 409 from local AtomicReference (state is non-null when RUNNING),
+        //   2. cross-kind gate claim (after the same-kind path so we never read nullable
+        //      state inside the gate-conflict branch),
+        //   3. publish state via CAS,
+        //   4. submit to executor.
+        // A naive "gate first" version had a window where thread A claimed the gate but
+        // hadn't yet written state, and thread B's same-kind 409 path would NPE on
+        // state.get()!!. Same-kind first dodges that.
         while (true) {
             val existing = state.get()
             if (existing?.state == JobState.RUNNING) {
                 return StartMigrationResult(existing, isNewlyStarted = false)
             }
+
             val candidate =
                 MigrationJobState(
                     id = UUID.randomUUID().toString(),
@@ -57,44 +77,72 @@ class MigrationJobServiceImpl(
                     currentComponent = null,
                     errorMessage = null,
                     result = null,
+                    // CRITICAL: phase is set on the candidate BEFORE executor.execute,
+                    // not inside the runnable. ThreadPoolTaskExecutor.execute returns
+                    // synchronously and the controller builds its response from
+                    // state.get() right after — if phase weren't already DEFAULTS the
+                    // first SPA poll tick would see RUNNING with no phase and render
+                    // the fallback "Running…" instead of "Loading defaults from Git…".
+                    // The whole point of the field would be defeated at the moment of
+                    // the click.
+                    phase = MigrationPhase.DEFAULTS,
                 )
-            if (state.compareAndSet(existing, candidate)) {
-                LOG.info("Starting migration job {}", candidate.id)
-                try {
-                    executor.execute { runMigration(candidate.id) }
-                } catch (
-                    @Suppress("TooGenericExceptionCaught") rejected: Throwable,
-                ) {
-                    // The slot was claimed for this candidate but the executor refused
-                    // (typical case: RejectedExecutionException during pod shutdown,
-                    // or a queue-capacity-exceeded if a future config narrows the
-                    // queue). Without this, the in-memory slot would stay RUNNING
-                    // forever — every subsequent POST /admin/migrate would return
-                    // 409, and the operator would be stuck without a way to retry.
-                    // Transition to FAILED so the slot is "done" and the next
-                    // startAsync claims a fresh one.
-                    LOG.error("Failed to submit migration job {} to executor", candidate.id, rejected)
-                    state.updateAndGet { current ->
-                        if (current?.id != candidate.id) {
-                            current
-                        } else {
-                            current.copy(
-                                state = JobState.FAILED,
-                                finishedAt = Instant.now(),
-                                errorMessage =
-                                    "Failed to submit migration: ${rejected.message ?: rejected::class.java.simpleName}",
-                            )
-                        }
-                    }
-                    throw rejected
+
+            val gateConflict = lifecycleGate.tryClaim(JobKind.COMPONENTS, candidate.id)
+            if (gateConflict != null) {
+                when (gateConflict.kind) {
+                    // A concurrent components-startAsync got the gate first — retry from
+                    // the top so we re-read state and either attach to its publication or
+                    // race for the next slot once it completes.
+                    JobKind.COMPONENTS -> continue
+                    // The other migration kind owns the gate. Surface as cross-kind 409
+                    // via the controller's exception handler.
+                    JobKind.HISTORY -> throw MigrationConflictException(gateConflict)
                 }
-                // Return the post-spawn current state — with SyncTaskExecutor (used in
-                // tests) the run has already finished by now, so callers see COMPLETED;
-                // with the production async executor they see RUNNING. Either way it's
-                // the authoritative state for "what is the job right now".
-                return StartMigrationResult(state.get() ?: candidate, isNewlyStarted = true)
             }
-            // Lost the CAS race against a concurrent caller; fall through to re-check.
+
+            // Gate is ours. Publish state. With the gate held, no other startAsync of
+            // either kind is in this critical section, so the CAS should always succeed
+            // — the false branch is a defensive belt-and-braces.
+            if (!state.compareAndSet(existing, candidate)) {
+                lifecycleGate.release(candidate.id)
+                continue
+            }
+
+            LOG.info("Starting migration job {}", candidate.id)
+            try {
+                executor.execute { runMigration(candidate.id) }
+            } catch (
+                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
+            ) {
+                // The slot was claimed for this candidate but the executor refused
+                // (typical case: RejectedExecutionException during pod shutdown).
+                // Without this rollback, the in-memory slot would stay RUNNING
+                // forever — every subsequent POST /admin/migrate would return
+                // 409 and the operator would be wedged. Transition to FAILED so
+                // the slot is "done" and the next startAsync claims a fresh one.
+                LOG.error("Failed to submit migration job {} to executor", candidate.id, rejected)
+                lifecycleGate.release(candidate.id)
+                state.updateAndGet { current ->
+                    if (current?.id != candidate.id) {
+                        current
+                    } else {
+                        current.copy(
+                            state = JobState.FAILED,
+                            finishedAt = Instant.now(),
+                            errorMessage =
+                                "Failed to submit migration: ${rejected.message ?: rejected::class.java.simpleName}",
+                            phase = null,
+                        )
+                    }
+                }
+                throw rejected
+            }
+            // Return the post-spawn current state — with SyncTaskExecutor (used in
+            // tests) the run has already finished by now, so callers see COMPLETED;
+            // with the production async executor they see RUNNING. Either way it's
+            // the authoritative state for "what is the job right now".
+            return StartMigrationResult(state.get() ?: candidate, isNewlyStarted = true)
         }
     }
 
@@ -102,8 +150,15 @@ class MigrationJobServiceImpl(
 
     private fun runMigration(jobId: String) {
         try {
-            val result = importService.migrate(progressListener(jobId))
-            val components = result.components
+            // phase=DEFAULTS was already published by startAsync(); we don't re-set it
+            // here because a) it's already correct, b) re-publishing would mean two
+            // observable phase-transitions for one logical phase boundary.
+            val defaults = importService.migrateDefaults()
+
+            updatePhase(jobId, MigrationPhase.COMPONENTS)
+            val components = importService.migrateAllComponents(progressListener(jobId))
+
+            val result = FullMigrationResult(defaults = defaults, components = components)
             state.updateAndGet { current ->
                 // Defend against a stale jobId update (e.g. another start happened in
                 // between, which shouldn't be possible while we're RUNNING but is cheap
@@ -115,6 +170,7 @@ class MigrationJobServiceImpl(
                         state = JobState.COMPLETED,
                         finishedAt = Instant.now(),
                         currentComponent = null,
+                        phase = null,
                         result = result,
                         total = components.total,
                         migrated = components.migrated,
@@ -143,9 +199,29 @@ class MigrationJobServiceImpl(
                         state = JobState.FAILED,
                         finishedAt = Instant.now(),
                         currentComponent = null,
+                        phase = null,
                         errorMessage = e.message ?: e::class.java.simpleName,
                     )
                 }
+            }
+        } finally {
+            // Always release the cross-kind gate, even on failure / unhandled throw,
+            // so a follow-up history migration isn't blocked forever by a leaked claim.
+            lifecycleGate.release(jobId)
+        }
+    }
+
+    private fun updatePhase(
+        jobId: String,
+        nextPhase: MigrationPhase,
+    ) {
+        state.updateAndGet { current ->
+            if (current?.id != jobId) {
+                current
+            } else {
+                // Clear currentComponent on phase boundary so the SPA doesn't keep showing
+                // a stale per-component label while the new phase is initializing.
+                current.copy(phase = nextPhase, currentComponent = null)
             }
         }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
@@ -48,6 +48,12 @@ class MigrationJobServiceImpl(
 ) : MigrationJobService {
     private val state = AtomicReference<MigrationJobState?>()
 
+    // Suppressed LoopWithTooManyJumpStatements — the loop IS the CAS-retry
+    // pattern: each branch (same-kind attach, cross-kind gate conflict, lost
+    // CAS race) needs its own non-local exit. Refactoring into helpers
+    // would pull non-trivial state across the boundary and make the
+    // ordering invariants harder to read, not easier.
+    @Suppress("LoopWithTooManyJumpStatements")
     override fun startAsync(): StartMigrationResult {
         // Order of operations is load-bearing:
         //   1. same-kind 409 from local AtomicReference (state is non-null when RUNNING),

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
@@ -48,107 +48,134 @@ class MigrationJobServiceImpl(
 ) : MigrationJobService {
     private val state = AtomicReference<MigrationJobState?>()
 
-    // Suppressed LoopWithTooManyJumpStatements — the loop IS the CAS-retry
-    // pattern: each branch (same-kind attach, cross-kind gate conflict, lost
-    // CAS race) needs its own non-local exit. Refactoring into helpers
-    // would pull non-trivial state across the boundary and make the
-    // ordering invariants harder to read, not easier.
-    @Suppress("LoopWithTooManyJumpStatements")
+    /**
+     * Outcome of a single CAS-retry iteration in [startAsync]. Replaces what
+     * was previously a multi-jump loop body with explicit named cases — each
+     * one maps to exactly one terminal action in the loop driver.
+     */
+    private sealed interface ClaimAttempt {
+        /** Same-kind start while one is RUNNING — caller attaches to existing. */
+        data class Attached(
+            val state: MigrationJobState,
+        ) : ClaimAttempt
+
+        /** Cross-kind gate held by HISTORY — caller throws to the controller's 409 mapper. */
+        data class CrossKindConflict(
+            val active: MigrationLifecycleGate.ActiveJob,
+        ) : ClaimAttempt
+
+        /** Lost a race (gate or state CAS); caller loops back for another attempt. */
+        data object Retry : ClaimAttempt
+
+        /** Won the slot; caller submits the runnable to the executor. */
+        data class Claimed(
+            val candidate: MigrationJobState,
+        ) : ClaimAttempt
+    }
+
     override fun startAsync(): StartMigrationResult {
-        // Order of operations is load-bearing:
-        //   1. same-kind 409 from local AtomicReference (state is non-null when RUNNING),
-        //   2. cross-kind gate claim (after the same-kind path so we never read nullable
-        //      state inside the gate-conflict branch),
-        //   3. publish state via CAS,
-        //   4. submit to executor.
-        // A naive "gate first" version had a window where thread A claimed the gate but
-        // hadn't yet written state, and thread B's same-kind 409 path would NPE on
-        // state.get()!!. Same-kind first dodges that.
+        // Order of operations is load-bearing — see [tryClaim]. We loop only on
+        // [ClaimAttempt.Retry]; every other case is a terminal action.
         while (true) {
-            val existing = state.get()
-            if (existing?.state == JobState.RUNNING) {
-                return StartMigrationResult(existing, isNewlyStarted = false)
+            when (val attempt = tryClaim()) {
+                is ClaimAttempt.Attached -> return StartMigrationResult(attempt.state, isNewlyStarted = false)
+                is ClaimAttempt.CrossKindConflict -> throw MigrationConflictException(attempt.active)
+                is ClaimAttempt.Claimed -> {
+                    submitToExecutor(attempt.candidate)
+                    // SyncTaskExecutor (used in tests) has already finished the run by now → callers see COMPLETED.
+                    // Production async executor → RUNNING. Either way, return the authoritative current state.
+                    return StartMigrationResult(state.get() ?: attempt.candidate, isNewlyStarted = true)
+                }
+                ClaimAttempt.Retry -> Unit // loop again
             }
+        }
+    }
 
-            val candidate =
-                MigrationJobState(
-                    id = UUID.randomUUID().toString(),
-                    state = JobState.RUNNING,
-                    startedAt = Instant.now(),
-                    finishedAt = null,
-                    total = 0,
-                    migrated = 0,
-                    failed = 0,
-                    skipped = 0,
-                    currentComponent = null,
-                    errorMessage = null,
-                    result = null,
-                    // CRITICAL: phase is set on the candidate BEFORE executor.execute,
-                    // not inside the runnable. ThreadPoolTaskExecutor.execute returns
-                    // synchronously and the controller builds its response from
-                    // state.get() right after — if phase weren't already DEFAULTS the
-                    // first SPA poll tick would see RUNNING with no phase and render
-                    // the fallback "Running…" instead of "Loading defaults from Git…".
-                    // The whole point of the field would be defeated at the moment of
-                    // the click.
-                    phase = MigrationPhase.DEFAULTS,
-                )
+    /**
+     * One CAS-retry iteration. Decomposes the original loop body into:
+     *   1. same-kind 409 from local AtomicReference (state is non-null when RUNNING),
+     *   2. cross-kind gate claim (after the same-kind path so we never read
+     *      nullable state inside the gate-conflict branch),
+     *   3. publish state via CAS.
+     *
+     * A naive "gate first" version had a window where thread A claimed the gate but
+     * hadn't yet written state, and thread B's same-kind 409 path would NPE on
+     * `state.get()!!`. Same-kind first dodges that.
+     */
+    private fun tryClaim(): ClaimAttempt {
+        val existing = state.get()
+        if (existing?.state == JobState.RUNNING) {
+            return ClaimAttempt.Attached(existing)
+        }
 
-            val gateConflict = lifecycleGate.tryClaim(JobKind.COMPONENTS, candidate.id)
-            if (gateConflict != null) {
-                when (gateConflict.kind) {
-                    // A concurrent components-startAsync got the gate first — retry from
-                    // the top so we re-read state and either attach to its publication or
-                    // race for the next slot once it completes.
-                    JobKind.COMPONENTS -> continue
-                    // The other migration kind owns the gate. Surface as cross-kind 409
-                    // via the controller's exception handler.
-                    JobKind.HISTORY -> throw MigrationConflictException(gateConflict)
+        val candidate =
+            MigrationJobState(
+                id = UUID.randomUUID().toString(),
+                state = JobState.RUNNING,
+                startedAt = Instant.now(),
+                finishedAt = null,
+                total = 0,
+                migrated = 0,
+                failed = 0,
+                skipped = 0,
+                currentComponent = null,
+                errorMessage = null,
+                result = null,
+                // CRITICAL: phase is set on the candidate BEFORE executor.execute,
+                // not inside the runnable. ThreadPoolTaskExecutor.execute returns
+                // synchronously and the controller builds its response from
+                // state.get() right after — if phase weren't already DEFAULTS the
+                // first SPA poll tick would see RUNNING with no phase and render
+                // the fallback "Running…" instead of "Loading defaults from Git…".
+                phase = MigrationPhase.DEFAULTS,
+            )
+
+        val gateConflict = lifecycleGate.tryClaim(JobKind.COMPONENTS, candidate.id)
+        if (gateConflict != null) {
+            return when (gateConflict.kind) {
+                JobKind.COMPONENTS -> ClaimAttempt.Retry
+                JobKind.HISTORY -> ClaimAttempt.CrossKindConflict(gateConflict)
+            }
+        }
+
+        // Gate is ours. Publish state. With the gate held no other startAsync of
+        // either kind is in this critical section, so the CAS should always succeed
+        // — the false branch is defensive belt-and-braces.
+        if (!state.compareAndSet(existing, candidate)) {
+            lifecycleGate.release(candidate.id)
+            return ClaimAttempt.Retry
+        }
+        return ClaimAttempt.Claimed(candidate)
+    }
+
+    @Suppress("TooGenericExceptionCaught") // Throwable so executor rejection ALWAYS unwinds the slot.
+    private fun submitToExecutor(candidate: MigrationJobState) {
+        LOG.info("Starting migration job {}", candidate.id)
+        try {
+            executor.execute { runMigration(candidate.id) }
+        } catch (rejected: Throwable) {
+            // The slot was claimed for this candidate but the executor refused
+            // (typical case: RejectedExecutionException during pod shutdown).
+            // Without this rollback, the in-memory slot would stay RUNNING
+            // forever — every subsequent POST /admin/migrate would return 409
+            // and the operator would be wedged. Transition to FAILED so the
+            // slot is "done" and the next startAsync claims a fresh one.
+            LOG.error("Failed to submit migration job {} to executor", candidate.id, rejected)
+            lifecycleGate.release(candidate.id)
+            state.updateAndGet { current ->
+                if (current?.id != candidate.id) {
+                    current
+                } else {
+                    current.copy(
+                        state = JobState.FAILED,
+                        finishedAt = Instant.now(),
+                        errorMessage =
+                            "Failed to submit migration: ${rejected.message ?: rejected::class.java.simpleName}",
+                        phase = null,
+                    )
                 }
             }
-
-            // Gate is ours. Publish state. With the gate held, no other startAsync of
-            // either kind is in this critical section, so the CAS should always succeed
-            // — the false branch is a defensive belt-and-braces.
-            if (!state.compareAndSet(existing, candidate)) {
-                lifecycleGate.release(candidate.id)
-                continue
-            }
-
-            LOG.info("Starting migration job {}", candidate.id)
-            try {
-                executor.execute { runMigration(candidate.id) }
-            } catch (
-                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
-            ) {
-                // The slot was claimed for this candidate but the executor refused
-                // (typical case: RejectedExecutionException during pod shutdown).
-                // Without this rollback, the in-memory slot would stay RUNNING
-                // forever — every subsequent POST /admin/migrate would return
-                // 409 and the operator would be wedged. Transition to FAILED so
-                // the slot is "done" and the next startAsync claims a fresh one.
-                LOG.error("Failed to submit migration job {} to executor", candidate.id, rejected)
-                lifecycleGate.release(candidate.id)
-                state.updateAndGet { current ->
-                    if (current?.id != candidate.id) {
-                        current
-                    } else {
-                        current.copy(
-                            state = JobState.FAILED,
-                            finishedAt = Instant.now(),
-                            errorMessage =
-                                "Failed to submit migration: ${rejected.message ?: rejected::class.java.simpleName}",
-                            phase = null,
-                        )
-                    }
-                }
-                throw rejected
-            }
-            // Return the post-spawn current state — with SyncTaskExecutor (used in
-            // tests) the run has already finished by now, so callers see COMPLETED;
-            // with the production async executor they see RUNNING. Either way it's
-            // the authoritative state for "what is the job right now".
-            return StartMigrationResult(state.get() ?: candidate, isNewlyStarted = true)
+            throw rejected
         }
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -9,9 +9,11 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
 import org.octopusden.octopus.components.registry.server.service.MigrationJobState
+import org.octopusden.octopus.components.registry.server.service.MigrationPhase
 import org.octopusden.octopus.components.registry.server.service.StartMigrationResult
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.octopusden.octopus.components.registry.server.support.editorJwt
@@ -53,6 +55,17 @@ class AdminControllerV4SecurityTest {
 
     @MockBean
     private lateinit var migrationJobService: MigrationJobService
+
+    /**
+     * Mocked too — the controller constructor wires it in for the new
+     * /migrate-history endpoints. The MIG-024 cases below don't drive it,
+     * but without the @MockBean Spring would try to wire the real
+     * HistoryMigrationJobServiceImpl which pulls in the DB layer and
+     * defeats this test's "no integration" stance.
+     */
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var historyMigrationJobService: HistoryMigrationJobService
 
     @Autowired
     private lateinit var mvc: MockMvc
@@ -105,6 +118,7 @@ class AdminControllerV4SecurityTest {
                 currentComponent = null,
                 errorMessage = null,
                 result = null,
+                phase = MigrationPhase.DEFAULTS,
             )
 
         @JvmStatic

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateEndpointTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateEndpointTest.kt
@@ -99,6 +99,13 @@ class MigrateEndpointTest {
             "Expected no migration failures: ${populated.components.results.filter { !it.success }}",
         )
         assertEquals(populated.components.migrated + populated.components.skipped, populated.components.total)
+
+        // phase must be cleared on COMPLETED. While RUNNING the field carries
+        // "DEFAULTS" / "COMPONENTS" so the SPA renders informative labels, but
+        // by the time we see COMPLETED there is no active sub-phase to report.
+        // Clearing it explicitly (rather than leaving e.g. "COMPONENTS") avoids
+        // the SPA mistakenly rendering a phase label next to the result tiles.
+        assertEquals(null, job.phase, "phase must be null on COMPLETED")
     }
 
     /**

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
@@ -123,6 +123,41 @@ class MigrateHistoryAsyncEndpointTest {
     }
 
     @Test
+    fun `JSON wire shape includes kind=job discriminator`() {
+        // P2 review fix: the SPA branches on `kind === 'conflict'` to
+        // distinguish same-kind 409 attach from cross-kind 409 conflict.
+        // Jackson serializes the data-class default value `kind = "job"`,
+        // but if a future refactor turns the response into an interface
+        // and an implementation forgets the field, no test would fire.
+        // This test pins the wire contract.
+        stubResult.set(
+            HistoryImportResult(
+                targetRef = "refs/tags/test-3.0",
+                targetSha = "kind-discriminator-test",
+                processedCommits = 0,
+                skippedNoGroovy = 0,
+                skippedParseError = 0,
+                skippedUnknownNames = 0,
+                auditRecords = 0,
+                durationMs = 0,
+            ),
+        )
+        val body =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-history").with(adminJwt()).accept(APPLICATION_JSON))
+                .andExpect(status().isAccepted)
+                .andReturn().response.contentAsString
+        // Asserting on the raw JSON (not the deserialized DTO) — the contract
+        // is "the field is present on the wire", and DTO deserialization
+        // would happily fall back to the data-class default if the field
+        // were missing in the JSON.
+        org.junit.jupiter.api.Assertions.assertTrue(
+            body.contains("\"kind\":\"job\""),
+            "Response JSON must include the 'kind' discriminator. Body was: $body",
+        )
+    }
+
+    @Test
     fun `POST then GET migrate-history-job returns the same job shape`() {
         stubResult.set(
             HistoryImportResult(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
@@ -146,7 +146,8 @@ class MigrateHistoryAsyncEndpointTest {
             mvc
                 .perform(post("/rest/api/4/admin/migrate-history").with(adminJwt()).accept(APPLICATION_JSON))
                 .andExpect(status().isAccepted)
-                .andReturn().response.contentAsString
+                .andReturn()
+                .response.contentAsString
         // Asserting on the raw JSON (not the deserialized DTO) — the contract
         // is "the field is present on the wire", and DTO deserialization
         // would happily fall back to the data-class default if the field
@@ -176,14 +177,16 @@ class MigrateHistoryAsyncEndpointTest {
             mvc
                 .perform(post("/rest/api/4/admin/migrate-history").with(adminJwt()).accept(APPLICATION_JSON))
                 .andExpect(status().isAccepted)
-                .andReturn().response.contentAsString
+                .andReturn()
+                .response.contentAsString
         val posted: HistoryMigrationJobResponse = objectMapper.readValue(postedBody)
 
         val gotBody =
             mvc
                 .perform(get("/rest/api/4/admin/migrate-history/job").with(adminJwt()).accept(APPLICATION_JSON))
                 .andExpect(status().isOk)
-                .andReturn().response.contentAsString
+                .andReturn()
+                .response.contentAsString
         val got: HistoryMigrationJobResponse = objectMapper.readValue(gotBody)
 
         assertEquals(posted.id, got.id)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
@@ -1,0 +1,174 @@
+package org.octopusden.octopus.components.registry.server.migration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryMigrationJobResponse
+import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
+import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.core.task.SyncTaskExecutor
+import org.springframework.core.task.TaskExecutor
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+
+/**
+ * Endpoint-shape smoke test for `POST /admin/migrate-history` + `GET
+ * /admin/migrate-history/job`. Heavier end-to-end coverage with a real JGit
+ * fixture lives in [MigrateHistoryIntegrationTest]; this file pins the wire
+ * contract that the SPA depends on (state field, populated `result` block on
+ * COMPLETED, GET /job returning the same shape) without paying the JGit
+ * fixture cost on every CI run.
+ *
+ * GitHistoryImportService is @MockBean'd so we don't need to set up a clone
+ * source or DSL fixtures — we control what `importHistory` returns and
+ * assert the controller wires the response correctly.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@Import(MigrateHistoryAsyncEndpointTest.SyncMigrationExecutorConfig::class)
+@ActiveProfiles("common", "test-db")
+class MigrateHistoryAsyncEndpointTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    /**
+     * Mocked: the controller wires the in-memory job service which in turn
+     * wires this. Replacing it with a stub returning a canned result lets us
+     * assert on the response wiring without paying for git clone + DSL parse.
+     */
+    @MockBean
+    private lateinit var gitHistoryImportService: GitHistoryImportService
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `POST migrate-history returns 202 + COMPLETED body once the sync executor finishes`() {
+        val cannedResult =
+            HistoryImportResult(
+                targetRef = "refs/tags/test-1.0",
+                targetSha = "abc1234567890",
+                processedCommits = 42,
+                skippedNoGroovy = 3,
+                skippedParseError = 1,
+                skippedUnknownNames = 0,
+                auditRecords = 99,
+                durationMs = 500,
+            )
+        `when`(
+            gitHistoryImportService.importHistory(
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.eq(false),
+                org.mockito.ArgumentMatchers.any(HistoryImportProgressListener::class.java),
+            ),
+        ).thenReturn(cannedResult)
+
+        val body =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-history").with(adminJwt()).accept(APPLICATION_JSON))
+                .andExpect(status().isAccepted)
+                .andReturn()
+                .response
+                .contentAsString
+
+        val job: HistoryMigrationJobResponse = objectMapper.readValue(body)
+        // SyncTaskExecutor: by the time the response was assembled, the
+        // runnable has already finished, so terminal state + populated
+        // result block are observable directly.
+        assertEquals(JobState.COMPLETED, job.state)
+        assertNotNull(job.finishedAt)
+        assertEquals(42, job.processedCommits)
+        assertEquals(99, job.auditRecords)
+        assertEquals(cannedResult, job.result)
+        assertNull(job.currentSha, "currentSha must be cleared once the run is done")
+    }
+
+    @Test
+    fun `POST then GET migrate-history-job returns the same job shape`() {
+        val cannedResult =
+            HistoryImportResult(
+                targetRef = "refs/tags/test-2.0",
+                targetSha = "deadbeef",
+                processedCommits = 5,
+                skippedNoGroovy = 0,
+                skippedParseError = 0,
+                skippedUnknownNames = 0,
+                auditRecords = 12,
+                durationMs = 100,
+            )
+        `when`(
+            gitHistoryImportService.importHistory(
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.eq(false),
+                org.mockito.ArgumentMatchers.any(HistoryImportProgressListener::class.java),
+            ),
+        ).thenReturn(cannedResult)
+
+        val postedBody =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-history").with(adminJwt()).accept(APPLICATION_JSON))
+                .andExpect(status().isAccepted)
+                .andReturn().response.contentAsString
+        val posted: HistoryMigrationJobResponse = objectMapper.readValue(postedBody)
+
+        val gotBody =
+            mvc
+                .perform(get("/rest/api/4/admin/migrate-history/job").with(adminJwt()).accept(APPLICATION_JSON))
+                .andExpect(status().isOk)
+                .andReturn().response.contentAsString
+        val got: HistoryMigrationJobResponse = objectMapper.readValue(gotBody)
+
+        assertEquals(posted.id, got.id)
+        assertEquals(posted.state, got.state)
+        assertEquals(posted.result, got.result)
+    }
+
+    @TestConfiguration
+    open class SyncMigrationExecutorConfig {
+        @Bean("migrationExecutor")
+        open fun syncMigrationExecutor(): TaskExecutor = SyncTaskExecutor()
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrateHistoryAsyncEndpointTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
@@ -22,6 +21,7 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Primary
 import org.springframework.core.task.SyncTaskExecutor
 import org.springframework.core.task.TaskExecutor
 import org.springframework.http.MediaType.APPLICATION_JSON
@@ -33,6 +33,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Endpoint-shape smoke test for `POST /admin/migrate-history` + `GET
@@ -42,29 +44,23 @@ import org.testcontainers.containers.PostgreSQLContainer
  * COMPLETED, GET /job returning the same shape) without paying the JGit
  * fixture cost on every CI run.
  *
- * GitHistoryImportService is @MockBean'd so we don't need to set up a clone
- * source or DSL fixtures — we control what `importHistory` returns and
- * assert the controller wires the response correctly.
+ * Why a hand-rolled stub instead of @MockBean: Mockito's `any(...)` returns
+ * null at the call site, which trips the JVM null-check on Kotlin's
+ * non-nullable `listener: HistoryImportProgressListener` parameter before the
+ * proxy intercepts. The same trap is documented in MigrationJobServiceImplTest
+ * — both files dodge it via a stub registered through @TestConfiguration.
  */
 @AutoConfigureMockMvc
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = [ComponentRegistryServiceApplication::class],
 )
-@Import(MigrateHistoryAsyncEndpointTest.SyncMigrationExecutorConfig::class)
+@Import(MigrateHistoryAsyncEndpointTest.AsyncEndpointTestConfig::class)
 @ActiveProfiles("common", "test-db")
 class MigrateHistoryAsyncEndpointTest {
     @MockBean
     @Suppress("UnusedPrivateProperty")
     private lateinit var authServerClient: AuthServerClient
-
-    /**
-     * Mocked: the controller wires the in-memory job service which in turn
-     * wires this. Replacing it with a stub returning a canned result lets us
-     * assert on the response wiring without paying for git clone + DSL parse.
-     */
-    @MockBean
-    private lateinit var gitHistoryImportService: GitHistoryImportService
 
     @Autowired
     private lateinit var mvc: MockMvc
@@ -72,9 +68,28 @@ class MigrateHistoryAsyncEndpointTest {
     @Autowired
     private lateinit var objectMapper: ObjectMapper
 
+    /**
+     * Test-controlled holder that the stub bean reads from. Each test sets
+     * the canned [HistoryImportResult] before driving a POST so the bean
+     * returns whatever the test wants.
+     */
+    @Autowired
+    private lateinit var stubResult: AtomicReference<HistoryImportResult>
+
+    init {
+        // ComponentsRegistryProperties has a property `groovy-path` whose
+        // default value references ${COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR}.
+        // Without it set, ApplicationContext fails to bind. Mirror the pattern
+        // from MigrateEndpointTest / AdminControllerV4SecurityTest: point at
+        // the test-resources dir so the placeholder resolves.
+        val testResourcesPath =
+            Paths.get(MigrateHistoryAsyncEndpointTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
     @Test
     fun `POST migrate-history returns 202 + COMPLETED body once the sync executor finishes`() {
-        val cannedResult =
+        stubResult.set(
             HistoryImportResult(
                 targetRef = "refs/tags/test-1.0",
                 targetSha = "abc1234567890",
@@ -84,14 +99,8 @@ class MigrateHistoryAsyncEndpointTest {
                 skippedUnknownNames = 0,
                 auditRecords = 99,
                 durationMs = 500,
-            )
-        `when`(
-            gitHistoryImportService.importHistory(
-                org.mockito.ArgumentMatchers.isNull(),
-                org.mockito.ArgumentMatchers.eq(false),
-                org.mockito.ArgumentMatchers.any(HistoryImportProgressListener::class.java),
             ),
-        ).thenReturn(cannedResult)
+        )
 
         val body =
             mvc
@@ -109,13 +118,13 @@ class MigrateHistoryAsyncEndpointTest {
         assertNotNull(job.finishedAt)
         assertEquals(42, job.processedCommits)
         assertEquals(99, job.auditRecords)
-        assertEquals(cannedResult, job.result)
+        assertEquals(stubResult.get(), job.result)
         assertNull(job.currentSha, "currentSha must be cleared once the run is done")
     }
 
     @Test
     fun `POST then GET migrate-history-job returns the same job shape`() {
-        val cannedResult =
+        stubResult.set(
             HistoryImportResult(
                 targetRef = "refs/tags/test-2.0",
                 targetSha = "deadbeef",
@@ -125,14 +134,8 @@ class MigrateHistoryAsyncEndpointTest {
                 skippedUnknownNames = 0,
                 auditRecords = 12,
                 durationMs = 100,
-            )
-        `when`(
-            gitHistoryImportService.importHistory(
-                org.mockito.ArgumentMatchers.isNull(),
-                org.mockito.ArgumentMatchers.eq(false),
-                org.mockito.ArgumentMatchers.any(HistoryImportProgressListener::class.java),
             ),
-        ).thenReturn(cannedResult)
+        )
 
         val postedBody =
             mvc
@@ -153,10 +156,43 @@ class MigrateHistoryAsyncEndpointTest {
         assertEquals(posted.result, got.result)
     }
 
+    /**
+     * @TestConfiguration replaces both the production migrationExecutor (with
+     * a SyncTaskExecutor so each POST runs the import inline) AND the real
+     * GitHistoryImportService (with a hand-rolled stub that returns whatever
+     * the test stuffs into [stubResult]). @Primary on the service bean wins
+     * over the production @Service-annotated impl during context wiring.
+     */
     @TestConfiguration
-    open class SyncMigrationExecutorConfig {
+    open class AsyncEndpointTestConfig {
         @Bean("migrationExecutor")
         open fun syncMigrationExecutor(): TaskExecutor = SyncTaskExecutor()
+
+        @Bean
+        open fun stubResult(): AtomicReference<HistoryImportResult> =
+            AtomicReference(
+                HistoryImportResult(
+                    targetRef = "",
+                    targetSha = "",
+                    processedCommits = 0,
+                    skippedNoGroovy = 0,
+                    skippedParseError = 0,
+                    skippedUnknownNames = 0,
+                    auditRecords = 0,
+                    durationMs = 0,
+                ),
+            )
+
+        @Bean
+        @Primary
+        open fun stubGitHistoryImportService(stubResult: AtomicReference<HistoryImportResult>): GitHistoryImportService =
+            object : GitHistoryImportService {
+                override fun importHistory(
+                    toRef: String?,
+                    reset: Boolean,
+                    listener: HistoryImportProgressListener,
+                ): HistoryImportResult = stubResult.get()
+            }
     }
 
     companion object {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
@@ -1,3 +1,9 @@
+// MaxLineLength suppressed because StubStateRepository overrides JpaRepository's
+// long generic-laden signatures verbatim — they are mostly `error("unused")`
+// boilerplate, breaking each one across multiple lines makes the file harder
+// to scan, not easier.
+@file:Suppress("MaxLineLength")
+
 package org.octopusden.octopus.components.registry.server.service.impl
 
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -20,7 +26,6 @@ import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.springframework.core.task.SyncTaskExecutor
-import org.springframework.data.repository.CrudRepository
 import java.time.Instant
 import java.util.Optional
 import kotlin.test.assertFailsWith
@@ -505,7 +510,9 @@ class HistoryMigrationJobServiceImplTest {
 
         override fun findAll(sort: org.springframework.data.domain.Sort): MutableList<GitHistoryImportStateEntity> = error("unused")
 
-        override fun findAll(pageable: org.springframework.data.domain.Pageable): org.springframework.data.domain.Page<GitHistoryImportStateEntity> = error("unused")
+        override fun findAll(
+            pageable: org.springframework.data.domain.Pageable,
+        ): org.springframework.data.domain.Page<GitHistoryImportStateEntity> = error("unused")
 
         override fun findAllById(ids: MutableIterable<String>): MutableList<GitHistoryImportStateEntity> = error("unused")
 
@@ -550,7 +557,8 @@ class HistoryMigrationJobServiceImplTest {
 
         override fun getReferenceById(id: String): GitHistoryImportStateEntity = error("unused")
 
-        override fun <S : GitHistoryImportStateEntity?> findAll(example: org.springframework.data.domain.Example<S>): MutableList<S> = error("unused")
+        override fun <S : GitHistoryImportStateEntity?> findAll(example: org.springframework.data.domain.Example<S>): MutableList<S> =
+            error("unused")
 
         override fun <S : GitHistoryImportStateEntity?> findAll(
             example: org.springframework.data.domain.Example<S>,
@@ -562,11 +570,13 @@ class HistoryMigrationJobServiceImplTest {
             pageable: org.springframework.data.domain.Pageable,
         ): org.springframework.data.domain.Page<S> = error("unused")
 
-        override fun <S : GitHistoryImportStateEntity?> findOne(example: org.springframework.data.domain.Example<S>): Optional<S> = error("unused")
+        override fun <S : GitHistoryImportStateEntity?> findOne(example: org.springframework.data.domain.Example<S>): Optional<S> =
+            error("unused")
 
         override fun <S : GitHistoryImportStateEntity?> count(example: org.springframework.data.domain.Example<S>): Long = error("unused")
 
-        override fun <S : GitHistoryImportStateEntity?> exists(example: org.springframework.data.domain.Example<S>): Boolean = error("unused")
+        override fun <S : GitHistoryImportStateEntity?> exists(example: org.springframework.data.domain.Example<S>): Boolean =
+            error("unused")
 
         override fun <S : GitHistoryImportStateEntity?, R : Any?> findBy(
             example: org.springframework.data.domain.Example<S>,

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
@@ -1,9 +1,3 @@
-// MaxLineLength suppressed because StubStateRepository overrides JpaRepository's
-// long generic-laden signatures verbatim — they are mostly `error("unused")`
-// boilerplate, breaking each one across multiple lines makes the file harder
-// to scan, not easier.
-@file:Suppress("MaxLineLength")
-
 package org.octopusden.octopus.components.registry.server.service.impl
 
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -27,7 +21,6 @@ import org.octopusden.octopus.components.registry.server.service.MigrationConfli
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.springframework.core.task.SyncTaskExecutor
 import java.time.Instant
-import java.util.Optional
 import kotlin.test.assertFailsWith
 
 /**
@@ -235,7 +228,7 @@ class HistoryMigrationJobServiceImplTest {
 
     @Test
     fun `current() falls back to DB row when in-memory state is null`() {
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
                 importKey = "component-history",
@@ -256,7 +249,7 @@ class HistoryMigrationJobServiceImplTest {
 
     @Test
     fun `current() synthesizes FAILED state with recoveryAction=RETRY when DB row is FAILED`() {
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
                 importKey = "component-history",
@@ -280,7 +273,7 @@ class HistoryMigrationJobServiceImplTest {
         // a brittle string contract spread across two repos. Now the contract is the
         // explicit `recoveryAction` discriminator. The errorMessage stays human-readable
         // but is no longer load-bearing.
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
                 importKey = "component-history",
@@ -324,7 +317,7 @@ class HistoryMigrationJobServiceImplTest {
         // unrecognised status values to FORCE_RESET, which confidently shows a
         // destructive button for a state the server doesn't even understand.
         // Now → UNKNOWN; SPA renders message but disables both action buttons.
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
                 importKey = "component-history",
@@ -342,7 +335,7 @@ class HistoryMigrationJobServiceImplTest {
 
     @Test
     fun `current() synthesized COMPLETED state has recoveryAction=RETRY`() {
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
                 importKey = "component-history",
@@ -362,7 +355,7 @@ class HistoryMigrationJobServiceImplTest {
         // (multiple sequential restarts against the unchanged row → same id),
         // making downstream consumers that key on `id` miss state transitions.
         // The new form `restored:<status>:<sha>:<millis>` is content-addressed.
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         val updatedAt = Instant.parse("2026-04-29T10:00:00Z")
         repo.saveRow(
             GitHistoryImportStateEntity(
@@ -381,7 +374,7 @@ class HistoryMigrationJobServiceImplTest {
 
     @Test
     fun `current() prefers in-memory state over DB row when both exist`() {
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
                 importKey = "component-history",
@@ -405,7 +398,7 @@ class HistoryMigrationJobServiceImplTest {
 
     @Test
     fun `clearInMemory drops the in-memory state so DB-fallback takes over`() {
-        val repo = StubStateRepository()
+        val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
                 importKey = "component-history",
@@ -430,7 +423,7 @@ class HistoryMigrationJobServiceImplTest {
 
     private fun newService(
         import: GitHistoryImportService = StubGitHistoryImportService(),
-        stateRepository: GitHistoryImportStateRepository = StubStateRepository(),
+        stateRepository: GitHistoryImportStateRepository = StubGitHistoryImportStateRepository(),
         executor: org.springframework.core.task.TaskExecutor = SyncTaskExecutor(),
         gate: MigrationLifecycleGate = MigrationLifecycleGate(),
     ): HistoryMigrationJobServiceImpl =
@@ -462,126 +455,6 @@ class HistoryMigrationJobServiceImplTest {
                 }
             return impl(toRef, reset, tap)
         }
-    }
-
-    /**
-     * Hand-rolled stub for [GitHistoryImportStateRepository] that only implements
-     * the methods HistoryMigrationJobServiceImpl actually uses (findById +
-     * tryInsert) plus the test-only [saveRow] seeder. JpaRepository has dozens
-     * of methods we don't touch; making them all `error("unused")` is the
-     * standard Kotlin pattern for "fail fast on unexpected usage in test".
-     */
-    private class StubStateRepository : GitHistoryImportStateRepository {
-        private val rows = mutableMapOf<String, GitHistoryImportStateEntity>()
-
-        fun saveRow(entity: GitHistoryImportStateEntity) {
-            rows[entity.importKey] = entity
-        }
-
-        override fun findById(id: String): Optional<GitHistoryImportStateEntity> = Optional.ofNullable(rows[id])
-
-        override fun tryInsert(
-            importKey: String,
-            targetRef: String,
-            targetSha: String,
-            status: String,
-        ): Int {
-            if (rows.containsKey(importKey)) return 0
-            rows[importKey] =
-                GitHistoryImportStateEntity(
-                    importKey = importKey,
-                    targetRef = targetRef,
-                    targetSha = targetSha,
-                    status = status,
-                    updatedAt = Instant.now(),
-                )
-            return 1
-        }
-
-        // Everything else: not used by the service-under-test. Failing loudly
-        // surfaces accidental usage in future tests.
-        override fun <S : GitHistoryImportStateEntity?> save(entity: S): S = error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> saveAll(entities: MutableIterable<S>): MutableList<S> = error("unused")
-
-        override fun existsById(id: String): Boolean = rows.containsKey(id)
-
-        override fun findAll(): MutableList<GitHistoryImportStateEntity> = rows.values.toMutableList()
-
-        override fun findAll(sort: org.springframework.data.domain.Sort): MutableList<GitHistoryImportStateEntity> = error("unused")
-
-        override fun findAll(
-            pageable: org.springframework.data.domain.Pageable,
-        ): org.springframework.data.domain.Page<GitHistoryImportStateEntity> = error("unused")
-
-        override fun findAllById(ids: MutableIterable<String>): MutableList<GitHistoryImportStateEntity> = error("unused")
-
-        override fun count(): Long = rows.size.toLong()
-
-        override fun deleteById(id: String) {
-            rows.remove(id)
-        }
-
-        override fun delete(entity: GitHistoryImportStateEntity) {
-            rows.remove(entity.importKey)
-        }
-
-        override fun deleteAllById(ids: MutableIterable<String>) {
-            ids.forEach(::deleteById)
-        }
-
-        override fun deleteAll(entities: MutableIterable<GitHistoryImportStateEntity>) = entities.forEach(::delete)
-
-        override fun deleteAll() {
-            rows.clear()
-        }
-
-        override fun flush() = Unit
-
-        override fun <S : GitHistoryImportStateEntity?> saveAndFlush(entity: S): S = error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> saveAllAndFlush(entities: MutableIterable<S>): MutableList<S> = error("unused")
-
-        @Suppress("DEPRECATION")
-        override fun deleteAllInBatch(entities: MutableIterable<GitHistoryImportStateEntity>) = error("unused")
-
-        override fun deleteAllByIdInBatch(ids: MutableIterable<String>) = error("unused")
-
-        override fun deleteAllInBatch() = error("unused")
-
-        @Suppress("DEPRECATION")
-        override fun getOne(id: String): GitHistoryImportStateEntity = error("unused")
-
-        @Suppress("DEPRECATION")
-        override fun getById(id: String): GitHistoryImportStateEntity = error("unused")
-
-        override fun getReferenceById(id: String): GitHistoryImportStateEntity = error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> findAll(example: org.springframework.data.domain.Example<S>): MutableList<S> =
-            error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> findAll(
-            example: org.springframework.data.domain.Example<S>,
-            sort: org.springframework.data.domain.Sort,
-        ): MutableList<S> = error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> findAll(
-            example: org.springframework.data.domain.Example<S>,
-            pageable: org.springframework.data.domain.Pageable,
-        ): org.springframework.data.domain.Page<S> = error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> findOne(example: org.springframework.data.domain.Example<S>): Optional<S> =
-            error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> count(example: org.springframework.data.domain.Example<S>): Long = error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?> exists(example: org.springframework.data.domain.Example<S>): Boolean =
-            error("unused")
-
-        override fun <S : GitHistoryImportStateEntity?, R : Any?> findBy(
-            example: org.springframework.data.domain.Example<S>,
-            queryFunction: java.util.function.Function<org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery<S>, R>,
-        ): R = error("unused")
     }
 
     /** Capture-but-don't-run executor mirroring the one in MigrationJobServiceImplTest. */

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
@@ -12,6 +12,7 @@ import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportRes
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.octopusden.octopus.components.registry.server.service.ForceResetOutcome
 import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
 import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressEvent
 import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
@@ -20,7 +21,9 @@ import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.springframework.core.task.SyncTaskExecutor
+import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
 
 /**
@@ -397,6 +400,122 @@ class HistoryMigrationJobServiceImplTest {
     }
 
     @Test
+    fun `clearInMemory is ignored when a job is RUNNING (prevents false FORCE_RESET synthesis)`() {
+        val deferred = DeferredExecutor()
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult }),
+                executor = deferred,
+            )
+
+        val result = service.startAsync(toRef = null, reset = false)
+        assertEquals(JobState.RUNNING, result.state.state)
+
+        service.clearInMemory()
+        assertEquals(JobState.RUNNING, service.current()!!.state, "clearInMemory must be a no-op while RUNNING")
+        assertEquals(result.state.id, service.current()!!.id, "job id must remain unchanged")
+    }
+
+    @Test
+    fun `forceReset returns Cleared on empty DB (idempotent)`() {
+        val service = newService()
+        val outcome = service.forceReset(ackMultipodRisk = false)
+        assertEquals(ForceResetOutcome.Cleared, outcome)
+    }
+
+    @Test
+    fun `forceReset returns Blocked with code=history-migration-running when a job is RUNNING in this pod`() {
+        val deferred = DeferredExecutor()
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult }),
+                executor = deferred,
+            )
+        service.startAsync(toRef = null, reset = false)
+        assertEquals(JobState.RUNNING, service.current()!!.state)
+
+        val outcome = service.forceReset(ackMultipodRisk = false) as ForceResetOutcome.Blocked
+        assertEquals("history-migration-running", outcome.code)
+        assertNotNull(outcome.activeJobId)
+    }
+
+    @Test
+    fun `forceReset returns Blocked when DB row is IN_PROGRESS and fresh (cross-pod guard)`() {
+        val repo = StubGitHistoryImportStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v1",
+                targetSha = "abc",
+                status = GitHistoryImportStatus.IN_PROGRESS.name,
+                // updatedAt = now → age < threshold
+                updatedAt = Instant.now(),
+            ),
+        )
+        val service = newService(stateRepository = repo)
+
+        val outcome = service.forceReset(ackMultipodRisk = false) as ForceResetOutcome.Blocked
+        assertEquals("history-import-likely-live-elsewhere", outcome.code)
+        assertNull(outcome.activeJobId)
+    }
+
+    @Test
+    fun `forceReset proceeds when DB row is IN_PROGRESS but stale (older than threshold)`() {
+        val forceResetCalls = AtomicInteger(0)
+        val repo = StubGitHistoryImportStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v1",
+                targetSha = "abc",
+                status = GitHistoryImportStatus.IN_PROGRESS.name,
+                // Make the row stale: updatedAt > STALE_IN_PROGRESS_THRESHOLD ago
+                updatedAt = Instant.now().minus(Duration.ofMinutes(31)),
+            ),
+        )
+        val service = newService(stateRepository = repo, forceResetter = HistoryForceResetter { forceResetCalls.incrementAndGet() })
+
+        val outcome = service.forceReset(ackMultipodRisk = false)
+        assertEquals(ForceResetOutcome.Cleared, outcome)
+        assertEquals(1, forceResetCalls.get(), "forceResetter must be called exactly once")
+    }
+
+    @Test
+    fun `forceReset with ackMultipodRisk=true bypasses the staleness guard and proceeds`() {
+        val forceResetCalls = AtomicInteger(0)
+        val repo = StubGitHistoryImportStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v1",
+                targetSha = "abc",
+                status = GitHistoryImportStatus.IN_PROGRESS.name,
+                // Fresh row that would normally be blocked
+                updatedAt = Instant.now(),
+            ),
+        )
+        val service = newService(stateRepository = repo, forceResetter = HistoryForceResetter { forceResetCalls.incrementAndGet() })
+
+        val outcome = service.forceReset(ackMultipodRisk = true)
+        assertEquals(ForceResetOutcome.Cleared, outcome)
+        assertEquals(1, forceResetCalls.get(), "staleness guard must be bypassed when ackMultipodRisk=true")
+    }
+
+    @Test
+    fun `forceReset clears in-memory state after wiping so DB-fallback shows idle`() {
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult }),
+            )
+        service.startAsync(toRef = null, reset = false)
+        assertEquals(JobState.COMPLETED, service.current()!!.state)
+
+        // forceReset with no DB row (COMPLETED was in-memory only) — still clears slot.
+        service.forceReset(ackMultipodRisk = false)
+        assertNull(service.current(), "after forceReset the in-memory slot must be cleared")
+    }
+
+    @Test
     fun `clearInMemory drops the in-memory state so DB-fallback takes over`() {
         val repo = StubGitHistoryImportStateRepository()
         repo.saveRow(
@@ -426,12 +545,14 @@ class HistoryMigrationJobServiceImplTest {
         stateRepository: GitHistoryImportStateRepository = StubGitHistoryImportStateRepository(),
         executor: org.springframework.core.task.TaskExecutor = SyncTaskExecutor(),
         gate: MigrationLifecycleGate = MigrationLifecycleGate(),
+        forceResetter: HistoryForceResetter = HistoryForceResetter {},
     ): HistoryMigrationJobServiceImpl =
         HistoryMigrationJobServiceImpl(
             gitHistoryImportService = import,
             stateRepository = stateRepository,
             executor = executor,
             lifecycleGate = gate,
+            forceResetter = forceResetter,
         )
 
     /** Hand-written stub for [GitHistoryImportService] mirroring StubImportService in the components test. */

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
@@ -1,0 +1,505 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
+import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressEvent
+import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.springframework.core.task.SyncTaskExecutor
+import org.springframework.data.repository.CrudRepository
+import java.time.Instant
+import java.util.Optional
+import kotlin.test.assertFailsWith
+
+/**
+ * Mirror of [MigrationJobServiceImplTest] for the history migration service.
+ * Same SyncTaskExecutor pattern (so terminal states are observable without a
+ * background thread) and same hand-written stubs (avoiding Mockito's NPE
+ * trap with non-nullable Kotlin progress parameters).
+ */
+class HistoryMigrationJobServiceImplTest {
+    private val emptyResult =
+        HistoryImportResult(
+            targetRef = "refs/tags/test-1.0",
+            targetSha = "abc1234567890",
+            processedCommits = 0,
+            skippedNoGroovy = 0,
+            skippedParseError = 0,
+            skippedUnknownNames = 0,
+            auditRecords = 0,
+            durationMs = 0,
+        )
+
+    @Test
+    fun `current() is null on a fresh service with empty DB`() {
+        val service = newService()
+        assertNull(service.current())
+    }
+
+    @Test
+    fun `first startAsync returns isNewlyStarted=true and runs the import`() {
+        val import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult })
+        val service = newService(import = import)
+
+        val result = service.startAsync(toRef = null, reset = false)
+
+        assertTrue(result.isNewlyStarted)
+        assertEquals(JobState.COMPLETED, result.state.state)
+        assertEquals(1, import.callCount)
+    }
+
+    @Test
+    fun `second startAsync while RUNNING returns the same job (same-kind 409 attach)`() {
+        val deferred = DeferredExecutor()
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult }),
+                executor = deferred,
+            )
+
+        val first = service.startAsync(toRef = null, reset = false)
+        assertEquals(JobState.RUNNING, first.state.state)
+        assertTrue(first.isNewlyStarted)
+
+        val second = service.startAsync(toRef = null, reset = false)
+        assertFalse(second.isNewlyStarted)
+        assertEquals(first.state.id, second.state.id)
+        assertEquals(1, deferred.taskCount)
+    }
+
+    @Test
+    fun `after COMPLETED the next startAsync starts a fresh job`() {
+        val import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult })
+        val service = newService(import = import)
+
+        val first = service.startAsync(toRef = null, reset = false)
+        val second = service.startAsync(toRef = null, reset = false)
+
+        assertTrue(second.isNewlyStarted)
+        assertNotEquals(first.state.id, second.state.id)
+        assertEquals(2, import.callCount)
+    }
+
+    @Test
+    fun `progress events update totalCommits processedCommits and currentSha`() {
+        val import =
+            StubGitHistoryImportService(impl = { _, _, listener ->
+                listener.onProgress(
+                    HistoryImportProgressEvent(
+                        totalCommits = 100,
+                        processedCommits = 7,
+                        auditRecords = 13,
+                        skippedNoGroovy = 1,
+                        skippedParseError = 0,
+                        skippedUnknownNames = 0,
+                        currentSha = "abc1234",
+                        targetRef = "refs/tags/test-1.0",
+                    ),
+                )
+                emptyResult
+            })
+        val service = newService(import = import)
+
+        service.startAsync(toRef = null, reset = false)
+
+        // The listener writes through to the AtomicReference; on COMPLETED the
+        // counters get overwritten by the final result. Verify mid-run by
+        // checking the import got the listener exactly once with the expected
+        // event shape.
+        assertEquals(1, import.progressEvents.size)
+        val event = import.progressEvents.single()
+        assertEquals(100, event.totalCommits)
+        assertEquals(7, event.processedCommits)
+        assertEquals("abc1234", event.currentSha)
+    }
+
+    @Test
+    fun `terminal COMPLETED state captures result counters and clears currentSha`() {
+        val populated =
+            HistoryImportResult(
+                targetRef = "refs/tags/main",
+                targetSha = "deadbeef",
+                processedCommits = 250,
+                skippedNoGroovy = 10,
+                skippedParseError = 2,
+                skippedUnknownNames = 1,
+                auditRecords = 800,
+                durationMs = 12_000,
+            )
+        val service = newService(import = StubGitHistoryImportService(impl = { _, _, _ -> populated }))
+
+        service.startAsync(toRef = null, reset = false)
+        val state = service.current()!!
+
+        assertEquals(JobState.COMPLETED, state.state)
+        assertNotNull(state.finishedAt)
+        assertNull(state.currentSha)
+        assertEquals(250, state.processedCommits)
+        assertEquals(800, state.auditRecords)
+        assertEquals(populated, state.result)
+    }
+
+    @Test
+    fun `terminal FAILED state captures the throwable message`() {
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> throw IllegalStateException("git refused clone") }),
+            )
+
+        service.startAsync(toRef = null, reset = false)
+        val state = service.current()!!
+
+        assertEquals(JobState.FAILED, state.state)
+        assertEquals("git refused clone", state.errorMessage)
+        assertNull(state.currentSha)
+    }
+
+    @Test
+    fun `cross-kind gate held by COMPONENTS makes startAsync throw MigrationConflictException`() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(MigrationLifecycleGate.JobKind.COMPONENTS, "components-1")
+
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> fail("must not run when cross-kind conflict") }),
+                gate = gate,
+            )
+
+        val ex = assertFailsWith<MigrationConflictException> { service.startAsync(toRef = null, reset = false) }
+        assertEquals(MigrationLifecycleGate.JobKind.COMPONENTS, ex.active.kind)
+        assertEquals("components-1", ex.active.jobId)
+    }
+
+    @Test
+    fun `gate is released on success`() {
+        val gate = MigrationLifecycleGate()
+        val service = newService(import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult }), gate = gate)
+        service.startAsync(toRef = null, reset = false)
+        assertNull(gate.current(), "gate must be released after COMPLETED")
+    }
+
+    @Test
+    fun `gate is released on failure`() {
+        val gate = MigrationLifecycleGate()
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> throw IllegalStateException("boom") }),
+                gate = gate,
+            )
+        service.startAsync(toRef = null, reset = false)
+        assertNull(gate.current(), "gate must be released after FAILED")
+    }
+
+    @Test
+    fun `executor rejection releases the gate and transitions the slot to FAILED`() {
+        val gate = MigrationLifecycleGate()
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> fail("must not be called") }),
+                executor = RejectingExecutor("queue closed"),
+                gate = gate,
+            )
+
+        runCatching { service.startAsync(toRef = null, reset = false) }
+        assertNull(gate.current(), "rejection must release the gate")
+        assertEquals(JobState.FAILED, service.current()!!.state)
+    }
+
+    @Test
+    fun `current() falls back to DB row when in-memory state is null`() {
+        val repo = StubStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/components-registry-1.5",
+                targetSha = "cafebabe",
+                status = GitHistoryImportStatus.COMPLETED.name,
+                updatedAt = Instant.parse("2026-04-29T10:00:00Z"),
+            ),
+        )
+        val service = newService(stateRepository = repo)
+
+        val state = service.current()!!
+        assertEquals(JobState.COMPLETED, state.state)
+        assertEquals("refs/tags/components-registry-1.5", state.targetRef)
+        assertNull(state.errorMessage, "COMPLETED synthesized state has no errorMessage")
+        assertNull(state.result, "synthesized state cannot reconstruct the full result body")
+    }
+
+    @Test
+    fun `current() synthesizes FAILED-with-explainer when DB row is FAILED`() {
+        val repo = StubStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v2",
+                targetSha = "abc",
+                status = GitHistoryImportStatus.FAILED.name,
+                updatedAt = Instant.now(),
+            ),
+        )
+        val service = newService(stateRepository = repo)
+
+        val state = service.current()!!
+        assertEquals(JobState.FAILED, state.state)
+        assertNotNull(state.errorMessage)
+        assertTrue(state.errorMessage!!.contains("Use Retry"))
+    }
+
+    @Test
+    fun `current() synthesizes IN_PROGRESS row as FAILED-with-marker so SPA shows Force-reset path`() {
+        // The SPA uses the literal substring "marked IN_PROGRESS" in errorMessage
+        // to switch its UI from "Retry" to "Force reset" — see B4
+        // HistoryActionButtons. This pin is load-bearing for the cross-pod
+        // recovery path; do not soften it without updating the SPA in lockstep.
+        val repo = StubStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v3",
+                targetSha = "abc",
+                status = GitHistoryImportStatus.IN_PROGRESS.name,
+                updatedAt = Instant.now(),
+            ),
+        )
+        val service = newService(stateRepository = repo)
+
+        val state = service.current()!!
+        assertEquals(JobState.FAILED, state.state, "IN_PROGRESS in DB but no in-memory job — surface as FAILED for the UI")
+        assertTrue(
+            state.errorMessage!!.contains("marked IN_PROGRESS"),
+            "errorMessage must contain the SPA-recognised marker 'marked IN_PROGRESS' (verbatim) so it routes to Force-reset",
+        )
+    }
+
+    @Test
+    fun `current() prefers in-memory state over DB row when both exist`() {
+        val repo = StubStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "old-ref",
+                targetSha = "old-sha",
+                status = GitHistoryImportStatus.COMPLETED.name,
+                updatedAt = Instant.parse("2025-01-01T00:00:00Z"),
+            ),
+        )
+        val service =
+            newService(
+                stateRepository = repo,
+                import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult }),
+            )
+
+        // Run a fresh import — in-memory now COMPLETED with the new result.
+        service.startAsync(toRef = null, reset = false)
+        val state = service.current()!!
+        assertNotEquals("old-ref", state.targetRef, "in-memory must win when populated")
+    }
+
+    @Test
+    fun `clearInMemory drops the in-memory state so DB-fallback takes over`() {
+        val repo = StubStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v1",
+                targetSha = "abc",
+                status = GitHistoryImportStatus.COMPLETED.name,
+                updatedAt = Instant.now(),
+            ),
+        )
+        val service =
+            newService(
+                stateRepository = repo,
+                import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult.copy(targetRef = "refs/tags/just-finished") }),
+            )
+
+        service.startAsync(toRef = null, reset = false)
+        assertEquals("refs/tags/just-finished", service.current()!!.targetRef)
+
+        service.clearInMemory()
+        assertEquals("refs/tags/v1", service.current()!!.targetRef, "after clearInMemory, DB-fallback re-surfaces")
+    }
+
+    private fun newService(
+        import: GitHistoryImportService = StubGitHistoryImportService(),
+        stateRepository: GitHistoryImportStateRepository = StubStateRepository(),
+        executor: org.springframework.core.task.TaskExecutor = SyncTaskExecutor(),
+        gate: MigrationLifecycleGate = MigrationLifecycleGate(),
+    ): HistoryMigrationJobServiceImpl =
+        HistoryMigrationJobServiceImpl(
+            gitHistoryImportService = import,
+            stateRepository = stateRepository,
+            executor = executor,
+            lifecycleGate = gate,
+        )
+
+    /** Hand-written stub for [GitHistoryImportService] mirroring StubImportService in the components test. */
+    private class StubGitHistoryImportService(
+        private val impl: (String?, Boolean, HistoryImportProgressListener) -> HistoryImportResult = { _, _, _ -> error("not stubbed") },
+    ) : GitHistoryImportService {
+        var callCount: Int = 0
+            private set
+        val progressEvents: MutableList<HistoryImportProgressEvent> = mutableListOf()
+
+        override fun importHistory(
+            toRef: String?,
+            reset: Boolean,
+            listener: HistoryImportProgressListener,
+        ): HistoryImportResult {
+            callCount++
+            val tap =
+                HistoryImportProgressListener { event ->
+                    progressEvents += event
+                    listener.onProgress(event)
+                }
+            return impl(toRef, reset, tap)
+        }
+    }
+
+    /**
+     * Hand-rolled stub for [GitHistoryImportStateRepository] that only implements
+     * the methods HistoryMigrationJobServiceImpl actually uses (findById +
+     * tryInsert) plus the test-only [saveRow] seeder. JpaRepository has dozens
+     * of methods we don't touch; making them all `error("unused")` is the
+     * standard Kotlin pattern for "fail fast on unexpected usage in test".
+     */
+    private class StubStateRepository : GitHistoryImportStateRepository {
+        private val rows = mutableMapOf<String, GitHistoryImportStateEntity>()
+
+        fun saveRow(entity: GitHistoryImportStateEntity) {
+            rows[entity.importKey] = entity
+        }
+
+        override fun findById(id: String): Optional<GitHistoryImportStateEntity> = Optional.ofNullable(rows[id])
+
+        override fun tryInsert(
+            importKey: String,
+            targetRef: String,
+            targetSha: String,
+            status: String,
+        ): Int {
+            if (rows.containsKey(importKey)) return 0
+            rows[importKey] =
+                GitHistoryImportStateEntity(
+                    importKey = importKey,
+                    targetRef = targetRef,
+                    targetSha = targetSha,
+                    status = status,
+                    updatedAt = Instant.now(),
+                )
+            return 1
+        }
+
+        // Everything else: not used by the service-under-test. Failing loudly
+        // surfaces accidental usage in future tests.
+        override fun <S : GitHistoryImportStateEntity?> save(entity: S): S = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> saveAll(entities: MutableIterable<S>): MutableList<S> = error("unused")
+
+        override fun existsById(id: String): Boolean = rows.containsKey(id)
+
+        override fun findAll(): MutableList<GitHistoryImportStateEntity> = rows.values.toMutableList()
+
+        override fun findAll(sort: org.springframework.data.domain.Sort): MutableList<GitHistoryImportStateEntity> = error("unused")
+
+        override fun findAll(pageable: org.springframework.data.domain.Pageable): org.springframework.data.domain.Page<GitHistoryImportStateEntity> = error("unused")
+
+        override fun findAllById(ids: MutableIterable<String>): MutableList<GitHistoryImportStateEntity> = error("unused")
+
+        override fun count(): Long = rows.size.toLong()
+
+        override fun deleteById(id: String) {
+            rows.remove(id)
+        }
+
+        override fun delete(entity: GitHistoryImportStateEntity) {
+            rows.remove(entity.importKey)
+        }
+
+        override fun deleteAllById(ids: MutableIterable<String>) {
+            ids.forEach(::deleteById)
+        }
+
+        override fun deleteAll(entities: MutableIterable<GitHistoryImportStateEntity>) = entities.forEach(::delete)
+
+        override fun deleteAll() {
+            rows.clear()
+        }
+
+        override fun flush() = Unit
+
+        override fun <S : GitHistoryImportStateEntity?> saveAndFlush(entity: S): S = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> saveAllAndFlush(entities: MutableIterable<S>): MutableList<S> = error("unused")
+
+        @Suppress("DEPRECATION")
+        override fun deleteAllInBatch(entities: MutableIterable<GitHistoryImportStateEntity>) = error("unused")
+
+        override fun deleteAllByIdInBatch(ids: MutableIterable<String>) = error("unused")
+
+        override fun deleteAllInBatch() = error("unused")
+
+        @Suppress("DEPRECATION")
+        override fun getOne(id: String): GitHistoryImportStateEntity = error("unused")
+
+        @Suppress("DEPRECATION")
+        override fun getById(id: String): GitHistoryImportStateEntity = error("unused")
+
+        override fun getReferenceById(id: String): GitHistoryImportStateEntity = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> findAll(example: org.springframework.data.domain.Example<S>): MutableList<S> = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> findAll(
+            example: org.springframework.data.domain.Example<S>,
+            sort: org.springframework.data.domain.Sort,
+        ): MutableList<S> = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> findAll(
+            example: org.springframework.data.domain.Example<S>,
+            pageable: org.springframework.data.domain.Pageable,
+        ): org.springframework.data.domain.Page<S> = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> findOne(example: org.springframework.data.domain.Example<S>): Optional<S> = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> count(example: org.springframework.data.domain.Example<S>): Long = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?> exists(example: org.springframework.data.domain.Example<S>): Boolean = error("unused")
+
+        override fun <S : GitHistoryImportStateEntity?, R : Any?> findBy(
+            example: org.springframework.data.domain.Example<S>,
+            queryFunction: java.util.function.Function<org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery<S>, R>,
+        ): R = error("unused")
+    }
+
+    /** Capture-but-don't-run executor mirroring the one in MigrationJobServiceImplTest. */
+    private class DeferredExecutor : org.springframework.core.task.TaskExecutor {
+        var taskCount: Int = 0
+            private set
+
+        override fun execute(task: Runnable) {
+            taskCount++
+            // intentionally no-op
+        }
+    }
+
+    /** Always throws RejectedExecutionException — simulates pod shutdown / queue full. */
+    private class RejectingExecutor(
+        private val reason: String,
+    ) : org.springframework.core.task.TaskExecutor {
+        override fun execute(task: Runnable): Unit = throw java.util.concurrent.RejectedExecutionException(reason)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
@@ -15,6 +15,7 @@ import org.octopusden.octopus.components.registry.server.repository.GitHistoryIm
 import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
 import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressEvent
 import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
+import org.octopusden.octopus.components.registry.server.service.HistoryRecoveryAction
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
@@ -150,10 +151,15 @@ class HistoryMigrationJobServiceImplTest {
         assertEquals(250, state.processedCommits)
         assertEquals(800, state.auditRecords)
         assertEquals(populated, state.result)
+        assertEquals(
+            HistoryRecoveryAction.RETRY,
+            state.recoveryAction,
+            "in-memory COMPLETED is recoverable via reset=true → SPA shows Retry button",
+        )
     }
 
     @Test
-    fun `terminal FAILED state captures the throwable message`() {
+    fun `terminal FAILED state captures the throwable message and sets recoveryAction=RETRY`() {
         val service =
             newService(
                 import = StubGitHistoryImportService(impl = { _, _, _ -> throw IllegalStateException("git refused clone") }),
@@ -165,6 +171,10 @@ class HistoryMigrationJobServiceImplTest {
         assertEquals(JobState.FAILED, state.state)
         assertEquals("git refused clone", state.errorMessage)
         assertNull(state.currentSha)
+        // In-memory FAILED is recoverable via reset=true (the underlying preflight
+        // clears the FAILED state row before the next claim). FORCE_RESET is reserved
+        // for the synthesized stuck-IN_PROGRESS DB-fallback case.
+        assertEquals(HistoryRecoveryAction.RETRY, state.recoveryAction)
     }
 
     @Test
@@ -240,7 +250,7 @@ class HistoryMigrationJobServiceImplTest {
     }
 
     @Test
-    fun `current() synthesizes FAILED-with-explainer when DB row is FAILED`() {
+    fun `current() synthesizes FAILED state with recoveryAction=RETRY when DB row is FAILED`() {
         val repo = StubStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
@@ -255,16 +265,16 @@ class HistoryMigrationJobServiceImplTest {
 
         val state = service.current()!!
         assertEquals(JobState.FAILED, state.state)
+        assertEquals(HistoryRecoveryAction.RETRY, state.recoveryAction, "FAILED row → SPA shows Retry (reset state) button")
         assertNotNull(state.errorMessage)
-        assertTrue(state.errorMessage!!.contains("Use Retry"))
     }
 
     @Test
-    fun `current() synthesizes IN_PROGRESS row as FAILED-with-marker so SPA shows Force-reset path`() {
-        // The SPA uses the literal substring "marked IN_PROGRESS" in errorMessage
-        // to switch its UI from "Retry" to "Force reset" — see B4
-        // HistoryActionButtons. This pin is load-bearing for the cross-pod
-        // recovery path; do not soften it without updating the SPA in lockstep.
+    fun `current() synthesizes IN_PROGRESS row with recoveryAction=FORCE_RESET so SPA shows Force-reset path`() {
+        // P1 review fix: the SPA used to match on `errorMessage.includes("marked IN_PROGRESS")`,
+        // a brittle string contract spread across two repos. Now the contract is the
+        // explicit `recoveryAction` discriminator. The errorMessage stays human-readable
+        // but is no longer load-bearing.
         val repo = StubStateRepository()
         repo.saveRow(
             GitHistoryImportStateEntity(
@@ -279,10 +289,50 @@ class HistoryMigrationJobServiceImplTest {
 
         val state = service.current()!!
         assertEquals(JobState.FAILED, state.state, "IN_PROGRESS in DB but no in-memory job — surface as FAILED for the UI")
-        assertTrue(
-            state.errorMessage!!.contains("marked IN_PROGRESS"),
-            "errorMessage must contain the SPA-recognised marker 'marked IN_PROGRESS' (verbatim) so it routes to Force-reset",
+        assertEquals(
+            HistoryRecoveryAction.FORCE_RESET,
+            state.recoveryAction,
+            "stuck IN_PROGRESS row must route the SPA to Force-reset, not Retry",
         )
+    }
+
+    @Test
+    fun `current() synthesized COMPLETED state has recoveryAction=RETRY`() {
+        val repo = StubStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v1",
+                targetSha = "abc",
+                status = GitHistoryImportStatus.COMPLETED.name,
+                updatedAt = Instant.now(),
+            ),
+        )
+        val service = newService(stateRepository = repo)
+        assertEquals(HistoryRecoveryAction.RETRY, service.current()!!.recoveryAction)
+    }
+
+    @Test
+    fun `synthesized id includes status + targetSha + millis so it does not collide across pod restarts`() {
+        // P1 review fix: previous "restored-${epochMillis}" form could collide
+        // (multiple sequential restarts against the unchanged row → same id),
+        // making downstream consumers that key on `id` miss state transitions.
+        // The new form `restored:<status>:<sha>:<millis>` is content-addressed.
+        val repo = StubStateRepository()
+        val updatedAt = Instant.parse("2026-04-29T10:00:00Z")
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v1",
+                targetSha = "abc1234",
+                status = GitHistoryImportStatus.COMPLETED.name,
+                updatedAt = updatedAt,
+            ),
+        )
+        val service = newService(stateRepository = repo)
+        val state = service.current()!!
+        assertTrue(state.id.startsWith("restored:completed:abc1234:"), "synthesized id must encode status + sha: ${state.id}")
+        assertTrue(state.id.endsWith(updatedAt.toEpochMilli().toString()), "synthesized id must include updatedAt millis: ${state.id}")
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImplTest.kt
@@ -297,6 +297,45 @@ class HistoryMigrationJobServiceImplTest {
     }
 
     @Test
+    fun `RUNNING in-memory state has recoveryAction == null (no recovery needed while running)`() {
+        // P2 review fix: the "null while RUNNING" contract was documented but
+        // not enforced. A future refactor populating recoveryAction on RUNNING
+        // would render a Retry button next to a live progress bar — visibly broken.
+        val deferred = DeferredExecutor()
+        val service =
+            newService(
+                import = StubGitHistoryImportService(impl = { _, _, _ -> emptyResult }),
+                executor = deferred,
+            )
+
+        val result = service.startAsync(toRef = null, reset = false)
+        assertEquals(JobState.RUNNING, result.state.state)
+        assertNull(result.state.recoveryAction, "RUNNING jobs must NOT carry a recoveryAction hint")
+    }
+
+    @Test
+    fun `current() synthesized state for unknown DB status has recoveryAction=UNKNOWN (defensive)`() {
+        // P2 review fix: previously the else-branch in synthesizeFromDb mapped
+        // unrecognised status values to FORCE_RESET, which confidently shows a
+        // destructive button for a state the server doesn't even understand.
+        // Now → UNKNOWN; SPA renders message but disables both action buttons.
+        val repo = StubStateRepository()
+        repo.saveRow(
+            GitHistoryImportStateEntity(
+                importKey = "component-history",
+                targetRef = "refs/tags/v1",
+                targetSha = "abc",
+                status = "SOMETHING_FROM_THE_FUTURE",
+                updatedAt = Instant.now(),
+            ),
+        )
+        val service = newService(stateRepository = repo)
+        val state = service.current()!!
+        assertEquals(JobState.FAILED, state.state)
+        assertEquals(HistoryRecoveryAction.UNKNOWN, state.recoveryAction)
+    }
+
+    @Test
     fun `current() synthesized COMPLETED state has recoveryAction=RETRY`() {
         val repo = StubStateRepository()
         repo.saveRow(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrateHistoryIntegrationTest.kt
@@ -19,7 +19,12 @@ import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.core.task.SyncTaskExecutor
+import org.springframework.core.task.TaskExecutor
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -34,11 +39,28 @@ import java.nio.file.StandardCopyOption
 import kotlin.io.path.writeText
 import kotlin.streams.asSequence
 
+/**
+ * End-to-end coverage for the async POST /admin/migrate-history flow against a
+ * real Postgres testcontainer + JGit fixture repo. The endpoint became async in
+ * this branch (returns 202 + HistoryMigrationJobResponse, runs the import on
+ * the migrationExecutor), so we swap in a SyncTaskExecutor — same trick as
+ * MigrateEndpointTest — to make the migration body finish inline before the
+ * POST returns. That way the test can read state=COMPLETED/FAILED + the
+ * populated `result` block right off the response, without polling /job.
+ *
+ * Note on 409 semantics: under the old sync endpoint, "history already ran"
+ * surfaced as HTTP 409 directly from the preflight. With the async endpoint
+ * the HTTP response is 202 (the job started in-memory) and the preflight 409
+ * is caught inside runHistoryMigration, transitioning state to FAILED with the
+ * "use reset=true to re-run" message. Tests assert on the in-memory state body
+ * rather than the HTTP status for that case.
+ */
 @AutoConfigureMockMvc
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = [ComponentRegistryServiceApplication::class],
 )
+@Import(MigrateHistoryIntegrationTest.SyncMigrationExecutorConfig::class)
 @ActiveProfiles("common", "test-db")
 class MigrateHistoryIntegrationTest {
     @MockBean
@@ -62,47 +84,69 @@ class MigrateHistoryIntegrationTest {
 
     @Test
     @Suppress("LongMethod")
-    fun `migrate-history end-to-end covers write, 409, reset, parse-error, DELETE, default toRef`() {
+    fun `migrate-history end-to-end covers write, terminal-row reset gate, parse-error, DELETE, default toRef`() {
         componentRepository.save(ComponentEntity(name = "ARCHIVED_TEST_COMPONENT"))
 
-        // Phase 1: explicit toRef to 1.1 (only c1..c3 in scope).
+        // Phase 1: explicit toRef to 1.1 (only c1..c3 in scope). With the
+        // SyncTaskExecutor swap, the inline runnable finishes before the POST
+        // response is built — the body carries state=COMPLETED + a populated
+        // `result` block we can assert on directly.
         val firstBody =
             mvc
                 .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1").with(adminJwt()))
-                .andExpect(status().isOk)
+                .andExpect(status().isAccepted)
                 .andReturn()
                 .response
                 .contentAsString
         val first = objectMapper.readTree(firstBody)
-        assertEquals("components-registry-1.1", first["targetRef"].asText())
-        assertTrue(first["processedCommits"].asInt() >= 2, "expected >= 2 processed commits, got $first")
+        assertEquals("COMPLETED", first["state"].asText(), "sync executor → state should be COMPLETED on response")
+        val firstResult = first["result"]
+        assertEquals("components-registry-1.1", firstResult["targetRef"].asText())
+        assertTrue(firstResult["processedCommits"].asInt() >= 2, "expected >= 2 processed commits, got $firstResult")
         val auditAfterFirst = auditLogRepository.findAll().filter { it.source == "git-history" }
         assertTrue(auditAfterFirst.isNotEmpty(), "expected at least one git-history audit row")
         assertTrue(auditAfterFirst.all { it.correlationId != null }, "every history row carries a commit SHA")
         assertTrue(auditAfterFirst.all { it.changedBy == "Tester <test@example.com>" })
         assertEquals(GitHistoryImportStatus.COMPLETED.name, stateRepository.findById("component-history").orElseThrow().status)
 
-        // Phase 2: repeat without reset → 409, audit_log unchanged.
-        mvc
-            .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1").with(adminJwt()))
-            .andExpect(status().isConflict)
+        // Phase 2: repeat without reset. Under the OLD sync endpoint this was
+        // an HTTP 409 from the preflight. Async semantics: the HTTP layer
+        // returns 202 (the job started in-memory) and the preflight 409 is
+        // raised inside runHistoryMigration, transitioning state to FAILED.
+        // No new audit_log rows must have been written — the FAILED transition
+        // happens before any walk.
+        val repeatBody =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-history?toRef=components-registry-1.1").with(adminJwt()))
+                .andExpect(status().isAccepted)
+                .andReturn()
+                .response
+                .contentAsString
+        val repeat = objectMapper.readTree(repeatBody)
+        assertEquals("FAILED", repeat["state"].asText(), "repeat without reset must end in FAILED, not 409")
+        assertTrue(
+            repeat["errorMessage"].asText().contains("use reset=true"),
+            "errorMessage must guide the operator toward reset=true: ${repeat["errorMessage"].asText()}",
+        )
         val auditAfterRepeat = auditLogRepository.findAll().filter { it.source == "git-history" }
-        assertEquals(auditAfterFirst.size, auditAfterRepeat.size)
+        assertEquals(auditAfterFirst.size, auditAfterRepeat.size, "FAILED retry must not have touched audit_log")
 
         // Phase 3: reset=true, no toRef → auto-resolves to latest tag (components-registry-1.2),
         // covers the unparseable commit (c4) and the DELETE of ARCHIVED_TEST_COMPONENT at c5.
         val secondBody =
             mvc
                 .perform(post("/rest/api/4/admin/migrate-history?reset=true").with(adminJwt()))
-                .andExpect(status().isOk)
+                .andExpect(status().isAccepted)
                 .andReturn()
                 .response
                 .contentAsString
         val second = objectMapper.readTree(secondBody)
-        assertEquals("refs/tags/components-registry-1.2", second["targetRef"].asText())
+        assertEquals("COMPLETED", second["state"].asText())
+        val secondResult = second["result"]
+        assertEquals("refs/tags/components-registry-1.2", secondResult["targetRef"].asText())
         assertTrue(
-            second["skippedParseError"].asInt() >= 1,
-            "c4 is deliberately unparseable, expected skippedParseError >= 1, got $second",
+            secondResult["skippedParseError"].asInt() >= 1,
+            "c4 is deliberately unparseable, expected skippedParseError >= 1, got $secondResult",
         )
 
         val auditFinal = auditLogRepository.findAll().filter { it.source == "git-history" }
@@ -120,7 +164,7 @@ class MigrateHistoryIntegrationTest {
     }
 
     @Test
-    fun `reset=true refuses to stomp on an IN_PROGRESS claim`() {
+    fun `reset=true refuses to stomp on an IN_PROGRESS claim — surfaces as in-memory FAILED, not HTTP 409`() {
         auditLogRepository.deleteAll()
         stateRepository.deleteAll()
         stateRepository.save(
@@ -132,14 +176,43 @@ class MigrateHistoryIntegrationTest {
             ),
         )
 
-        mvc
-            .perform(post("/rest/api/4/admin/migrate-history?reset=true").with(adminJwt()))
-            .andExpect(status().isConflict)
+        // Async: HTTP returns 202; the preflight CONFLICT raised inside the
+        // import is caught and transitioned to FAILED in the in-memory state.
+        val body =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-history?reset=true").with(adminJwt()))
+                .andExpect(status().isAccepted)
+                .andReturn()
+                .response
+                .contentAsString
+        val response = objectMapper.readTree(body)
+        assertEquals("FAILED", response["state"].asText())
+        assertTrue(
+            response["errorMessage"].asText().lowercase().contains("in_progress"),
+            "errorMessage must mention IN_PROGRESS so operator understands the conflict: ${response["errorMessage"].asText()}",
+        )
 
         // Pre-existing IN_PROGRESS row must survive the rejected reset.
         val state = stateRepository.findById("component-history").orElseThrow()
         assertEquals(GitHistoryImportStatus.IN_PROGRESS.name, state.status)
         assertEquals("deadbeef", state.targetSha, "reset must not have wiped the live claim")
+    }
+
+    /**
+     * Replaces the production single-thread migrationExecutor with a
+     * SyncTaskExecutor so each /migrate-history POST runs the import inline
+     * on the request thread. Without this swap the test would have to poll
+     * /migrate-history/job for COMPLETED state, which adds flake to a test
+     * already gated on a real Postgres testcontainer + JGit fixture.
+     *
+     * Mirrors the SyncMigrationExecutorConfig in MigrateEndpointTest. The
+     * production bean is `@ConditionalOnMissingBean`, so registering this
+     * @Bean("migrationExecutor") first means the production one steps aside.
+     */
+    @TestConfiguration
+    open class SyncMigrationExecutorConfig {
+        @Bean("migrationExecutor")
+        open fun syncMigrationExecutor(): TaskExecutor = SyncTaskExecutor()
     }
 
     companion object {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImplTest.kt
@@ -12,6 +12,8 @@ import org.octopusden.octopus.components.registry.server.service.BatchMigrationR
 import org.octopusden.octopus.components.registry.server.service.FullMigrationResult
 import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.octopusden.octopus.components.registry.server.service.MigrationPhase
 import org.octopusden.octopus.components.registry.server.service.MigrationProgressEvent
 import org.octopusden.octopus.components.registry.server.service.MigrationProgressListener
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
@@ -47,14 +49,14 @@ class MigrationJobServiceImplTest {
 
     @Test
     fun `current() is null before any job has been started`() {
-        val service = MigrationJobServiceImpl(StubImportService(), SyncTaskExecutor())
+        val service = MigrationJobServiceImpl(StubImportService(), SyncTaskExecutor(), MigrationLifecycleGate())
         assertNull(service.current())
     }
 
     @Test
     fun `first startAsync returns isNewlyStarted=true and the migration runs`() {
         val importService = StubImportService(migrateImpl = { emptyResult })
-        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor())
+        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor(), MigrationLifecycleGate())
 
         val result = service.startAsync()
 
@@ -69,7 +71,7 @@ class MigrationJobServiceImplTest {
     fun `second startAsync while RUNNING returns the existing job and does not spawn a duplicate`() {
         val deferredExecutor = DeferredExecutor()
         val importService = StubImportService(migrateImpl = { emptyResult })
-        val service = MigrationJobServiceImpl(importService, deferredExecutor)
+        val service = MigrationJobServiceImpl(importService, deferredExecutor, MigrationLifecycleGate())
 
         val first = service.startAsync()
         // Migration runnable hasn't actually been run yet (deferred), so the job is
@@ -87,7 +89,7 @@ class MigrationJobServiceImplTest {
     @Test
     fun `after job COMPLETES the next startAsync starts a fresh job with a different id`() {
         val importService = StubImportService(migrateImpl = { emptyResult })
-        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor())
+        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor(), MigrationLifecycleGate())
 
         val first = service.startAsync()
         assertEquals(JobState.COMPLETED, first.state.state)
@@ -120,7 +122,7 @@ class MigrationJobServiceImplTest {
                 // lambda the test can flip from outside, then complete after.
                 emptyResult
             })
-        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor())
+        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor(), MigrationLifecycleGate())
 
         service.startAsync()
 
@@ -147,7 +149,7 @@ class MigrationJobServiceImplTest {
                     ),
             )
         val importService = StubImportService(migrateImpl = { populatedResult })
-        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor())
+        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor(), MigrationLifecycleGate())
 
         service.startAsync()
         val state = service.current()!!
@@ -164,7 +166,7 @@ class MigrationJobServiceImplTest {
     @Test
     fun `terminal state is FAILED with error message when ImportService throws`() {
         val importService = StubImportService(migrateImpl = { throw IllegalStateException("disk full") })
-        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor())
+        val service = MigrationJobServiceImpl(importService, SyncTaskExecutor(), MigrationLifecycleGate())
 
         service.startAsync()
         val state = service.current()!!
@@ -183,7 +185,7 @@ class MigrationJobServiceImplTest {
         // rollback, the slot stays RUNNING forever and every subsequent POST
         // returns 409 from the controller layer. The operator would be wedged.
         val importService = StubImportService(migrateImpl = { fail("executor refused; importService should never be touched") })
-        val service = MigrationJobServiceImpl(importService, RejectingExecutor("pool shutting down"))
+        val service = MigrationJobServiceImpl(importService, RejectingExecutor("pool shutting down"), MigrationLifecycleGate())
 
         val thrown = assertFailsWith<java.util.concurrent.RejectedExecutionException> { service.startAsync() }
         assertEquals("pool shutting down", thrown.message)
@@ -209,7 +211,7 @@ class MigrationJobServiceImplTest {
                     runnable.run()
                 },
             )
-        val service = MigrationJobServiceImpl(importService, executor)
+        val service = MigrationJobServiceImpl(importService, executor, MigrationLifecycleGate())
 
         // First call → rejection → FAILED slot.
         runCatching { service.startAsync() }
@@ -223,13 +225,160 @@ class MigrationJobServiceImplTest {
         assertEquals(JobState.COMPLETED, retry.state.state)
     }
 
+    @Test
+    fun `phase is set to DEFAULTS in the published state BEFORE the runnable runs`() {
+        // Pin the race fix from A2: ThreadPoolTaskExecutor.execute() returns
+        // synchronously, and the controller builds its 202 response from
+        // state.get() right after. If phase were set inside runMigration
+        // (the runnable), the SPA would briefly see RUNNING with phase=null
+        // and render fallback "Running…" instead of "Loading defaults…" —
+        // exactly the UX bug we set out to fix. DeferredExecutor never runs
+        // the captured runnable, so the only way state.phase can be DEFAULTS
+        // here is if it was published at startAsync time.
+        val deferredExecutor = DeferredExecutor()
+        val service =
+            MigrationJobServiceImpl(
+                StubImportService(migrateImpl = { fail("runnable should not have run") }),
+                deferredExecutor,
+                MigrationLifecycleGate(),
+            )
+
+        val result = service.startAsync()
+
+        assertEquals(JobState.RUNNING, result.state.state)
+        assertEquals(MigrationPhase.DEFAULTS, result.state.phase)
+        assertEquals(MigrationPhase.DEFAULTS, service.current()!!.phase)
+    }
+
+    @Test
+    fun `phase transitions to COMPONENTS before migrateAllComponents and clears on COMPLETED`() {
+        // Capture phase observed inside each ImportService method to assert ordering.
+        val phaseAtMigrateDefaults = AtomicPhaseRef()
+        val phaseAtMigrateAllComponents = AtomicPhaseRef()
+        // Use a service ref captured by closure so the stub can read live phase from
+        // the same instance under test.
+        lateinit var service: MigrationJobServiceImpl
+        val importService =
+            object : StubImportService() {
+                override fun migrateDefaults(): Map<String, Any?> {
+                    phaseAtMigrateDefaults.value = service.current()?.phase
+                    return emptyMap()
+                }
+
+                override fun migrateAllComponents(progress: MigrationProgressListener): BatchMigrationResult {
+                    phaseAtMigrateAllComponents.value = service.current()?.phase
+                    return BatchMigrationResult(0, 0, 0, 0, emptyList())
+                }
+            }
+        service = MigrationJobServiceImpl(importService, SyncTaskExecutor(), MigrationLifecycleGate())
+
+        service.startAsync()
+
+        assertEquals(MigrationPhase.DEFAULTS, phaseAtMigrateDefaults.value, "migrateDefaults runs while phase=DEFAULTS")
+        assertEquals(MigrationPhase.COMPONENTS, phaseAtMigrateAllComponents.value, "migrateAllComponents runs while phase=COMPONENTS")
+        assertNull(service.current()!!.phase, "terminal COMPLETED state must clear phase to null")
+    }
+
+    @Test
+    fun `phase is cleared on FAILED transition`() {
+        val service =
+            MigrationJobServiceImpl(
+                StubImportService(migrateImpl = { throw IllegalStateException("boom") }),
+                SyncTaskExecutor(),
+                MigrationLifecycleGate(),
+            )
+        service.startAsync()
+        assertEquals(JobState.FAILED, service.current()!!.state)
+        assertNull(service.current()!!.phase, "terminal FAILED state must also clear phase")
+    }
+
+    @Test
+    fun `runMigration releases the lifecycle gate on success`() {
+        val gate = MigrationLifecycleGate()
+        val service =
+            MigrationJobServiceImpl(
+                StubImportService(migrateImpl = {
+                    BatchMigrationResult(0, 0, 0, 0, emptyList())
+                    org.octopusden.octopus.components.registry.server.service.FullMigrationResult(
+                        defaults = emptyMap(),
+                        components = BatchMigrationResult(0, 0, 0, 0, emptyList()),
+                    )
+                }),
+                SyncTaskExecutor(),
+                gate,
+            )
+        service.startAsync()
+        assertNull(gate.current(), "gate must be released after a successful run so other migrations are not blocked")
+    }
+
+    @Test
+    fun `runMigration releases the lifecycle gate on failure`() {
+        val gate = MigrationLifecycleGate()
+        val service =
+            MigrationJobServiceImpl(
+                StubImportService(migrateImpl = { throw IllegalStateException("boom") }),
+                SyncTaskExecutor(),
+                gate,
+            )
+        service.startAsync()
+        assertNull(gate.current(), "gate must be released after FAILED too — leak would block any future history migration")
+    }
+
+    @Test
+    fun `executor rejection releases the lifecycle gate so the next startAsync can proceed`() {
+        val gate = MigrationLifecycleGate()
+        val service =
+            MigrationJobServiceImpl(
+                StubImportService(migrateImpl = { fail("must not be called") }),
+                RejectingExecutor("queue closed"),
+                gate,
+            )
+        runCatching { service.startAsync() }
+        assertNull(gate.current(), "rejection branch must release the gate too — defends against gate-leak on submit failure")
+    }
+
+    @Test
+    fun `cross-kind gate held by HISTORY makes startAsync throw MigrationConflictException`() {
+        val gate = MigrationLifecycleGate()
+        // Simulate history-job currently holding the gate.
+        gate.tryClaim(MigrationLifecycleGate.JobKind.HISTORY, "history-1")
+
+        val service =
+            MigrationJobServiceImpl(
+                StubImportService(migrateImpl = { fail("must not be called when cross-kind conflict") }),
+                SyncTaskExecutor(),
+                gate,
+            )
+
+        val ex =
+            assertFailsWith<org.octopusden.octopus.components.registry.server.service.MigrationConflictException> {
+                service.startAsync()
+            }
+        assertEquals(MigrationLifecycleGate.JobKind.HISTORY, ex.active.kind)
+        assertEquals("history-1", ex.active.jobId)
+    }
+
+    /** Captures a [MigrationPhase] observed from a different thread / call site. */
+    private class AtomicPhaseRef {
+        @Volatile
+        var value: MigrationPhase? = null
+    }
+
     /**
      * Hand-written stub for [ImportService]. Mockito would have been smaller, but
      * the non-nullable Kotlin progress parameter trips its `any()` matcher
      * (returns null → NPE before the proxy intercepts). The stub records call
      * counts + the last progress event so tests can assert on flow.
+     *
+     * Adapter contract: the constructor takes a `migrateImpl` that returns a
+     * full [FullMigrationResult]; the stub splits this between [migrateDefaults]
+     * (returns the `defaults` map) and [migrateAllComponents] (returns the
+     * `components` value AND drives any progress events the body would have
+     * emitted). This preserves existing test ergonomics from when
+     * MigrationJobServiceImpl called `migrate(progress)` as one step before A2
+     * split it into two phases.
      */
-    private class StubImportService(
+    private open class StubImportService(
         private val migrateImpl: (MigrationProgressListener) -> FullMigrationResult = { unused() },
     ) : ImportService {
         var migrateCallCount: Int = 0
@@ -239,17 +388,32 @@ class MigrationJobServiceImplTest {
         var lastProgressEvent: MigrationProgressEvent? = null
             private set
 
-        override fun migrate(progress: MigrationProgressListener): FullMigrationResult {
+        // Memoize across the two phase calls so the result-building lambda
+        // runs exactly once per logical migration. migrateDefaults is called
+        // first, then migrateAllComponents — both pull from the same memo.
+        private var memoized: FullMigrationResult? = null
+        private var capturedListener: MigrationProgressListener? = null
+
+        private fun buildResult(): FullMigrationResult {
+            val cached = memoized
+            if (cached != null) return cached
             migrateCallCount++
-            // Wrap the listener so we can also see what events ImportService would
-            // have driven through it; useful for tests that assert on mid-run state.
+            val listener = capturedListener ?: MigrationProgressListener.NOOP
             val tap =
                 MigrationProgressListener { event ->
                     progressCallCount++
                     lastProgressEvent = event
-                    progress.onProgress(event)
+                    listener.onProgress(event)
                 }
-            return migrateImpl(tap)
+            val result = migrateImpl(tap)
+            memoized = result
+            return result
+        }
+
+        override fun migrate(progress: MigrationProgressListener): FullMigrationResult {
+            // Legacy entrypoint kept for the few tests / callers that still use it.
+            capturedListener = progress
+            return buildResult()
         }
 
         override fun migrateComponent(
@@ -257,13 +421,29 @@ class MigrationJobServiceImplTest {
             dryRun: Boolean,
         ): MigrationResult = unused()
 
-        override fun migrateAllComponents(progress: MigrationProgressListener): BatchMigrationResult = unused()
+        // `open` so phase-ordering tests can override per-method to capture state mid-run.
+        open override fun migrateAllComponents(progress: MigrationProgressListener): BatchMigrationResult {
+            capturedListener = progress
+            val result = buildResult()
+            // Logical migration boundary: defaults+components both ran. Reset memo
+            // so the next startAsync (post-COMPLETED retry) re-evaluates the lambda
+            // and migrateCallCount climbs as expected.
+            memoized = null
+            return result.components
+        }
 
         override fun getMigrationStatus(): MigrationStatus = unused()
 
         override fun validateMigration(name: String): ValidationResult = unused()
 
-        override fun migrateDefaults(): Map<String, Any?> = unused()
+        open override fun migrateDefaults(): Map<String, Any?> {
+            // Defaults runs first under A2, but if migrateImpl throws we want it to
+            // fire from migrateAllComponents (so phase=COMPONENTS at failure-time
+            // matches what the existing tests expect about FAILED transitions).
+            // To preserve that, defaults returns an empty placeholder and the
+            // real lambda fires inside migrateAllComponents.
+            return emptyMap()
+        }
 
         companion object {
             private fun <T> unused(): T = error("not stubbed for this test")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationLifecycleGateTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationLifecycleGateTest.kt
@@ -145,17 +145,40 @@ class MigrationLifecycleGateTest {
      */
     @Test
     fun `release-then-CAS-retry never produces phantom successful claims`() {
+        // P2 review fix: previously asserted only `claimsObserved == releasesPerformed`,
+        // which catches *bookkeeping* leaks but NOT the actual phantom-claim
+        // scenario this test claims to cover. The proper invariant is
+        // `peakSimultaneousOwners <= 1` — if two threads ever both observe a
+        // successful claim AT THE SAME TIME, the gate's mutual-exclusion
+        // contract is broken regardless of the eventual release counts.
         val gate = MigrationLifecycleGate()
         val claimsObserved = AtomicInteger(0)
         val releasesPerformed = AtomicInteger(0)
+        val activeOwners = AtomicInteger(0)
+        val peakOwners = AtomicInteger(0)
         val iterations = 2_000
+
+        fun ownClaimWindow() {
+            val current = activeOwners.incrementAndGet()
+            // Track high-water-mark via CAS-loop so we don't miss a transient peak.
+            while (true) {
+                val seen = peakOwners.get()
+                if (current <= seen || peakOwners.compareAndSet(seen, current)) break
+            }
+            claimsObserved.incrementAndGet()
+            // Brief active window so concurrent claimers have a chance to overlap
+            // and the peak counter has time to observe the violation, if any.
+            // Thread.yield is enough; sleep would slow the test pointlessly.
+            Thread.yield()
+            activeOwners.decrementAndGet()
+        }
 
         val claimer =
             Thread {
                 repeat(iterations) { i ->
                     val result = gate.tryClaim(JobKind.COMPONENTS, "claim-$i")
                     if (result == null) {
-                        claimsObserved.incrementAndGet()
+                        ownClaimWindow()
                         gate.release("claim-$i")
                         releasesPerformed.incrementAndGet()
                     }
@@ -166,7 +189,7 @@ class MigrationLifecycleGateTest {
                 repeat(iterations) { i ->
                     val result = gate.tryClaim(JobKind.HISTORY, "challenge-$i")
                     if (result == null) {
-                        claimsObserved.incrementAndGet()
+                        ownClaimWindow()
                         gate.release("challenge-$i")
                         releasesPerformed.incrementAndGet()
                     }
@@ -179,9 +202,14 @@ class MigrationLifecycleGateTest {
         challenger.join(10_000)
 
         assertEquals(
+            1,
+            peakOwners.get(),
+            "peakSimultaneousOwners must be 1 — two threads both observing a successful claim is the phantom-claim bug this test exists to prevent",
+        )
+        assertEquals(
             claimsObserved.get(),
             releasesPerformed.get(),
-            "every observed claim must be paired with a release — phantom claims would skew this count",
+            "every observed claim must be paired with a release — bookkeeping cross-check",
         )
         assertNull(gate.current(), "after all releases the gate must be empty")
         assertTrue(claimsObserved.get() > 0, "sanity check: at least one claim should have happened")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationLifecycleGateTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationLifecycleGateTest.kt
@@ -204,7 +204,8 @@ class MigrationLifecycleGateTest {
         assertEquals(
             1,
             peakOwners.get(),
-            "peakSimultaneousOwners must be 1 — two threads both observing a successful claim is the phantom-claim bug this test exists to prevent",
+            "peakSimultaneousOwners must be 1 — two threads both observing a successful claim " +
+                "is the phantom-claim bug this test exists to prevent",
         )
         assertEquals(
             claimsObserved.get(),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationLifecycleGateTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationLifecycleGateTest.kt
@@ -1,0 +1,189 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Pin the cross-job concurrency contract:
+ *   - At most one job kind owns the gate at any time (cross- or same-kind).
+ *   - tryClaim is CAS-loop safe: a release between a failed CAS and a re-read
+ *     must not let a third caller report success without actually owning the
+ *     slot (the bug a naive `compareAndSet → return active.get()` would have).
+ *   - release is owner-scoped + idempotent.
+ */
+class MigrationLifecycleGateTest {
+    @Test
+    fun `current() is null on a fresh gate`() {
+        assertNull(MigrationLifecycleGate().current())
+    }
+
+    @Test
+    fun `first tryClaim succeeds and publishes the active job`() {
+        val gate = MigrationLifecycleGate()
+        val conflict = gate.tryClaim(JobKind.COMPONENTS, "job-1")
+        assertNull(conflict, "first claim on an empty gate should report no conflict")
+        val active = gate.current()
+        assertNotNull(active)
+        assertEquals(JobKind.COMPONENTS, active!!.kind)
+        assertEquals("job-1", active.jobId)
+    }
+
+    @Test
+    fun `same-kind second tryClaim returns the existing owner without overwriting it`() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(JobKind.COMPONENTS, "job-1")
+        val conflict = gate.tryClaim(JobKind.COMPONENTS, "job-2")
+        assertNotNull(conflict)
+        assertEquals(JobKind.COMPONENTS, conflict!!.kind)
+        assertEquals("job-1", conflict.jobId, "owner must remain job-1; the second claimant must NOT overwrite")
+        assertEquals("job-1", gate.current()!!.jobId)
+    }
+
+    @Test
+    fun `cross-kind tryClaim returns the existing owner so the controller can map to 409`() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(JobKind.COMPONENTS, "components-1")
+        val conflict = gate.tryClaim(JobKind.HISTORY, "history-1")
+        assertNotNull(conflict)
+        assertEquals(JobKind.COMPONENTS, conflict!!.kind)
+        assertEquals("components-1", conflict.jobId)
+    }
+
+    @Test
+    fun `release by owner clears the slot, release by stranger is a no-op`() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(JobKind.HISTORY, "history-1")
+
+        gate.release("not-the-owner")
+        assertEquals(
+            "history-1",
+            gate.current()!!.jobId,
+            "release with a foreign jobId must not clear the slot — defends against a stale finally block",
+        )
+
+        gate.release("history-1")
+        assertNull(gate.current(), "owner-scoped release must clear the slot")
+
+        // Idempotent: a second release on an already-empty slot is harmless.
+        gate.release("history-1")
+        assertNull(gate.current())
+    }
+
+    @Test
+    fun `released slot is claimable by the other kind`() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(JobKind.COMPONENTS, "components-1")
+        gate.release("components-1")
+
+        val conflict = gate.tryClaim(JobKind.HISTORY, "history-1")
+        assertNull(conflict, "after release, a different kind must be able to claim")
+        assertEquals(JobKind.HISTORY, gate.current()!!.kind)
+    }
+
+    /**
+     * Two threads race for the same gate kind in a tight loop. The contract:
+     *   - Exactly one of them must observe a successful claim (`null` return).
+     *   - The other must observe a non-null conflict.
+     * Never both null (two owners of one slot) and never both non-null with the
+     * gate empty (lost-update where neither owns it).
+     *
+     * Repeated 100x to surface the race window — the bug a naive
+     * `compareAndSet → active.get()` design would hit is timing-dependent.
+     */
+    @RepeatedTest(100)
+    fun `two threads claiming the same kind in parallel — exactly one wins`() {
+        val gate = MigrationLifecycleGate()
+        val nullReturns = AtomicInteger(0)
+        val conflictReturns = AtomicInteger(0)
+        val ready = CountDownLatch(2)
+        val go = CountDownLatch(1)
+
+        val workers =
+            (0 until 2).map { i ->
+                Thread {
+                    ready.countDown()
+                    go.await()
+                    val result = gate.tryClaim(JobKind.COMPONENTS, "job-$i")
+                    if (result == null) nullReturns.incrementAndGet() else conflictReturns.incrementAndGet()
+                }.also { it.start() }
+            }
+
+        ready.await(5, TimeUnit.SECONDS)
+        go.countDown()
+        workers.forEach { it.join(5_000) }
+
+        assertEquals(1, nullReturns.get(), "exactly one thread must claim the gate")
+        assertEquals(1, conflictReturns.get(), "exactly one thread must observe the conflict")
+        assertNotNull(gate.current(), "gate must end up owned by the winner")
+    }
+
+    /**
+     * The classic lost-update scenario the CAS-loop is designed to prevent:
+     *
+     * 1. Thread A claims (active = A).
+     * 2. Thread B reads active → sees A → would return conflict, BUT a naive
+     *    impl reads active a second time after a failed CAS to build the
+     *    response, and between those two reads A releases, so the second read
+     *    returns null. The naive impl then returns null = "no conflict =
+     *    success", but never installed B in the slot. Thread C then claims
+     *    successfully too. Both B and C think they own the gate.
+     *
+     * The CAS-loop impl reacts to the now-null slot by retrying the CAS, which
+     * either publishes B or sees a fresh non-null owner. We verify by counting:
+     * across many thrashing iterations the number of "successful claims"
+     * (returns null) must never exceed the number of releases + 1 (the initial
+     * empty slot).
+     */
+    @Test
+    fun `release-then-CAS-retry never produces phantom successful claims`() {
+        val gate = MigrationLifecycleGate()
+        val claimsObserved = AtomicInteger(0)
+        val releasesPerformed = AtomicInteger(0)
+        val iterations = 2_000
+
+        val claimer =
+            Thread {
+                repeat(iterations) { i ->
+                    val result = gate.tryClaim(JobKind.COMPONENTS, "claim-$i")
+                    if (result == null) {
+                        claimsObserved.incrementAndGet()
+                        gate.release("claim-$i")
+                        releasesPerformed.incrementAndGet()
+                    }
+                }
+            }
+        val challenger =
+            Thread {
+                repeat(iterations) { i ->
+                    val result = gate.tryClaim(JobKind.HISTORY, "challenge-$i")
+                    if (result == null) {
+                        claimsObserved.incrementAndGet()
+                        gate.release("challenge-$i")
+                        releasesPerformed.incrementAndGet()
+                    }
+                }
+            }
+
+        claimer.start()
+        challenger.start()
+        claimer.join(10_000)
+        challenger.join(10_000)
+
+        assertEquals(
+            claimsObserved.get(),
+            releasesPerformed.get(),
+            "every observed claim must be paired with a release — phantom claims would skew this count",
+        )
+        assertNull(gate.current(), "after all releases the gate must be empty")
+        assertTrue(claimsObserved.get() > 0, "sanity check: at least one claim should have happened")
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/StubGitHistoryImportStateRepository.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/StubGitHistoryImportStateRepository.kt
@@ -1,0 +1,140 @@
+// MaxLineLength suppressed because JpaRepository's overrides have long
+// generic-laden signatures (`Example<S>`, `FluentQuery.FetchableFluentQuery<S>`)
+// that ktlint can't shorten meaningfully. They are mostly `error("unused")`
+// boilerplate; breaking each across multiple lines makes the file harder
+// to scan, not easier. Suppression is scoped to this stub file ONLY — the
+// test file itself keeps the default 140-char limit so genuine long
+// assertion messages get caught.
+@file:Suppress("MaxLineLength")
+
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
+import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import java.time.Instant
+import java.util.Optional
+
+/**
+ * Hand-rolled stub for [GitHistoryImportStateRepository]. Spring Data's
+ * JpaRepository declares dozens of methods we don't need; the ones that
+ * matter are [findById] / [tryInsert] / [save] / a couple of delete
+ * operations. The rest is `error("unused")` so accidental usage in a future
+ * test fails loudly rather than silently no-op'ing.
+ *
+ * Used by `HistoryMigrationJobServiceImplTest` (DB-fallback synthesis tests
+ * + clearInMemory) instead of a Mockito mock — Mockito's `any()` returns
+ * null, which trips the JVM null-check on Kotlin's non-nullable parameters
+ * before the proxy can intercept. This stub also exposes [saveRow] for
+ * test setup.
+ */
+internal class StubGitHistoryImportStateRepository : GitHistoryImportStateRepository {
+    private val rows = mutableMapOf<String, GitHistoryImportStateEntity>()
+
+    fun saveRow(entity: GitHistoryImportStateEntity) {
+        rows[entity.importKey] = entity
+    }
+
+    override fun findById(id: String): Optional<GitHistoryImportStateEntity> = Optional.ofNullable(rows[id])
+
+    override fun tryInsert(
+        importKey: String,
+        targetRef: String,
+        targetSha: String,
+        status: String,
+    ): Int {
+        if (rows.containsKey(importKey)) return 0
+        rows[importKey] =
+            GitHistoryImportStateEntity(
+                importKey = importKey,
+                targetRef = targetRef,
+                targetSha = targetSha,
+                status = status,
+                updatedAt = Instant.now(),
+            )
+        return 1
+    }
+
+    override fun existsById(id: String): Boolean = rows.containsKey(id)
+
+    override fun findAll(): MutableList<GitHistoryImportStateEntity> = rows.values.toMutableList()
+
+    override fun count(): Long = rows.size.toLong()
+
+    override fun deleteById(id: String) {
+        rows.remove(id)
+    }
+
+    override fun delete(entity: GitHistoryImportStateEntity) {
+        rows.remove(entity.importKey)
+    }
+
+    override fun deleteAllById(ids: MutableIterable<String>) {
+        ids.forEach(::deleteById)
+    }
+
+    override fun deleteAll(entities: MutableIterable<GitHistoryImportStateEntity>) = entities.forEach(::delete)
+
+    override fun deleteAll() {
+        rows.clear()
+    }
+
+    override fun flush() = Unit
+
+    // Everything below: not used by the service-under-test. Failing loudly
+    // surfaces accidental usage in future tests.
+    override fun <S : GitHistoryImportStateEntity?> save(entity: S): S = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> saveAll(entities: MutableIterable<S>): MutableList<S> = error("unused")
+
+    override fun findAll(sort: org.springframework.data.domain.Sort): MutableList<GitHistoryImportStateEntity> = error("unused")
+
+    override fun findAll(
+        pageable: org.springframework.data.domain.Pageable,
+    ): org.springframework.data.domain.Page<GitHistoryImportStateEntity> = error("unused")
+
+    override fun findAllById(ids: MutableIterable<String>): MutableList<GitHistoryImportStateEntity> = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> saveAndFlush(entity: S): S = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> saveAllAndFlush(entities: MutableIterable<S>): MutableList<S> = error("unused")
+
+    @Suppress("DEPRECATION")
+    override fun deleteAllInBatch(entities: MutableIterable<GitHistoryImportStateEntity>) = error("unused")
+
+    override fun deleteAllByIdInBatch(ids: MutableIterable<String>) = error("unused")
+
+    override fun deleteAllInBatch() = error("unused")
+
+    @Suppress("DEPRECATION")
+    override fun getOne(id: String): GitHistoryImportStateEntity = error("unused")
+
+    @Suppress("DEPRECATION")
+    override fun getById(id: String): GitHistoryImportStateEntity = error("unused")
+
+    override fun getReferenceById(id: String): GitHistoryImportStateEntity = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> findAll(example: org.springframework.data.domain.Example<S>): MutableList<S> =
+        error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> findAll(
+        example: org.springframework.data.domain.Example<S>,
+        sort: org.springframework.data.domain.Sort,
+    ): MutableList<S> = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> findAll(
+        example: org.springframework.data.domain.Example<S>,
+        pageable: org.springframework.data.domain.Pageable,
+    ): org.springframework.data.domain.Page<S> = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> findOne(example: org.springframework.data.domain.Example<S>): Optional<S> =
+        error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> count(example: org.springframework.data.domain.Example<S>): Long = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?> exists(example: org.springframework.data.domain.Example<S>): Boolean = error("unused")
+
+    override fun <S : GitHistoryImportStateEntity?, R : Any?> findBy(
+        example: org.springframework.data.domain.Example<S>,
+        queryFunction: java.util.function.Function<org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery<S>, R>,
+    ): R = error("unused")
+}


### PR DESCRIPTION
## Summary

Two related migration UX fixes that share infrastructure:

1. **Phase indicator on `/admin/migrate`** — the early window between POST and the first per-component progress event used to render frozen \"Running…\" with no movement (cold git clone, defaults loading — many seconds). New \`phase\` field on \`MigrationJobResponse\` (\`DEFAULTS\` | \`COMPONENTS\` | null on terminal). Set on the candidate state **before** \`executor.execute\`, not inside the runnable, so the SPA never sees RUNNING-without-phase.

2. **Async `/admin/migrate-history`** — was synchronous. Now mirrors the components flow: 202 + \`HistoryMigrationJobResponse\`, \`GET /migrate-history/job\` for polling, per-commit progress events. The runnable runs on the same single-thread \`migrationExecutor\`.

3. **`MigrationLifecycleGate`** — shared cross-kind concurrency gate. \`ThreadPoolTaskExecutor\` with \`queueCapacity > 0\` queues a second submit, so without the gate both \`startAsync\` calls would return 202 and the SPA would render two RUNNING cards. CAS-loop \`tryClaim\` (a naive \`compareAndSet → active.get()\` has a race where a \`release\` between the failed CAS and \`get\` lets two callers think they own the slot — pinned by a 100-iteration RepeatedTest).

4. **`POST /migrate-history/force-reset`** — destructive recovery: deletes the import claim row AND all \`audit_log\` rows with \`source='git-history'\`. Required because \`GitHistoryCommitWriter.resetIfNotInProgress()\` refuses to clear IN_PROGRESS, and a pod restart leaves orphan IN_PROGRESS rows that block every subsequent run. Refused with 409 if a history job is RUNNING in the current pod.

5. **DB-fallback in `HistoryMigrationJobService.current()`** — synthesizes state from \`git_history_import_state\` when in-memory is null (post-restart), so the SPA sees prior-pod outcomes and surfaces the right action. IN_PROGRESS DB rows surface as JobState.FAILED with a verbatim \`marked IN_PROGRESS\` marker that the SPA matches on to route to Force-reset.

6. **Cross-kind 409 contract** — same-kind 409 returns the existing job body (SPA attaches); cross-kind 409 returns \`MigrationConflictResponse{code, message, activeKind, activeJobId}\` (SPA renders destructive block).

7. **\`FaultInjectionConfig\`** — \`@Profile(\"dev-fault-injection\")\` + \`@ConditionalOnProperty\` two-layer gate so an accidentally-set JVM property can't become a prod kill switch. Used by the Verification 5/5a manual E2E to drive the SPA into FAILED for retry testing.

## Multi-pod note

\`MigrationLifecycleGate\` is in-memory per-pod scope. Single CRS instance is required for the migration features (\`replicas: 1\`, \`strategy: Recreate\` or \`maxSurge: 0\`); multi-pod overlap can lead to two pods each thinking they own the gate. Followup TD: DB-backed gate.

## Tests

- New: \`MigrationLifecycleGateTest\` (ownership race × 100, release-then-CAS no phantom claims), \`HistoryMigrationJobServiceImplTest\` (14 cases: same-kind attach, RejectingExecutor, ToggleableExecutor retry, DB-fallback synthesis for COMPLETED/FAILED/IN_PROGRESS, in-memory wins over DB, clearInMemory, cross-kind throws, gate release on success/failure/rejection), \`MigrateHistoryAsyncEndpointTest\` (POST 202+COMPLETED+result wire shape, POST→GET same shape).
- Updated: \`MigrationJobServiceImplTest\` (DeferredExecutor pin that phase=DEFAULTS published BEFORE runnable runs, DEFAULTS→COMPONENTS ordering, phase cleared on COMPLETED/FAILED, gate released, cross-kind throws), \`MigrateEndpointTest\` (phase=null after COMPLETED), \`MigrateHistoryIntegrationTest\` (async-shape adaptation: 202+state=COMPLETED, terminal-row repeat surfaces as in-memory FAILED instead of HTTP 409).

## Test plan

- [x] Unit: \`./gradlew :components-registry-service-server:test --tests '*MigrationLifecycleGateTest' --tests '*MigrationJobServiceImplTest' --tests '*HistoryMigrationJobServiceImplTest'\` — all green
- [x] Integration: \`./gradlew :components-registry-service-server:test --tests '*MigrateEndpointTest' --tests '*MigrateHistoryIntegrationTest' --tests '*MigrateHistoryAsyncEndpointTest' --tests '*AdminControllerV4SecurityTest'\` — all green
- [ ] Manual E2E in browser (Verification 1-8 in plan) — depends on portal PR also being on dev
- [ ] Verification 5/5a — \`SPRING_PROFILES_ACTIVE=dev,dev-fault-injection\` + \`migration.fault-injection.fail-after-defaults=true\` / \`migration.fault-injection.fail-history-after-clone=true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)