### PR TITLE
fix(tc-sync): configure teamcity properties via service-config, not env vars

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.client.RestClientException
 
 @ControllerAdvice
 class ControllerExceptionHandler {
@@ -34,6 +35,13 @@ class ControllerExceptionHandler {
     fun illegalStateExceptionHandler(e: IllegalStateException): HttpEntity<ErrorResponse> {
         log.error(e.localizedMessage)
         return HttpEntity(ErrorResponse(e.localizedMessage))
+    }
+
+    @ExceptionHandler(RestClientException::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun restClientExceptionHandler(e: RestClientException): HttpEntity<ErrorResponse> {
+        log.error("Upstream HTTP call failed: {}", e.localizedMessage)
+        return HttpEntity(ErrorResponse("Upstream call failed: ${e.localizedMessage}"))
     }
 
     @ExceptionHandler(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClient.kt
@@ -100,7 +100,7 @@ class TeamcityClient(
         if (baseUrl.isBlank()) {
             throw IllegalStateException(
                 "TC sync is not configured: teamcity.base-url is blank. " +
-                    "Set the TEAMCITY_BASE_URL environment variable.",
+                    "Set teamcity.base-url in service-config (components-registry-service.yml).",
             )
         }
         if (componentsByName.isEmpty()) return emptyMap()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -20,12 +20,12 @@ class TeamcityProperties(
      * Trailing slashes are tolerated. Blank is a misconfiguration —
      * [TeamcityClient] throws [IllegalStateException] so the caller surfaces
      * the error rather than silently returning all-NO_MATCH. Set via
-     * `TEAMCITY_BASE_URL` environment variable.
+     * `teamcity.base-url` in service-config (components-registry-service.yml).
      */
     val baseUrl: String = "",
-    /** TC service account username (HTTP Basic auth). */
+    /** TC service account username (HTTP Basic auth). Set via service-config. */
     val username: String = "",
-    /** TC service account password (HTTP Basic auth). */
+    /** TC service account password (HTTP Basic auth). Set via service-config. */
     val password: String = "",
     /**
      * TCP connect timeout for the TC HTTP client, in seconds. Bounded so a
@@ -44,7 +44,7 @@ class TeamcityProperties(
         /**
          * Master switch for the weekly cron + idle behavior. False by default
          * so dev/unconfigured envs don't fail at startup. Production sets it
-         * via `TEAMCITY_SYNC_ENABLED` per env.
+         * via `teamcity.sync.enabled` in service-config.
          */
         val enabled: Boolean = false,
         /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component
  * Weekly cron that resyncs TC project ids/urls.
  *
  * Conditional bean — registered only when `teamcity.sync.enabled=true`
- * (`TEAMCITY_SYNC_ENABLED=true` in env). With the property absent or false
+ * (`teamcity.sync.enabled=true` in service-config). With the property absent or false
  * (the default), the bean is not registered and Spring's `@EnableScheduling`
  * task scheduler ignores the cron entirely. Production service-config sets
  * the property per env that has TC credentials wired through; CI/test envs

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -6,14 +6,13 @@ components-registry:
 # TeamCity sync engine. Defaults are inert: with `base-url` blank and
 # `sync.enabled` false, the client makes no HTTP calls and the weekly cron
 # bean does not register. Production values come from `service-config`
-# per env (see f1/service-config). Set TEAMCITY_SYNC_ENABLED=true and the
-# host/credentials to turn it on.
+# per env (f1/service-config: components-registry-service.yml).
 teamcity:
-  base-url: ${TEAMCITY_BASE_URL:}
-  username: ${TEAMCITY_USERNAME:}
-  password: ${TEAMCITY_PASSWORD:}
+  base-url:
+  username:
+  password:
   sync:
-    enabled: ${TEAMCITY_SYNC_ENABLED:false}
+    enabled: false
     cron: "0 0 4 * * SUN"
 
 # auth-server.url and auth-server.realm bind from AUTH_SERVER_URL / AUTH_SERVER_REALM

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -253,7 +253,7 @@ class TeamcitySyncServiceTest {
         val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val ex = assertThrows<IllegalStateException> { service.resync() }
-        assertTrue(ex.message!!.contains("TEAMCITY_BASE_URL"), "message should mention the env var")
+        assertTrue(ex.message!!.contains("teamcity.base-url"), "message should mention the config property")
     }
 
     @Test
@@ -265,7 +265,7 @@ class TeamcitySyncServiceTest {
         val service = TeamcitySyncService(repo, client, publisher, fixedUser("admin"), inlineTx())
 
         val ex = assertThrows<IllegalStateException> { service.resync() }
-        assertTrue(ex.message!!.contains("TEAMCITY_BASE_URL"), "message should mention the env var")
+        assertTrue(ex.message!!.contains("teamcity.base-url"), "message should mention the config property")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Remove `${TEAMCITY_BASE_URL:}` / `${TEAMCITY_USERNAME:}` / `${TEAMCITY_PASSWORD:}` / `${TEAMCITY_SYNC_ENABLED:false}` env-var placeholders from `application.yml`; replace with direct empty defaults
- Spring Cloud Config (service-config) and Vault properties are exposed as Spring property keys (`teamcity.base-url`, `teamcity.username`, `teamcity.password`). The old `${TEAMCITY_*}` placeholders resolved env vars — a different key namespace — so service-config values were shadowed by empty env var defaults, leaving `base-url` blank at runtime
- Update error message in `TeamcityClient` to point operators at `service-config (components-registry-service.yml)` instead of env vars
- Update KDocs and test assertions accordingly

## Test plan

- [ ] Unit tests pass (`TeamcitySyncServiceTest` — blank base-url assertions now check for `teamcity.base-url` in message)
- [ ] Deploy to env with service-config `teamcity.base-url` set and Vault credentials wired — resync button should work without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)