### PR TITLE
docs: fix security-config accuracy in technical-design §6.2/6.3

### DIFF
--- a/docs/db-migration/implementation-progress.md
+++ b/docs/db-migration/implementation-progress.md
@@ -20,7 +20,7 @@
 | Task | Status | Notes |
 |------|--------|-------|
 | 3A | ✅ Done | DatabaseComponentRegistryResolver (@Transactional readOnly) |
-| 3B | ✅ Done | ComponentRoutingResolver (@Primary) + ComponentSourceRegistry (Caffeine cache) |
+| 3B | ✅ Done | ComponentRoutingResolver (@Primary) + ComponentSourceRegistry (in-process cache removed by SYS-032) |
 
 ## Phase 4: React UI ✅ (extracted to `octopus-components-management-portal`)
 

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -417,7 +417,7 @@ Implemented in `WebSecurityConfig.kt` (extends `CloudCommonWebSecurityConfig` fr
 - All other `/rest/api/4/**` (writes, admin, audit) → `authenticated()` + `@PreAuthorize`.
 - `/auth/**` → `authenticated()` (covers `/auth/me`, SYS-034).
 - `/actuator/health`, `/actuator/health/**` → `permitAll()`. All other `/actuator/**` paths fall through to `authenticated()` — only health probes are anonymous (see inline comment in `WebSecurityConfig.kt:49-54`).
-- `/swagger-ui/**`, `/webjars/**`, `/v3/api-docs/swagger-config`, `/swagger-resources/**` → `permitAll()` (springdoc-openapi assets; configured in this class, not inherited from parent).
+- `/swagger-ui/**`, `/webjars/**`, `/v2/api-docs`, `/v3/api-docs`, `/v3/api-docs/**`, `/v3/api-docs.yaml`, `/swagger-resources/**` → `permitAll()` (springdoc-openapi assets; configured in this class, not inherited from parent).
 - CSRF disabled (CRS is a Resource Server; CSRF is enforced by Portal at the gateway level — see ADR-012).
 
 ### 6.3 Permission Evaluator

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -417,7 +417,7 @@ Implemented in `WebSecurityConfig.kt` (extends `CloudCommonWebSecurityConfig` fr
 - All other `/rest/api/4/**` (writes, admin, audit) → `authenticated()` + `@PreAuthorize`.
 - `/auth/**` → `authenticated()` (covers `/auth/me`, SYS-034).
 - `/actuator/health`, `/actuator/health/**` → `permitAll()`. All other `/actuator/**` paths fall through to `authenticated()` — only health probes are anonymous (see inline comment in `WebSecurityConfig.kt:49-54`).
-- `/swagger-ui/**`, `/webjars/**`, `/v2/api-docs`, `/v3/api-docs`, `/v3/api-docs/**`, `/v3/api-docs.yaml`, `/swagger-resources/**` → `permitAll()` (springdoc-openapi assets; configured in this class, not inherited from parent).
+- `/swagger-ui/**`, `/webjars/**`, `/v2/api-docs`, `/v3/api-docs`, `/v3/api-docs/**`, `/v3/api-docs.yaml`, `/v3/api-docs/swagger-config`, `/swagger-resources/**` → `permitAll()` (springdoc-openapi assets; configured in this class, not inherited from parent).
 - CSRF disabled (CRS is a Resource Server; CSRF is enforced by Portal at the gateway level — see ADR-012).
 
 ### 6.3 Permission Evaluator

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -416,7 +416,8 @@ Implemented in `WebSecurityConfig.kt` (extends `CloudCommonWebSecurityConfig` fr
 - `GET /rest/api/4/info` → `permitAll()` (anonymous build-info for Portal footer; SYS-033).
 - All other `/rest/api/4/**` (writes, admin, audit) → `authenticated()` + `@PreAuthorize`.
 - `/auth/**` → `authenticated()` (covers `/auth/me`, SYS-034).
-- `/actuator/**`, `/swagger-ui/**`, `/v3/api-docs/**` → `permitAll()` from parent.
+- `/actuator/health`, `/actuator/health/**` → `permitAll()`. All other `/actuator/**` paths fall through to `authenticated()` — only health probes are anonymous (see inline comment in `WebSecurityConfig.kt:49-54`).
+- `/swagger-ui/**`, `/webjars/**`, `/v3/api-docs/swagger-config`, `/swagger-resources/**` → `permitAll()` (springdoc-openapi assets; configured in this class, not inherited from parent).
 - CSRF disabled (CRS is a Resource Server; CSRF is enforced by Portal at the gateway level — see ADR-012).
 
 ### 6.3 Permission Evaluator
@@ -425,7 +426,7 @@ Implemented in `WebSecurityConfig.kt` (extends `CloudCommonWebSecurityConfig` fr
 
 | Method | Required permission | Used on |
 |---|---|---|
-| `canEditComponent(name)` | `EDIT_COMPONENTS` | `POST /components`, `PATCH /components/{id}` (plain edit) |
+| `canEditComponent(name)` | `EDIT_COMPONENTS` | `PATCH /components/{id}` (plain edit; `POST /components` uses `hasPermission('EDIT_COMPONENTS')` directly — no `name` arg available) |
 | `canArchiveComponent(name)` | `ARCHIVE_COMPONENTS` | `PATCH /components/{id}` when `archived` is in payload |
 | `canRenameComponent(name)` | `RENAME_COMPONENTS` | `PATCH /components/{id}` when `name` is in payload |
 | `canDeleteComponent(name)` | `DELETE_COMPONENTS` | `DELETE /components/{id}` |
@@ -434,7 +435,7 @@ Implemented in `WebSecurityConfig.kt` (extends `CloudCommonWebSecurityConfig` fr
 
 The `PATCH /components/{id}` SpEL guard combines these (the path variable is a `UUID`; the helper takes `String`, so the SpEL passes `#id.toString()`):
 ```
-@PreAuthorize("@permissionEvaluator.canEditComponent(#id.toString()) and (#request.archived == null or @permissionEvaluator.canArchiveComponent(#id.toString())) and (#request.name == null or @permissionEvaluator.canRenameComponent(#id.toString()))")
+@PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS') and @permissionEvaluator.canEditComponent(#id.toString()) and (#request.archived == null or @permissionEvaluator.canArchiveComponent(#id.toString())) and (#request.name == null or @permissionEvaluator.canRenameComponent(#id.toString()))")
 ```
 Plain edits stay on `EDIT_COMPONENTS`; archive/rename payloads fail closed with 403 for anyone without the extra permission.
 


### PR DESCRIPTION
## Summary

Three accuracy fixes in `technical-design.md` found during post-merge review of PR #157, applied on top of the current `v3` (which includes PR #158):

- **§6.2 (P1 fix)**: `/actuator/**` → `permitAll()` was wrong. Only `/actuator/health` and `/actuator/health/**` are anonymous; other actuator paths fall through to `authenticated()`. Also, the swagger/api-docs paths (`/v2/api-docs`, `/v3/api-docs`, `/v3/api-docs/**`, `/v3/api-docs.yaml`, `/v3/api-docs/swagger-config`, `/swagger-resources/**`, `/swagger-ui/**`, `/webjars/**`) are configured in this class — not "inherited from parent".
- **§6.3 (P2 fix)**: The `PATCH /components/{id}` SpEL guard example was missing the leading `@permissionEvaluator.hasPermission('ACCESS_COMPONENTS') and` that exists in the real code. The `canEditComponent` table row incorrectly listed `POST /components` as a use-site — that endpoint uses `hasPermission('EDIT_COMPONENTS')` directly (no `name` argument available at that call site).
- **`implementation-progress.md` Phase 3B (P3 fix)**: Stale "Caffeine cache" reference removed; cache was removed by SYS-032.

## Test plan

- [ ] Read `technical-design.md §6.2` — verify actuator paths match `WebSecurityConfig.kt` lines 49–66
- [ ] Read `technical-design.md §6.3` — verify SpEL guard matches `ComponentControllerV4.kt` lines 114–118
- [ ] Read `implementation-progress.md` Phase 3B — verify "Caffeine cache" is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)