### PR TITLE
docs: SYS-037 — v4 CRUD API for dependency mappings

### DIFF
--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -1099,7 +1099,7 @@ Supported filters:
 **Status:** ❌ Not implemented
 
 **Motivation:**
-`dependency_mapping.properties` in the Git DSL defined alias→component mappings consumed by downstream tools via `GET /rest/api/2/dependency-mapping`. These mappings live in the `dependency_mappings` table (`DependencyMappingEntity`: `alias` PK, `componentName`), populated during `/admin/migrate-history`. Currently there is no v4 management API — edits require direct DB access or re-running the history backfill. UI for editing these mappings is not planned (they change rarely); the API alone is sufficient to remove the Git-DSL dependency for this data.
+`dependency_mapping.properties` in the Git DSL defined alias→component mappings consumed by downstream tools via `GET /rest/api/2/common/dependency-aliases`. These mappings live in the `dependency_mappings` table (`DependencyMappingEntity`: `alias` PK, `componentName`), populated during `/admin/migrate-history`. Currently there is no v4 management API — edits require direct DB access or re-running the history backfill. UI for editing these mappings is not planned (they change rarely); the API alone is sufficient to remove the Git-DSL dependency for this data.
 
 **Description:**
 Add four endpoints under `/rest/api/4/dependency-mappings`:
@@ -1111,12 +1111,12 @@ Add four endpoints under `/rest/api/4/dependency-mappings`:
 | `PUT` | `/rest/api/4/dependency-mappings/{alias}` | Replace `componentName` for an existing alias. Returns 200. 404 if alias not found. |
 | `DELETE` | `/rest/api/4/dependency-mappings/{alias}` | Delete a mapping. Returns 204. 404 if alias not found. |
 
-Auth: `@PreAuthorize("@permissionEvaluator.canImport()")` (same gate as other admin data-management endpoints — `IMPORT_DATA` permission, `ROLE_REGISTRY_ADMIN` in the default role map).
+Auth: `@PreAuthorize("@permissionEvaluator.canImport()")` (same gate as other admin data-management endpoints — `IMPORT_DATA` permission, `ROLE_ADMIN` in the default role map).
 
-The existing v2 read endpoint (`GET /rest/api/2/dependency-mapping`) remains unchanged — it reads from the same `dependency_mappings` table.
+The existing v2 read endpoint (`GET /rest/api/2/common/dependency-aliases`) remains unchanged — it reads from the same `dependency_mappings` table.
 
 **Preconditions:**
-- Caller has `ROLE_REGISTRY_ADMIN` (or a role that grants `IMPORT_DATA`).
+- Caller has `ROLE_ADMIN` (or a role that grants `IMPORT_DATA`).
 - `dependency_mappings` table exists (V1 schema).
 
 **Acceptance criteria:**
@@ -1128,7 +1128,7 @@ The existing v2 read endpoint (`GET /rest/api/2/dependency-mapping`) remains unc
 6. `DELETE /rest/api/4/dependency-mappings/foo` returns 204 and subsequent `GET` no longer lists the entry.
 7. `DELETE` for a non-existent alias returns 404.
 8. All write endpoints require auth; `GET` without a valid JWT returns 401 (consistent with other v4 non-info endpoints).
-9. The existing `GET /rest/api/2/dependency-mapping` response is unaffected by v4 CRUD operations (reads same table).
+9. The existing `GET /rest/api/2/common/dependency-aliases` response is unaffected by v4 CRUD operations (reads same table).
 
 **Test method:** —
 

--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -46,6 +46,7 @@
 | SYS-034 | GET /auth/me returns current user (username, roles, groups), authenticated | Medium | integration-test | ❌ Not tested |
 | SYS-035 | GET /components?owner=&lt;username&gt; filters by componentOwner exact match | High | integration-test | ✅ Tested |
 | SYS-036 | GET /audit/recent accepts entityType/entityId/changedBy/source/action/from/to filter params | High | integration-test | ✅ Tested |
+| SYS-037 | v4 CRUD API for dependency mappings (alias → componentName) | Medium | integration-test | ❌ Not implemented |
 
 ---
 
@@ -1088,3 +1089,50 @@ Supported filters:
 - Free-text search inside `oldValue` / `newValue` / `changeDiff` JSON.
 - OR-combining values inside a single param (e.g. `source=api,git-history` — pass them as separate calls or use a different endpoint when needed).
 - Pagination metadata changes — Spring Data `Pageable` + `Page<>` shape unchanged.
+
+---
+
+### SYS-037: v4 CRUD API for dependency mappings
+
+**Priority:** Medium
+**Test layer:** integration-test
+**Status:** ❌ Not implemented
+
+**Motivation:**
+`dependency_mapping.properties` in the Git DSL defined alias→component mappings consumed by downstream tools via `GET /rest/api/2/dependency-mapping`. These mappings live in the `dependency_mappings` table (`DependencyMappingEntity`: `alias` PK, `componentName`), populated during `/admin/migrate-history`. Currently there is no v4 management API — edits require direct DB access or re-running the history backfill. UI for editing these mappings is not planned (they change rarely); the API alone is sufficient to remove the Git-DSL dependency for this data.
+
+**Description:**
+Add four endpoints under `/rest/api/4/dependency-mappings`:
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/rest/api/4/dependency-mappings` | Return all mappings as a list of `{alias, componentName}`. No pagination needed (expected < 1000 entries). |
+| `POST` | `/rest/api/4/dependency-mappings` | Create a new mapping. Body: `{alias, componentName}`. Returns 201 with the created resource. 409 if `alias` already exists. |
+| `PUT` | `/rest/api/4/dependency-mappings/{alias}` | Replace `componentName` for an existing alias. Returns 200. 404 if alias not found. |
+| `DELETE` | `/rest/api/4/dependency-mappings/{alias}` | Delete a mapping. Returns 204. 404 if alias not found. |
+
+Auth: `@PreAuthorize("@permissionEvaluator.canImport()")` (same gate as other admin data-management endpoints — `IMPORT_DATA` permission, `ROLE_REGISTRY_ADMIN` in the default role map).
+
+The existing v2 read endpoint (`GET /rest/api/2/dependency-mapping`) remains unchanged — it reads from the same `dependency_mappings` table.
+
+**Preconditions:**
+- Caller has `ROLE_REGISTRY_ADMIN` (or a role that grants `IMPORT_DATA`).
+- `dependency_mappings` table exists (V1 schema).
+
+**Acceptance criteria:**
+1. `GET /rest/api/4/dependency-mappings` (authenticated) returns HTTP 200 and an array of `{alias, componentName}` objects. An empty table returns `[]`.
+2. `POST /rest/api/4/dependency-mappings` with `{"alias": "foo", "componentName": "bar"}` returns 201 and `GET` lists the new entry.
+3. `POST` with a duplicate `alias` returns 409 Conflict.
+4. `PUT /rest/api/4/dependency-mappings/foo` with `{"componentName": "baz"}` returns 200 and updates the mapping.
+5. `PUT` for a non-existent alias returns 404.
+6. `DELETE /rest/api/4/dependency-mappings/foo` returns 204 and subsequent `GET` no longer lists the entry.
+7. `DELETE` for a non-existent alias returns 404.
+8. All write endpoints require auth; `GET` without a valid JWT returns 401 (consistent with other v4 non-info endpoints).
+9. The existing `GET /rest/api/2/dependency-mapping` response is unaffected by v4 CRUD operations (reads same table).
+
+**Test method:** —
+
+**Out of scope:**
+- Bulk import/replace-all (single-entry operations are sufficient; bulk is handled by `/admin/migrate-history`).
+- Portal UI — not planned; the v2 read endpoint and direct API calls cover the use cases.
+- Pagination — the mapping set is small enough for a flat list response.

--- a/docs/db-migration/todo.md
+++ b/docs/db-migration/todo.md
@@ -29,7 +29,7 @@
 
 ## Backlog
 
-- [ ] **SYS-037** v4 CRUD API for dependency mappings (`GET/POST/PUT/DELETE /rest/api/4/dependency-mappings`). Removes the last Git-DSL data dependency that has no management endpoint. No UI planned — API only. See [requirements-common.md §SYS-037](requirements-common.md).
+- [ ] **SYS-037** v4 CRUD API for dependency mappings (`GET/POST/PUT/DELETE /rest/api/4/dependency-mappings`). Removes the last Git-DSL data dependency that has no management endpoint. No UI planned — API only. See [requirements-common.md §SYS-037](requirements-common.md#sys-037-v4-crud-api-for-dependency-mappings).
 
 ## Tech Debt
 _(будет пополняться по мере реализации)_

--- a/docs/db-migration/todo.md
+++ b/docs/db-migration/todo.md
@@ -27,6 +27,10 @@
 - [ ] `/dev-start` — skill для запуска docker-compose + bootRun с dev-db профилем
 - [ ] `/ui-dev` — skill для запуска npm run dev в components-registry-ui/
 
+## Backlog
+
+- [ ] **SYS-037** v4 CRUD API for dependency mappings (`GET/POST/PUT/DELETE /rest/api/4/dependency-mappings`). Removes the last Git-DSL data dependency that has no management endpoint. No UI planned — API only. See [requirements-common.md §SYS-037](requirements-common.md).
+
 ## Tech Debt
 _(будет пополняться по мере реализации)_
 


### PR DESCRIPTION
## Summary

- Adds **SYS-037** to `requirements-common.md`: v4 CRUD API for `dependency_mappings` table (`GET/POST/PUT/DELETE /rest/api/4/dependency-mappings`).
- Adds backlog entry to `todo.md`.

**Background:** `dependency_mapping.properties` data is in the DB (`DependencyMappingEntity`) but has no v4 management endpoint — only a legacy read-only `GET /rest/api/2/dependency-mapping`. This requirement specifies the write side so the Git-DSL dependency can be fully removed. No Portal UI planned.

## Test plan

- [ ] Read `requirements-common.md SYS-037` — verify endpoint specs, auth gate, and acceptance criteria match `DependencyMappingEntity` (`alias` PK, `componentName` column)
- [ ] Read `todo.md` — verify backlog entry links to the requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)