### PR TITLE
fix(tc-sync): throw on blank base-url instead of silent all-NO_MATCH

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -81,8 +81,11 @@ class TeamcityClient(
      * COMPONENT_NAME parameter) → component UUID.
      *
      * Behaviour contract:
+     * - `teamcity.base-url` blank → throws [IllegalStateException] regardless of
+     *   input size; caller surfaces it as an error. Checked first so a
+     *   misconfigured environment is never silently treated as successful (the
+     *   empty-registry fast-path would otherwise mask the missing URL).
      * - Empty input → empty result, no HTTP call.
-     * - `teamcity.base-url` blank → throws [IllegalStateException]; caller surfaces it as an error.
      * - TC returns multiple projects for the same name → all included in the
      *   raw return; the SyncService is responsible for "skipped_ambiguous".
      * - TC API failure → exception propagates; SyncService catches and counts
@@ -93,7 +96,6 @@ class TeamcityClient(
      * by name string via [componentsByName].
      */
     fun findProjectsByComponentParameter(componentsByName: Map<String, UUID>): Map<UUID, List<TeamcityProject>> {
-        if (componentsByName.isEmpty()) return emptyMap()
         val baseUrl = properties.baseUrl.trimEnd('/')
         if (baseUrl.isBlank()) {
             throw IllegalStateException(
@@ -101,6 +103,7 @@ class TeamcityClient(
                     "Set the TEAMCITY_BASE_URL environment variable.",
             )
         }
+        if (componentsByName.isEmpty()) return emptyMap()
 
         // Locator: parameter:(name:COMPONENT_NAME) — match every project
         // carrying the parameter regardless of value, then group client-side.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -47,8 +47,8 @@ data class TeamcityProject(
  *   the simpler dependency-free path.
  *
  * Disabled when `teamcity.base-url` is blank — [findProjectsByComponentParameter]
- * returns an empty map so the sync service can run end-to-end on
- * unconfigured envs (returning `scanned=0, updated=0, ...`) without HTTP.
+ * throws [IllegalStateException] so the caller (admin endpoint or scheduler)
+ * surfaces the misconfiguration rather than silently returning all-NO_MATCH.
  */
 @Component
 class TeamcityClient(
@@ -96,8 +96,10 @@ class TeamcityClient(
         if (componentsByName.isEmpty()) return emptyMap()
         val baseUrl = properties.baseUrl.trimEnd('/')
         if (baseUrl.isBlank()) {
-            log.debug { "TC sync disabled (teamcity.base-url is blank); returning empty result" }
-            return emptyMap()
+            throw IllegalStateException(
+                "TC sync is not configured: teamcity.base-url is blank. " +
+                    "Set the TEAMCITY_BASE_URL environment variable.",
+            )
         }
 
         // Locator: parameter:(name:COMPONENT_NAME) — match every project

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -82,7 +82,7 @@ class TeamcityClient(
      *
      * Behaviour contract:
      * - Empty input → empty result, no HTTP call.
-     * - `teamcity.base-url` blank → empty result, no HTTP call.
+     * - `teamcity.base-url` blank → throws [IllegalStateException]; caller surfaces it as an error.
      * - TC returns multiple projects for the same name → all included in the
      *   raw return; the SyncService is responsible for "skipped_ambiguous".
      * - TC API failure → exception propagates; SyncService catches and counts

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -7,17 +7,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * application*.yml (defaults below).
  *
  * Defaults are intentionally inert: with `base-url` blank and `sync.enabled`
- * false, the [TeamcityClient] does not register HTTP, the [TeamcitySyncService]
- * skips all calls, and the [TeamcitySyncScheduler] does not fire — so dev /
- * unconfigured envs boot cleanly without TC credentials. Production wires
- * through `service-config` per env.
+ * false, the [TeamcitySyncScheduler] bean is not registered — so dev /
+ * unconfigured envs boot cleanly without TC credentials. The manual admin
+ * resync endpoint will throw when `base-url` is blank, which is the intended
+ * behaviour (surfaces misconfiguration). Production wires through
+ * `service-config` per env.
  */
 @ConfigurationProperties(prefix = "teamcity")
 class TeamcityProperties(
     /**
      * Base URL of the TC server, e.g. `https://teamcity.example.com`.
-     * Trailing slashes are tolerated. Blank disables the integration —
-     * [TeamcitySyncService] short-circuits and returns an empty result.
+     * Trailing slashes are tolerated. Blank is a misconfiguration —
+     * [TeamcityClient] throws [IllegalStateException] so the caller surfaces
+     * the error rather than silently returning all-NO_MATCH. Set via
+     * `TEAMCITY_BASE_URL` environment variable.
      */
     val baseUrl: String = "",
     /** TC service account username (HTTP Basic auth). */

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * false, the [TeamcitySyncScheduler] bean is not registered — so dev /
  * unconfigured envs boot cleanly without TC credentials. The manual admin
  * resync endpoint will throw when `base-url` is blank, which is the intended
- * behaviour (surfaces misconfiguration). Production wires through
+ * behavior (surfaces misconfiguration). Production wires through
  * `service-config` per env.
  */
 @ConfigurationProperties(prefix = "teamcity")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -10,6 +10,7 @@ import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.event.AuditEvent
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.ApplicationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.Example
@@ -246,7 +247,7 @@ class TeamcitySyncServiceTest {
     fun blankBaseUrlThrows() {
         val components = listOf(component(alice, "alpha"))
         // Real client with default (blank) base-url — no HTTP call is made.
-        val client = TeamcityClient(TeamcityProperties(), org.springframework.boot.web.client.RestTemplateBuilder())
+        val client = TeamcityClient(TeamcityProperties(), RestTemplateBuilder())
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
         val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -242,6 +242,20 @@ class TeamcitySyncServiceTest {
     }
 
     @Test
+    @DisplayName("blank base-url: resync throws IllegalStateException instead of returning all-NO_MATCH")
+    fun blankBaseUrlThrows() {
+        val components = listOf(component(alice, "alpha"))
+        // Real client with default (blank) base-url — no HTTP call is made.
+        val client = TeamcityClient(TeamcityProperties(), org.springframework.boot.web.client.RestTemplateBuilder())
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
+
+        val ex = assertThrows<IllegalStateException> { service.resync() }
+        assertTrue(ex.message!!.contains("TEAMCITY_BASE_URL"), "message should mention the env var")
+    }
+
+    @Test
     @DisplayName("TC client failure on the batched call: exception propagates")
     fun clientFailurePropagates() {
         val components = listOf(component(alice, "alpha"))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -257,6 +257,18 @@ class TeamcitySyncServiceTest {
     }
 
     @Test
+    @DisplayName("blank base-url: throws even when the registry is empty (no silent scanned=0 on misconfiguration)")
+    fun blankBaseUrlThrowsOnEmptyRegistry() {
+        val client = TeamcityClient(TeamcityProperties(), RestTemplateBuilder())
+        val repo = StubComponentRepository(emptyList())
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
+
+        val ex = assertThrows<IllegalStateException> { service.resync() }
+        assertTrue(ex.message!!.contains("TEAMCITY_BASE_URL"), "message should mention the env var")
+    }
+
+    @Test
     @DisplayName("TC client failure on the batched call: exception propagates")
     fun clientFailurePropagates() {
         val components = listOf(component(alice, "alpha"))


### PR DESCRIPTION
## Summary
- When `teamcity.base-url` is not configured, `TeamcityClient` silently returned `emptyMap()`, causing the admin resync to respond HTTP 200 with `scanned=N / no_match=N` — indistinguishable from a legitimate result where TC simply has no matching projects
- Now throws `IllegalStateException` → `ControllerExceptionHandler` maps it to HTTP 500 with `{"message":"TC sync is not configured: ... Set TEAMCITY_BASE_URL"}` → portal renders a clear error banner

## Context
The rest of the TC sync feature landed in v3 via #169. This is the one missing piece: explicit misconfiguration detection.

## Test plan
- [x] `TeamcitySyncServiceTest.blankBaseUrlThrows` — verifies `IllegalStateException` is thrown and message mentions `TEAMCITY_BASE_URL`
- [x] All 9 sync service unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)