### PR TITLE
feat(api/4): summary.labels + buildSystem filter (Wave 2 unblocker)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -67,6 +67,7 @@ class ComponentControllerV4(
         @RequestParam(required = false) archived: Boolean?,
         @RequestParam(required = false) search: String?,
         @RequestParam(required = false) owner: String?,
+        @RequestParam(required = false) buildSystem: String?,
         pageable: Pageable,
     ): Page<ComponentSummaryResponse> {
         val filter =
@@ -76,6 +77,7 @@ class ComponentControllerV4(
                 archived = archived,
                 search = search,
                 owner = owner,
+                buildSystem = buildSystem,
             )
         return componentManagementService.listComponents(filter, pageable)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentFilter.kt
@@ -6,4 +6,5 @@ data class ComponentFilter(
     val archived: Boolean? = null,
     val search: String? = null,
     val owner: String? = null,
+    val buildSystem: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentSummaryResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentSummaryResponse.kt
@@ -12,6 +12,9 @@ data class ComponentSummaryResponse(
     val productType: String?,
     val archived: Boolean,
     val updatedAt: Instant?,
+    // SYS-039: mirror of ComponentDetailResponse.labels — non-null default empty
+    // list so Portal can always iterate without null-check.
+    val labels: List<String> = emptyList(),
     // SYS-040: list-view extras. Derived from nested entities (first row only —
     // list view shows one badge / one link per component, not the full set).
     // null in three cases: (1) the parent nested entity is absent, (2) the

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -71,6 +71,7 @@ fun ComponentEntity.toSummaryResponse(): ComponentSummaryResponse =
         productType = this.productType,
         archived = this.archived,
         updatedAt = this.updatedAt,
+        labels = this.labels.toList(),
         // SYS-040: list-view extras. firstOrNull mirrors V4Mappers convention
         // for nested-collection access; in practice the same row is
         // returned across queries (heap order on H2; physical-storage order

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -515,6 +515,20 @@ class ComponentManagementServiceImpl(
                 )
         }
 
+        filter.buildSystem?.let { bs ->
+            // INNER JOIN on buildConfigurations: components without any build config
+            // row are excluded (the join produces no match). Components that have at
+            // least one row with the matching buildSystem value are included.
+            spec =
+                spec.and(
+                    Specification { root, query, cb ->
+                        val join = root.join<ComponentEntity, BuildConfigurationEntity>("buildConfigurations")
+                        query?.distinct(true)
+                        cb.equal(join.get<String>("buildSystem"), bs)
+                    },
+                )
+        }
+
         // filter.system is not yet supported against the text[] column. JPA Criteria
         // can't portably express "array contains" across H2 PG-compat and PostgreSQL,
         // and we don't have a native query for it yet. The earlier implementation

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsBuildSystemFilterTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsBuildSystemFilterTest.kt
@@ -1,0 +1,165 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+class ListComponentsBuildSystemFilterTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(ListComponentsBuildSystemFilterTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun uniqueName(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    private fun createComponentWithBuildSystem(
+        name: String,
+        buildSystem: String,
+    ) {
+        val id = createComponent(name)
+        val version = getComponentVersion(id)
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"version":$version,"buildConfiguration":{"buildSystem":"$buildSystem"}}""",
+                    ),
+            ).andExpect(status().isOk)
+    }
+
+    private fun createComponentWithoutBuildSystem(name: String) {
+        createComponent(name)
+    }
+
+    private fun createComponent(name: String): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"name":"$name","displayName":"$name"}"""),
+                ).andExpect(status().isCreated)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun getComponentVersion(id: String): Long {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["version"].asLong()
+    }
+
+    @Test
+    @DisplayName("listComponents with ?buildSystem=GRADLE returns only components with that buildSystem")
+    fun listComponents_byBuildSystem_returnsMatching() {
+        val gradleComp = uniqueName("bs_gradle")
+        val mavenComp = uniqueName("bs_maven")
+        val noBuildComp = uniqueName("bs_none")
+
+        createComponentWithBuildSystem(gradleComp, "GRADLE")
+        createComponentWithBuildSystem(mavenComp, "MAVEN")
+        createComponentWithoutBuildSystem(noBuildComp)
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/components")
+                        .with(viewerJwt())
+                        .param("buildSystem", "GRADLE")
+                        .param("size", "200"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val names = json["content"].map { it["name"].asText() }.toSet()
+        assert(names.contains(gradleComp)) { "expected $gradleComp in $names" }
+        assert(!names.contains(mavenComp)) { "did not expect $mavenComp in $names" }
+        assert(!names.contains(noBuildComp)) { "did not expect $noBuildComp in $names (no build config)" }
+    }
+
+    @Test
+    @DisplayName("component without buildConfigurations is excluded when buildSystem filter is set")
+    fun listComponents_noBuildConfig_excludedWhenFilterSet() {
+        val noBuildComp = uniqueName("bs_edge_none")
+        createComponentWithoutBuildSystem(noBuildComp)
+
+        mvc
+            .perform(
+                get("/rest/api/4/components")
+                    .with(viewerJwt())
+                    .param("buildSystem", "GRADLE"),
+            ).andExpect(status().isOk)
+            .andExpect(
+                jsonPath("$.content[?(@.name == '$noBuildComp')]").doesNotExist(),
+            )
+    }
+
+    @Test
+    @DisplayName("listComponents without buildSystem filter returns 200 (filter is optional)")
+    fun listComponents_withoutBuildSystem_ok() {
+        mvc.perform(get("/rest/api/4/components").with(viewerJwt())).andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("listComponents with ?buildSystem=<unknown> returns empty page")
+    fun listComponents_byUnknownBuildSystem_returnsEmpty() {
+        val unknownBs = uniqueName("UNKNOWN_BS")
+
+        mvc
+            .perform(
+                get("/rest/api/4/components")
+                    .with(viewerJwt())
+                    .param("buildSystem", unknownBs),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(0))
+            .andExpect(jsonPath("$.totalElements").value(0))
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.components.registry.server.mapper
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.octopusden.octopus.components.registry.server.entity.BuildConfigurationEntity
@@ -31,13 +32,25 @@ class ComponentSummaryMapperTest {
         )
 
     @Test
-    @DisplayName("empty nested collections → all three SYS-040 fields null")
+    @DisplayName("empty nested collections → all three SYS-040 fields null, labels empty")
     fun emptyNested_allNull() {
         val response = baseComponent().toSummaryResponse()
 
         assertNull(response.buildSystem)
         assertNull(response.jiraProjectKey)
         assertNull(response.vcsPath)
+        assertTrue(response.labels.isEmpty())
+    }
+
+    @Test
+    @DisplayName("labels are mapped from entity array to List<String>")
+    fun labels_mappedFromEntityArray() {
+        val component = baseComponent()
+        component.labels = arrayOf("backend", "core")
+
+        val response = component.toSummaryResponse()
+
+        assertEquals(listOf("backend", "core"), response.labels)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Bundled CRS PR unblocking two Portal §7.0 Wave 2 list-side features in one round-trip:

1. **`labels: List<String>` in `ComponentSummaryResponse`** — mirrors the existing `ComponentDetailResponse.labels` (SYS-039, #163) into the list-view DTO so the Portal can render labels chips on the components list. Default `emptyList()`, non-null.
2. **`?buildSystem=` filter param in `ComponentControllerV4.listComponents`** — extends the existing `system / productType / archived / search` filter set with `buildSystem`, propagated through the server-side `ComponentFilter` into a JPA `Specification` with INNER JOIN on the nested `buildConfigurations`. Components without `buildConfigurations` are excluded when the filter is set; otherwise unaffected.

## Why bundled

Both unblock the same Portal PR (Wave 2 list updates: labels chips column + Build System filter dropdown). Single CRS round-trip, single Portal bump.

## Implementation notes

- `ComponentEntity.labels` is `Array<String>` with `emptyArray()` default — `this.labels.toList()` is null-safe by construction.
- Specification uses INNER JOIN (default for `root.join(...)` without `JoinType` arg), which naturally excludes buildless components when filter is active. `query?.distinct(true)` prevents duplicates from multi-row cartesian when a component has multiple matching buildConfigurations.
- No JSON test fixtures exist in this module — controller tests use programmatic MockMvc setup, matching the `ListComponentsOwnerFilterTest` pattern.
- No version bump in `gradle.properties` — CRS uses `octopus-release-management` plugin reading git tags, no manual build-number field.

## Test plan

- [x] `compileKotlin + compileTestKotlin BUILD SUCCESSFUL`
- [x] `ComponentSummaryMapperTest` (6 tests) — positive label population + empty-labels case
- [x] `ListComponentsBuildSystemFilterTest` (4 tests) — positive match, edge-case (no buildConfig excluded), absent filter, unknown value returns empty page
- [x] All `*ListComponents*` filter tests pass (no regression on existing `system / productType / search / owner` filters)

## Plan reference

Portal-side execution plan: `~/.claude/plans/linked-wiggling-valiant.md` § Sprint 2 · S2.0. Closes Portal-side blocker for both labels chips column and Build System filter UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)