### PR TITLE
fix(mapper): normalise SSH vcsPath to project/repo in summary response

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -217,8 +217,9 @@ fun AuditLogEntity.toResponse(): AuditLogResponse =
  * Portal for constructing Bitbucket (and future Gitea) browse links.
  *
  * Handles:
- *  - `ssh://git@host/[scm/]project/repo.git`   (Bitbucket ssh scheme)
- *  - `ssh://git@host:port/[scm/]project/repo.git` (with explicit port)
+ *  - `ssh://git@host/[scm/]project/repo.git`    (Bitbucket ssh scheme, no port)
+ *  - `ssh://git@host:port/[scm/]project/repo.git` (Bitbucket, numeric port)
+ *  - `ssh://git@host:org/repo.git`              (GitHub SCP-over-SSH, org not a port)
  *  - `git@host:project/repo.git`               (SCP-style git, Gitea / Bitbucket)
  *  - `project/repo`                            (already normalised, returned as-is)
  *
@@ -229,8 +230,21 @@ internal fun String.sshUrlToProjectRepo(): String {
     val pathPart: String =
         when {
             startsWith("ssh://git@") -> {
-                // ssh://git@host[:port]/[scm/]project/repo.git → strip scheme + host
-                substringAfter("://").substringAfter("/")
+                val afterAt = substringAfter("@")
+                val colonIdx = afterAt.indexOf(':')
+                if (colonIdx >= 0) {
+                    val portOrOrg = afterAt.substring(colonIdx + 1).substringBefore("/")
+                    if (portOrOrg.isNotEmpty() && portOrOrg.all { it.isDigit() }) {
+                        // Numeric port: ssh://git@host:7999/project/repo.git
+                        afterAt.substringAfter("/")
+                    } else {
+                        // SCP-over-SSH org: ssh://git@host:org/repo.git
+                        afterAt.substringAfter(":")
+                    }
+                } else {
+                    // No port: ssh://git@host/project/repo.git
+                    afterAt.substringAfter("/")
+                }
             }
             startsWith("git@") -> {
                 // git@host:project/repo.git → strip everything before the colon

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -101,7 +101,8 @@ fun ComponentEntity.toSummaryResponse(): ComponentSummaryResponse =
                 ?.entries
                 ?.firstOrNull()
                 ?.vcsPath
-                ?.takeIf { it.isNotBlank() },
+                ?.takeIf { it.isNotBlank() }
+                ?.sshUrlToProjectRepo(),
         teamcityProjectId = this.teamcityProjectId,
         teamcityProjectUrl = this.teamcityProjectUrl,
     )
@@ -210,3 +211,35 @@ fun AuditLogEntity.toResponse(): AuditLogResponse =
         correlationId = this.correlationId,
         source = this.source,
     )
+
+/**
+ * Normalises a raw VCS path to the `project/repo` format expected by the
+ * Portal for constructing Bitbucket (and future Gitea) browse links.
+ *
+ * Handles:
+ *  - `ssh://git@host/[scm/]project/repo.git`   (Bitbucket ssh scheme)
+ *  - `ssh://git@host:port/[scm/]project/repo.git` (with explicit port)
+ *  - `git@host:project/repo.git`               (SCP-style, Gitea / Bitbucket)
+ *  - `project/repo`                            (already normalised, returned as-is)
+ *
+ * If the value does not match any known pattern the original string is
+ * returned unchanged so the Portal can decide how to handle it.
+ */
+internal fun String.sshUrlToProjectRepo(): String {
+    val pathPart: String = when {
+        startsWith("ssh://") -> {
+            // ssh://git@host[:port]/[scm/]project/repo.git → strip scheme + host
+            substringAfter("://").substringAfter("/")
+        }
+        contains("@") && contains(":") -> {
+            // git@host:project/repo.git → strip everything before the colon
+            substringAfter(":")
+        }
+        else -> return this
+    }
+    val cleaned = pathPart.trimEnd('/').removeSuffix(".git")
+    // Bitbucket sometimes inserts "scm/" between the host and the project key
+    val normalized = if (cleaned.startsWith("scm/")) cleaned.removePrefix("scm/") else cleaned
+    val parts = normalized.split("/").filter { it.isNotEmpty() }
+    return if (parts.size >= 2) "${parts[parts.size - 2]}/${parts.last()}" else this
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -219,24 +219,25 @@ fun AuditLogEntity.toResponse(): AuditLogResponse =
  * Handles:
  *  - `ssh://git@host/[scm/]project/repo.git`   (Bitbucket ssh scheme)
  *  - `ssh://git@host:port/[scm/]project/repo.git` (with explicit port)
- *  - `git@host:project/repo.git`               (SCP-style, Gitea / Bitbucket)
+ *  - `git@host:project/repo.git`               (SCP-style git, Gitea / Bitbucket)
  *  - `project/repo`                            (already normalised, returned as-is)
  *
  * If the value does not match any known pattern the original string is
  * returned unchanged so the Portal can decide how to handle it.
  */
 internal fun String.sshUrlToProjectRepo(): String {
-    val pathPart: String = when {
-        startsWith("ssh://") -> {
-            // ssh://git@host[:port]/[scm/]project/repo.git → strip scheme + host
-            substringAfter("://").substringAfter("/")
+    val pathPart: String =
+        when {
+            startsWith("ssh://git@") -> {
+                // ssh://git@host[:port]/[scm/]project/repo.git → strip scheme + host
+                substringAfter("://").substringAfter("/")
+            }
+            startsWith("git@") -> {
+                // git@host:project/repo.git → strip everything before the colon
+                substringAfter(":")
+            }
+            else -> return this
         }
-        contains("@") && contains(":") -> {
-            // git@host:project/repo.git → strip everything before the colon
-            substringAfter(":")
-        }
-        else -> return this
-    }
     val cleaned = pathPart.trimEnd('/').removeSuffix(".git")
     // Bitbucket sometimes inserts "scm/" between the host and the project key
     val normalized = if (cleaned.startsWith("scm/")) cleaned.removePrefix("scm/") else cleaned

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -81,8 +81,11 @@ class TeamcityClient(
      * COMPONENT_NAME parameter) → component UUID.
      *
      * Behaviour contract:
+     * - `teamcity.base-url` blank → throws [IllegalStateException] regardless of
+     *   input size; caller surfaces it as an error. Checked first so a
+     *   misconfigured environment is never silently treated as successful (the
+     *   empty-registry fast-path would otherwise mask the missing URL).
      * - Empty input → empty result, no HTTP call.
-     * - `teamcity.base-url` blank → throws [IllegalStateException]; caller surfaces it as an error.
      * - TC returns multiple projects for the same name → all included in the
      *   raw return; the SyncService is responsible for "skipped_ambiguous".
      * - TC API failure → exception propagates; SyncService catches and counts
@@ -93,7 +96,6 @@ class TeamcityClient(
      * by name string via [componentsByName].
      */
     fun findProjectsByComponentParameter(componentsByName: Map<String, UUID>): Map<UUID, List<TeamcityProject>> {
-        if (componentsByName.isEmpty()) return emptyMap()
         val baseUrl = properties.baseUrl.trimEnd('/')
         if (baseUrl.isBlank()) {
             throw IllegalStateException(
@@ -101,6 +103,7 @@ class TeamcityClient(
                     "Set the TEAMCITY_BASE_URL environment variable.",
             )
         }
+        if (componentsByName.isEmpty()) return emptyMap()
 
         // Locator: parameter:(name:COMPONENT_NAME) — match every project
         // carrying the parameter regardless of value, then group client-side.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -47,8 +47,8 @@ data class TeamcityProject(
  *   the simpler dependency-free path.
  *
  * Disabled when `teamcity.base-url` is blank — [findProjectsByComponentParameter]
- * returns an empty map so the sync service can run end-to-end on
- * unconfigured envs (returning `scanned=0, updated=0, ...`) without HTTP.
+ * throws [IllegalStateException] so the caller (admin endpoint or scheduler)
+ * surfaces the misconfiguration rather than silently returning all-NO_MATCH.
  */
 @Component
 class TeamcityClient(
@@ -96,8 +96,10 @@ class TeamcityClient(
         if (componentsByName.isEmpty()) return emptyMap()
         val baseUrl = properties.baseUrl.trimEnd('/')
         if (baseUrl.isBlank()) {
-            log.debug { "TC sync disabled (teamcity.base-url is blank); returning empty result" }
-            return emptyMap()
+            throw IllegalStateException(
+                "TC sync is not configured: teamcity.base-url is blank. " +
+                    "Set the TEAMCITY_BASE_URL environment variable.",
+            )
         }
 
         // Locator: parameter:(name:COMPONENT_NAME) — match every project

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -82,7 +82,7 @@ class TeamcityClient(
      *
      * Behaviour contract:
      * - Empty input → empty result, no HTTP call.
-     * - `teamcity.base-url` blank → empty result, no HTTP call.
+     * - `teamcity.base-url` blank → throws [IllegalStateException]; caller surfaces it as an error.
      * - TC returns multiple projects for the same name → all included in the
      *   raw return; the SyncService is responsible for "skipped_ambiguous".
      * - TC API failure → exception propagates; SyncService catches and counts

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -7,17 +7,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * application*.yml (defaults below).
  *
  * Defaults are intentionally inert: with `base-url` blank and `sync.enabled`
- * false, the [TeamcityClient] does not register HTTP, the [TeamcitySyncService]
- * skips all calls, and the [TeamcitySyncScheduler] does not fire — so dev /
- * unconfigured envs boot cleanly without TC credentials. Production wires
- * through `service-config` per env.
+ * false, the [TeamcitySyncScheduler] bean is not registered — so dev /
+ * unconfigured envs boot cleanly without TC credentials. The manual admin
+ * resync endpoint will throw when `base-url` is blank, which is the intended
+ * behaviour (surfaces misconfiguration). Production wires through
+ * `service-config` per env.
  */
 @ConfigurationProperties(prefix = "teamcity")
 class TeamcityProperties(
     /**
      * Base URL of the TC server, e.g. `https://teamcity.example.com`.
-     * Trailing slashes are tolerated. Blank disables the integration —
-     * [TeamcitySyncService] short-circuits and returns an empty result.
+     * Trailing slashes are tolerated. Blank is a misconfiguration —
+     * [TeamcityClient] throws [IllegalStateException] so the caller surfaces
+     * the error rather than silently returning all-NO_MATCH. Set via
+     * `TEAMCITY_BASE_URL` environment variable.
      */
     val baseUrl: String = "",
     /** TC service account username (HTTP Basic auth). */

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * false, the [TeamcitySyncScheduler] bean is not registered — so dev /
  * unconfigured envs boot cleanly without TC credentials. The manual admin
  * resync endpoint will throw when `base-url` is blank, which is the intended
- * behaviour (surfaces misconfiguration). Production wires through
+ * behavior (surfaces misconfiguration). Production wires through
  * `service-config` per env.
  */
 @ConfigurationProperties(prefix = "teamcity")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
@@ -170,19 +170,19 @@ class ComponentSummaryMapperTest {
     @DisplayName("sshUrlToProjectRepo normalises SSH URLs to project/repo")
     @CsvSource(
         // Bitbucket ssh:// with no port
-        "ssh://git@bitbucket.example.com/neo/access-contol.git,       neo/access-contol",
-        // Bitbucket ssh:// with explicit port — substringAfter("/") on
-        // "git@host:7999/neo/repo.git" finds the FIRST slash (before neo),
-        // so the port does NOT appear in pathPart; result is correct.
-        "ssh://git@bitbucket.example.com:7999/neo/access-contol.git,  neo/access-contol",
+        "ssh://git@bitbucket.example.com/neo/access-contol.git,                    neo/access-contol",
+        // Bitbucket ssh:// with explicit numeric port
+        "ssh://git@bitbucket.example.com:7999/neo/access-contol.git,               neo/access-contol",
         // Bitbucket ssh:// with scm/ prefix + port
-        "ssh://git@bitbucket.example.com:7999/scm/project/repo.git,   project/repo",
+        "ssh://git@bitbucket.example.com:7999/scm/project/repo.git,                project/repo",
+        // GitHub SCP-over-SSH: colon introduces org name (not a port)
+        "ssh://git@github.com:octopusden/octopus-rm-gradle-plugin.git,             octopusden/octopus-rm-gradle-plugin",
         // SCP-style (Gitea / Bitbucket SCP)
-        "git@gitea.example.com:org/repo.git,                          org/repo",
+        "git@gitea.example.com:org/repo.git,                                       org/repo",
         // Nested group path — only last two segments are taken (group/sub/repo → sub/repo)
-        "git@gitea.example.com:group/sub/repo.git,                    sub/repo",
+        "git@gitea.example.com:group/sub/repo.git,                                 sub/repo",
         // Already normalised — must be returned as-is
-        "org/repo,                                                     org/repo",
+        "org/repo,                                                                  org/repo",
         delimiter = ',',
     )
     fun sshUrlToProjectRepo_normalisesVcsPath(
@@ -195,8 +195,8 @@ class ComponentSummaryMapperTest {
     @Test
     @DisplayName("sshUrlToProjectRepo returns original value when path has fewer than two segments (no misfire)")
     fun sshUrlToProjectRepo_singleSegment_returnsOriginal() {
-        // ssh://git@host:7999/repo.git  → pathPart = "repo.git" → parts = ["repo"] → size < 2
-        // The function must NOT return "7999/repo" — proof that port stays out of pathPart.
+        // "7999" is all-digits → treated as port → afterAt.substringAfter("/") = "repo.git"
+        // parts = ["repo"] → size < 2 → original URL is returned, not "7999/repo"
         val raw = "ssh://git@bitbucket.example.com:7999/repo.git"
         assertEquals(raw, raw.sshUrlToProjectRepo())
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
@@ -185,7 +185,10 @@ class ComponentSummaryMapperTest {
         "org/repo,                                                     org/repo",
         delimiter = ',',
     )
-    fun sshUrlToProjectRepo_normalisesVcsPath(raw: String, expected: String) {
+    fun sshUrlToProjectRepo_normalisesVcsPath(
+        raw: String,
+        expected: String,
+    ) {
         assertEquals(expected.trim(), raw.trim().sshUrlToProjectRepo())
     }
 
@@ -195,6 +198,20 @@ class ComponentSummaryMapperTest {
         // ssh://git@host:7999/repo.git  → pathPart = "repo.git" → parts = ["repo"] → size < 2
         // The function must NOT return "7999/repo" — proof that port stays out of pathPart.
         val raw = "ssh://git@bitbucket.example.com:7999/repo.git"
+        assertEquals(raw, raw.sshUrlToProjectRepo())
+    }
+
+    @Test
+    @DisplayName("sshUrlToProjectRepo returns non-git SSH URLs unchanged (e.g. Mercurial ssh://)")
+    fun sshUrlToProjectRepo_nonGitSshUrl_returnsOriginal() {
+        val raw = "ssh://hg@mercurial.example.com/ddd/technical"
+        assertEquals(raw, raw.sshUrlToProjectRepo())
+    }
+
+    @Test
+    @DisplayName("sshUrlToProjectRepo returns non-git SCP-style URLs unchanged (e.g. Mercurial hg@)")
+    fun sshUrlToProjectRepo_nonGitScpUrl_returnsOriginal() {
+        val raw = "hg@mercurial.example.com:ddd/technical"
         assertEquals(raw, raw.sshUrlToProjectRepo())
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.octopusden.octopus.components.registry.server.entity.BuildConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.JiraComponentConfigEntity
@@ -158,5 +160,57 @@ class ComponentSummaryMapperTest {
         val response = component.toSummaryResponse()
 
         assertEquals("GRADLE", response.buildSystem)
+    }
+
+    // -----------------------------------------------------------------------
+    // sshUrlToProjectRepo — SSH URL normalisation for Portal Bitbucket links
+    // -----------------------------------------------------------------------
+
+    @ParameterizedTest(name = "[{index}] \"{0}\" → \"{1}\"")
+    @DisplayName("sshUrlToProjectRepo normalises SSH URLs to project/repo")
+    @CsvSource(
+        // Bitbucket ssh:// with no port
+        "ssh://git@bitbucket.example.com/neo/access-contol.git,       neo/access-contol",
+        // Bitbucket ssh:// with explicit port — substringAfter("/") on
+        // "git@host:7999/neo/repo.git" finds the FIRST slash (before neo),
+        // so the port does NOT appear in pathPart; result is correct.
+        "ssh://git@bitbucket.example.com:7999/neo/access-contol.git,  neo/access-contol",
+        // Bitbucket ssh:// with scm/ prefix + port
+        "ssh://git@bitbucket.example.com:7999/scm/project/repo.git,   project/repo",
+        // SCP-style (Gitea / Bitbucket SCP)
+        "git@gitea.example.com:org/repo.git,                          org/repo",
+        // Nested group path — only last two segments are taken (group/sub/repo → sub/repo)
+        "git@gitea.example.com:group/sub/repo.git,                    sub/repo",
+        // Already normalised — must be returned as-is
+        "org/repo,                                                     org/repo",
+        delimiter = ',',
+    )
+    fun sshUrlToProjectRepo_normalisesVcsPath(raw: String, expected: String) {
+        assertEquals(expected.trim(), raw.trim().sshUrlToProjectRepo())
+    }
+
+    @Test
+    @DisplayName("sshUrlToProjectRepo returns original value when path has fewer than two segments (no misfire)")
+    fun sshUrlToProjectRepo_singleSegment_returnsOriginal() {
+        // ssh://git@host:7999/repo.git  → pathPart = "repo.git" → parts = ["repo"] → size < 2
+        // The function must NOT return "7999/repo" — proof that port stays out of pathPart.
+        val raw = "ssh://git@bitbucket.example.com:7999/repo.git"
+        assertEquals(raw, raw.sshUrlToProjectRepo())
+    }
+
+    @Test
+    @DisplayName("vcsPath stored as SSH URL → toSummaryResponse returns project/repo")
+    fun sshUrlInEntity_returnedAsProjectRepo() {
+        val component = baseComponent()
+        val vcs = VcsSettingsEntity(component = component)
+        vcs.entries.add(
+            VcsSettingsEntryEntity(
+                vcsSettings = vcs,
+                vcsPath = "ssh://git@bitbucket.spb.example.com/neo/access-contol.git",
+            ),
+        )
+        component.vcsSettings.add(vcs)
+
+        assertEquals("neo/access-contol", component.toSummaryResponse().vcsPath)
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -10,6 +10,7 @@ import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.event.AuditEvent
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.ApplicationEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.Example
@@ -246,7 +247,7 @@ class TeamcitySyncServiceTest {
     fun blankBaseUrlThrows() {
         val components = listOf(component(alice, "alpha"))
         // Real client with default (blank) base-url — no HTTP call is made.
-        val client = TeamcityClient(TeamcityProperties(), org.springframework.boot.web.client.RestTemplateBuilder())
+        val client = TeamcityClient(TeamcityProperties(), RestTemplateBuilder())
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
         val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -242,6 +242,20 @@ class TeamcitySyncServiceTest {
     }
 
     @Test
+    @DisplayName("blank base-url: resync throws IllegalStateException instead of returning all-NO_MATCH")
+    fun blankBaseUrlThrows() {
+        val components = listOf(component(alice, "alpha"))
+        // Real client with default (blank) base-url — no HTTP call is made.
+        val client = TeamcityClient(TeamcityProperties(), org.springframework.boot.web.client.RestTemplateBuilder())
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
+
+        val ex = assertThrows<IllegalStateException> { service.resync() }
+        assertTrue(ex.message!!.contains("TEAMCITY_BASE_URL"), "message should mention the env var")
+    }
+
+    @Test
     @DisplayName("TC client failure on the batched call: exception propagates")
     fun clientFailurePropagates() {
         val components = listOf(component(alice, "alpha"))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -257,6 +257,18 @@ class TeamcitySyncServiceTest {
     }
 
     @Test
+    @DisplayName("blank base-url: throws even when the registry is empty (no silent scanned=0 on misconfiguration)")
+    fun blankBaseUrlThrowsOnEmptyRegistry() {
+        val client = TeamcityClient(TeamcityProperties(), RestTemplateBuilder())
+        val repo = StubComponentRepository(emptyList())
+        val publisher = RecordingPublisher()
+        val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
+
+        val ex = assertThrows<IllegalStateException> { service.resync() }
+        assertTrue(ex.message!!.contains("TEAMCITY_BASE_URL"), "message should mention the env var")
+    }
+
+    @Test
     @DisplayName("TC client failure on the batched call: exception propagates")
     fun clientFailurePropagates() {
         val components = listOf(component(alice, "alpha"))


### PR DESCRIPTION
## Summary

- **SSH vcsPath normalisation**: `ComponentEntity.toSummaryResponse()` now returns `project/repo` instead of the raw SSH URL stored in the entity. Handles all known SSH URL variants:
  - `ssh://git@host/[scm/]project/repo.git` (Bitbucket, no port)
  - `ssh://git@host:port/[scm/]project/repo.git` (Bitbucket, numeric port)
  - `ssh://git@host:org/repo.git` (GitHub SCP-over-SSH — colon introduces org, not port)
  - `git@host:project/repo.git` (SCP-style, Gitea / Bitbucket)
  - Non-git SSH paths (e.g. `ssh://hg@...`) are returned unchanged.

- **TeamCity blank-URL behavior change**: `TeamcityClient.findProjectsByComponentParameter()` now throws `IllegalStateException` when `teamcity.base-url` is blank (previously returned an empty map silently). This surfaces misconfiguration at sync time rather than hiding it.

## Test plan

- [x] Parameterised unit tests cover: Bitbucket no-port, numeric port, `scm/` prefix, GitHub SCP-over-SSH, SCP-style Gitea, nested groups, already-normalised path
- [x] Tests prove non-git SSH URLs (`ssh://hg@...`, `hg@host:path`) are returned unchanged
- [x] Single-segment fallback: `ssh://git@host:7999/repo.git` returns original (no org/port misfire)
- [x] Integration test through `toSummaryResponse()`: entity with SSH URL returns `project/repo`
- [x] TeamCity sync unit tests assert `IllegalStateException` is thrown when base-url is blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)