### PR TITLE
feat(api/4): SYS-039 component-detail fields for §7.0 Wave 2

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
@@ -11,4 +11,12 @@ data class ComponentCreateRequest(
     val parentComponentName: String? = null,
     val archived: Boolean = false,
     val metadata: Map<String, Any?> = emptyMap(),
+    // SYS-039: §7.0 Wave 2 PR-G fields. Optional on create with null /
+    // empty defaults so legacy callers don't have to set them.
+    val groupId: String? = null,
+    val releaseManager: String? = null,
+    val securityChampion: String? = null,
+    val copyright: String? = null,
+    val releasesInDefaultBranch: Boolean? = null,
+    val labels: Set<String> = emptySet(),
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
@@ -18,6 +18,15 @@ data class ComponentDetailResponse(
     val version: Long,
     val createdAt: Instant?,
     val updatedAt: Instant?,
+    // SYS-039: §7.0 Wave 2 PR-G fields. All optional with null / empty
+    // defaults so legacy clients constructed before SYS-039 still
+    // deserialize cleanly when CRS responses include the new fields.
+    val groupId: String? = null,
+    val releaseManager: String? = null,
+    val securityChampion: String? = null,
+    val copyright: String? = null,
+    val releasesInDefaultBranch: Boolean? = null,
+    val labels: Set<String> = emptySet(),
     val buildConfigurations: List<BuildConfigurationResponse> = emptyList(),
     val vcsSettings: List<VcsSettingsResponse> = emptyList(),
     val distributions: List<DistributionResponse> = emptyList(),

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -12,6 +12,14 @@ data class ComponentUpdateRequest(
     val parentComponentName: String? = null,
     val archived: Boolean? = null,
     val metadata: Map<String, Any?>? = null,
+    // SYS-039: §7.0 Wave 2 PR-G fields. Null means "don't touch" per the
+    // existing JSON Merge Patch semantics for scalar fields.
+    val groupId: String? = null,
+    val releaseManager: String? = null,
+    val securityChampion: String? = null,
+    val copyright: String? = null,
+    val releasesInDefaultBranch: Boolean? = null,
+    val labels: Set<String>? = null,
     val buildConfiguration: BuildConfigurationUpdateRequest? = null,
     val vcsSettings: VcsSettingsUpdateRequest? = null,
     val distribution: DistributionUpdateRequest? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
@@ -39,6 +39,21 @@ class ComponentEntity(
     var clientCode: String? = null,
     var archived: Boolean = false,
     var solution: Boolean? = null,
+    // SYS-039: §7.0 Wave 2 PR-G fields. All nullable / empty-default so
+    // existing rows survive the V6 migration without rewrite. Portal-side
+    // visibility/required is field-config controlled per ADR-011.
+    @Column(name = "group_id")
+    var groupId: String? = null,
+    @Column(name = "release_manager")
+    var releaseManager: String? = null,
+    @Column(name = "security_champion")
+    var securityChampion: String? = null,
+    @Column(columnDefinition = "TEXT")
+    var copyright: String? = null,
+    @Column(name = "releases_in_default_branch")
+    var releasesInDefaultBranch: Boolean? = null,
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    var labels: Array<String> = emptyArray(),
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_component_id")
     var parentComponent: ComponentEntity? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -44,6 +44,15 @@ fun ComponentEntity.toDetailResponse(): ComponentDetailResponse =
         version = this.version,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
+        // SYS-039: §7.0 Wave 2 PR-G fields, surfaced verbatim. labels is
+        // converted from Array<String> to Set<String> matching the
+        // existing `system` projection convention.
+        groupId = this.groupId,
+        releaseManager = this.releaseManager,
+        securityChampion = this.securityChampion,
+        copyright = this.copyright,
+        releasesInDefaultBranch = this.releasesInDefaultBranch,
+        labels = this.labels.toSet(),
         buildConfigurations = this.buildConfigurations.map { it.toResponse() },
         vcsSettings = this.vcsSettings.map { it.toResponse() },
         distributions = this.distributions.map { it.toResponse() },

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -71,6 +71,13 @@ class ComponentManagementServiceImpl(
                 parentComponent = parentComponent,
                 archived = request.archived,
                 metadata = request.metadata.toMutableMap(),
+                // SYS-039
+                groupId = request.groupId,
+                releaseManager = request.releaseManager,
+                securityChampion = request.securityChampion,
+                copyright = request.copyright,
+                releasesInDefaultBranch = request.releasesInDefaultBranch,
+                labels = request.labels.toTypedArray(),
             )
 
         val saved = componentRepository.save(entity)
@@ -148,6 +155,13 @@ class ComponentManagementServiceImpl(
                 "parentComponentName" to entity.parentComponent?.name,
                 "archived" to entity.archived,
                 "metadata" to entity.metadata.toMap(),
+                // SYS-039
+                "groupId" to entity.groupId,
+                "releaseManager" to entity.releaseManager,
+                "securityChampion" to entity.securityChampion,
+                "copyright" to entity.copyright,
+                "releasesInDefaultBranch" to entity.releasesInDefaultBranch,
+                "labels" to entity.labels.toList(),
             )
 
         if (isRename) {
@@ -161,6 +175,13 @@ class ComponentManagementServiceImpl(
         request.solution?.let { entity.solution = it }
         request.archived?.let { entity.archived = it }
         request.metadata?.let { entity.metadata = it.toMutableMap() }
+        // SYS-039
+        request.groupId?.let { entity.groupId = it }
+        request.releaseManager?.let { entity.releaseManager = it }
+        request.securityChampion?.let { entity.securityChampion = it }
+        request.copyright?.let { entity.copyright = it }
+        request.releasesInDefaultBranch?.let { entity.releasesInDefaultBranch = it }
+        request.labels?.let { entity.labels = it.toTypedArray() }
 
         request.parentComponentName?.let { parentName ->
             entity.parentComponent = componentRepository.findByName(parentName)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -301,6 +301,16 @@ class ComponentManagementServiceImpl(
                 "parentComponentName" to saved.parentComponent?.name,
                 "archived" to saved.archived,
                 "metadata" to saved.metadata.toMap(),
+                // SYS-039 — must mirror the oldValue map above; without these
+                // keys the audit changeDiff would report a spurious deletion
+                // (oldValue has the field, newValue doesn't) on every update
+                // that touches a SYS-039 field.
+                "groupId" to saved.groupId,
+                "releaseManager" to saved.releaseManager,
+                "securityChampion" to saved.securityChampion,
+                "copyright" to saved.copyright,
+                "releasesInDefaultBranch" to saved.releasesInDefaultBranch,
+                "labels" to saved.labels.toList(),
             )
 
         applicationEventPublisher.publishEvent(

--- a/components-registry-service-server/src/main/resources/db/migration/V6__component_detail_fields_sys_039.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V6__component_detail_fields_sys_039.sql
@@ -1,0 +1,25 @@
+-- SYS-039: extend `components` with the six fields the §7.0 Wave 2 portal
+-- editor needs in the General tab. All additive; existing rows get NULL /
+-- empty-array defaults so the migration is metadata-only on Postgres 11+
+-- (no table rewrite).
+--
+--   group_id                    Identity column — Maven groupId, used by
+--                               releng tooling. Nullable.
+--   release_manager             Ownership — single username, follows the
+--                               same VARCHAR(255) pattern as component_owner.
+--   security_champion           Ownership — single username, R* when the
+--                               component is externally distributed.
+--   copyright                   Metadata — longer free-form text (license /
+--                               attribution snippet). TEXT, not VARCHAR.
+--   releases_in_default_branch  Identity — boolean toggle, nullable so we
+--                               can distinguish "unset" from "explicitly off".
+--   labels                      Metadata — `text[]` matching the existing
+--                               `system` column pattern, default empty array.
+
+ALTER TABLE components
+    ADD COLUMN group_id VARCHAR(255),
+    ADD COLUMN release_manager VARCHAR(255),
+    ADD COLUMN security_champion VARCHAR(255),
+    ADD COLUMN copyright TEXT,
+    ADD COLUMN releases_in_default_branch BOOLEAN,
+    ADD COLUMN labels text[] NOT NULL DEFAULT '{}';

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
@@ -48,7 +48,7 @@ class ComponentDetailMapperTest {
                 it.groupId = "org.octopusden.alpha"
                 it.releaseManager = "rm-user"
                 it.securityChampion = "sc-user"
-                it.copyright = "(c) 2026 OpenWay"
+                it.copyright = "(c) 2026 Acme Inc."
                 it.releasesInDefaultBranch = true
                 it.labels = arrayOf("backend", "internal")
             }
@@ -58,7 +58,7 @@ class ComponentDetailMapperTest {
         assertEquals("org.octopusden.alpha", response.groupId)
         assertEquals("rm-user", response.releaseManager)
         assertEquals("sc-user", response.securityChampion)
-        assertEquals("(c) 2026 OpenWay", response.copyright)
+        assertEquals("(c) 2026 Acme Inc.", response.copyright)
         assertEquals(true, response.releasesInDefaultBranch)
         assertEquals(setOf("backend", "internal"), response.labels)
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
@@ -1,0 +1,91 @@
+package org.octopusden.octopus.components.registry.server.mapper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import java.util.UUID
+
+/**
+ * SYS-039 — `ComponentEntity.toDetailResponse()` surfaces six new fields
+ * required by the §7.0 Wave 2 portal General-tab editor:
+ *   `groupId`, `releaseManager`, `securityChampion`, `copyright`,
+ *   `releasesInDefaultBranch`, `labels`.
+ *
+ * The mapper just projects entity values verbatim (with one shape change
+ * — `labels: Array<String>` becomes `Set<String>` on the wire). These
+ * tests pin the round-trip from entity to DTO so a future refactor can't
+ * silently drop a field; the V4 controller test in
+ * BaseComponentsRegistryServiceTest covers the integrated read path.
+ */
+class ComponentDetailMapperTest {
+    private fun baseComponent() =
+        ComponentEntity(
+            id = UUID.randomUUID(),
+            name = "alpha",
+        )
+
+    @Test
+    @DisplayName("default entity → all six SYS-039 fields are absent / empty")
+    fun defaults_allAbsent() {
+        val response = baseComponent().toDetailResponse()
+
+        assertNull(response.groupId)
+        assertNull(response.releaseManager)
+        assertNull(response.securityChampion)
+        assertNull(response.copyright)
+        assertNull(response.releasesInDefaultBranch)
+        assertTrue(response.labels.isEmpty())
+    }
+
+    @Test
+    @DisplayName("populated entity → all six SYS-039 fields propagate")
+    fun populated_allPropagate() {
+        val component =
+            baseComponent().also {
+                it.groupId = "org.octopusden.alpha"
+                it.releaseManager = "rm-user"
+                it.securityChampion = "sc-user"
+                it.copyright = "(c) 2026 OpenWay"
+                it.releasesInDefaultBranch = true
+                it.labels = arrayOf("backend", "internal")
+            }
+
+        val response = component.toDetailResponse()
+
+        assertEquals("org.octopusden.alpha", response.groupId)
+        assertEquals("rm-user", response.releaseManager)
+        assertEquals("sc-user", response.securityChampion)
+        assertEquals("(c) 2026 OpenWay", response.copyright)
+        assertEquals(true, response.releasesInDefaultBranch)
+        assertEquals(setOf("backend", "internal"), response.labels)
+    }
+
+    @Test
+    @DisplayName("labels Array → Set conversion deduplicates while preserving membership")
+    fun labels_arrayToSet_dedupes() {
+        val component =
+            baseComponent().also {
+                it.labels = arrayOf("a", "b", "a", "c")
+            }
+
+        val response = component.toDetailResponse()
+
+        assertEquals(setOf("a", "b", "c"), response.labels)
+    }
+
+    @Test
+    @DisplayName("releasesInDefaultBranch=false stays distinct from null")
+    fun releasesInDefaultBranch_explicitFalse() {
+        val component =
+            baseComponent().also {
+                it.releasesInDefaultBranch = false
+            }
+
+        val response = component.toDetailResponse()
+
+        assertEquals(false, response.releasesInDefaultBranch)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the six fields the §7.0 Wave 2 portal General-tab editor needs and that the current v4 `ComponentDetail` doesn't yet expose:

| Field | Section | Type |
|---|---|---|
| `groupId` | Identity | `String?` |
| `releaseManager` | Ownership | `String?` |
| `securityChampion` | Ownership | `String?` |
| `copyright` | Metadata | `String?` (TEXT) |
| `releasesInDefaultBranch` | Identity | `Boolean?` |
| `labels` | Metadata | `Set<String>` (`text[]`) |

All additive — V4 only. V1/V2/V3 controllers / mappers / Feign client untouched. Sequel to #162.

## Changes

- **V6 Flyway migration:** `ALTER TABLE components ADD COLUMN` for the six. `text[] NOT NULL DEFAULT '{}'` for labels mirrors the existing `system` column pattern; the four scalar additions are nullable. Postgres 11+ treats the constant defaults as metadata-only — no table rewrite.
- **Entity:** six new fields with standard `@Column` / `@JdbcTypeCode(SqlTypes.ARRAY)` (labels) annotations.
- **DTOs:** `ComponentDetailResponse`, `ComponentUpdateRequest`, `ComponentCreateRequest` extended with the six. Update path uses the existing scalar JSON Merge Patch convention — `null` means "don't touch".
- **Mapper:** `V4Mappers.toDetailResponse()` projects all six (labels Array→Set).
- **Service:** `ComponentManagementServiceImpl.createComponent` populates the six on the new entity; `updateComponent` extends the existing `request.X?.let { entity.X = it }` chain. Audit `oldValue` snapshot captures pre-update values.

## Test plan

- [x] `:components-registry-service-server:test` — full suite green incl. existing `DbBackedComponentsRegistryServiceControllerTest` (V2/V3 contract unchanged).
- [x] `:components-registry-service-server:detekt` — green.
- [x] `:components-registry-service-server:ktlintCheck` — green.
- [x] New `ComponentDetailMapperTest` (pure JUnit 5, 4 cases): default-absent, populated propagate, labels Array→Set dedup, explicit-false distinct from null.
- [ ] CI on this branch.

## Notes / backlog

- `newValue` audit map in `updateComponent` should also capture the six new fields if it doesn't already — verify against the existing map shape after merge if needed.
- DB-level uniqueness constraint on `labels` is not enforced; mapper Set conversion masks dupes in the response. Decide on add-time dedup (Portal-side) vs DB CHECK constraint as a follow-up.
- Persistence-level test (write entity → flush → read back) for SYS-039 fields would cover the entity-↔SQL round-trip; mapper test covers entity-↔DTO. Backlog if integration coverage is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)