### PR TITLE
feat(api/4): server-side FieldConfig enforcement on component update (Risk-1 mitigation)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -180,47 +180,57 @@ class ComponentManagementServiceImpl(
         // clients. `archived`, `metadata`, `parentComponentName`, and
         // `name` (rename) are NOT FC-controlled and stay un-gated; they
         // have their own permission gates (@PreAuthorize at the
-        // controller). `productType` lives on the Component entity but
-        // the Portal renders/saves it from EscrowTab, so it's gated
-        // under the "escrow.productType" path here to match.
-        if (!fieldConfigService.isHidden("component.displayName")) {
-            request.displayName?.let { entity.displayName = it }
+        // controller). All field-config paths follow the section-prefixed
+        // ADR-011 convention — `productType` is `component.productType`
+        // even though the Portal renders the editor from EscrowTab; FC
+        // path is keyed by the entity owner, not the UX placement.
+        //
+        // Null-skip: `request.X?.let { ... }` already short-circuits when
+        // the request field is absent, but isHidden() runs first under
+        // the original layout and would still hit FieldConfigService once
+        // per scalar even on a no-op patch. Reorder so null check comes
+        // first — the JPA query lands at most once per actually-present
+        // field, which on a typical Portal save is 1–3 keys.
+        request.displayName?.let {
+            if (!fieldConfigService.isHidden("component.displayName")) entity.displayName = it
         }
-        if (!fieldConfigService.isHidden("component.componentOwner")) {
-            request.componentOwner?.let { entity.componentOwner = it }
+        request.componentOwner?.let {
+            if (!fieldConfigService.isHidden("component.componentOwner")) entity.componentOwner = it
         }
-        if (!fieldConfigService.isHidden("escrow.productType")) {
-            request.productType?.let { entity.productType = it }
+        request.productType?.let {
+            if (!fieldConfigService.isHidden("component.productType")) entity.productType = it
         }
-        if (!fieldConfigService.isHidden("component.system")) {
-            request.system?.let { entity.system = it.toTypedArray() }
+        request.system?.let {
+            if (!fieldConfigService.isHidden("component.system")) entity.system = it.toTypedArray()
         }
-        if (!fieldConfigService.isHidden("component.clientCode")) {
-            request.clientCode?.let { entity.clientCode = it }
+        request.clientCode?.let {
+            if (!fieldConfigService.isHidden("component.clientCode")) entity.clientCode = it
         }
-        if (!fieldConfigService.isHidden("component.solution")) {
-            request.solution?.let { entity.solution = it }
+        request.solution?.let {
+            if (!fieldConfigService.isHidden("component.solution")) entity.solution = it
         }
         request.archived?.let { entity.archived = it }
         request.metadata?.let { entity.metadata = it.toMutableMap() }
-        // SYS-039 — same gating
-        if (!fieldConfigService.isHidden("component.groupId")) {
-            request.groupId?.let { entity.groupId = it }
+        // SYS-039 — same gating, same null-skip ordering
+        request.groupId?.let {
+            if (!fieldConfigService.isHidden("component.groupId")) entity.groupId = it
         }
-        if (!fieldConfigService.isHidden("component.releaseManager")) {
-            request.releaseManager?.let { entity.releaseManager = it }
+        request.releaseManager?.let {
+            if (!fieldConfigService.isHidden("component.releaseManager")) entity.releaseManager = it
         }
-        if (!fieldConfigService.isHidden("component.securityChampion")) {
-            request.securityChampion?.let { entity.securityChampion = it }
+        request.securityChampion?.let {
+            if (!fieldConfigService.isHidden("component.securityChampion")) entity.securityChampion = it
         }
-        if (!fieldConfigService.isHidden("component.copyright")) {
-            request.copyright?.let { entity.copyright = it }
+        request.copyright?.let {
+            if (!fieldConfigService.isHidden("component.copyright")) entity.copyright = it
         }
-        if (!fieldConfigService.isHidden("component.releasesInDefaultBranch")) {
-            request.releasesInDefaultBranch?.let { entity.releasesInDefaultBranch = it }
+        request.releasesInDefaultBranch?.let {
+            if (!fieldConfigService.isHidden("component.releasesInDefaultBranch")) {
+                entity.releasesInDefaultBranch = it
+            }
         }
-        if (!fieldConfigService.isHidden("component.labels")) {
-            request.labels?.let { entity.labels = it.toTypedArray() }
+        request.labels?.let {
+            if (!fieldConfigService.isHidden("component.labels")) entity.labels = it.toTypedArray()
         }
 
         request.parentComponentName?.let { parentName ->

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -46,6 +46,12 @@ class ComponentManagementServiceImpl(
     private val sourceRegistry: ComponentSourceRegistry,
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val currentUserResolver: CurrentUserResolver,
+    // Risk-1 mitigation: see FieldConfigService class doc. Used by
+    // updateComponent to silently strip writes to hidden fields,
+    // matching the Portal-side filter so a buggy client can't bypass
+    // it. Create path is admin-driven (component import) and reads
+    // the full payload — not gated.
+    private val fieldConfigService: FieldConfigService,
 ) : ComponentManagementService {
     @Suppress("CyclomaticComplexMethod")
     override fun createComponent(request: ComponentCreateRequest): ComponentDetailResponse {
@@ -167,21 +173,55 @@ class ComponentManagementServiceImpl(
         if (isRename) {
             entity.name = normalizedName!!
         }
-        request.displayName?.let { entity.displayName = it }
-        request.componentOwner?.let { entity.componentOwner = it }
-        request.productType?.let { entity.productType = it }
-        request.system?.let { entity.system = it.toTypedArray() }
-        request.clientCode?.let { entity.clientCode = it }
-        request.solution?.let { entity.solution = it }
+        // Risk-1 mitigation: each component-section scalar is gated on
+        // FieldConfig visibility. A request that arrives with a value
+        // for a field whose admin-configured visibility is "hidden" gets
+        // silently stripped — defence-in-depth against buggy / outdated
+        // clients. `archived`, `metadata`, `parentComponentName`, and
+        // `name` (rename) are NOT FC-controlled and stay un-gated; they
+        // have their own permission gates (@PreAuthorize at the
+        // controller). `productType` lives on the Component entity but
+        // the Portal renders/saves it from EscrowTab, so it's gated
+        // under the "escrow.productType" path here to match.
+        if (!fieldConfigService.isHidden("component.displayName")) {
+            request.displayName?.let { entity.displayName = it }
+        }
+        if (!fieldConfigService.isHidden("component.componentOwner")) {
+            request.componentOwner?.let { entity.componentOwner = it }
+        }
+        if (!fieldConfigService.isHidden("escrow.productType")) {
+            request.productType?.let { entity.productType = it }
+        }
+        if (!fieldConfigService.isHidden("component.system")) {
+            request.system?.let { entity.system = it.toTypedArray() }
+        }
+        if (!fieldConfigService.isHidden("component.clientCode")) {
+            request.clientCode?.let { entity.clientCode = it }
+        }
+        if (!fieldConfigService.isHidden("component.solution")) {
+            request.solution?.let { entity.solution = it }
+        }
         request.archived?.let { entity.archived = it }
         request.metadata?.let { entity.metadata = it.toMutableMap() }
-        // SYS-039
-        request.groupId?.let { entity.groupId = it }
-        request.releaseManager?.let { entity.releaseManager = it }
-        request.securityChampion?.let { entity.securityChampion = it }
-        request.copyright?.let { entity.copyright = it }
-        request.releasesInDefaultBranch?.let { entity.releasesInDefaultBranch = it }
-        request.labels?.let { entity.labels = it.toTypedArray() }
+        // SYS-039 — same gating
+        if (!fieldConfigService.isHidden("component.groupId")) {
+            request.groupId?.let { entity.groupId = it }
+        }
+        if (!fieldConfigService.isHidden("component.releaseManager")) {
+            request.releaseManager?.let { entity.releaseManager = it }
+        }
+        if (!fieldConfigService.isHidden("component.securityChampion")) {
+            request.securityChampion?.let { entity.securityChampion = it }
+        }
+        if (!fieldConfigService.isHidden("component.copyright")) {
+            request.copyright?.let { entity.copyright = it }
+        }
+        if (!fieldConfigService.isHidden("component.releasesInDefaultBranch")) {
+            request.releasesInDefaultBranch?.let { entity.releasesInDefaultBranch = it }
+        }
+        if (!fieldConfigService.isHidden("component.labels")) {
+            request.labels?.let { entity.labels = it.toTypedArray() }
+        }
 
         request.parentComponentName?.let { parentName ->
             entity.parentComponent = componentRepository.findByName(parentName)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
@@ -1,0 +1,64 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Risk-1 mitigation (master plan §7.0 Top risks #1) — server-side
+ * enforcement of FieldConfig visibility. Pre-Risk-1, the Portal was
+ * the only line of defence: if a buggy / outdated client sent a value
+ * for a field whose admin-configured visibility is `"hidden"`, the
+ * server would happily persist it.
+ *
+ * This service reads `registry_config[field-config].value` (a JSONB
+ * blob written by `ConfigControllerV4.updateFieldConfig`) and exposes
+ * a single visibility lookup. Callers — currently
+ * `ComponentManagementServiceImpl.update` — gate scalar field writes on
+ * `isHidden(...)` to silently strip values for hidden fields rather
+ * than rejecting the request. The strip-vs-reject choice keeps the
+ * server defensive without breaking existing clients that send
+ * complete payloads.
+ *
+ * Path convention is section-prefixed per ADR-011:
+ *   "component.displayName" / "build.javaVersion" / "jira.projectKey".
+ *
+ * Graceful fallbacks:
+ *   - field-config row absent (fresh install)         → "editable"
+ *   - JSONB shape mismatch                            → "editable"
+ *   - section absent / field absent / visibility null → "editable"
+ *
+ * The "editable" default preserves pre-Risk-1 behaviour for any
+ * un-configured field, so this service can land without a config-data
+ * migration.
+ */
+@Service
+@Transactional(readOnly = true)
+class FieldConfigService(
+    private val registryConfigRepository: RegistryConfigRepository,
+) {
+    fun visibilityFor(fieldPath: String): String {
+        val parts = fieldPath.split('.', limit = 2)
+        if (parts.size != 2) return EDITABLE
+
+        val config = registryConfigRepository.findById(FIELD_CONFIG_KEY).orElse(null) ?: return EDITABLE
+
+        @Suppress("UNCHECKED_CAST")
+        val sectionMap =
+            (config.value as? Map<String, Any?>)?.get(parts[0]) as? Map<String, Any?>
+                ?: return EDITABLE
+
+        @Suppress("UNCHECKED_CAST")
+        val entry = sectionMap[parts[1]] as? Map<String, Any?> ?: return EDITABLE
+
+        return (entry["visibility"] as? String)?.takeIf { it.isNotBlank() } ?: EDITABLE
+    }
+
+    fun isHidden(fieldPath: String): Boolean = visibilityFor(fieldPath) == HIDDEN
+
+    companion object {
+        private const val FIELD_CONFIG_KEY = "field-config"
+        private const val EDITABLE = "editable"
+        private const val HIDDEN = "hidden"
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional
  * This service reads `registry_config[field-config].value` (a JSONB
  * blob written by `ConfigControllerV4.updateFieldConfig`) and exposes
  * a single visibility lookup. Callers — currently
- * `ComponentManagementServiceImpl.update` — gate scalar field writes on
+ * `ComponentManagementServiceImpl.updateComponent` — gate scalar field writes on
  * `isHidden(...)` to silently strip values for hidden fields rather
  * than rejecting the request. The strip-vs-reject choice keeps the
  * server defensive without breaking existing clients that send
@@ -51,7 +51,15 @@ class FieldConfigService(
         @Suppress("UNCHECKED_CAST")
         val entry = sectionMap[parts[1]] as? Map<String, Any?> ?: return EDITABLE
 
-        return (entry["visibility"] as? String)?.takeIf { it.isNotBlank() } ?: EDITABLE
+        // Normalize: trim + lowercase before returning so a typo like
+        // `"Hidden"` or `"hidden "` in admin-edited JSON still matches the
+        // canonical "hidden"/"readonly"/"editable" tokens that callers
+        // (and tests) compare against.
+        return (entry["visibility"] as? String)
+            ?.trim()
+            ?.lowercase()
+            ?.takeIf { it.isNotBlank() }
+            ?: EDITABLE
     }
 
     fun isHidden(fieldPath: String): Boolean = visibilityFor(fieldPath) == HIDDEN

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigServiceTest.kt
@@ -121,6 +121,20 @@ class FieldConfigServiceTest {
     }
 
     @Test
+    @DisplayName("visibility with surrounding whitespace and mixed case → trimmed + lowercased")
+    fun whitespaceAndCase_normalized() {
+        val svc =
+            service(
+                mapOf(
+                    "component" to mapOf("displayName" to mapOf("visibility" to "  Hidden  ")),
+                ),
+            )
+
+        assertTrue(svc.isHidden("component.displayName"))
+        assertEquals("hidden", svc.visibilityFor("component.displayName"))
+    }
+
+    @Test
     @DisplayName("blank visibility string → editable fallback")
     fun blankVisibility_editable() {
         val svc =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigServiceTest.kt
@@ -1,0 +1,135 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.octopusden.octopus.components.registry.server.entity.RegistryConfigEntity
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
+import java.util.Optional
+import org.mockito.Mockito.`when` as whenMock
+
+/**
+ * Risk-1 mitigation — `FieldConfigService` resolves visibility for a
+ * section-prefixed path against `registry_config[field-config].value`,
+ * with several "missing" branches that all fall back to "editable" so
+ * the service can land without a config-data migration.
+ */
+class FieldConfigServiceTest {
+    private fun service(stored: Map<String, Any?>?): FieldConfigService {
+        val repo = mock(RegistryConfigRepository::class.java)
+        val optional =
+            stored?.let { Optional.of(RegistryConfigEntity(key = "field-config", value = it)) }
+                ?: Optional.empty()
+        whenMock(repo.findById("field-config")).thenReturn(optional)
+        return FieldConfigService(repo)
+    }
+
+    @Test
+    @DisplayName("field-config row absent → all paths resolve to editable")
+    fun rowAbsent_allEditable() {
+        val svc = service(stored = null)
+
+        assertEquals("editable", svc.visibilityFor("component.displayName"))
+        assertFalse(svc.isHidden("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("section-prefixed path with hidden visibility → isHidden=true")
+    fun sectioned_hidden() {
+        val svc =
+            service(
+                mapOf(
+                    "component" to
+                        mapOf(
+                            "displayName" to mapOf("visibility" to "hidden"),
+                        ),
+                ),
+            )
+
+        assertTrue(svc.isHidden("component.displayName"))
+        assertEquals("hidden", svc.visibilityFor("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("readonly field → visibility returned but isHidden=false (server only enforces hidden)")
+    fun readonly_notHidden() {
+        val svc =
+            service(
+                mapOf(
+                    "component" to
+                        mapOf(
+                            "displayName" to mapOf("visibility" to "readonly"),
+                        ),
+                ),
+            )
+
+        assertEquals("readonly", svc.visibilityFor("component.displayName"))
+        assertFalse(svc.isHidden("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("section absent → editable fallback")
+    fun sectionAbsent_editable() {
+        val svc = service(mapOf("build" to emptyMap<String, Any?>()))
+
+        assertEquals("editable", svc.visibilityFor("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("field absent within section → editable fallback")
+    fun fieldAbsent_editable() {
+        val svc =
+            service(
+                mapOf(
+                    "component" to mapOf("componentOwner" to mapOf("visibility" to "hidden")),
+                ),
+            )
+
+        assertEquals("editable", svc.visibilityFor("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("malformed entry (visibility not a string) → editable fallback")
+    fun malformed_editable() {
+        val svc =
+            service(
+                mapOf(
+                    "component" to mapOf("displayName" to mapOf("visibility" to 42)),
+                ),
+            )
+
+        assertEquals("editable", svc.visibilityFor("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("path without dot → editable fallback (silently — not an exception)")
+    fun bareFieldPath_editable() {
+        val svc =
+            service(
+                mapOf(
+                    "component" to mapOf("displayName" to mapOf("visibility" to "hidden")),
+                ),
+            )
+
+        // Bare paths are not the section-prefixed convention; the service
+        // intentionally does NOT scan sections to find them. Callers must
+        // pass the full "section.field" form.
+        assertEquals("editable", svc.visibilityFor("displayName"))
+    }
+
+    @Test
+    @DisplayName("blank visibility string → editable fallback")
+    fun blankVisibility_editable() {
+        val svc =
+            service(
+                mapOf(
+                    "component" to mapOf("displayName" to mapOf("visibility" to "")),
+                ),
+            )
+
+        assertEquals("editable", svc.visibilityFor("component.displayName"))
+    }
+}


### PR DESCRIPTION
## Summary

Closes the HIGH-severity Risk #1 from the §7.0 master plan: pre-this PR, the Portal was the only line of defence for hidden-field overwrites. A buggy or outdated client that sent a value for a field configured as `visibility=hidden` would silently overwrite the stored value, because `ComponentManagementServiceImpl.updateComponent` applied every present scalar in the request without consulting the FieldConfig.

## Strategy — silent strip

- Each component-section scalar in the update path now goes through `if (!fieldConfigService.isHidden("component.<field>"))`.
- A request whose hidden field carries a value is accepted (no 4xx) but the value is dropped before mutation. This matches what the Portal's editor already does client-side, so behaviour is unchanged for compliant clients but resilient to drift.
- Apply scope is **update only**. Create paths run from admin-driven component import and need full payloads.
- `archived`, `metadata`, `parentComponentName`, `name` (rename) and the FieldOverride routes stay un-gated — they have their own permission gates at the controller layer.

## Files

- New `service/impl/FieldConfigService.kt` — reads `registry_config[field-config].value` JSONB and resolves a section-prefixed path (per ADR-011) to a visibility string. Five fall-back branches all default to `"editable"`, preserving pre-Risk-1 behaviour for any unconfigured field — service lands without a config-data migration.
- `service/impl/ComponentManagementServiceImpl.kt` — inject `FieldConfigService`; gate the 12 component-section scalar writes (6 pre-SYS-039 + 6 SYS-039) on `isHidden`. `productType` writes go through `escrow.productType` to match the Portal Escrow-tab path.
- New `test/service/impl/FieldConfigServiceTest.kt` — pure JUnit 5 + Mockito, 8 cases: row absent, hidden, readonly, missing section, missing field, malformed entry, bare path, blank visibility.

## Test plan

- [x] `:components-registry-service-server:test` — full suite green incl. existing controller / DbBacked tests (V2/V3 contract unchanged; un-configured FieldConfig means all-editable fallback so legacy paths see no behaviour change).
- [x] `:components-registry-service-server:detekt` + `:ktlintCheck` — green.
- [ ] CI on this branch.

## Notes / backlog

- Readonly enforcement is intentionally not implemented here — server only strips `hidden`. Readonly is a UI-only concern (Portal renders disabled but server accepts). If a future contract decides readonly should be server-enforced (compare-with-stored-value semantic), it's a follow-up.
- Admin-override (an admin should be able to write hidden fields) is not modelled. Could be added by checking caller role inside `isHidden` or by a separate `forceWrite` flag on the request.
- A persistence-level integration test (config row → update → assert hidden field unchanged) would close the loop with end-to-end coverage; the unit suite covers the service contract today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)