### PR TITLE
refactor(jobs): extract AsyncJobLifecycle helper from migration services

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/AsyncJobLifecycle.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/AsyncJobLifecycle.kt
@@ -1,0 +1,164 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.core.task.TaskExecutor
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Composition-based async-job lifecycle helper extracted from
+ * [org.octopusden.octopus.components.registry.server.service.impl.MigrationJobServiceImpl]
+ * and [org.octopusden.octopus.components.registry.server.service.impl.HistoryMigrationJobServiceImpl].
+ * Owns:
+ *  - the in-memory state slot ([AtomicReference]);
+ *  - the CAS+gate+publish claim ordering;
+ *  - [TaskExecutor.execute] submit with rollback on rejection;
+ *  - the id-guarded [update] helper for transitions inside the running work;
+ *  - cross-kind serialization through [MigrationLifecycleGate].
+ *
+ * Composition over inheritance: each impl is a Spring `@Service` with its own
+ * domain-specific dependencies, and we don't want every constructor to drag a
+ * super-class with `executor` / `gate` arguments through the DI graph. With
+ * composition each impl simply owns a `private val lifecycle = AsyncJobLifecycle<TState>(...)`
+ * and delegates the boilerplate.
+ *
+ * Single-pod scope, mirroring the underlying [MigrationLifecycleGate]: this is
+ * an in-memory slot, so a pod restart drops it. Operations that need cross-pod
+ * resilience (e.g. history migration's table-backed `git_history_import_state`)
+ * layer their own DB persistence on top of this helper rather than inside it.
+ */
+class AsyncJobLifecycle<TState : Any>(
+    private val jobKind: MigrationLifecycleGate.JobKind,
+    private val executor: TaskExecutor,
+    private val gate: MigrationLifecycleGate,
+    private val getId: (TState) -> String,
+    private val isRunning: (TState) -> Boolean,
+    /**
+     * Build the FAILED-state replacement when the executor rejects the submission
+     * (typical case: [java.util.concurrent.RejectedExecutionException] during pod
+     * shutdown). Called inside the rollback path with the **current slot value
+     * whose id equals jobId** — typically the freshly-published candidate, but
+     * may be a successor produced by a progress update if one slipped in before
+     * the rejection handler observed the slot. Either way the impl returns a
+     * `state.copy(...)` flipped to FAILED with the appropriate error message
+     * and any kind-specific clears (phase=null, recoveryAction=RETRY, etc.).
+     */
+    private val markRejected: (current: TState, rejection: Throwable) -> TState,
+) {
+    private val state = AtomicReference<TState?>()
+
+    /** Latest known state in this pod, or `null` if no job has been claimed since boot. */
+    fun current(): TState? = state.get()
+
+    /**
+     * Direct slot reset. Used by callers that maintain their own RUNNING-guard
+     * (e.g. `HistoryMigrationJobService.clearInMemory` / `forceReset`) and are
+     * willing to take responsibility for not stomping on a live job.
+     */
+    fun setIdle() {
+        state.set(null)
+    }
+
+    /** Outcome of [claimAndSubmit]. Cross-kind conflicts are signalled via [MigrationConflictException]. */
+    sealed interface ClaimOutcome<TState : Any> {
+        /** A same-kind RUNNING state was already present; caller "attaches" rather than spawning a duplicate. */
+        data class Attached<T : Any>(val state: T) : ClaimOutcome<T>
+
+        /** Slot was claimed for a freshly-built candidate and the work has been submitted to the executor. */
+        data class Started<T : Any>(val state: T) : ClaimOutcome<T>
+    }
+
+    /**
+     * Atomic CAS-retry claim + submit.
+     *
+     * Order of operations is load-bearing:
+     *  1. Read the slot. If a RUNNING state is present → return [ClaimOutcome.Attached].
+     *  2. Mint a fresh `jobId` and ask [buildCandidate] for a candidate keyed off it.
+     *  3. Try to claim the cross-kind gate.
+     *      - cross-kind held → throw [MigrationConflictException] (controllers map to HTTP 409).
+     *      - same-kind held but no RUNNING state visible to us → tiny race window between
+     *        a peer's gate-claim and its state publication; retry the loop.
+     *      - free → we own the gate; proceed.
+     *  4. Publish the candidate via [AtomicReference.compareAndSet]. If the CAS races
+     *     and loses (defensive — should be unreachable while we hold the gate),
+     *     release the gate and retry.
+     *  5. Hand the runnable to the executor as `executor.execute { work(jobId) }`.
+     *     A `SyncTaskExecutor` (used in tests) runs the work to completion before
+     *     this call returns; a real async executor returns immediately while the
+     *     state is still RUNNING. Either way we read `state.get()` once more so
+     *     the returned state is authoritative.
+     *  6. If the executor refuses the submission (typically pod shutdown), the slot
+     *     is rolled back: gate released, state flipped to FAILED via [markRejected],
+     *     and the rejection is rethrown so the caller can surface the error.
+     */
+    fun claimAndSubmit(
+        buildCandidate: (jobId: String) -> TState,
+        work: (jobId: String) -> Unit,
+    ): ClaimOutcome<TState> {
+        while (true) {
+            val existing = state.get()
+            if (existing != null && isRunning(existing)) {
+                return ClaimOutcome.Attached(existing)
+            }
+
+            val jobId = UUID.randomUUID().toString()
+            val candidate = buildCandidate(jobId)
+
+            val gateConflict = gate.tryClaim(jobKind, jobId)
+            if (gateConflict != null) {
+                if (gateConflict.kind != jobKind) {
+                    throw MigrationConflictException(gateConflict)
+                }
+                // Same-kind gate is held by a peer that has claimed the gate but
+                // not yet published its state. Retry — the next iteration will
+                // see RUNNING and return Attached.
+                continue
+            }
+
+            if (!state.compareAndSet(existing, candidate)) {
+                // Defensive: with the gate held no other startAsync can overwrite
+                // the slot, so this branch should be unreachable in practice.
+                gate.release(jobId)
+                continue
+            }
+
+            LOG.info("Starting {} job {}", jobKind, jobId)
+            @Suppress("TooGenericExceptionCaught") // Throwable so executor rejection ALWAYS unwinds the slot.
+            try {
+                executor.execute { work(jobId) }
+            } catch (rejected: Throwable) {
+                LOG.error("Failed to submit {} job {} to executor", jobKind, jobId, rejected)
+                gate.release(jobId)
+                state.updateAndGet { current ->
+                    if (current == null || getId(current) != jobId) current else markRejected(current, rejected)
+                }
+                throw rejected
+            }
+
+            return ClaimOutcome.Started(state.get() ?: candidate)
+        }
+    }
+
+    /**
+     * id-guarded transition. The [transform] runs only if the slot still carries
+     * a state whose id equals [jobId] — otherwise this is a no-op. Used by the
+     * running work to publish progress / completion / failure transitions
+     * without ever overwriting a freshly-claimed successor.
+     *
+     * Returns the post-update state (or the un-touched current state if the guard
+     * tripped); generally the caller can ignore the return value.
+     */
+    fun update(jobId: String, transform: (TState) -> TState): TState? =
+        state.updateAndGet { current ->
+            if (current == null || getId(current) != jobId) current else transform(current)
+        }
+
+    /** Release the cross-kind gate. Idempotent: safe to call from finally on a rejection-rolled-back jobId. */
+    fun release(jobId: String) {
+        gate.release(jobId)
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(AsyncJobLifecycle::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.service.impl
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
+import org.octopusden.octopus.components.registry.server.service.AsyncJobLifecycle
 import org.octopusden.octopus.components.registry.server.service.ForceResetOutcome
 import org.octopusden.octopus.components.registry.server.service.GitHistoryImportService
 import org.octopusden.octopus.components.registry.server.service.HistoryImportProgressListener
@@ -10,7 +11,6 @@ import org.octopusden.octopus.components.registry.server.service.HistoryMigratio
 import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobState
 import org.octopusden.octopus.components.registry.server.service.HistoryRecoveryAction
 import org.octopusden.octopus.components.registry.server.service.JobState
-import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
 import org.octopusden.octopus.components.registry.server.service.StartHistoryMigrationResult
@@ -20,131 +20,66 @@ import org.springframework.core.task.TaskExecutor
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.atomic.AtomicReference
 
 /**
- * In-memory async wrapper around [GitHistoryImportService.importHistory]. Mirrors
- * [MigrationJobServiceImpl] for the components flow — same gate integration, same
- * CAS-then-publish ordering, same finally-release.
+ * In-memory async wrapper around [GitHistoryImportService.importHistory].
+ * Mirrors [MigrationJobServiceImpl] for the components flow — same gate
+ * integration via [AsyncJobLifecycle], same CAS-then-publish ordering, same
+ * finally-release.
  *
  * Difference from components: history has a table-backed claim
  * (`git_history_import_state`) that survives pod restarts. The in-memory state
  * is what the SPA sees while a job is RUNNING in this pod; after the pod
  * restarts the in-memory ref is empty but the DB row is still there, and
  * [current] synthesizes a state from it so the SPA can render the right action
- * (Retry on COMPLETED/FAILED, Force-reset on stale IN_PROGRESS — see A7.1).
+ * (Retry on COMPLETED/FAILED, Force-reset on stale IN_PROGRESS).
  */
 @Service
 class HistoryMigrationJobServiceImpl(
     private val gitHistoryImportService: GitHistoryImportService,
     private val stateRepository: GitHistoryImportStateRepository,
-    @Qualifier("migrationExecutor") private val executor: TaskExecutor,
-    private val lifecycleGate: MigrationLifecycleGate,
+    @Qualifier("migrationExecutor") executor: TaskExecutor,
+    lifecycleGate: MigrationLifecycleGate,
     private val forceResetter: HistoryForceResetter,
 ) : HistoryMigrationJobService {
-    private val state = AtomicReference<HistoryMigrationJobState?>()
-
-    /** Mirror of [MigrationJobServiceImpl.ClaimAttempt] for the history flow. */
-    private sealed interface ClaimAttempt {
-        data class Attached(
-            val state: HistoryMigrationJobState,
-        ) : ClaimAttempt
-
-        data class CrossKindConflict(
-            val active: MigrationLifecycleGate.ActiveJob,
-        ) : ClaimAttempt
-
-        data object Retry : ClaimAttempt
-
-        data class Claimed(
-            val candidate: HistoryMigrationJobState,
-        ) : ClaimAttempt
-    }
+    private val lifecycle =
+        AsyncJobLifecycle<HistoryMigrationJobState>(
+            jobKind = JobKind.HISTORY,
+            executor = executor,
+            gate = lifecycleGate,
+            getId = { it.id },
+            isRunning = { it.state == JobState.RUNNING },
+            markRejected = { current, rejected ->
+                current.copy(
+                    state = JobState.FAILED,
+                    finishedAt = Instant.now(),
+                    errorMessage =
+                        "Failed to submit history migration: ${rejected.message ?: rejected::class.java.simpleName}",
+                    recoveryAction = HistoryRecoveryAction.RETRY,
+                )
+            },
+        )
 
     override fun startAsync(
         toRef: String?,
         reset: Boolean,
     ): StartHistoryMigrationResult {
-        while (true) {
-            when (val attempt = tryClaim()) {
-                is ClaimAttempt.Attached -> return StartHistoryMigrationResult(attempt.state, isNewlyStarted = false)
-                is ClaimAttempt.CrossKindConflict -> throw MigrationConflictException(attempt.active)
-                is ClaimAttempt.Claimed -> {
-                    submitToExecutor(attempt.candidate, toRef, reset)
-                    return StartHistoryMigrationResult(state.get() ?: attempt.candidate, isNewlyStarted = true)
-                }
-                ClaimAttempt.Retry -> Unit
-            }
-        }
-    }
-
-    /** See [MigrationJobServiceImpl.tryClaim] — same CAS-retry shape, same ordering rationale. */
-    private fun tryClaim(): ClaimAttempt {
-        val existing = state.get()
-        if (existing?.state == JobState.RUNNING) {
-            return ClaimAttempt.Attached(existing)
-        }
-
-        val candidate =
-            HistoryMigrationJobState(
-                id = UUID.randomUUID().toString(),
-                state = JobState.RUNNING,
-                startedAt = Instant.now(),
-                finishedAt = null,
-                totalCommits = 0,
-                processedCommits = 0,
-                auditRecords = 0,
-                skippedNoGroovy = 0,
-                skippedParseError = 0,
-                skippedUnknownNames = 0,
-                currentSha = null,
-                targetRef = null,
-                errorMessage = null,
-                result = null,
+        val outcome =
+            lifecycle.claimAndSubmit(
+                buildCandidate = ::buildCandidate,
+                work = { jobId -> runHistoryMigration(jobId, toRef, reset) },
             )
-
-        val gateConflict = lifecycleGate.tryClaim(JobKind.HISTORY, candidate.id)
-        if (gateConflict != null) {
-            return when (gateConflict.kind) {
-                JobKind.HISTORY -> ClaimAttempt.Retry
-                JobKind.COMPONENTS -> ClaimAttempt.CrossKindConflict(gateConflict)
+        return when (outcome) {
+            is AsyncJobLifecycle.ClaimOutcome.Attached ->
+                StartHistoryMigrationResult(outcome.state, isNewlyStarted = false)
+            is AsyncJobLifecycle.ClaimOutcome.Started -> {
+                // Preserve the pre-refactor "Starting history migration job ..."
+                // breadcrumb (the generic helper line carries only kind+id, which
+                // log-greppers and runbooks looking for the previous prefix would
+                // miss). Logged only on Started so attach attempts don't double-log.
+                LOG.info("Starting history migration job {} (toRef={}, reset={})", outcome.state.id, toRef, reset)
+                StartHistoryMigrationResult(outcome.state, isNewlyStarted = true)
             }
-        }
-
-        if (!state.compareAndSet(existing, candidate)) {
-            lifecycleGate.release(candidate.id)
-            return ClaimAttempt.Retry
-        }
-        return ClaimAttempt.Claimed(candidate)
-    }
-
-    @Suppress("TooGenericExceptionCaught") // Throwable so executor rejection ALWAYS unwinds the slot.
-    private fun submitToExecutor(
-        candidate: HistoryMigrationJobState,
-        toRef: String?,
-        reset: Boolean,
-    ) {
-        LOG.info("Starting history migration job {} (toRef={}, reset={})", candidate.id, toRef, reset)
-        try {
-            executor.execute { runHistoryMigration(candidate.id, toRef, reset) }
-        } catch (rejected: Throwable) {
-            LOG.error("Failed to submit history migration job {} to executor", candidate.id, rejected)
-            lifecycleGate.release(candidate.id)
-            state.updateAndGet { current ->
-                if (current?.id != candidate.id) {
-                    current
-                } else {
-                    current.copy(
-                        state = JobState.FAILED,
-                        finishedAt = Instant.now(),
-                        errorMessage =
-                            "Failed to submit history migration: ${rejected.message ?: rejected::class.java.simpleName}",
-                        recoveryAction = HistoryRecoveryAction.RETRY,
-                    )
-                }
-            }
-            throw rejected
         }
     }
 
@@ -159,13 +94,13 @@ class HistoryMigrationJobServiceImpl(
      * Force-reset.
      */
     override fun current(): HistoryMigrationJobState? {
-        state.get()?.let { return it }
+        lifecycle.current()?.let { return it }
         val row = stateRepository.findById(HISTORY_IMPORT_KEY).orElse(null) ?: return null
         return synthesizeFromDb(row)
     }
 
     override fun clearInMemory() {
-        val current = state.get()
+        val current = lifecycle.current()
         if (current?.state == JobState.RUNNING) {
             LOG.warn(
                 "clearInMemory() called while job {} is RUNNING — ignored. " +
@@ -174,13 +109,13 @@ class HistoryMigrationJobServiceImpl(
             )
             return
         }
-        state.set(null)
+        lifecycle.setIdle()
     }
 
     /**
      * Guards → wipe → return outcome. See [HistoryMigrationJobService.forceReset].
      *
-     * Guard ordering mirrors [AdminControllerV4.forceResetHistory] before refactor:
+     * Guard ordering mirrors the pre-refactor controller flow:
      *  1. In-pod RUNNING check (in-memory read, no DB).
      *  2. DB staleness check (DB read + age compare).
      *  3. TOCTOU re-read: re-check in-memory state after DB read to catch a
@@ -188,7 +123,7 @@ class HistoryMigrationJobServiceImpl(
      */
     override fun forceReset(ackMultipodRisk: Boolean): ForceResetOutcome {
         // Guard 1: same-pod active job.
-        val active = state.get()
+        val active = lifecycle.current()
         if (active?.state == JobState.RUNNING) {
             return ForceResetOutcome.Blocked(
                 code = "history-migration-running",
@@ -200,8 +135,8 @@ class HistoryMigrationJobServiceImpl(
             )
         }
 
-        // Guard 2: cross-pod staleness. Inspect the DB row directly so a live import
-        // in another pod (with a fresh updatedAt) is detected.
+        // Guard 2: cross-pod staleness. Inspect the DB row directly so a live
+        // import in another pod (with a fresh updatedAt) is detected.
         val row = stateRepository.findById(HISTORY_IMPORT_KEY).orElse(null)
         if (row != null &&
             row.status == GitHistoryImportStatus.IN_PROGRESS.name &&
@@ -229,11 +164,12 @@ class HistoryMigrationJobServiceImpl(
             }
         }
 
-        // TOCTOU re-read: re-check in-memory state after the DB row read. The window
-        // between Guard 1 and this point is at most one DB round-trip wide. A concurrent
-        // startAsync that slipped past Guard 1 (it hadn't claimed the gate yet) and has
-        // since published its state will be caught here.
-        val activeAfterRowRead = state.get()
+        // TOCTOU re-read: re-check in-memory state after the DB row read. The
+        // window between Guard 1 and this point is at most one DB round-trip
+        // wide. A concurrent startAsync that slipped past Guard 1 (it hadn't
+        // claimed the gate yet) and has since published its state will be
+        // caught here.
+        val activeAfterRowRead = lifecycle.current()
         if (activeAfterRowRead?.state == JobState.RUNNING) {
             return ForceResetOutcome.Blocked(
                 code = "history-migration-running",
@@ -245,9 +181,9 @@ class HistoryMigrationJobServiceImpl(
             )
         }
 
-        // Audit-loud destructive action: log before the wipe so the pre-state survives
-        // in the log stream. ackMultipodRisk override logged at ERROR so alert pipelines
-        // that filter on ERROR-only catch it.
+        // Audit-loud destructive action: log before the wipe so the pre-state
+        // survives in the log stream. ackMultipodRisk override logged at ERROR
+        // so alert pipelines that filter on ERROR-only catch it.
         if (row != null) {
             val msg =
                 "FORCE-RESET: deleting git_history_import_state " +
@@ -259,11 +195,30 @@ class HistoryMigrationJobServiceImpl(
         }
 
         forceResetter.forceReset()
-        // Bypass the clearInMemory() RUNNING guard — we already verified there is no
-        // RUNNING job above (Guards 1, 3). Direct set avoids the redundant re-check.
-        state.set(null)
+        // Bypass the clearInMemory() RUNNING guard — we already verified there
+        // is no RUNNING job above (Guards 1, 3). Direct setIdle avoids the
+        // redundant re-check.
+        lifecycle.setIdle()
         return ForceResetOutcome.Cleared
     }
+
+    private fun buildCandidate(jobId: String): HistoryMigrationJobState =
+        HistoryMigrationJobState(
+            id = jobId,
+            state = JobState.RUNNING,
+            startedAt = Instant.now(),
+            finishedAt = null,
+            totalCommits = 0,
+            processedCommits = 0,
+            auditRecords = 0,
+            skippedNoGroovy = 0,
+            skippedParseError = 0,
+            skippedUnknownNames = 0,
+            currentSha = null,
+            targetRef = null,
+            errorMessage = null,
+            result = null,
+        )
 
     private fun runHistoryMigration(
         jobId: String,
@@ -272,27 +227,23 @@ class HistoryMigrationJobServiceImpl(
     ) {
         try {
             val result = gitHistoryImportService.importHistory(toRef, reset, progressListener(jobId))
-            state.updateAndGet { current ->
-                if (current?.id != jobId) {
-                    current
-                } else {
-                    current.copy(
-                        state = JobState.COMPLETED,
-                        finishedAt = Instant.now(),
-                        currentSha = null,
-                        targetRef = result.targetRef,
-                        totalCommits = result.processedCommits,
-                        processedCommits = result.processedCommits,
-                        auditRecords = result.auditRecords,
-                        skippedNoGroovy = result.skippedNoGroovy,
-                        skippedParseError = result.skippedParseError,
-                        skippedUnknownNames = result.skippedUnknownNames,
-                        result = result,
-                        // Operator can re-run the import on top of a COMPLETED row
-                        // via reset=true; SPA shows "Retry (reset state)".
-                        recoveryAction = HistoryRecoveryAction.RETRY,
-                    )
-                }
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    state = JobState.COMPLETED,
+                    finishedAt = Instant.now(),
+                    currentSha = null,
+                    targetRef = result.targetRef,
+                    totalCommits = result.processedCommits,
+                    processedCommits = result.processedCommits,
+                    auditRecords = result.auditRecords,
+                    skippedNoGroovy = result.skippedNoGroovy,
+                    skippedParseError = result.skippedParseError,
+                    skippedUnknownNames = result.skippedUnknownNames,
+                    result = result,
+                    // Operator can re-run the import on top of a COMPLETED row
+                    // via reset=true; SPA shows "Retry (reset state)".
+                    recoveryAction = HistoryRecoveryAction.RETRY,
+                )
             }
             LOG.info(
                 "History migration job {} COMPLETED: {} commits processed, {} audit rows, {} ms",
@@ -305,45 +256,37 @@ class HistoryMigrationJobServiceImpl(
             @Suppress("TooGenericExceptionCaught") e: Throwable,
         ) {
             LOG.error("History migration job {} FAILED", jobId, e)
-            state.updateAndGet { current ->
-                if (current?.id != jobId) {
-                    current
-                } else {
-                    current.copy(
-                        state = JobState.FAILED,
-                        finishedAt = Instant.now(),
-                        currentSha = null,
-                        errorMessage = e.message ?: e::class.java.simpleName,
-                        // FAILED in-memory paths are recoverable with reset=true
-                        // (the underlying preflight will clear the FAILED row
-                        // before re-claiming). FORCE_RESET is reserved for the
-                        // synthesized stuck-IN_PROGRESS DB-fallback case only.
-                        recoveryAction = HistoryRecoveryAction.RETRY,
-                    )
-                }
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    state = JobState.FAILED,
+                    finishedAt = Instant.now(),
+                    currentSha = null,
+                    errorMessage = e.message ?: e::class.java.simpleName,
+                    // FAILED in-memory paths are recoverable with reset=true
+                    // (the underlying preflight will clear the FAILED row
+                    // before re-claiming). FORCE_RESET is reserved for the
+                    // synthesized stuck-IN_PROGRESS DB-fallback case only.
+                    recoveryAction = HistoryRecoveryAction.RETRY,
+                )
             }
         } finally {
-            lifecycleGate.release(jobId)
+            lifecycle.release(jobId)
         }
     }
 
     private fun progressListener(jobId: String): HistoryImportProgressListener =
         HistoryImportProgressListener { event ->
-            state.updateAndGet { current ->
-                if (current?.id != jobId) {
-                    current
-                } else {
-                    current.copy(
-                        totalCommits = event.totalCommits,
-                        processedCommits = event.processedCommits,
-                        auditRecords = event.auditRecords,
-                        skippedNoGroovy = event.skippedNoGroovy,
-                        skippedParseError = event.skippedParseError,
-                        skippedUnknownNames = event.skippedUnknownNames,
-                        currentSha = event.currentSha,
-                        targetRef = event.targetRef,
-                    )
-                }
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    totalCommits = event.totalCommits,
+                    processedCommits = event.processedCommits,
+                    auditRecords = event.auditRecords,
+                    skippedNoGroovy = event.skippedNoGroovy,
+                    skippedParseError = event.skippedParseError,
+                    skippedUnknownNames = event.skippedUnknownNames,
+                    currentSha = event.currentSha,
+                    targetRef = event.targetRef,
+                )
             }
         }
 
@@ -353,10 +296,7 @@ class HistoryMigrationJobServiceImpl(
         // makes the id distinguishable across the COMPLETED→re-claimed→FAILED
         // sequence in the same pod-restart window; targetSha disambiguates
         // imports against different refs; updatedAt covers the rare
-        // same-content same-ref case. The previous "restored-${epochMillis}"
-        // form could collide on identical updatedAt (multiple sequential
-        // restarts against the unchanged row), causing downstream consumers
-        // that key on `id` to miss state transitions.
+        // same-content same-ref case.
         val shaPart = row.targetSha.takeIf { it.isNotEmpty() } ?: "no-sha"
         val syntheticId = "restored:${row.status.lowercase()}:$shaPart:${row.updatedAt.toEpochMilli()}"
         return when (row.status) {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
@@ -1,9 +1,9 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.service.AsyncJobLifecycle
 import org.octopusden.octopus.components.registry.server.service.FullMigrationResult
 import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.JobState
-import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
 import org.octopusden.octopus.components.registry.server.service.MigrationJobState
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
@@ -16,201 +16,122 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.task.TaskExecutor
 import org.springframework.stereotype.Service
 import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.atomic.AtomicReference
 
 /**
- * In-memory async wrapper around [ImportService.migrate].
+ * In-memory async wrapper around [ImportService.migrate]. Lifecycle boilerplate
+ * (CAS+gate claim, executor submit-with-rollback, id-guarded state updates) is
+ * delegated to [AsyncJobLifecycle]; this class is the components-specific
+ * adapter — it owns the [MigrationJobState] DTO, phase model, and progress
+ * listener wiring.
  *
- * Why in-memory and not table-backed: a single CRS pod owns the migration; a hard
- * restart kills the run regardless of where state lives. The
- * GitHistoryImportStateEntity pattern (PR #151) earns its keep when the operation
- * is genuinely resumable, which `ImportService.migrate` is not — it would re-do
- * every component on restart. So we trade resilience for code we can read in one
- * sitting.
+ * Why in-memory and not table-backed: a single CRS pod owns the migration; a
+ * hard restart kills the run regardless of where state lives. The
+ * `git_history_import_state` pattern earns its keep when the operation is
+ * genuinely resumable — `ImportService.migrate` would re-do every component on
+ * restart, so we trade resilience for code we can read in one sitting.
  *
  * Concurrency model:
- *  - Same-kind 409 (a second components POST while one is RUNNING) is decided by
- *    reading the local AtomicReference. The SPA "attaches" to the in-flight job
- *    rather than spawning a duplicate.
+ *  - Same-kind 409 (a second components POST while one is RUNNING) is decided
+ *    by the lifecycle's local in-memory slot: the SPA "attaches" to the
+ *    in-flight job rather than spawning a duplicate.
  *  - Cross-kind serialization (a components POST while history is RUNNING) is
- *    decided by [MigrationLifecycleGate] — a shared bean both this service and
- *    HistoryMigrationJobService consult before claiming. ThreadPoolTaskExecutor
- *    on its own does NOT serialize cross-service: it queues the second submit,
- *    so without the gate both `startAsync` calls would return 202 and the SPA
- *    would render two RUNNING jobs.
+ *    decided by [MigrationLifecycleGate] which the lifecycle consults before
+ *    claiming. ThreadPoolTaskExecutor on its own does NOT serialize cross-service:
+ *    it queues the second submit, so without the gate both `startAsync` calls
+ *    would return 202 and the SPA would render two RUNNING jobs.
  */
 @Service
 class MigrationJobServiceImpl(
     private val importService: ImportService,
-    @Qualifier("migrationExecutor") private val executor: TaskExecutor,
-    private val lifecycleGate: MigrationLifecycleGate,
+    @Qualifier("migrationExecutor") executor: TaskExecutor,
+    lifecycleGate: MigrationLifecycleGate,
 ) : MigrationJobService {
-    private val state = AtomicReference<MigrationJobState?>()
-
-    /**
-     * Outcome of a single CAS-retry iteration in [startAsync]. Replaces what
-     * was previously a multi-jump loop body with explicit named cases — each
-     * one maps to exactly one terminal action in the loop driver.
-     */
-    private sealed interface ClaimAttempt {
-        /** Same-kind start while one is RUNNING — caller attaches to existing. */
-        data class Attached(
-            val state: MigrationJobState,
-        ) : ClaimAttempt
-
-        /** Cross-kind gate held by HISTORY — caller throws to the controller's 409 mapper. */
-        data class CrossKindConflict(
-            val active: MigrationLifecycleGate.ActiveJob,
-        ) : ClaimAttempt
-
-        /** Lost a race (gate or state CAS); caller loops back for another attempt. */
-        data object Retry : ClaimAttempt
-
-        /** Won the slot; caller submits the runnable to the executor. */
-        data class Claimed(
-            val candidate: MigrationJobState,
-        ) : ClaimAttempt
-    }
+    private val lifecycle =
+        AsyncJobLifecycle<MigrationJobState>(
+            jobKind = JobKind.COMPONENTS,
+            executor = executor,
+            gate = lifecycleGate,
+            getId = { it.id },
+            isRunning = { it.state == JobState.RUNNING },
+            markRejected = { current, rejected ->
+                current.copy(
+                    state = JobState.FAILED,
+                    finishedAt = Instant.now(),
+                    errorMessage =
+                        "Failed to submit migration: ${rejected.message ?: rejected::class.java.simpleName}",
+                    phase = null,
+                )
+            },
+        )
 
     override fun startAsync(): StartMigrationResult {
-        // Order of operations is load-bearing — see [tryClaim]. We loop only on
-        // [ClaimAttempt.Retry]; every other case is a terminal action.
-        while (true) {
-            when (val attempt = tryClaim()) {
-                is ClaimAttempt.Attached -> return StartMigrationResult(attempt.state, isNewlyStarted = false)
-                is ClaimAttempt.CrossKindConflict -> throw MigrationConflictException(attempt.active)
-                is ClaimAttempt.Claimed -> {
-                    submitToExecutor(attempt.candidate)
-                    // SyncTaskExecutor (used in tests) has already finished the run by now → callers see COMPLETED.
-                    // Production async executor → RUNNING. Either way, return the authoritative current state.
-                    return StartMigrationResult(state.get() ?: attempt.candidate, isNewlyStarted = true)
-                }
-                ClaimAttempt.Retry -> Unit // loop again
-            }
+        val outcome =
+            lifecycle.claimAndSubmit(
+                buildCandidate = ::buildCandidate,
+                work = ::runMigration,
+            )
+        return when (outcome) {
+            is AsyncJobLifecycle.ClaimOutcome.Attached -> StartMigrationResult(outcome.state, isNewlyStarted = false)
+            is AsyncJobLifecycle.ClaimOutcome.Started -> StartMigrationResult(outcome.state, isNewlyStarted = true)
         }
     }
+
+    override fun current(): MigrationJobState? = lifecycle.current()
 
     /**
-     * One CAS-retry iteration. Decomposes the original loop body into:
-     *   1. same-kind 409 from local AtomicReference (state is non-null when RUNNING),
-     *   2. cross-kind gate claim (after the same-kind path so we never read
-     *      nullable state inside the gate-conflict branch),
-     *   3. publish state via CAS.
+     * Build the freshly-RUNNING candidate seeded with `phase=DEFAULTS`.
      *
-     * A naive "gate first" version had a window where thread A claimed the gate but
-     * hadn't yet written state, and thread B's same-kind 409 path would NPE on
-     * `state.get()!!`. Same-kind first dodges that.
+     * CRITICAL: phase is set on the candidate BEFORE executor.execute, not inside
+     * the runnable. ThreadPoolTaskExecutor.execute returns synchronously and the
+     * controller builds its response from `current()` right after — if phase
+     * weren't already DEFAULTS the first SPA poll tick would see RUNNING with no
+     * phase and render the fallback "Running…" instead of "Loading defaults from
+     * Git…".
      */
-    private fun tryClaim(): ClaimAttempt {
-        val existing = state.get()
-        if (existing?.state == JobState.RUNNING) {
-            return ClaimAttempt.Attached(existing)
-        }
-
-        val candidate =
-            MigrationJobState(
-                id = UUID.randomUUID().toString(),
-                state = JobState.RUNNING,
-                startedAt = Instant.now(),
-                finishedAt = null,
-                total = 0,
-                migrated = 0,
-                failed = 0,
-                skipped = 0,
-                currentComponent = null,
-                errorMessage = null,
-                result = null,
-                // CRITICAL: phase is set on the candidate BEFORE executor.execute,
-                // not inside the runnable. ThreadPoolTaskExecutor.execute returns
-                // synchronously and the controller builds its response from
-                // state.get() right after — if phase weren't already DEFAULTS the
-                // first SPA poll tick would see RUNNING with no phase and render
-                // the fallback "Running…" instead of "Loading defaults from Git…".
-                phase = MigrationPhase.DEFAULTS,
-            )
-
-        val gateConflict = lifecycleGate.tryClaim(JobKind.COMPONENTS, candidate.id)
-        if (gateConflict != null) {
-            return when (gateConflict.kind) {
-                JobKind.COMPONENTS -> ClaimAttempt.Retry
-                JobKind.HISTORY -> ClaimAttempt.CrossKindConflict(gateConflict)
-            }
-        }
-
-        // Gate is ours. Publish state. With the gate held no other startAsync of
-        // either kind is in this critical section, so the CAS should always succeed
-        // — the false branch is defensive belt-and-braces.
-        if (!state.compareAndSet(existing, candidate)) {
-            lifecycleGate.release(candidate.id)
-            return ClaimAttempt.Retry
-        }
-        return ClaimAttempt.Claimed(candidate)
-    }
-
-    @Suppress("TooGenericExceptionCaught") // Throwable so executor rejection ALWAYS unwinds the slot.
-    private fun submitToExecutor(candidate: MigrationJobState) {
-        LOG.info("Starting migration job {}", candidate.id)
-        try {
-            executor.execute { runMigration(candidate.id) }
-        } catch (rejected: Throwable) {
-            // The slot was claimed for this candidate but the executor refused
-            // (typical case: RejectedExecutionException during pod shutdown).
-            // Without this rollback, the in-memory slot would stay RUNNING
-            // forever — every subsequent POST /admin/migrate would return 409
-            // and the operator would be wedged. Transition to FAILED so the
-            // slot is "done" and the next startAsync claims a fresh one.
-            LOG.error("Failed to submit migration job {} to executor", candidate.id, rejected)
-            lifecycleGate.release(candidate.id)
-            state.updateAndGet { current ->
-                if (current?.id != candidate.id) {
-                    current
-                } else {
-                    current.copy(
-                        state = JobState.FAILED,
-                        finishedAt = Instant.now(),
-                        errorMessage =
-                            "Failed to submit migration: ${rejected.message ?: rejected::class.java.simpleName}",
-                        phase = null,
-                    )
-                }
-            }
-            throw rejected
-        }
-    }
-
-    override fun current(): MigrationJobState? = state.get()
+    private fun buildCandidate(jobId: String): MigrationJobState =
+        MigrationJobState(
+            id = jobId,
+            state = JobState.RUNNING,
+            startedAt = Instant.now(),
+            finishedAt = null,
+            total = 0,
+            migrated = 0,
+            failed = 0,
+            skipped = 0,
+            currentComponent = null,
+            errorMessage = null,
+            result = null,
+            phase = MigrationPhase.DEFAULTS,
+        )
 
     private fun runMigration(jobId: String) {
         try {
-            // phase=DEFAULTS was already published by startAsync(); we don't re-set it
-            // here because a) it's already correct, b) re-publishing would mean two
-            // observable phase-transitions for one logical phase boundary.
+            // phase=DEFAULTS was already published by buildCandidate(); we don't
+            // re-set it here because a) it's already correct, b) re-publishing
+            // would mean two observable phase-transitions for one logical
+            // phase boundary.
             val defaults = importService.migrateDefaults()
 
-            updatePhase(jobId, MigrationPhase.COMPONENTS)
+            lifecycle.update(jobId) { current ->
+                // Clear currentComponent on phase boundary so the SPA doesn't keep
+                // showing a stale per-component label while the new phase is initializing.
+                current.copy(phase = MigrationPhase.COMPONENTS, currentComponent = null)
+            }
             val components = importService.migrateAllComponents(progressListener(jobId))
 
             val result = FullMigrationResult(defaults = defaults, components = components)
-            state.updateAndGet { current ->
-                // Defend against a stale jobId update (e.g. another start happened in
-                // between, which shouldn't be possible while we're RUNNING but is cheap
-                // to guard against).
-                if (current?.id != jobId) {
-                    current
-                } else {
-                    current.copy(
-                        state = JobState.COMPLETED,
-                        finishedAt = Instant.now(),
-                        currentComponent = null,
-                        phase = null,
-                        result = result,
-                        total = components.total,
-                        migrated = components.migrated,
-                        failed = components.failed,
-                        skipped = components.skipped,
-                    )
-                }
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    state = JobState.COMPLETED,
+                    finishedAt = Instant.now(),
+                    currentComponent = null,
+                    phase = null,
+                    result = result,
+                    total = components.total,
+                    migrated = components.migrated,
+                    failed = components.failed,
+                    skipped = components.skipped,
+                )
             }
             LOG.info(
                 "Migration job {} COMPLETED: {}/{} migrated, {} failed, {} skipped",
@@ -224,55 +145,33 @@ class MigrationJobServiceImpl(
             @Suppress("TooGenericExceptionCaught") e: Throwable,
         ) {
             LOG.error("Migration job {} FAILED", jobId, e)
-            state.updateAndGet { current ->
-                if (current?.id != jobId) {
-                    current
-                } else {
-                    current.copy(
-                        state = JobState.FAILED,
-                        finishedAt = Instant.now(),
-                        currentComponent = null,
-                        phase = null,
-                        errorMessage = e.message ?: e::class.java.simpleName,
-                    )
-                }
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    state = JobState.FAILED,
+                    finishedAt = Instant.now(),
+                    currentComponent = null,
+                    phase = null,
+                    errorMessage = e.message ?: e::class.java.simpleName,
+                )
             }
         } finally {
-            // Always release the cross-kind gate, even on failure / unhandled throw,
-            // so a follow-up history migration isn't blocked forever by a leaked claim.
-            lifecycleGate.release(jobId)
-        }
-    }
-
-    private fun updatePhase(
-        jobId: String,
-        nextPhase: MigrationPhase,
-    ) {
-        state.updateAndGet { current ->
-            if (current?.id != jobId) {
-                current
-            } else {
-                // Clear currentComponent on phase boundary so the SPA doesn't keep showing
-                // a stale per-component label while the new phase is initializing.
-                current.copy(phase = nextPhase, currentComponent = null)
-            }
+            // Always release the cross-kind gate, even on failure / unhandled
+            // throw, so a follow-up history migration isn't blocked forever by
+            // a leaked claim.
+            lifecycle.release(jobId)
         }
     }
 
     private fun progressListener(jobId: String): MigrationProgressListener =
         MigrationProgressListener { event ->
-            state.updateAndGet { current ->
-                if (current?.id != jobId) {
-                    current
-                } else {
-                    current.copy(
-                        currentComponent = event.componentName,
-                        migrated = event.migrated,
-                        failed = event.failed,
-                        skipped = event.skipped,
-                        total = event.total,
-                    )
-                }
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    currentComponent = event.componentName,
+                    migrated = event.migrated,
+                    failed = event.failed,
+                    skipped = event.skipped,
+                    total = event.total,
+                )
             }
         }
 


### PR DESCRIPTION
## Summary
- Extracts a generic `AsyncJobLifecycle<TState>` helper that owns the in-memory state slot, CAS+gate+publish claim ordering, executor submit-with-rollback, and id-guarded state updates.
- `MigrationJobServiceImpl` and `HistoryMigrationJobServiceImpl` are rewritten on top of the helper; lifecycle boilerplate is gone, kind-specific surface (state DTO, candidate factory, runtime body, history's `forceReset`/`synthesizeFromDb`) stays.
- Pure refactor — **no behavior change**. The 16+27 existing unit tests on the two services pass without any test-side modifications. Full local `./gradlew build` is green.

## Why now
A third async-job kind (TeamCity sync resync, follow-up PR) is queued behind this. Adding it as a third ~280-line copy of the same boilerplate would be a maintenance trap; with the helper in place each new kind ships only the kind-specific code.

## Notes
- Composition over inheritance: each impl owns a `private val lifecycle = AsyncJobLifecycle<TState>(...)` rather than extending an abstract base. Keeps Spring DI clean and concentrates the boilerplate in one place.
- Helper logs `Starting {kind} job {id}` / `Failed to submit {kind} job {id} ...` under its own SLF4J logger. The pre-existing `Starting history migration job ... (toRef=, reset=)` breadcrumb is preserved verbatim in `HistoryMigrationJobServiceImpl`, conditional on `Started` outcome so attach attempts don't double-log.
- `markRejected` is the only impl-supplied lambda for the rollback path; KDoc spells out that it receives the current id-matching slot value (which may be the freshly-published candidate or a successor produced by a progress update before the rejection handler observed the slot).

## Test plan
- [x] `./gradlew :components-registry-service-server:test` — green, including all 16 + 27 lifecycle tests unchanged.
- [x] `./gradlew build` (with project-standard CI-only excludes) — green.
- [ ] CI on PR
- [ ] Independent code review (already passed once locally — addressed `markRejected` KDoc precision and history breadcrumb preservation before pushing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)