### PR TITLE
Remove QueryMap annotation from getAllComponents

### DIFF
--- a/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceClient.kt
+++ b/components-registry-service-client/src/main/kotlin/org/octopusden/octopus/components/registry/client/ComponentsRegistryServiceClient.kt
@@ -65,7 +65,7 @@ interface ComponentsRegistryServiceClient {
         @Param("vcsPath") vcsPath: String? = null,
         @Param("buildSystem") buildSystem: BuildSystem? = null,
         @Param("solution") solution: Boolean? = null,
-        @Param("systems") @QueryMap systems: List<String> = emptyList()
+        @Param("systems") systems: List<String> = emptyList()
     ): ComponentsDTO<ComponentV2>
 
     @RequestLine("GET rest/api/1/components/{componentKey}/versions/{version}/distribution")


### PR DESCRIPTION
`systems` is a regular query parameter list, but it was annotated with `@QueryMap.`
This worked on JDK 8, but on JDK 21 Feign tries to encode the list via reflection and fails with `InaccessibleObjectException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter handling in the components registry service client for improved query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->