### PR TITLE
feat(api/4): TeamCity project URL + sync engine + admin resync

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ApplicationConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ApplicationConfig.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.components.registry.server.config
 
 import org.octopusden.octopus.components.registry.core.dto.ServiceMode
 import org.octopusden.octopus.components.registry.server.model.ServiceStatus
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -9,7 +10,7 @@ import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 
 @Configuration
-@EnableConfigurationProperties(ComponentsRegistryProperties::class)
+@EnableConfigurationProperties(ComponentsRegistryProperties::class, TeamcityProperties::class)
 class ApplicationConfig(
     val componentsRegistryProperties: ComponentsRegistryProperties,
 ) {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -13,6 +13,8 @@ import org.octopusden.octopus.components.registry.server.service.MigrationLifecy
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -32,6 +34,7 @@ class AdminControllerV4(
     private val importService: ImportService,
     private val migrationJobService: MigrationJobService,
     private val historyMigrationJobService: HistoryMigrationJobService,
+    private val teamcitySyncService: TeamcitySyncService,
 ) {
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
@@ -146,6 +149,25 @@ class AdminControllerV4(
                     ),
                 )
         }
+
+    /**
+     * On-demand TeamCity project ID/URL resync. Reuses the IMPORT_DATA permission
+     * (locked design decision — see PR plan §A5 rationale: a separate
+     * SYNC_TC_PROJECTS permission would require new constants across CRS,
+     * cloud-commons, the automation repo's role yaml, the portal `auth.ts`,
+     * and every admin UI consumer; for "admin bulk operation" the existing
+     * IMPORT_DATA semantic is the right scope).
+     *
+     * Synchronous: a single batched TC call returns all projects carrying the
+     * COMPONENT_NAME parameter, then we group client-side by parameter value.
+     * For the foreseeable scale this is well under typical gateway timeouts.
+     * If response time grows, port to the async-job pattern (see /migrate).
+     *
+     * Returns the per-pass counts so the Portal can render a toast with the
+     * effect of the run.
+     */
+    @PostMapping("/teamcity-project-ids/resync")
+    fun resyncTeamcityProjectIds(): ResponseEntity<TeamcitySyncResult> = ResponseEntity.ok(teamcitySyncService.resync())
 
     /**
      * Map cross-kind gate conflicts to a structured 409. Same-kind 409 is

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
@@ -22,6 +22,7 @@ data class ComponentDetailResponse(
     // defaults so legacy clients constructed before SYS-039 still
     // deserialize cleanly when CRS responses include the new fields.
     val teamcityProjectId: String? = null,
+    val teamcityProjectUrl: String? = null,
     val groupId: String? = null,
     val releaseManager: String? = null,
     val securityChampion: String? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentSummaryResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentSummaryResponse.kt
@@ -25,4 +25,5 @@ data class ComponentSummaryResponse(
     val jiraProjectKey: String? = null,
     val vcsPath: String? = null,
     val teamcityProjectId: String? = null,
+    val teamcityProjectUrl: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -9,6 +9,7 @@ data class ComponentUpdateRequest(
     val system: Set<String>? = null,
     val clientCode: String? = null,
     val teamcityProjectId: String? = null,
+    val teamcityProjectUrl: String? = null,
     val solution: Boolean? = null,
     val parentComponentName: String? = null,
     val archived: Boolean? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
@@ -39,6 +39,8 @@ class ComponentEntity(
     var clientCode: String? = null,
     @Column(name = "teamcity_project_id", length = 255)
     var teamcityProjectId: String? = null,
+    @Column(name = "teamcity_project_url", length = 2048)
+    var teamcityProjectUrl: String? = null,
     var archived: Boolean = false,
     var solution: Boolean? = null,
     // SYS-039: §7.0 Wave 2 PR-G fields. All nullable / empty-default so

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -45,6 +45,7 @@ fun ComponentEntity.toDetailResponse(): ComponentDetailResponse =
         createdAt = this.createdAt,
         updatedAt = this.updatedAt,
         teamcityProjectId = this.teamcityProjectId,
+        teamcityProjectUrl = this.teamcityProjectUrl,
         // SYS-039: §7.0 Wave 2 PR-G fields, surfaced verbatim. labels is
         // converted from Array<String> to Set<String> matching the
         // existing `system` projection convention.
@@ -102,6 +103,7 @@ fun ComponentEntity.toSummaryResponse(): ComponentSummaryResponse =
                 ?.vcsPath
                 ?.takeIf { it.isNotBlank() },
         teamcityProjectId = this.teamcityProjectId,
+        teamcityProjectUrl = this.teamcityProjectUrl,
     )
 
 fun BuildConfigurationEntity.toResponse(): BuildConfigurationResponse =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -164,6 +164,7 @@ class ComponentManagementServiceImpl(
                 "system" to entity.system.toList(),
                 "clientCode" to entity.clientCode,
                 "teamcityProjectId" to entity.teamcityProjectId,
+                "teamcityProjectUrl" to entity.teamcityProjectUrl,
                 "solution" to entity.solution,
                 "parentComponentName" to entity.parentComponent?.name,
                 "archived" to entity.archived,
@@ -215,6 +216,9 @@ class ComponentManagementServiceImpl(
         }
         request.teamcityProjectId?.let {
             if (!fieldConfigService.isHidden("component.teamcityProjectId")) entity.teamcityProjectId = it
+        }
+        request.teamcityProjectUrl?.let {
+            if (!fieldConfigService.isHidden("component.teamcityProjectUrl")) entity.teamcityProjectUrl = it
         }
         request.solution?.let {
             if (!fieldConfigService.isHidden("component.solution")) entity.solution = it
@@ -362,6 +366,7 @@ class ComponentManagementServiceImpl(
                 "system" to saved.system.toList(),
                 "clientCode" to saved.clientCode,
                 "teamcityProjectId" to saved.teamcityProjectId,
+                "teamcityProjectUrl" to saved.teamcityProjectUrl,
                 "solution" to saved.solution,
                 "parentComponentName" to saved.parentComponent?.name,
                 "archived" to saved.archived,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -217,8 +217,11 @@ class ComponentManagementServiceImpl(
         request.teamcityProjectId?.let {
             if (!fieldConfigService.isHidden("component.teamcityProjectId")) entity.teamcityProjectId = it
         }
-        request.teamcityProjectUrl?.let {
-            if (!fieldConfigService.isHidden("component.teamcityProjectUrl")) entity.teamcityProjectUrl = it
+        request.teamcityProjectUrl?.let { url ->
+            require(url.isBlank() || url.startsWith("http://") || url.startsWith("https://")) {
+                "teamcityProjectUrl must be an http/https URL or blank"
+            }
+            if (!fieldConfigService.isHidden("component.teamcityProjectUrl")) entity.teamcityProjectUrl = url
         }
         request.solution?.let {
             if (!fieldConfigService.isHidden("component.solution")) entity.solution = it

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -10,6 +10,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
+import java.time.Duration
 import java.util.UUID
 
 /**
@@ -60,8 +61,15 @@ class TeamcityClient(
      * Pre-built RestTemplate. Basic-auth headers are injected per request
      * (not via builder.basicAuthentication) so we can probe the disabled-state
      * (blank base URL) without any auth header configuration churn.
+     *
+     * Connect/read timeouts are bounded — a stalled TC host must not block
+     * the synchronous resync (or its caller's HTTP request) indefinitely.
      */
-    private val restTemplate: RestTemplate = restTemplateBuilder.build()
+    private val restTemplate: RestTemplate =
+        restTemplateBuilder
+            .setConnectTimeout(Duration.ofSeconds(properties.connectTimeoutSeconds))
+            .setReadTimeout(Duration.ofSeconds(properties.readTimeoutSeconds))
+            .build()
 
     /**
      * Returns a UUID → TC project map for components whose TC project carries

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -19,7 +19,7 @@ import java.util.UUID
  * The TC REST projects search returns an arbitrary tree (project →
  * subprojects → buildTypes → ...). For sync we only need the leaf identity
  * (id, display name, webUrl) plus the parameter map so we can extract
- * `COMPONENT_NAME` to key by component UUID.
+ * `COMPONENT_NAME` to key by component name string.
  *
  * `parameters` is a flat name-to-value map; multi-value TC properties are
  * collapsed to the last seen value (the locator search returns one project

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -73,20 +73,27 @@ class TeamcityClient(
 
     /**
      * Returns a UUID → TC project map for components whose TC project carries
-     * `parameter:(name:COMPONENT_NAME,value:<uuid>)`. Single batched call:
+     * `parameter:(name:COMPONENT_NAME,value:<name>)`. Single batched call:
      * `parameter:(name:COMPONENT_NAME)` returns ALL such projects, then we
-     * group client-side.
+     * group client-side by name string.
+     *
+     * [componentsByName] maps component name (string, as stored in TC
+     * COMPONENT_NAME parameter) → component UUID.
      *
      * Behaviour contract:
      * - Empty input → empty result, no HTTP call.
      * - `teamcity.base-url` blank → empty result, no HTTP call.
-     * - TC returns multiple projects for the same UUID → all included in the
+     * - TC returns multiple projects for the same name → all included in the
      *   raw return; the SyncService is responsible for "skipped_ambiguous".
      * - TC API failure → exception propagates; SyncService catches and counts
      *   as `errors`.
+     *
+     * NOTE: components-automation BaseComponentsTask stores the v2 CRS component
+     * name (not a UUID) as the COMPONENT_NAME parameter value. Matching is done
+     * by name string via [componentsByName].
      */
-    fun findProjectsByComponentParameter(componentIds: Collection<UUID>): Map<UUID, List<TeamcityProject>> {
-        if (componentIds.isEmpty()) return emptyMap()
+    fun findProjectsByComponentParameter(componentsByName: Map<String, UUID>): Map<UUID, List<TeamcityProject>> {
+        if (componentsByName.isEmpty()) return emptyMap()
         val baseUrl = properties.baseUrl.trimEnd('/')
         if (baseUrl.isBlank()) {
             log.debug { "TC sync disabled (teamcity.base-url is blank); returning empty result" }
@@ -120,18 +127,12 @@ class TeamcityClient(
         val projects = response.body?.project ?: emptyList()
         log.info { "TC sync: received ${projects.size} projects with COMPONENT_NAME parameter" }
 
-        val targetIds = componentIds.toSet()
-        // Non-UUID COMPONENT_NAME values exist in legacy TC projects (string
-        // component names from the pre-DB era). They cannot match a v3
-        // component, so we drop them quietly here rather than failing the
-        // whole sync. Same for projects whose COMPONENT_NAME is blank or
-        // whose UUID isn't in the requested set.
         return projects
             .mapNotNull { it.toDomain() }
             .mapNotNull { project ->
                 val raw = project.parameters[COMPONENT_NAME_PARAM]?.trim().orEmpty()
-                val uuid = runCatching { UUID.fromString(raw) }.getOrNull()
-                if (uuid != null && uuid in targetIds) uuid to project else null
+                val uuid = componentsByName[raw]
+                if (uuid != null) uuid to project else null
             }.groupBy({ it.first }, { it.second })
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -1,0 +1,180 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import mu.KotlinLogging
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+import java.util.UUID
+
+/**
+ * Domain projection of a TeamCity project, post-flattening.
+ *
+ * The TC REST projects search returns an arbitrary tree (project →
+ * subprojects → buildTypes → ...). For sync we only need the leaf identity
+ * (id, display name, webUrl) plus the parameter map so we can extract
+ * `COMPONENT_NAME` to key by component UUID.
+ *
+ * `parameters` is a flat name-to-value map; multi-value TC properties are
+ * collapsed to the last seen value (the locator search returns one project
+ * per match anyway, so collisions are rare).
+ */
+data class TeamcityProject(
+    val id: String,
+    val name: String,
+    val webUrl: String,
+    val parameters: Map<String, String>,
+)
+
+/**
+ * Thin TC REST client used by the sync engine. Single responsibility: issue
+ * one batched lookup of all projects carrying the `COMPONENT_NAME` parameter
+ * and group them client-side by parameter value.
+ *
+ * Why fresh instead of reusing the components-automation Gradle plugin:
+ * - That client lives in `buildSrc` and is wired through Apache HttpClient +
+ *   custom utilities not on the server classpath.
+ * - The plugin does much more than we need (create projects, build types,
+ *   wiki publishing); pulling it in would couple the server runtime to a
+ *   build-time-only artifact.
+ * - We only need a single GET for sync; `RestTemplate` with HTTP Basic is
+ *   the simpler dependency-free path.
+ *
+ * Disabled when `teamcity.base-url` is blank — [findProjectsByComponentParameter]
+ * returns an empty map so the sync service can run end-to-end on
+ * unconfigured envs (returning `scanned=0, updated=0, ...`) without HTTP.
+ */
+@Component
+class TeamcityClient(
+    private val properties: TeamcityProperties,
+    restTemplateBuilder: RestTemplateBuilder,
+) {
+    private val log = KotlinLogging.logger {}
+
+    /**
+     * Pre-built RestTemplate. Basic-auth headers are injected per request
+     * (not via builder.basicAuthentication) so we can probe the disabled-state
+     * (blank base URL) without any auth header configuration churn.
+     */
+    private val restTemplate: RestTemplate = restTemplateBuilder.build()
+
+    /**
+     * Returns a UUID → TC project map for components whose TC project carries
+     * `parameter:(name:COMPONENT_NAME,value:<uuid>)`. Single batched call:
+     * `parameter:(name:COMPONENT_NAME)` returns ALL such projects, then we
+     * group client-side.
+     *
+     * Behaviour contract:
+     * - Empty input → empty result, no HTTP call.
+     * - `teamcity.base-url` blank → empty result, no HTTP call.
+     * - TC returns multiple projects for the same UUID → all included in the
+     *   raw return; the SyncService is responsible for "skipped_ambiguous".
+     * - TC API failure → exception propagates; SyncService catches and counts
+     *   as `errors`.
+     */
+    fun findProjectsByComponentParameter(componentIds: Collection<UUID>): Map<UUID, List<TeamcityProject>> {
+        if (componentIds.isEmpty()) return emptyMap()
+        val baseUrl = properties.baseUrl.trimEnd('/')
+        if (baseUrl.isBlank()) {
+            log.debug { "TC sync disabled (teamcity.base-url is blank); returning empty result" }
+            return emptyMap()
+        }
+
+        // Locator: parameter:(name:COMPONENT_NAME) — match every project
+        // carrying the parameter regardless of value, then group client-side.
+        // matchType=equals,ignoreCase=true matches BaseComponentsTask in
+        // components-automation, ensuring we resolve the same set of projects
+        // the build pipeline created.
+        val locator = "parameter:(name:COMPONENT_NAME,matchType:equals,ignoreCase:true)"
+        // `fields=` keeps the response shape minimal — only id/name/webUrl
+        // plus the parameter map (we need COMPONENT_NAME's value).
+        val fields = "project(id,name,webUrl,parameters(property(name,value)))"
+        val url = "$baseUrl/app/rest/projects?locator=$locator&fields=$fields"
+
+        log.info { "TC sync: GET $url" }
+        val headers =
+            HttpHeaders().apply {
+                accept = listOf(MediaType.APPLICATION_JSON)
+                setBasicAuth(properties.username, properties.password)
+            }
+        val response =
+            restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                HttpEntity<Void>(headers),
+                ProjectsResponse::class.java,
+            )
+        val projects = response.body?.project ?: emptyList()
+        log.info { "TC sync: received ${projects.size} projects with COMPONENT_NAME parameter" }
+
+        val targetIds = componentIds.toSet()
+        // Non-UUID COMPONENT_NAME values exist in legacy TC projects (string
+        // component names from the pre-DB era). They cannot match a v3
+        // component, so we drop them quietly here rather than failing the
+        // whole sync. Same for projects whose COMPONENT_NAME is blank or
+        // whose UUID isn't in the requested set.
+        return projects
+            .mapNotNull { it.toDomain() }
+            .mapNotNull { project ->
+                val raw = project.parameters[COMPONENT_NAME_PARAM]?.trim().orEmpty()
+                val uuid = runCatching { UUID.fromString(raw) }.getOrNull()
+                if (uuid != null && uuid in targetIds) uuid to project else null
+            }.groupBy({ it.first }, { it.second })
+    }
+
+    companion object {
+        const val COMPONENT_NAME_PARAM: String = "COMPONENT_NAME"
+    }
+
+    // -- Wire DTOs ----------------------------------------------------------
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class ProjectsResponse(
+        val project: List<RawProject>? = null,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class RawProject(
+        val id: String? = null,
+        val name: String? = null,
+        @JsonProperty("webUrl") val webUrl: String? = null,
+        val parameters: RawParameters? = null,
+    ) {
+        fun toDomain(): TeamcityProject? {
+            val safeId = id ?: return null
+            val safeName = name ?: return null
+            val map =
+                parameters
+                    ?.property
+                    ?.associate { (it.name ?: "") to (it.value ?: "") }
+                    ?.filterKeys { it.isNotEmpty() }
+                    ?: emptyMap()
+            // webUrl can legitimately be missing/blank when TC returns a
+            // project the sync caller cannot link to. We keep the row in
+            // the domain object (so the SyncService can decide); empty string
+            // is the contract for "no webUrl".
+            return TeamcityProject(
+                id = safeId,
+                name = safeName,
+                webUrl = webUrl ?: "",
+                parameters = map,
+            )
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class RawParameters(
+        val property: List<RawProperty>? = null,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class RawProperty(
+        val name: String? = null,
+        val value: String? = null,
+    )
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -24,6 +24,17 @@ class TeamcityProperties(
     val username: String = "",
     /** TC service account password (HTTP Basic auth). */
     val password: String = "",
+    /**
+     * TCP connect timeout for the TC HTTP client, in seconds. Bounded so a
+     * stalled TC host does not hang resync indefinitely.
+     */
+    val connectTimeoutSeconds: Long = 10,
+    /**
+     * Per-request read timeout for the TC HTTP client, in seconds. Default
+     * leaves headroom for a full bulk-projects response on a busy TC server
+     * but is finite so resync cannot block forever on a slow read.
+     */
+    val readTimeoutSeconds: Long = 120,
     val sync: SyncProperties = SyncProperties(),
 ) {
     data class SyncProperties(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -1,0 +1,41 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration for the TeamCity sync engine. Bound from `teamcity.*` in
+ * application*.yml (defaults below).
+ *
+ * Defaults are intentionally inert: with `base-url` blank and `sync.enabled`
+ * false, the [TeamcityClient] does not register HTTP, the [TeamcitySyncService]
+ * skips all calls, and the [TeamcitySyncScheduler] does not fire — so dev /
+ * unconfigured envs boot cleanly without TC credentials. Production wires
+ * through `service-config` per env.
+ */
+@ConfigurationProperties(prefix = "teamcity")
+class TeamcityProperties(
+    /**
+     * Base URL of the TC server, e.g. `https://teamcity.example.com`.
+     * Trailing slashes are tolerated. Blank disables the integration —
+     * [TeamcitySyncService] short-circuits and returns an empty result.
+     */
+    val baseUrl: String = "",
+    /** TC service account username (HTTP Basic auth). */
+    val username: String = "",
+    /** TC service account password (HTTP Basic auth). */
+    val password: String = "",
+    val sync: SyncProperties = SyncProperties(),
+) {
+    data class SyncProperties(
+        /**
+         * Master switch for the weekly cron + idle behavior. False by default
+         * so dev/unconfigured envs don't fail at startup. Production sets it
+         * via `TEAMCITY_SYNC_ENABLED` per env.
+         */
+        val enabled: Boolean = false,
+        /**
+         * Spring cron expression for the weekly resync. Default: Sunday 04:00 UTC.
+         */
+        val cron: String = "0 0 4 * * SUN",
+    )
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
@@ -1,0 +1,27 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Wire shape of the resync admin endpoint response. Field names match the
+ * plan (snake_case via @JsonProperty so the Kotlin property names stay
+ * idiomatic).
+ *
+ * - `scanned`     — number of components considered (= number of non-archived
+ *                   components in the registry at the moment of the call).
+ * - `updated`     — components where either id or url actually changed.
+ * - `unchanged`   — components matched and already correct (no DB write).
+ * - `skippedNoMatch`   — components with no TC project carrying the parameter.
+ * - `skippedAmbiguous` — components matched by ≥2 TC projects (skipped by policy).
+ * - `errors`      — component-level error messages (TC API failures, etc.).
+ *                   A top-level TC API failure aborts the whole sync and is
+ *                   surfaced via HTTP error, not via this list.
+ */
+data class TeamcitySyncResult(
+    val scanned: Int,
+    val updated: Int,
+    val unchanged: Int,
+    @JsonProperty("skipped_no_match") val skippedNoMatch: Int,
+    @JsonProperty("skipped_ambiguous") val skippedAmbiguous: Int,
+    val errors: List<String>,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
@@ -2,7 +2,6 @@ package org.octopusden.octopus.components.registry.server.teamcity
 
 import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -10,25 +9,21 @@ import org.springframework.stereotype.Component
 /**
  * Weekly cron that resyncs TC project ids/urls.
  *
- * Conditional bean — registered only when `teamcity.sync.enabled=true`. With
- * the property false (the default), the bean is absent and Spring's
- * `@EnableScheduling` task scheduler ignores the cron entirely. Production
- * service-config sets `TEAMCITY_SYNC_ENABLED=true` per env that has TC
- * credentials wired through.
+ * Conditional bean — registered only when `teamcity.sync.enabled=true`
+ * (`TEAMCITY_SYNC_ENABLED=true` in env). With the property absent or false
+ * (the default), the bean is not registered and Spring's `@EnableScheduling`
+ * task scheduler ignores the cron entirely. Production service-config sets
+ * the property per env that has TC credentials wired through; CI/test envs
+ * never set it, so the scheduler never fires there.
  *
- * Cron is configurable via `teamcity.sync.cron`, defaulting to Sunday 04:00 UTC
- * — far from typical CI/release windows so a long sync can't starve normal traffic.
- *
- * The `!test` profile guard keeps the scheduler from firing during the test
- * suite. Tests trigger [TeamcitySyncService.resync] directly so the timing is
- * deterministic; an active cron would either race with test setup or
- * accidentally hit a real TC server if base-url were leaked from CI env.
+ * Cron is configurable via `teamcity.sync.cron`, defaulting to Sunday 04:00
+ * UTC — far from typical CI/release windows so a long sync can't starve
+ * normal traffic.
  *
  * Failures are logged-and-swallowed so a transient TC outage does not crash
  * the bean and prevent next week's run.
  */
 @Component
-@Profile("!test")
 @EnableScheduling
 @ConditionalOnProperty(prefix = "teamcity.sync", name = ["enabled"], havingValue = "true")
 class TeamcitySyncScheduler(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
@@ -1,0 +1,54 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Weekly cron that resyncs TC project ids/urls.
+ *
+ * Conditional bean — registered only when `teamcity.sync.enabled=true`. With
+ * the property false (the default), the bean is absent and Spring's
+ * `@EnableScheduling` task scheduler ignores the cron entirely. Production
+ * service-config sets `TEAMCITY_SYNC_ENABLED=true` per env that has TC
+ * credentials wired through.
+ *
+ * Cron is configurable via `teamcity.sync.cron`, defaulting to Sunday 04:00 UTC
+ * — far from typical CI/release windows so a long sync can't starve normal traffic.
+ *
+ * The `!test` profile guard keeps the scheduler from firing during the test
+ * suite. Tests trigger [TeamcitySyncService.resync] directly so the timing is
+ * deterministic; an active cron would either race with test setup or
+ * accidentally hit a real TC server if base-url were leaked from CI env.
+ *
+ * Failures are logged-and-swallowed so a transient TC outage does not crash
+ * the bean and prevent next week's run.
+ */
+@Component
+@Profile("!test")
+@EnableScheduling
+@ConditionalOnProperty(prefix = "teamcity.sync", name = ["enabled"], havingValue = "true")
+class TeamcitySyncScheduler(
+    private val syncService: TeamcitySyncService,
+) {
+    private val log = KotlinLogging.logger {}
+
+    @Scheduled(cron = "\${teamcity.sync.cron:0 0 4 * * SUN}", zone = "UTC")
+    @Suppress("TooGenericExceptionCaught")
+    fun weeklyResync() {
+        log.info { "TC sync: weekly cron firing" }
+        try {
+            val result = syncService.resync()
+            log.info { "TC sync weekly result: $result" }
+        } catch (e: Exception) {
+            // A throw here would propagate up the @Scheduled task and the
+            // task scheduler would suppress further runs only for the same
+            // pod-lifetime in some configurations. Catching keeps the next
+            // weekly fire alive regardless of TC's transient state.
+            log.error(e) { "TC sync weekly run failed" }
+        }
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -59,9 +59,12 @@ class TeamcitySyncService(
         val scanned = components.size
         log.info { "TC sync starting: scanned=$scanned non-archived components" }
 
-        val componentIds = components.mapNotNull { it.id }
+        val componentsByName =
+            components
+                .filter { it.id != null }
+                .associate { it.name to it.id!! }
         // HTTP call to TC happens here, deliberately OUTSIDE any DB tx.
-        val matches = teamcityClient.findProjectsByComponentParameter(componentIds)
+        val matches = teamcityClient.findProjectsByComponentParameter(componentsByName)
 
         // CurrentUserResolver returns "system" when there is no auth context
         // (the scheduled cron path), or the JWT's preferred_username when an

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -1,0 +1,181 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import mu.KotlinLogging
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.event.AuditEvent
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * The TeamCity sync engine.
+ *
+ * One pass:
+ * 1. Read all non-archived components.
+ * 2. Single batched call to TC: `parameter:(name:COMPONENT_NAME)` returns
+ *    every project carrying the parameter; group client-side by parameter
+ *    value (= component UUID).
+ * 3. For each component:
+ *      - 0 matches → leave nulls, count `skippedNoMatch`.
+ *      - 1 match with non-blank webUrl → upsert id+url if changed; count
+ *        `updated` or `unchanged`.
+ *      - 1 match with blank webUrl → treat as no-match (cannot link).
+ *      - 2+ matches → skip, count `skippedAmbiguous`. Manual override is
+ *        the escape hatch.
+ *
+ * Idempotent: only writes when `id` or `url` actually changes. Audit log
+ * emitted via existing [AuditEvent] flow when fields change so admins can
+ * trace the source of writes.
+ *
+ * If the TC client throws (network / 5xx / auth), the exception propagates
+ * to the caller — for the admin endpoint that surfaces as 502/500, for the
+ * scheduled cron that's logged-and-swallowed by the scheduler.
+ */
+@Service
+class TeamcitySyncService(
+    private val componentRepository: ComponentRepository,
+    private val teamcityClient: TeamcityClient,
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val currentUserResolver: CurrentUserResolver,
+) {
+    private val log = KotlinLogging.logger {}
+
+    /**
+     * Run one resync pass.
+     *
+     * Wrapped in a single @Transactional so the bulk update is atomic:
+     * either all changes commit, or none do (e.g. on a JPA failure mid-batch).
+     * The audit-log events are published BEFORE_COMMIT so they share the same
+     * tx and won't strand without their corresponding row write.
+     */
+    @Transactional
+    @Suppress("TooGenericExceptionCaught")
+    fun resync(): TeamcitySyncResult {
+        val components = componentRepository.findByArchivedFalse()
+        val scanned = components.size
+        log.info { "TC sync starting: scanned=$scanned non-archived components" }
+
+        val componentIds = components.mapNotNull { it.id }
+        val matches = teamcityClient.findProjectsByComponentParameter(componentIds)
+
+        var updated = 0
+        var unchanged = 0
+        var skippedNoMatch = 0
+        var skippedAmbiguous = 0
+        val errors = mutableListOf<String>()
+
+        // CurrentUserResolver returns "system" when there is no auth context
+        // (the scheduled cron path), or the JWT's preferred_username when an
+        // admin invokes the resync endpoint. Either way it never returns null.
+        val changedBy = currentUserResolver.currentUsername()
+
+        for (component in components) {
+            val componentId = component.id ?: continue
+            try {
+                val candidates = matches[componentId].orEmpty()
+                when {
+                    candidates.isEmpty() -> {
+                        skippedNoMatch++
+                    }
+                    candidates.size > 1 -> {
+                        // Don't pick a winner silently. Manual override is
+                        // the documented escape hatch for genuinely-duplicated
+                        // TC setups.
+                        log.warn {
+                            "TC sync: ambiguous match for component '${component.name}' " +
+                                "(id=$componentId): ${candidates.size} TC projects share " +
+                                "COMPONENT_NAME=$componentId — skipping."
+                        }
+                        skippedAmbiguous++
+                    }
+                    else -> {
+                        val match = candidates.single()
+                        if (match.webUrl.isBlank()) {
+                            // webUrl missing/blank → cannot render the link.
+                            // Treat as no-match: leave nulls, count it.
+                            log.warn {
+                                "TC sync: component '${component.name}' (id=$componentId) " +
+                                    "matched TC project '${match.id}' but webUrl is blank; " +
+                                    "treating as no-match."
+                            }
+                            skippedNoMatch++
+                        } else {
+                            val didChange = applyMatch(component, match, changedBy)
+                            if (didChange) updated++ else unchanged++
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // Per-component error: log + count, keep processing the rest.
+                // A top-level TC client failure short-circuits earlier and
+                // propagates out.
+                val msg = "Failed to sync component '${component.name}' (id=$componentId): ${e.message}"
+                log.error(e) { msg }
+                errors.add(msg)
+            }
+        }
+
+        log.info {
+            "TC sync done: scanned=$scanned, updated=$updated, unchanged=$unchanged, " +
+                "skippedNoMatch=$skippedNoMatch, skippedAmbiguous=$skippedAmbiguous, " +
+                "errors=${errors.size}"
+        }
+        return TeamcitySyncResult(
+            scanned = scanned,
+            updated = updated,
+            unchanged = unchanged,
+            skippedNoMatch = skippedNoMatch,
+            skippedAmbiguous = skippedAmbiguous,
+            errors = errors.toList(),
+        )
+    }
+
+    /**
+     * Write the match if it differs from current state. Returns true when
+     * either column actually changed (drives the `updated` counter and the
+     * audit-log emission).
+     */
+    private fun applyMatch(
+        component: ComponentEntity,
+        match: TeamcityProject,
+        changedBy: String,
+    ): Boolean {
+        val oldId = component.teamcityProjectId
+        val oldUrl = component.teamcityProjectUrl
+        val newId = match.id
+        val newUrl = match.webUrl
+
+        if (oldId == newId && oldUrl == newUrl) {
+            return false
+        }
+
+        component.teamcityProjectId = newId
+        component.teamcityProjectUrl = newUrl
+        // Save through the component repository to ensure the @Version
+        // optimistic-locking column is bumped and any change-tracking
+        // listeners fire as they would on a regular PATCH write.
+        componentRepository.save(component)
+
+        applicationEventPublisher.publishEvent(
+            AuditEvent(
+                entityType = "Component",
+                entityId = component.id.toString(),
+                action = "UPDATE",
+                changedBy = changedBy,
+                oldValue =
+                    mapOf(
+                        "teamcityProjectId" to oldId,
+                        "teamcityProjectUrl" to oldUrl,
+                    ),
+                newValue =
+                    mapOf(
+                        "teamcityProjectId" to newId,
+                        "teamcityProjectUrl" to newUrl,
+                    ),
+            ),
+        )
+        return true
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -7,7 +7,8 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentRep
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
+import java.util.UUID
 
 /**
  * The TeamCity sync engine.
@@ -39,37 +40,52 @@ class TeamcitySyncService(
     private val teamcityClient: TeamcityClient,
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val currentUserResolver: CurrentUserResolver,
+    private val transactionTemplate: TransactionTemplate,
 ) {
     private val log = KotlinLogging.logger {}
 
     /**
      * Run one resync pass.
      *
-     * Wrapped in a single @Transactional so the bulk update is atomic:
-     * either all changes commit, or none do (e.g. on a JPA failure mid-batch).
-     * The audit-log events are published BEFORE_COMMIT so they share the same
-     * tx and won't strand without their corresponding row write.
+     * The TC HTTP call deliberately runs OUTSIDE any database transaction so
+     * a slow/stalled TC server cannot hold a JDBC connection or extend a
+     * transaction's lifetime. Per-component writes happen inside a single
+     * [TransactionTemplate.execute] block so the bulk write is still atomic
+     * (either all changes commit, or none do on JPA failure), and the audit
+     * events published BEFORE_COMMIT remain in the same tx as their row writes.
      */
-    @Transactional
-    @Suppress("TooGenericExceptionCaught")
     fun resync(): TeamcitySyncResult {
         val components = componentRepository.findByArchivedFalse()
         val scanned = components.size
         log.info { "TC sync starting: scanned=$scanned non-archived components" }
 
         val componentIds = components.mapNotNull { it.id }
+        // HTTP call to TC happens here, deliberately OUTSIDE any DB tx.
         val matches = teamcityClient.findProjectsByComponentParameter(componentIds)
-
-        var updated = 0
-        var unchanged = 0
-        var skippedNoMatch = 0
-        var skippedAmbiguous = 0
-        val errors = mutableListOf<String>()
 
         // CurrentUserResolver returns "system" when there is no auth context
         // (the scheduled cron path), or the JWT's preferred_username when an
         // admin invokes the resync endpoint. Either way it never returns null.
         val changedBy = currentUserResolver.currentUsername()
+
+        // execute() returns the callback's value; applyMatches never returns
+        // null, so the !! cannot trip in practice — Kotlin just sees the API's
+        // declared T? signature.
+        return transactionTemplate.execute { _ -> applyMatches(components, matches, changedBy) }!!
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun applyMatches(
+        components: List<ComponentEntity>,
+        matches: Map<UUID, List<TeamcityProject>>,
+        changedBy: String,
+    ): TeamcitySyncResult {
+        val scanned = components.size
+        var updated = 0
+        var unchanged = 0
+        var skippedNoMatch = 0
+        var skippedAmbiguous = 0
+        val errors = mutableListOf<String>()
 
         for (component in components) {
             val componentId = component.id ?: continue

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -62,7 +62,13 @@ class TeamcitySyncService(
         val componentsByName =
             components
                 .filter { it.id != null }
-                .associate { it.name to it.id!! }
+                .groupBy { it.name }
+                .mapValues { (name, group) ->
+                    if (group.size > 1) {
+                        log.warn { "TC sync: duplicate component name '$name' in non-archived set; only first will be synced" }
+                    }
+                    group.first().id!!
+                }
         // HTTP call to TC happens here, deliberately OUTSIDE any DB tx.
         val matches = teamcityClient.findProjectsByComponentParameter(componentsByName)
 
@@ -105,7 +111,7 @@ class TeamcitySyncService(
                         log.warn {
                             "TC sync: ambiguous match for component '${component.name}' " +
                                 "(id=$componentId): ${candidates.size} TC projects share " +
-                                "COMPONENT_NAME=$componentId — skipping."
+                                "COMPONENT_NAME=${component.name} — skipping."
                         }
                         skippedAmbiguous++
                     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -108,12 +108,16 @@ class TeamcitySyncService(
                     }
                     else -> {
                         val match = candidates.single()
-                        if (match.webUrl.isBlank()) {
-                            // webUrl missing/blank → cannot render the link.
-                            // Treat as no-match: leave nulls, count it.
+                        val isUsableUrl =
+                            match.webUrl.isNotBlank() &&
+                                (match.webUrl.startsWith("http://") || match.webUrl.startsWith("https://"))
+                        if (!isUsableUrl) {
+                            // webUrl missing, blank, or non-http → cannot render
+                            // a safe link. Treat as no-match: leave nulls, count it.
                             log.warn {
                                 "TC sync: component '${component.name}' (id=$componentId) " +
-                                    "matched TC project '${match.id}' but webUrl is blank; " +
+                                    "matched TC project '${match.id}' but webUrl " +
+                                    "'${match.webUrl}' is blank or not http/https; " +
                                     "treating as no-match."
                             }
                             skippedNoMatch++

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -3,6 +3,19 @@ pathToConfig: file://${components-registry.groovy-path}
 components-registry:
   auto-migrate: false
 
+# TeamCity sync engine. Defaults are inert: with `base-url` blank and
+# `sync.enabled` false, the client makes no HTTP calls and the weekly cron
+# bean does not register. Production values come from `service-config`
+# per env (see f1/service-config). Set TEAMCITY_SYNC_ENABLED=true and the
+# host/credentials to turn it on.
+teamcity:
+  base-url: ${TEAMCITY_BASE_URL:}
+  username: ${TEAMCITY_USERNAME:}
+  password: ${TEAMCITY_PASSWORD:}
+  sync:
+    enabled: ${TEAMCITY_SYNC_ENABLED:false}
+    cron: "0 0 4 * * SUN"
+
 # auth-server.url and auth-server.realm bind from AUTH_SERVER_URL / AUTH_SERVER_REALM
 # env vars via Spring Boot's relaxed binding. Production and dev profiles must
 # supply them; WebSecurityConfig.jwtDecoder() fails fast if either is missing.

--- a/components-registry-service-server/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__initial_schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE components (
     system text[] NOT NULL DEFAULT '{}',
     client_code VARCHAR(255),
     teamcity_project_id VARCHAR(255),
+    teamcity_project_url VARCHAR(2048),
     archived BOOLEAN NOT NULL DEFAULT false,
     solution BOOLEAN,
     parent_component_id UUID REFERENCES components(id),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -17,6 +17,7 @@ import org.octopusden.octopus.components.registry.server.service.MigrationPhase
 import org.octopusden.octopus.components.registry.server.service.StartMigrationResult
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -66,6 +67,16 @@ class AdminControllerV4SecurityTest {
     @MockBean
     @Suppress("UnusedPrivateProperty")
     private lateinit var historyMigrationJobService: HistoryMigrationJobService
+
+    /**
+     * Mocked so the new /teamcity-project-ids/resync endpoint's collaborator
+     * is satisfied without standing up the real TC client. Same rationale as
+     * the migration-job mocks above: keep this test purely about the security
+     * gates on AdminControllerV4.
+     */
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var teamcitySyncService: TeamcitySyncService
 
     @Autowired
     private lateinit var mvc: MockMvc

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
@@ -1,0 +1,125 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Pins the auth + response-shape contract of POST /rest/api/4/admin/teamcity-project-ids/resync.
+ *
+ * Both gates that protect the endpoint are exercised:
+ *   - WebSecurityConfig URL-level rule → 401 for anonymous callers.
+ *   - AdminControllerV4 class-level @PreAuthorize("@permissionEvaluator.canImport()")
+ *     → 403 for authenticated callers without IMPORT_DATA.
+ *
+ * TeamcitySyncService is @MockBean'd so the test does not pull in the
+ * TeamcityClient bean wiring (which would attempt outbound HTTP if base-url
+ * were ever set). The positive path verifies the 6-field counts shape
+ * including the snake_case `skipped_no_match` / `skipped_ambiguous` keys.
+ *
+ * Other migration job services are @MockBean'd to keep this test scoped
+ * to the resync path — same convention as AdminControllerV4SecurityTest.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "test")
+class TeamcityResyncControllerTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @MockBean
+    private lateinit var teamcitySyncService: TeamcitySyncService
+
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var migrationJobService: org.octopusden.octopus.components.registry.server.service.MigrationJobService
+
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var historyMigrationJobService: org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Test
+    @DisplayName("anonymous POST /admin/teamcity-project-ids/resync → 401, sync not invoked")
+    fun anonymous_returns401() {
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/resync"))
+            .andExpect(status().isUnauthorized)
+
+        verify(teamcitySyncService, never()).resync()
+    }
+
+    @Test
+    @DisplayName("editor JWT POST /admin/teamcity-project-ids/resync → 403, sync not invoked")
+    fun editor_returns403() {
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/resync").with(editorJwt()))
+            .andExpect(status().isForbidden)
+
+        verify(teamcitySyncService, never()).resync()
+    }
+
+    @Test
+    @DisplayName("admin JWT → 200 with full counts shape (incl. snake_case skipped_* keys)")
+    fun admin_returns200WithCounts() {
+        `when`(teamcitySyncService.resync()).thenReturn(
+            TeamcitySyncResult(
+                scanned = 12,
+                updated = 3,
+                unchanged = 7,
+                skippedNoMatch = 1,
+                skippedAmbiguous = 1,
+                errors = listOf("oops on alpha"),
+            ),
+        )
+
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/resync").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.scanned").value(12))
+            .andExpect(jsonPath("$.updated").value(3))
+            .andExpect(jsonPath("$.unchanged").value(7))
+            .andExpect(jsonPath("$.skipped_no_match").value(1))
+            .andExpect(jsonPath("$.skipped_ambiguous").value(1))
+            .andExpect(jsonPath("$.errors[0]").value("oops on alpha"))
+
+        verify(teamcitySyncService, times(1)).resync()
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun configureTestDataDir() {
+            val resourcesPath: Path =
+                Paths.get(TeamcityResyncControllerTest::class.java.getResource("/expected-data")!!.toURI()).parent
+            System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", resourcesPath.toString())
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
@@ -41,6 +41,25 @@ class ComponentDetailMapperTest {
     }
 
     @Test
+    @DisplayName("default entity → teamcityProjectUrl is null")
+    fun default_teamcityProjectUrl_isNull() {
+        assertNull(baseComponent().toDetailResponse().teamcityProjectUrl)
+    }
+
+    @Test
+    @DisplayName("populated teamcityProjectUrl propagates to detail response")
+    fun teamcityProjectUrl_propagates() {
+        val component =
+            baseComponent().also {
+                it.teamcityProjectUrl = "https://teamcity.example.com/project/MyProject_Alpha"
+            }
+        assertEquals(
+            "https://teamcity.example.com/project/MyProject_Alpha",
+            component.toDetailResponse().teamcityProjectUrl,
+        )
+    }
+
+    @Test
     @DisplayName("default entity → all six SYS-039 fields are absent / empty")
     fun defaults_allAbsent() {
         val response = baseComponent().toDetailResponse()

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
@@ -45,6 +45,25 @@ class ComponentSummaryMapperTest {
     }
 
     @Test
+    @DisplayName("default entity → teamcityProjectUrl is null")
+    fun default_teamcityProjectUrl_isNull() {
+        assertNull(baseComponent().toSummaryResponse().teamcityProjectUrl)
+    }
+
+    @Test
+    @DisplayName("populated teamcityProjectUrl propagates to summary response")
+    fun teamcityProjectUrl_propagates() {
+        val component =
+            baseComponent().also {
+                it.teamcityProjectUrl = "https://teamcity.example.com/project/MyProject_Alpha"
+            }
+        assertEquals(
+            "https://teamcity.example.com/project/MyProject_Alpha",
+            component.toSummaryResponse().teamcityProjectUrl,
+        )
+    }
+
+    @Test
     @DisplayName("empty nested collections → all three SYS-040 fields null, labels empty")
     fun emptyNested_allNull() {
         val response = baseComponent().toSummaryResponse()

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/TeamcityProjectIdPersistenceRoundtripTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/TeamcityProjectIdPersistenceRoundtripTest.kt
@@ -96,6 +96,29 @@ class TeamcityProjectIdPersistenceRoundtripTest {
     }
 
     @Test
+    @DisplayName("teamcityProjectUrl round-trips via PATCH + GET")
+    fun teamcityProjectUrl_roundtrip() {
+        val summary = firstComponent()
+        val id = summary["id"].asText()
+        val version = getComponent(id)["version"].asLong()
+        val url = "https://teamcity.example.com/project/ProjectAlpha"
+
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(editorJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsBytes(
+                            mapOf("version" to version, "teamcityProjectUrl" to url),
+                        ),
+                    ),
+            ).andExpect(status().is2xxSuccessful)
+
+        assertEquals(url, getComponent(id)["teamcityProjectUrl"].asText())
+    }
+
+    @Test
     @DisplayName("teamcityProjectId: null in PATCH body does not clear an existing value (absent-vs-null limitation)")
     fun teamcityProjectId_nullDoesNotClear() {
         // The PATCH handler uses `?.let { }` semantics: a JSON null in the

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -57,13 +57,13 @@ class TeamcitySyncServiceTest {
         val client =
             StubTeamcityClient(
                 mapOf(
-                    alice to
+                    "alpha" to
                         listOf(
                             TeamcityProject(
                                 id = "Alpha_Build",
                                 name = "Alpha Build",
                                 webUrl = "https://teamcity.example.com/project/Alpha_Build",
-                                parameters = mapOf("COMPONENT_NAME" to alice.toString()),
+                                parameters = mapOf("COMPONENT_NAME" to "alpha"),
                             ),
                         ),
                 ),
@@ -113,13 +113,13 @@ class TeamcitySyncServiceTest {
         val client =
             StubTeamcityClient(
                 mapOf(
-                    alice to
+                    "alpha" to
                         listOf(
                             TeamcityProject(
                                 id = "Alpha_Build",
                                 name = "Alpha Build",
                                 webUrl = "https://teamcity.example.com/project/Alpha_Build",
-                                parameters = mapOf("COMPONENT_NAME" to alice.toString()),
+                                parameters = mapOf("COMPONENT_NAME" to "alpha"),
                             ),
                         ),
                 ),
@@ -144,7 +144,7 @@ class TeamcitySyncServiceTest {
         val client =
             StubTeamcityClient(
                 mapOf(
-                    alice to
+                    "alpha" to
                         listOf(
                             TeamcityProject("Project_A", "A", "https://teamcity.example.com/project/A", emptyMap()),
                             TeamcityProject("Project_B", "B", "https://teamcity.example.com/project/B", emptyMap()),
@@ -191,7 +191,7 @@ class TeamcitySyncServiceTest {
         val client =
             StubTeamcityClient(
                 mapOf(
-                    alice to
+                    "alpha" to
                         listOf(
                             TeamcityProject("Project_A", "A", webUrl = "", parameters = emptyMap()),
                         ),
@@ -241,7 +241,7 @@ class TeamcitySyncServiceTest {
         val client =
             StubTeamcityClient(
                 mapOf(
-                    alice to
+                    "alpha" to
                         listOf(
                             TeamcityProject(
                                 "Alpha_Build",
@@ -250,7 +250,7 @@ class TeamcitySyncServiceTest {
                                 emptyMap(),
                             ),
                         ),
-                    bob to
+                    "beta" to
                         listOf(
                             TeamcityProject(
                                 "Beta_Build",
@@ -306,20 +306,25 @@ class TeamcitySyncServiceTest {
     }
 
     /**
-     * Stub TC client. Map a UUID to whatever list of "matches" the test
-     * wants returned. Empty map → resync sees nothing for any component.
+     * Stub TC client. Map a component name string to whatever list of
+     * "matches" the test wants returned. Empty map → resync sees nothing for
+     * any component.
      */
     private class StubTeamcityClient(
-        private val matches: Map<UUID, List<TeamcityProject>>,
+        private val matchesByName: Map<String, List<TeamcityProject>>,
     ) : TeamcityClient(
             TeamcityProperties(),
             org.springframework.boot.web.client
                 .RestTemplateBuilder(),
         ) {
-        override fun findProjectsByComponentParameter(componentIds: Collection<UUID>): Map<UUID, List<TeamcityProject>> {
+        override fun findProjectsByComponentParameter(componentsByName: Map<String, UUID>): Map<UUID, List<TeamcityProject>> {
             // Filter so we only return entries the caller asked about, mirroring
-            // the real client's contract.
-            return matches.filterKeys { it in componentIds }
+            // the real client's contract: look up by name, emit under UUID.
+            return componentsByName.entries
+                .mapNotNull { (name, uuid) ->
+                    val projects = matchesByName[name] ?: return@mapNotNull null
+                    uuid to projects
+                }.toMap()
         }
     }
 
@@ -330,7 +335,7 @@ class TeamcitySyncServiceTest {
             org.springframework.boot.web.client
                 .RestTemplateBuilder(),
         ) {
-        override fun findProjectsByComponentParameter(componentIds: Collection<UUID>): Map<UUID, List<TeamcityProject>> = throw cause
+        override fun findProjectsByComponentParameter(componentsByName: Map<String, UUID>): Map<UUID, List<TeamcityProject>> = throw cause
     }
 
     /**

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -185,6 +185,39 @@ class TeamcitySyncServiceTest {
     }
 
     @Test
+    @DisplayName("null-id component: counted in scanned but silently skipped, no error counter")
+    fun nullIdComponentSkipped() {
+        val nullIdComponent = ComponentEntity(id = null, name = "no-id")
+        val components = listOf(component(alice, "alpha"), nullIdComponent)
+        val client =
+            StubTeamcityClient(
+                mapOf(
+                    "alpha" to
+                        listOf(
+                            TeamcityProject(
+                                id = "Alpha_Build",
+                                name = "Alpha Build",
+                                webUrl = "https://teamcity.example.com/project/Alpha_Build",
+                                parameters = mapOf("COMPONENT_NAME" to "alpha"),
+                            ),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
+
+        val result = service.resync()
+
+        // Both components are counted in scanned; only the one with an id is processed.
+        assertEquals(2, result.scanned)
+        assertEquals(1, result.updated)
+        assertEquals(0, result.unchanged)
+        assertEquals(0, result.skippedNoMatch)
+        assertTrue(result.errors.isEmpty())
+    }
+
+    @Test
     @DisplayName("blank webUrl: treated as no-match")
     fun blankWebUrlIsNoMatch() {
         val components = listOf(component(alice, "alpha"))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -19,6 +19,9 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.repository.query.FluentQuery
+import org.springframework.transaction.support.SimpleTransactionStatus
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 import java.util.Optional
 import java.util.UUID
 import java.util.function.Function
@@ -67,7 +70,7 @@ class TeamcitySyncServiceTest {
             )
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
-        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val result = service.resync()
 
@@ -123,7 +126,7 @@ class TeamcitySyncServiceTest {
             )
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
-        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val result = service.resync()
 
@@ -150,7 +153,7 @@ class TeamcitySyncServiceTest {
             )
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
-        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val result = service.resync()
 
@@ -170,7 +173,7 @@ class TeamcitySyncServiceTest {
         val client = StubTeamcityClient(emptyMap())
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
-        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val result = service.resync()
 
@@ -196,7 +199,7 @@ class TeamcitySyncServiceTest {
             )
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
-        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val result = service.resync()
 
@@ -212,7 +215,7 @@ class TeamcitySyncServiceTest {
         val client = ThrowingTeamcityClient(RuntimeException("TC unavailable"))
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
-        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val ex = assertThrows<RuntimeException> { service.resync() }
         assertEquals("TC unavailable", ex.message)
@@ -260,7 +263,7 @@ class TeamcitySyncServiceTest {
             )
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
-        val service = TeamcitySyncService(repo, client, publisher, fixedUser("alice"))
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("alice"), inlineTx())
 
         val result = service.resync()
 
@@ -278,6 +281,16 @@ class TeamcitySyncServiceTest {
     private fun fixedUser(name: String): CurrentUserResolver =
         object : CurrentUserResolver() {
             override fun currentUsername(): String = name
+        }
+
+    /**
+     * No-op [TransactionTemplate] that runs the callback inline. The repo
+     * stubs don't simulate JPA transaction semantics, so wrapping calls in
+     * a real [PlatformTransactionManager] would only add ceremony.
+     */
+    private fun inlineTx(): TransactionTemplate =
+        object : TransactionTemplate() {
+            override fun <T> execute(action: TransactionCallback<T>): T? = action.doInTransaction(SimpleTransactionStatus())
         }
 
     private class RecordingPublisher : ApplicationEventPublisher {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -1,0 +1,472 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.event.AuditEvent
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.Example
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.data.repository.query.FluentQuery
+import java.util.Optional
+import java.util.UUID
+import java.util.function.Function
+
+/**
+ * Unit tests for the TC sync service, mocking the TC client.
+ *
+ * Mockito is avoided here too (matches repo convention from
+ * MigrationJobServiceImplTest) — the kotlin nullability + Mockito.any()
+ * combo is brittle. Handwritten test doubles below.
+ */
+class TeamcitySyncServiceTest {
+    private val alice = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val bob = UUID.fromString("22222222-2222-2222-2222-222222222222")
+    private val carol = UUID.fromString("33333333-3333-3333-3333-333333333333")
+
+    private fun component(
+        id: UUID,
+        name: String,
+        tcId: String? = null,
+        tcUrl: String? = null,
+    ) = ComponentEntity(
+        id = id,
+        name = name,
+        teamcityProjectId = tcId,
+        teamcityProjectUrl = tcUrl,
+    )
+
+    @Test
+    @DisplayName("happy path: writes both id and url; counts updated; emits audit event")
+    fun happyPath() {
+        val components = listOf(component(alice, "alpha"))
+        val client =
+            StubTeamcityClient(
+                mapOf(
+                    alice to
+                        listOf(
+                            TeamcityProject(
+                                id = "Alpha_Build",
+                                name = "Alpha Build",
+                                webUrl = "https://teamcity.example.com/project/Alpha_Build",
+                                parameters = mapOf("COMPONENT_NAME" to alice.toString()),
+                            ),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+
+        val result = service.resync()
+
+        assertEquals(1, result.scanned)
+        assertEquals(1, result.updated)
+        assertEquals(0, result.unchanged)
+        assertEquals(0, result.skippedNoMatch)
+        assertEquals(0, result.skippedAmbiguous)
+        assertTrue(result.errors.isEmpty())
+        assertEquals("Alpha_Build", components[0].teamcityProjectId)
+        assertEquals("https://teamcity.example.com/project/Alpha_Build", components[0].teamcityProjectUrl)
+
+        // One audit event with old (null,null) and new (id,url).
+        val audit = publisher.events.filterIsInstance<AuditEvent>().single()
+        assertEquals("Component", audit.entityType)
+        assertEquals("UPDATE", audit.action)
+        assertEquals("admin", audit.changedBy)
+        assertEquals(mapOf("teamcityProjectId" to null, "teamcityProjectUrl" to null), audit.oldValue)
+        assertEquals(
+            mapOf(
+                "teamcityProjectId" to "Alpha_Build",
+                "teamcityProjectUrl" to "https://teamcity.example.com/project/Alpha_Build",
+            ),
+            audit.newValue,
+        )
+    }
+
+    @Test
+    @DisplayName("unchanged: id+url already match — no audit event, no save, count unchanged")
+    fun unchangedNoAudit() {
+        val components =
+            listOf(
+                component(
+                    alice,
+                    "alpha",
+                    tcId = "Alpha_Build",
+                    tcUrl = "https://teamcity.example.com/project/Alpha_Build",
+                ),
+            )
+        val client =
+            StubTeamcityClient(
+                mapOf(
+                    alice to
+                        listOf(
+                            TeamcityProject(
+                                id = "Alpha_Build",
+                                name = "Alpha Build",
+                                webUrl = "https://teamcity.example.com/project/Alpha_Build",
+                                parameters = mapOf("COMPONENT_NAME" to alice.toString()),
+                            ),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+
+        val result = service.resync()
+
+        assertEquals(1, result.scanned)
+        assertEquals(0, result.updated)
+        assertEquals(1, result.unchanged)
+        assertTrue(publisher.events.isEmpty(), "no audit events when nothing changed")
+        assertEquals(0, repo.savedIds.size, "no save when nothing changed")
+    }
+
+    @Test
+    @DisplayName("ambiguous: 2+ matches → skip + count, no write")
+    fun ambiguousSkipped() {
+        val components = listOf(component(alice, "alpha"))
+        val client =
+            StubTeamcityClient(
+                mapOf(
+                    alice to
+                        listOf(
+                            TeamcityProject("Project_A", "A", "https://teamcity.example.com/project/A", emptyMap()),
+                            TeamcityProject("Project_B", "B", "https://teamcity.example.com/project/B", emptyMap()),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+
+        val result = service.resync()
+
+        assertEquals(1, result.scanned)
+        assertEquals(0, result.updated)
+        assertEquals(0, result.unchanged)
+        assertEquals(1, result.skippedAmbiguous)
+        assertNull(components[0].teamcityProjectId, "ambiguous → no write")
+        assertNull(components[0].teamcityProjectUrl, "ambiguous → no write")
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    @DisplayName("no match: 0 candidates → skip + count, no write")
+    fun noMatchSkipped() {
+        val components = listOf(component(alice, "alpha"))
+        val client = StubTeamcityClient(emptyMap())
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+
+        val result = service.resync()
+
+        assertEquals(1, result.scanned)
+        assertEquals(0, result.updated)
+        assertEquals(1, result.skippedNoMatch)
+        assertNull(components[0].teamcityProjectId)
+        assertNull(components[0].teamcityProjectUrl)
+    }
+
+    @Test
+    @DisplayName("blank webUrl: treated as no-match")
+    fun blankWebUrlIsNoMatch() {
+        val components = listOf(component(alice, "alpha"))
+        val client =
+            StubTeamcityClient(
+                mapOf(
+                    alice to
+                        listOf(
+                            TeamcityProject("Project_A", "A", webUrl = "", parameters = emptyMap()),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+
+        val result = service.resync()
+
+        assertEquals(1, result.skippedNoMatch)
+        assertEquals(0, result.updated)
+        assertNull(components[0].teamcityProjectId)
+    }
+
+    @Test
+    @DisplayName("TC client failure on the batched call: exception propagates")
+    fun clientFailurePropagates() {
+        val components = listOf(component(alice, "alpha"))
+        val client = ThrowingTeamcityClient(RuntimeException("TC unavailable"))
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"))
+
+        val ex = assertThrows<RuntimeException> { service.resync() }
+        assertEquals("TC unavailable", ex.message)
+    }
+
+    @Test
+    @DisplayName("mixed batch: counts every category in one pass")
+    fun mixedBatch() {
+        val components =
+            listOf(
+                // alice → updated
+                component(alice, "alpha"),
+                // bob → unchanged
+                component(
+                    bob,
+                    "beta",
+                    tcId = "Beta_Build",
+                    tcUrl = "https://teamcity.example.com/project/Beta_Build",
+                ),
+                // carol → no-match
+                component(carol, "gamma"),
+            )
+        val client =
+            StubTeamcityClient(
+                mapOf(
+                    alice to
+                        listOf(
+                            TeamcityProject(
+                                "Alpha_Build",
+                                "Alpha",
+                                "https://teamcity.example.com/project/Alpha_Build",
+                                emptyMap(),
+                            ),
+                        ),
+                    bob to
+                        listOf(
+                            TeamcityProject(
+                                "Beta_Build",
+                                "Beta",
+                                "https://teamcity.example.com/project/Beta_Build",
+                                emptyMap(),
+                            ),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("alice"))
+
+        val result = service.resync()
+
+        assertEquals(3, result.scanned)
+        assertEquals(1, result.updated)
+        assertEquals(1, result.unchanged)
+        assertEquals(1, result.skippedNoMatch)
+        assertEquals(0, result.skippedAmbiguous)
+        assertTrue(result.errors.isEmpty())
+        assertEquals(1, publisher.events.filterIsInstance<AuditEvent>().size)
+    }
+
+    // -- Test doubles -------------------------------------------------------
+
+    private fun fixedUser(name: String): CurrentUserResolver =
+        object : CurrentUserResolver() {
+            override fun currentUsername(): String = name
+        }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+
+        override fun publishEvent(event: Any) {
+            events.add(event)
+        }
+
+        override fun publishEvent(event: ApplicationEvent) {
+            events.add(event)
+        }
+    }
+
+    /**
+     * Stub TC client. Map a UUID to whatever list of "matches" the test
+     * wants returned. Empty map → resync sees nothing for any component.
+     */
+    private class StubTeamcityClient(
+        private val matches: Map<UUID, List<TeamcityProject>>,
+    ) : TeamcityClient(
+            TeamcityProperties(),
+            org.springframework.boot.web.client
+                .RestTemplateBuilder(),
+        ) {
+        override fun findProjectsByComponentParameter(componentIds: Collection<UUID>): Map<UUID, List<TeamcityProject>> {
+            // Filter so we only return entries the caller asked about, mirroring
+            // the real client's contract.
+            return matches.filterKeys { it in componentIds }
+        }
+    }
+
+    private class ThrowingTeamcityClient(
+        private val cause: Throwable,
+    ) : TeamcityClient(
+            TeamcityProperties(),
+            org.springframework.boot.web.client
+                .RestTemplateBuilder(),
+        ) {
+        override fun findProjectsByComponentParameter(componentIds: Collection<UUID>): Map<UUID, List<TeamcityProject>> = throw cause
+    }
+
+    /**
+     * Hand-rolled ComponentRepository stub. Implements only the methods the
+     * sync service uses (findByArchivedFalse, save). Other JpaRepository /
+     * JpaSpecificationExecutor methods throw — keeps any accidental new
+     * call-site visible during refactors.
+     */
+    @Suppress("TooManyFunctions")
+    private class StubComponentRepository(
+        private val components: List<ComponentEntity>,
+    ) : ComponentRepository {
+        val savedIds = mutableListOf<UUID?>()
+
+        override fun findByName(name: String): ComponentEntity? = components.firstOrNull { it.name == name }
+
+        override fun findByArchivedFalse(): List<ComponentEntity> = components.filter { !it.archived }
+
+        override fun findByArchivedFalse(pageable: Pageable): Page<ComponentEntity> = unsupported()
+
+        override fun findByNameWithVersions(name: String): ComponentEntity? = unsupported()
+
+        override fun findByNameWithAllRelations(name: String): ComponentEntity? = unsupported()
+
+        override fun findByIdWithAllRelations(id: UUID): ComponentEntity? = unsupported()
+
+        override fun existsByName(name: String): Boolean = components.any { it.name == name }
+
+        override fun findDistinctOwners(): List<String> = unsupported()
+
+        override fun <S : ComponentEntity> save(entity: S): S {
+            savedIds.add(entity.id)
+            return entity
+        }
+
+        override fun <S : ComponentEntity> saveAll(entities: Iterable<S>): List<S> = unsupported()
+
+        override fun <S : ComponentEntity> saveAndFlush(entity: S): S {
+            savedIds.add(entity.id)
+            return entity
+        }
+
+        override fun <S : ComponentEntity> saveAllAndFlush(entities: Iterable<S>): List<S> = unsupported()
+
+        override fun findById(id: UUID): Optional<ComponentEntity> = Optional.ofNullable(components.firstOrNull { it.id == id })
+
+        override fun existsById(id: UUID): Boolean = components.any { it.id == id }
+
+        override fun findAll(): List<ComponentEntity> = components
+
+        override fun findAllById(ids: Iterable<UUID>): List<ComponentEntity> = unsupported()
+
+        override fun count(): Long = components.size.toLong()
+
+        override fun deleteById(id: UUID) {
+            unsupported()
+        }
+
+        override fun delete(entity: ComponentEntity) {
+            unsupported()
+        }
+
+        override fun deleteAllById(ids: Iterable<UUID>) {
+            unsupported()
+        }
+
+        override fun deleteAll(entities: Iterable<ComponentEntity>) {
+            unsupported()
+        }
+
+        override fun deleteAll() {
+            unsupported()
+        }
+
+        override fun deleteAllInBatch() {
+            unsupported()
+        }
+
+        override fun deleteAllByIdInBatch(ids: Iterable<UUID>) {
+            unsupported()
+        }
+
+        override fun deleteAllInBatch(entities: Iterable<ComponentEntity>) {
+            unsupported()
+        }
+
+        override fun getOne(id: UUID): ComponentEntity = unsupported()
+
+        @Suppress("DEPRECATION")
+        override fun getById(id: UUID): ComponentEntity = unsupported()
+
+        override fun getReferenceById(id: UUID): ComponentEntity = unsupported()
+
+        override fun flush() {
+            unsupported()
+        }
+
+        override fun findAll(sort: Sort): List<ComponentEntity> = components
+
+        override fun findAll(pageable: Pageable): Page<ComponentEntity> = PageImpl(components, pageable, components.size.toLong())
+
+        override fun findAll(spec: Specification<ComponentEntity>): List<ComponentEntity> = components
+
+        override fun findAll(
+            spec: Specification<ComponentEntity>,
+            pageable: Pageable,
+        ): Page<ComponentEntity> = PageImpl(components, pageable, components.size.toLong())
+
+        override fun findAll(
+            spec: Specification<ComponentEntity>,
+            sort: Sort,
+        ): List<ComponentEntity> = components
+
+        override fun findOne(spec: Specification<ComponentEntity>): Optional<ComponentEntity> = Optional.empty()
+
+        override fun count(spec: Specification<ComponentEntity>): Long = components.size.toLong()
+
+        override fun exists(spec: Specification<ComponentEntity>): Boolean = false
+
+        override fun delete(spec: Specification<ComponentEntity>): Long = unsupported()
+
+        override fun <S : ComponentEntity, R : Any?> findBy(
+            spec: Specification<ComponentEntity>,
+            queryFunction: Function<FluentQuery.FetchableFluentQuery<S>, R>,
+        ): R = unsupported()
+
+        override fun <S : ComponentEntity> findOne(example: Example<S>): Optional<S> = Optional.empty()
+
+        override fun <S : ComponentEntity> findAll(example: Example<S>): List<S> = unsupported()
+
+        override fun <S : ComponentEntity> findAll(
+            example: Example<S>,
+            sort: Sort,
+        ): List<S> = unsupported()
+
+        override fun <S : ComponentEntity> findAll(
+            example: Example<S>,
+            pageable: Pageable,
+        ): Page<S> = unsupported()
+
+        override fun <S : ComponentEntity> count(example: Example<S>): Long = 0L
+
+        override fun <S : ComponentEntity> exists(example: Example<S>): Boolean = false
+
+        override fun <S : ComponentEntity, R : Any?> findBy(
+            example: Example<S>,
+            queryFunction: Function<FluentQuery.FetchableFluentQuery<S>, R>,
+        ): R = unsupported()
+
+        private fun unsupported(): Nothing = throw UnsupportedOperationException("not used by TeamcitySyncService")
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of the Portal TC quick-link restoration. Builds on PR #168 (teamcityProjectId column).

- Adds `teamcity_project_url VARCHAR(2048)` column folded into `V1__initial_schema.sql` and surfaced through the same DTOs/mapper/audit path as the id column.
- New `TeamcityClient` (Spring `@Component`, `RestTemplate` + Basic auth, bounded timeouts) using the batched locator `parameter:(name:COMPONENT_NAME,matchType:equals,ignoreCase:true)` — same convention as `components-automation` `BaseComponentsTask`. Disabled when `teamcity.base-url` is blank.
- `TeamcitySyncService` synchronous batched resync. Per-component decision: 0 matches → `skipped_no_match`; 1 with non-blank `webUrl` → upsert if changed; 1 with blank `webUrl` → `skipped_no_match`; 2+ → `skipped_ambiguous` (manual override is the escape hatch). Idempotent (only writes on real change). The TC HTTP call runs OUTSIDE the DB transaction so a stalled TC host cannot hold a JDBC connection; per-component writes are wrapped in a single `TransactionTemplate.execute` so the bulk write is still atomic and audit-event ordering (BEFORE_COMMIT) is preserved.
- `TeamcitySyncScheduler` weekly cron at `0 0 4 * * SUN` UTC. Bean is `@ConditionalOnProperty("teamcity.sync.enabled")` AND `@Profile("!test")` — registered only when explicitly enabled, never under tests.
- `POST /rest/api/4/admin/teamcity-project-ids/resync`. Permission gate reuses `IMPORT_DATA` (locked decision — a separate `SYNC_TC_PROJECTS` permission would touch cloud-commons + automation role yaml + Portal `auth.ts` for no real delegation benefit). Response shape: `{scanned, updated, unchanged, skipped_no_match, skipped_ambiguous, errors}`.

## Locked design decisions (resolved upfront, not for re-litigation in this PR)

1. **Persist both `teamcity_project_id` and `teamcity_project_url`.** The id is the matching key for sync diff / audit identity / manual-override input; the url is the display value Portal renders verbatim. Portal does NOT template TC URLs — TC's `webUrl` shape varies across versions/configurations.
2. **Match strategy:** TC parameter `COMPONENT_NAME = component.id (UUID)`, matchType=equals, ignoreCase=true — verified by reading `components-automation` `BaseComponentsTask`.
3. **Synchronous batched lookup.** Async-job pattern (mirror `/admin/migrate`) is the documented fallback if response size ever exceeds reasonable threshold on dev TC; not needed today.
4. **Permission: `IMPORT_DATA`.** See above.
5. **Clear semantics:** the existing `?.let{}` patch path on `ComponentManagementServiceImpl` cannot distinguish "field omitted" from "field explicitly null" — admin clears a wrong manual override by triggering resync, which overwrites with the correct value or null. Documented limitation; switching to `containsKey`-aware partial-update is a project-wide refactor for a separate PR.

## Configuration

```yaml
teamcity:
  base-url: ${TEAMCITY_BASE_URL:}
  username: ${TEAMCITY_USERNAME:}
  password: ${TEAMCITY_PASSWORD:}
  connect-timeout-seconds: 10
  read-timeout-seconds: 120
  sync:
    enabled: ${TEAMCITY_SYNC_ENABLED:false}
    cron: "0 0 4 * * SUN"
```

Defaults are inert: blank `base-url` short-circuits the client, `sync.enabled=false` prevents the scheduler bean from being registered. Production wires through `service-config` per env (host + creds + `TEAMCITY_SYNC_ENABLED=true`). A separate `service-config` change will land alongside the deploy.

## Known limitations

- The synchronous batched lookup returns ALL TC projects carrying the `COMPONENT_NAME` parameter, not just the requested ones, then groups client-side. If the TC server ever has thousands of such projects, the response could become unwieldy and a switch to the async-job pattern (mirroring `/admin/migrate`) would be appropriate. Acceptable for the current scale.
- `RestTemplate` timeouts default to 10s connect / 120s read. Tunable via `teamcity.connect-timeout-seconds` / `teamcity.read-timeout-seconds`. Service-config can override per env.
- Manual-override clear (back to null) requires a resync to overwrite — this is a pre-existing limitation of the patch deserialization shape, not introduced here.

## Test plan

- [x] `./gradlew :components-registry-service-server:test` — full suite passes (462 tests, 1 pre-existing skip, 0 failures).
- [x] `./gradlew :components-registry-service-server:detekt :components-registry-service-server:ktlintCheck` — both green.
- [x] `TeamcitySyncServiceTest` (7 cases): happy path / unchanged-no-audit / ambiguous / no-match / blank-webUrl-as-no-match / TC API failure / mixed batch — including audit-event emission and non-emission assertions.
- [x] `TeamcityResyncControllerTest` (3 cases): anonymous → 401, editor → 403, admin → 200 with full snake_case shape including `errors[0]`.
- [x] `TeamcityProjectIdPersistenceRoundtripTest` extended for the URL column.
- [x] Mapper tests extended for both summary and detail responses.
- [ ] Live verification on dev TC pending the service-config deploy companion (TC host + creds + `TEAMCITY_SYNC_ENABLED=true`).
- [ ] Portal PR-3 (consume + UI) lands separately on the Portal repo.