### PR TITLE
feat(api/4): teamcityProjectId column + DTO surface (Portal TC quick-link prep)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
@@ -21,6 +21,7 @@ data class ComponentDetailResponse(
     // SYS-039: §7.0 Wave 2 PR-G fields. All optional with null / empty
     // defaults so legacy clients constructed before SYS-039 still
     // deserialize cleanly when CRS responses include the new fields.
+    val teamcityProjectId: String? = null,
     val groupId: String? = null,
     val releaseManager: String? = null,
     val securityChampion: String? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentSummaryResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentSummaryResponse.kt
@@ -24,4 +24,5 @@ data class ComponentSummaryResponse(
     val buildSystem: String? = null,
     val jiraProjectKey: String? = null,
     val vcsPath: String? = null,
+    val teamcityProjectId: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -8,6 +8,7 @@ data class ComponentUpdateRequest(
     val productType: String? = null,
     val system: Set<String>? = null,
     val clientCode: String? = null,
+    val teamcityProjectId: String? = null,
     val solution: Boolean? = null,
     val parentComponentName: String? = null,
     val archived: Boolean? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
@@ -37,6 +37,8 @@ class ComponentEntity(
     var system: Array<String> = emptyArray(),
     @Column(name = "client_code")
     var clientCode: String? = null,
+    @Column(name = "teamcity_project_id", length = 255)
+    var teamcityProjectId: String? = null,
     var archived: Boolean = false,
     var solution: Boolean? = null,
     // SYS-039: §7.0 Wave 2 PR-G fields. All nullable / empty-default so

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -44,6 +44,7 @@ fun ComponentEntity.toDetailResponse(): ComponentDetailResponse =
         version = this.version,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
+        teamcityProjectId = this.teamcityProjectId,
         // SYS-039: §7.0 Wave 2 PR-G fields, surfaced verbatim. labels is
         // converted from Array<String> to Set<String> matching the
         // existing `system` projection convention.
@@ -100,6 +101,7 @@ fun ComponentEntity.toSummaryResponse(): ComponentSummaryResponse =
                 ?.firstOrNull()
                 ?.vcsPath
                 ?.takeIf { it.isNotBlank() },
+        teamcityProjectId = this.teamcityProjectId,
     )
 
 fun BuildConfigurationEntity.toResponse(): BuildConfigurationResponse =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -163,6 +163,7 @@ class ComponentManagementServiceImpl(
                 "productType" to entity.productType,
                 "system" to entity.system.toList(),
                 "clientCode" to entity.clientCode,
+                "teamcityProjectId" to entity.teamcityProjectId,
                 "solution" to entity.solution,
                 "parentComponentName" to entity.parentComponent?.name,
                 "archived" to entity.archived,
@@ -211,6 +212,9 @@ class ComponentManagementServiceImpl(
         }
         request.clientCode?.let {
             if (!fieldConfigService.isHidden("component.clientCode")) entity.clientCode = it
+        }
+        request.teamcityProjectId?.let {
+            if (!fieldConfigService.isHidden("component.teamcityProjectId")) entity.teamcityProjectId = it
         }
         request.solution?.let {
             if (!fieldConfigService.isHidden("component.solution")) entity.solution = it
@@ -357,6 +361,7 @@ class ComponentManagementServiceImpl(
                 "productType" to saved.productType,
                 "system" to saved.system.toList(),
                 "clientCode" to saved.clientCode,
+                "teamcityProjectId" to saved.teamcityProjectId,
                 "solution" to saved.solution,
                 "parentComponentName" to saved.parentComponent?.name,
                 "archived" to saved.archived,

--- a/components-registry-service-server/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__initial_schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE components (
     product_type VARCHAR(50),
     system text[] NOT NULL DEFAULT '{}',
     client_code VARCHAR(255),
+    teamcity_project_id VARCHAR(255),
     archived BOOLEAN NOT NULL DEFAULT false,
     solution BOOLEAN,
     parent_component_id UUID REFERENCES components(id),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
@@ -28,6 +28,19 @@ class ComponentDetailMapperTest {
         )
 
     @Test
+    @DisplayName("default entity → teamcityProjectId is null")
+    fun default_teamcityProjectId_isNull() {
+        assertNull(baseComponent().toDetailResponse().teamcityProjectId)
+    }
+
+    @Test
+    @DisplayName("populated teamcityProjectId propagates to detail response")
+    fun teamcityProjectId_propagates() {
+        val component = baseComponent().also { it.teamcityProjectId = "MyProject_Alpha" }
+        assertEquals("MyProject_Alpha", component.toDetailResponse().teamcityProjectId)
+    }
+
+    @Test
     @DisplayName("default entity → all six SYS-039 fields are absent / empty")
     fun defaults_allAbsent() {
         val response = baseComponent().toDetailResponse()

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
@@ -32,6 +32,19 @@ class ComponentSummaryMapperTest {
         )
 
     @Test
+    @DisplayName("default entity → teamcityProjectId is null")
+    fun default_teamcityProjectId_isNull() {
+        assertNull(baseComponent().toSummaryResponse().teamcityProjectId)
+    }
+
+    @Test
+    @DisplayName("populated teamcityProjectId propagates to summary response")
+    fun teamcityProjectId_propagates() {
+        val component = baseComponent().also { it.teamcityProjectId = "MyProject_Alpha" }
+        assertEquals("MyProject_Alpha", component.toSummaryResponse().teamcityProjectId)
+    }
+
+    @Test
     @DisplayName("empty nested collections → all three SYS-040 fields null, labels empty")
     fun emptyNested_allNull() {
         val response = baseComponent().toSummaryResponse()

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/TeamcityProjectIdPersistenceRoundtripTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/TeamcityProjectIdPersistenceRoundtripTest.kt
@@ -1,0 +1,143 @@
+package org.octopusden.octopus.components.registry.server.migration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+class TeamcityProjectIdPersistenceRoundtripTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths
+                .get(TeamcityProjectIdPersistenceRoundtripTest::class.java.getResource("/expected-data")!!.toURI())
+                .parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun firstComponent(): JsonNode {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components").with(editorJwt()).param("page", "0").param("size", "1"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val root = objectMapper.readTree(body)
+        val content = root.path("content")
+        assertTrue(content.isArray && content.size() > 0)
+        return content[0]
+    }
+
+    private fun getComponent(id: String): JsonNode {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(editorJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)
+    }
+
+    @Test
+    @DisplayName("teamcityProjectId round-trips via PATCH + GET")
+    fun teamcityProjectId_roundtrip() {
+        val summary = firstComponent()
+        val id = summary["id"].asText()
+        val version = getComponent(id)["version"].asLong()
+
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(editorJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsBytes(
+                            mapOf("version" to version, "teamcityProjectId" to "ProjectAlpha"),
+                        ),
+                    ),
+            ).andExpect(status().is2xxSuccessful)
+
+        assertEquals("ProjectAlpha", getComponent(id)["teamcityProjectId"].asText())
+    }
+
+    @Test
+    @DisplayName("teamcityProjectId: null in PATCH body does not clear an existing value (absent-vs-null limitation)")
+    fun teamcityProjectId_nullDoesNotClear() {
+        // The PATCH handler uses `?.let { }` semantics: a JSON null in the
+        // request body is treated the same as the field being absent — the
+        // existing persisted value is left unchanged. This is a documented
+        // limitation noted in PR #168; explicit-null-as-clear is out of scope
+        // for this PR. The test pins the current behaviour so any future
+        // change to the semantics is visible as a test failure.
+        val summary = firstComponent()
+        val id = summary["id"].asText()
+        var detail = getComponent(id)
+        var version = detail["version"].asLong()
+
+        // Establish a known value.
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(editorJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsBytes(
+                            mapOf("version" to version, "teamcityProjectId" to "ProjectBeta"),
+                        ),
+                    ),
+            ).andExpect(status().is2xxSuccessful)
+        detail = getComponent(id)
+        assertEquals("ProjectBeta", detail["teamcityProjectId"].asText(), "baseline value established")
+        version = detail["version"].asLong()
+
+        // PATCH with explicit null — must leave the stored value intact.
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(editorJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsBytes(
+                            mapOf("version" to version, "teamcityProjectId" to null),
+                        ),
+                    ),
+            ).andExpect(status().is2xxSuccessful)
+
+        assertEquals("ProjectBeta", getComponent(id)["teamcityProjectId"].asText(), "null patch must not clear")
+    }
+}


### PR DESCRIPTION
## Summary

Storage-only PR for restoring the Portal's TeamCity quick-link icon. Adds a nullable `teamcity_project_id varchar(255)` column on `components`, exposed via `ComponentSummaryResponse` / `ComponentDetailResponse` / `ComponentUpdateRequest`, propagated through `V4Mappers` and the audit log.

This is **PR-1 of 3**:

- **PR-1 (this):** schema + DTO surface. No data sync; column stays NULL until populated.
- **PR-2 (CRS, follow-up):** TC API client + scheduled weekly resync + admin-only `/admin/teamcity-project-ids/resync` endpoint.
- **PR-3 (Portal):** consume the field, render TC link as `${tcBaseUrl}/project/<projectId>`, admin "Resync" button + per-component manual override in the editor.

## What changed

- `V1__initial_schema.sql` — `teamcity_project_id VARCHAR(255)` inside `CREATE TABLE components` (nullable, no default). V6 untouched.
- `ComponentEntity.teamcityProjectId: String?` with `@Column(name = "teamcity_project_id", length = 255)`.
- `ComponentSummaryResponse / ComponentDetailResponse / ComponentUpdateRequest`: new optional field, default `null`.
- `V4Mappers.toSummaryResponse / toDetailResponse`: propagation in both directions.
- `ComponentManagementServiceImpl`: update-request applies through the existing FieldConfig hidden-gate; audit log emission includes the field in both `oldValue` and `newValue` maps (mirrors SYS-039).
- Mapper tests: null-default + non-null propagation, both DTOs.

## Convention note

Per the v3 dev-policy (DB recreates each deploy), the column folds into V1 directly rather than landing as a V7 ALTER. V6 (SYS-039 fields) is left as-is — folding it into V1 is out of scope.

## Test plan

- [x] `./gradlew :components-registry-service-server:compileKotlin :components-registry-service-server:compileTestKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :components-registry-service-server:test --tests '*ComponentSummaryMapperTest' --tests '*ComponentDetailMapperTest'` — passing
- [ ] Manual: deploy CRS, hit `GET /rest/api/4/components/{id}` — `teamcityProjectId: null` in response. PATCH with `{ "teamcityProjectId": "Cards3DSecure" }` — value persists, audit log records the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)