### PR TITLE
feat(tc-sync): add async TC resync job (POST /sync + GET /sync/job)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.controller
 import org.octopusden.octopus.components.registry.server.dto.v4.HistoryMigrationJobResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationConflictResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationJobResponse
+import org.octopusden.octopus.components.registry.server.dto.v4.TeamcitySyncJobResponse
 import org.octopusden.octopus.components.registry.server.service.BatchMigrationResult
 import org.octopusden.octopus.components.registry.server.service.ForceResetOutcome
 import org.octopusden.octopus.components.registry.server.service.HistoryMigrationJobService
@@ -13,6 +14,7 @@ import org.octopusden.octopus.components.registry.server.service.MigrationLifecy
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.http.HttpStatus
@@ -35,6 +37,7 @@ class AdminControllerV4(
     private val migrationJobService: MigrationJobService,
     private val historyMigrationJobService: HistoryMigrationJobService,
     private val teamcitySyncService: TeamcitySyncService,
+    private val teamcitySyncJobService: TeamcitySyncJobService,
 ) {
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
@@ -151,23 +154,57 @@ class AdminControllerV4(
         }
 
     /**
-     * On-demand TeamCity project ID/URL resync. Reuses the IMPORT_DATA permission
-     * (locked design decision — see PR plan §A5 rationale: a separate
-     * SYNC_TC_PROJECTS permission would require new constants across CRS,
-     * cloud-commons, the automation repo's role yaml, the portal `auth.ts`,
-     * and every admin UI consumer; for "admin bulk operation" the existing
-     * IMPORT_DATA semantic is the right scope).
+     * **Deprecated** — synchronous TC resync. Kept for backwards-compatibility
+     * with portal builds that haven't switched to the async pair yet
+     * (`POST /teamcity-project-ids/sync` + `GET .../sync/job`). Once the portal
+     * deploy is complete in all envs, this endpoint is removed in a follow-up.
      *
-     * Synchronous: a single batched TC call returns all projects carrying the
-     * COMPONENT_NAME parameter, then we group client-side by parameter value.
-     * For the foreseeable scale this is well under typical gateway timeouts.
-     * If response time grows, port to the async-job pattern (see /migrate).
+     * Reuses the IMPORT_DATA permission (locked design decision — see PR plan
+     * §A5 rationale: a separate SYNC_TC_PROJECTS permission would require new
+     * constants across CRS, cloud-commons, the automation repo's role yaml,
+     * the portal `auth.ts`, and every admin UI consumer; for "admin bulk
+     * operation" the existing IMPORT_DATA semantic is the right scope).
      *
-     * Returns the per-pass counts so the Portal can render a toast with the
-     * effect of the run.
+     * Synchronous and gateway-blocking: TC sync issues one REST call per
+     * non-archived component, so on registries past ~150 components the round
+     * trip exceeds typical gateway HTTP read timeouts and returns 504. The
+     * async pair below was added specifically to fix that.
      */
+    @Deprecated("Use POST /teamcity-project-ids/sync (async). This endpoint is removed once portal switches.")
     @PostMapping("/teamcity-project-ids/resync")
     fun resyncTeamcityProjectIds(): ResponseEntity<TeamcitySyncResult> = ResponseEntity.ok(teamcitySyncService.resync())
+
+    /**
+     * Async TC resync — kicks off the run on the background executor.
+     *
+     * Returns 202 Accepted with a [TeamcitySyncJobResponse] describing the
+     * freshly-started job. If a TC resync is already RUNNING in this pod,
+     * returns 409 Conflict with the existing job's state — the SPA "attaches"
+     * to the in-flight job rather than spawning a duplicate. Either way,
+     * callers poll `GET /admin/teamcity-project-ids/sync/job` for progress
+     * and pick up the final per-pass counts once `state == COMPLETED`.
+     *
+     * If the OTHER migration kind (components / history) is currently RUNNING,
+     * the service throws [MigrationConflictException] which the handler below
+     * maps to a 409 with [MigrationConflictResponse] body so the SPA can
+     * surface a clear "something else is running" message.
+     */
+    @PostMapping("/teamcity-project-ids/sync")
+    fun startTeamcitySync(): ResponseEntity<TeamcitySyncJobResponse> {
+        val outcome = teamcitySyncJobService.startAsync()
+        val httpStatus = if (outcome.isNewlyStarted) HttpStatus.ACCEPTED else HttpStatus.CONFLICT
+        return ResponseEntity.status(httpStatus).body(TeamcitySyncJobResponse.from(outcome.state))
+    }
+
+    /**
+     * Returns the latest known [TeamcitySyncJobResponse], or 404 if no TC
+     * resync has been started since the pod came up.
+     */
+    @GetMapping("/teamcity-project-ids/sync/job")
+    fun getTeamcitySyncJob(): ResponseEntity<TeamcitySyncJobResponse> {
+        val state = teamcitySyncJobService.current() ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(TeamcitySyncJobResponse.from(state))
+    }
 
     /**
      * Map cross-kind gate conflicts to a structured 409. Same-kind 409 is
@@ -180,6 +217,7 @@ class AdminControllerV4(
             when (e.active.kind) {
                 MigrationLifecycleGate.JobKind.COMPONENTS -> "components-migration-running"
                 MigrationLifecycleGate.JobKind.HISTORY -> "history-migration-running"
+                MigrationLifecycleGate.JobKind.TC_RESYNC -> "tc-resync-running"
             }
         return ResponseEntity.status(HttpStatus.CONFLICT).body(
             MigrationConflictResponse(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/TeamcitySyncJobResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/TeamcitySyncJobResponse.kt
@@ -1,0 +1,42 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobState
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
+import java.time.Instant
+
+/**
+ * Wire shape for `POST /admin/teamcity-project-ids/sync` and
+ * `GET /admin/teamcity-project-ids/sync/job`.
+ *
+ * `result` is populated only after the job reaches [JobState.COMPLETED]. While
+ * RUNNING the SPA renders an indeterminate spinner; on COMPLETED it switches
+ * to rendering the per-pass counter tiles + the first error from the result
+ * payload.
+ *
+ * The `kind = "job"` discriminator mirrors [MigrationJobResponse] so the SPA's
+ * `parseSameKindAttach` 409-branching helper works the same way for TC as for
+ * components / history.
+ */
+data class TeamcitySyncJobResponse(
+    val id: String,
+    val state: JobState,
+    val startedAt: Instant,
+    val finishedAt: Instant?,
+    val errorMessage: String?,
+    val result: TeamcitySyncResult?,
+    /** Discriminator for unambiguous 409 branching on the SPA. Always `"job"` for this shape. */
+    val kind: String = "job",
+) {
+    companion object {
+        fun from(state: TeamcitySyncJobState): TeamcitySyncJobResponse =
+            TeamcitySyncJobResponse(
+                id = state.id,
+                state = state.state,
+                startedAt = state.startedAt,
+                finishedAt = state.finishedAt,
+                errorMessage = state.errorMessage,
+                result = state.result,
+            )
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationLifecycleGate.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationLifecycleGate.kt
@@ -4,14 +4,15 @@ import org.springframework.stereotype.Component
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Cross-job concurrency gate shared by [MigrationJobService] (components) and
- * [HistoryMigrationJobService] — only one of the two may be RUNNING at a time.
+ * Cross-job concurrency gate shared by [MigrationJobService] (components),
+ * [HistoryMigrationJobService] (history) and the TeamCity-resync job
+ * (`TeamcitySyncJobService`) — only one of the three may be RUNNING at a time.
  *
  * Why this exists separately from each service's own AtomicReference: each job
  * service has its own slot for the response shape ("what is the current
  * components job?") but neither knows about the other. Without a shared gate
- * both would happily start in parallel — the SPA would render two RUNNING
- * jobs, both backed by importers writing to the same DB tables. The
+ * all three would happily start in parallel — the SPA would render multiple
+ * RUNNING jobs, all backed by writers touching the same DB tables. The
  * single-thread `migrationExecutor` doesn't help: ThreadPoolTaskExecutor with
  * `queueCapacity > 0` queues the second submit instead of rejecting it, so
  * both `startAsync()` calls return 202 with RUNNING and the second job just
@@ -24,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference
  */
 @Component
 class MigrationLifecycleGate {
-    enum class JobKind { COMPONENTS, HISTORY }
+    enum class JobKind { COMPONENTS, HISTORY, TC_RESYNC }
 
     data class ActiveJob(
         val kind: JobKind,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncJobService.kt
@@ -1,0 +1,73 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import org.octopusden.octopus.components.registry.server.service.JobState
+import java.time.Instant
+
+/**
+ * Server-side state of a long-running `POST /admin/teamcity-project-ids/sync` run.
+ *
+ * Mirrors `MigrationJobState` for components but with TC-specific shape: the only
+ * domain-specific payload is the per-pass [result] (component counts) emitted on
+ * COMPLETED. There are no per-component progress fields in v1 — adding them
+ * would require threading a `TeamcitySyncProgressListener` through
+ * `TcProjectFetcher`; the JSON shape leaves room (the SPA can flip a spinner
+ * to a counter view without a backend contract change).
+ *
+ * State lives in an [java.util.concurrent.atomic.AtomicReference] inside the
+ * impl — single-pod scope. A pod restart drops it (and the in-flight sync along
+ * with it); the operator sees "no current job" and starts fresh. TC sync is
+ * **not resumable** — restarting from scratch is the right semantic.
+ */
+data class TeamcitySyncJobState(
+    val id: String,
+    val state: JobState,
+    val startedAt: Instant,
+    val finishedAt: Instant?,
+    /** Populated only on [JobState.COMPLETED]; carries the per-pass counters. */
+    val result: TeamcitySyncResult?,
+    val errorMessage: String?,
+)
+
+/** Outcome of [TeamcitySyncJobService.startAsync]. */
+data class StartTeamcitySyncResult(
+    /** Either the freshly-started job, or the already-running one. */
+    val state: TeamcitySyncJobState,
+    /** `true` if this call started a new job; `false` if a RUNNING job was already active. */
+    val isNewlyStarted: Boolean,
+)
+
+/**
+ * Async wrapper around [TeamcitySyncService.resync]. Mirrors
+ * `MigrationJobService` for the components flow.
+ *
+ * The synchronous endpoint `POST /admin/teamcity-project-ids/resync` is kept for
+ * backwards-compatibility (deprecated; will be removed once portal is on the
+ * async path) and delegates to [TeamcitySyncService] directly. The new async
+ * endpoint pair `POST /admin/teamcity-project-ids/sync` + `GET .../sync/job`
+ * goes through this service so callers can poll instead of holding an HTTP
+ * connection through TC's per-component REST roundtrip storm.
+ */
+interface TeamcitySyncJobService {
+    /**
+     * If no resync is currently RUNNING, claim a slot, start the work on the
+     * background executor, and return the freshly-created [TeamcitySyncJobState]
+     * with `isNewlyStarted=true`.
+     *
+     * If a same-kind RUNNING job is already active, return the existing state
+     * with `isNewlyStarted=false` and do NOT spawn a duplicate run. The
+     * controller maps `isNewlyStarted=false` to HTTP 409 so the SPA can
+     * "attach" to the in-flight job rather than start a parallel one.
+     *
+     * If the gate is held by a different kind (components migration, history
+     * migration), throws
+     * [org.octopusden.octopus.components.registry.server.service.MigrationConflictException]
+     * which the controller maps to HTTP 409 with a structured cross-kind body.
+     *
+     * COMPLETED / FAILED states do not block: a new call after a finished job
+     * replaces the slot.
+     */
+    fun startAsync(): StartTeamcitySyncResult
+
+    /** Latest known state, or `null` if no job has been started since the pod booted. */
+    fun current(): TeamcitySyncJobState?
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.components.registry.server.teamcity
 
 import mu.KotlinLogging
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.annotation.Scheduled
@@ -10,24 +11,35 @@ import org.springframework.stereotype.Component
  * Weekly cron that resyncs TC project ids/urls.
  *
  * Conditional bean — registered only when `teamcity.sync.enabled=true`
- * (`teamcity.sync.enabled=true` in service-config). With the property absent or false
- * (the default), the bean is not registered and Spring's `@EnableScheduling`
- * task scheduler ignores the cron entirely. Production service-config sets
- * the property per env that has TC credentials wired through; CI/test envs
- * never set it, so the scheduler never fires there.
+ * (`teamcity.sync.enabled=true` in service-config). With the property absent
+ * or false (the default), the bean is not registered and Spring's
+ * `@EnableScheduling` task scheduler ignores the cron entirely. Production
+ * service-config sets the property per env that has TC credentials wired
+ * through; CI/test envs never set it, so the scheduler never fires there.
  *
  * Cron is configurable via `teamcity.sync.cron`, defaulting to Sunday 04:00
  * UTC — far from typical CI/release windows so a long sync can't starve
  * normal traffic.
  *
- * Failures are logged-and-swallowed so a transient TC outage does not crash
- * the bean and prevent next week's run.
+ * Goes through [TeamcitySyncJobService.startAsync] rather than calling
+ * [TeamcitySyncService.resync] directly so the cron-fired sync participates
+ * in the same shared concurrency gate as admin-triggered runs (and as the
+ * components / history migration jobs). This means:
+ *  - if an admin already pressed the SPA Resync button and the job is still
+ *    RUNNING when the cron fires, the cron skips the week instead of fighting
+ *    the manual run;
+ *  - if a components or history migration is RUNNING, the cron skips with
+ *    a structured cross-kind exception logged at WARN.
+ *
+ * Failures from the underlying resync (or from `startAsync` itself) are
+ * logged-and-swallowed so a transient TC outage / live migration does not
+ * crash the bean and prevent next week's run.
  */
 @Component
 @EnableScheduling
 @ConditionalOnProperty(prefix = "teamcity.sync", name = ["enabled"], havingValue = "true")
 class TeamcitySyncScheduler(
-    private val syncService: TeamcitySyncService,
+    private val teamcitySyncJobService: TeamcitySyncJobService,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -36,14 +48,35 @@ class TeamcitySyncScheduler(
     fun weeklyResync() {
         log.info { "TC sync: weekly cron firing" }
         try {
-            val result = syncService.resync()
-            log.info { "TC sync weekly result: $result" }
+            val outcome = teamcitySyncJobService.startAsync()
+            if (outcome.isNewlyStarted) {
+                log.info { "TC sync: weekly cron started job ${outcome.state.id}" }
+            } else {
+                // Same-kind attach — a TC resync is already RUNNING in this
+                // pod, almost certainly because an admin pressed the Resync
+                // button before the cron fired. Skip the week; do not block
+                // on someone else's job.
+                log.warn {
+                    "TC sync: weekly cron skipped — TC resync ${outcome.state.id} already RUNNING in this pod"
+                }
+            }
+        } catch (e: MigrationConflictException) {
+            // Cross-kind: components or history migration holds the gate.
+            // Skip the week; the operator will see this in logs if it
+            // happens repeatedly (which would be unusual — migrations
+            // are not weekly events).
+            log.warn { "TC sync: weekly cron skipped — ${e.active.kind} job ${e.active.jobId} is RUNNING" }
         } catch (e: Exception) {
             // A throw here would propagate up the @Scheduled task and the
             // task scheduler would suppress further runs only for the same
             // pod-lifetime in some configurations. Catching keeps the next
-            // weekly fire alive regardless of TC's transient state.
-            log.error(e) { "TC sync weekly run failed" }
+            // weekly fire alive regardless of TC's transient state. Note
+            // the resync itself runs on the executor thread and its
+            // failures are captured by [TeamcitySyncJobService] into the
+            // job state, not rethrown here — so this catch fires only if
+            // `startAsync` itself fails (e.g., RejectedExecutionException
+            // on pod shutdown).
+            log.error(e) { "TC sync: weekly cron failed to start" }
         }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
@@ -1,0 +1,116 @@
+package org.octopusden.octopus.components.registry.server.teamcity.impl
+
+import org.octopusden.octopus.components.registry.server.service.AsyncJobLifecycle
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
+import org.octopusden.octopus.components.registry.server.teamcity.StartTeamcitySyncResult
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobState
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.task.TaskExecutor
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+/**
+ * In-memory async wrapper around [TeamcitySyncService.resync]. Mirrors
+ * `MigrationJobServiceImpl` for the components flow — same gate integration via
+ * [AsyncJobLifecycle], same CAS-then-publish ordering, same finally-release.
+ *
+ * No DB-backed claim: TC sync is not resumable, so a pod restart starts the
+ * next run from scratch. There is also no `forceReset` / `clearInMemory`
+ * surface — those exist on history because of its DB-backed
+ * `git_history_import_state` row; TC has nothing equivalent to clear.
+ */
+@Service
+class TeamcitySyncJobServiceImpl(
+    private val teamcitySyncService: TeamcitySyncService,
+    @Qualifier("migrationExecutor") executor: TaskExecutor,
+    lifecycleGate: MigrationLifecycleGate,
+) : TeamcitySyncJobService {
+    private val lifecycle =
+        AsyncJobLifecycle<TeamcitySyncJobState>(
+            jobKind = JobKind.TC_RESYNC,
+            executor = executor,
+            gate = lifecycleGate,
+            getId = { it.id },
+            isRunning = { it.state == JobState.RUNNING },
+            markRejected = { current, rejected ->
+                current.copy(
+                    state = JobState.FAILED,
+                    finishedAt = Instant.now(),
+                    errorMessage =
+                        "Failed to submit teamcity resync: ${rejected.message ?: rejected::class.java.simpleName}",
+                )
+            },
+        )
+
+    override fun startAsync(): StartTeamcitySyncResult {
+        val outcome =
+            lifecycle.claimAndSubmit(
+                buildCandidate = ::buildCandidate,
+                work = ::runResync,
+            )
+        return when (outcome) {
+            is AsyncJobLifecycle.ClaimOutcome.Attached ->
+                StartTeamcitySyncResult(outcome.state, isNewlyStarted = false)
+            is AsyncJobLifecycle.ClaimOutcome.Started ->
+                StartTeamcitySyncResult(outcome.state, isNewlyStarted = true)
+        }
+    }
+
+    override fun current(): TeamcitySyncJobState? = lifecycle.current()
+
+    private fun buildCandidate(jobId: String): TeamcitySyncJobState =
+        TeamcitySyncJobState(
+            id = jobId,
+            state = JobState.RUNNING,
+            startedAt = Instant.now(),
+            finishedAt = null,
+            result = null,
+            errorMessage = null,
+        )
+
+    private fun runResync(jobId: String) {
+        try {
+            val result = teamcitySyncService.resync()
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    state = JobState.COMPLETED,
+                    finishedAt = Instant.now(),
+                    result = result,
+                )
+            }
+            LOG.info(
+                "TC resync job {} COMPLETED: scanned={}, updated={}, unchanged={}, " +
+                    "skippedNoMatch={}, skippedAmbiguous={}, errors={}",
+                jobId,
+                result.scanned,
+                result.updated,
+                result.unchanged,
+                result.skippedNoMatch,
+                result.skippedAmbiguous,
+                result.errors.size,
+            )
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Throwable,
+        ) {
+            LOG.error("TC resync job {} FAILED", jobId, e)
+            lifecycle.update(jobId) { current ->
+                current.copy(
+                    state = JobState.FAILED,
+                    finishedAt = Instant.now(),
+                    errorMessage = e.message ?: e::class.java.simpleName,
+                )
+            }
+        } finally {
+            lifecycle.release(jobId)
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(TeamcitySyncJobServiceImpl::class.java)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -78,6 +78,16 @@ class AdminControllerV4SecurityTest {
     @Suppress("UnusedPrivateProperty")
     private lateinit var teamcitySyncService: TeamcitySyncService
 
+    /**
+     * Mocked too — the controller wires this in for the async TC resync pair
+     * (`POST /sync` + `GET /sync/job`). Same isolation rationale as the other
+     * job-service mocks.
+     */
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var teamcitySyncJobService:
+        org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
+
     @Autowired
     private lateinit var mvc: MockMvc
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
@@ -9,8 +9,14 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.octopusden.octopus.components.registry.server.teamcity.StartTeamcitySyncResult
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobState
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,27 +25,33 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.Instant
 
 /**
- * Pins the auth + response-shape contract of POST /rest/api/4/admin/teamcity-project-ids/resync.
+ * Pins the auth + response-shape contract of the TeamCity resync endpoints
+ * (legacy synchronous `POST /resync`, new async pair `POST /sync` + `GET
+ * /sync/job`).
  *
- * Both gates that protect the endpoint are exercised:
+ * Both gates that protect the endpoints are exercised:
  *   - WebSecurityConfig URL-level rule → 401 for anonymous callers.
  *   - AdminControllerV4 class-level @PreAuthorize("@permissionEvaluator.canImport()")
  *     → 403 for authenticated callers without IMPORT_DATA.
  *
- * TeamcitySyncService is @MockBean'd so the test does not pull in the
- * TeamcityClient bean wiring (which would attempt outbound HTTP if base-url
- * were ever set). The positive path verifies the 6-field counts shape
- * including the snake_case `skipped_no_match` / `skipped_ambiguous` keys.
+ * Both TeamcitySyncService and TeamcitySyncJobService are @MockBean'd so the
+ * test does not pull in the TeamcityClient bean wiring (which would attempt
+ * outbound HTTP if base-url were ever set). The legacy path verifies the
+ * 6-field counts shape including the snake_case `skipped_no_match` /
+ * `skipped_ambiguous` keys; the async path verifies 202/409 attach, 200/404
+ * polling, and the cross-kind 409 envelope.
  *
- * Other migration job services are @MockBean'd to keep this test scoped
- * to the resync path — same convention as AdminControllerV4SecurityTest.
+ * Other migration job services are @MockBean'd to keep this test scoped to
+ * the resync paths — same convention as AdminControllerV4SecurityTest.
  */
 @AutoConfigureMockMvc
 @SpringBootTest(
@@ -56,6 +68,9 @@ class TeamcityResyncControllerTest {
     private lateinit var teamcitySyncService: TeamcitySyncService
 
     @MockBean
+    private lateinit var teamcitySyncJobService: TeamcitySyncJobService
+
+    @MockBean
     @Suppress("UnusedPrivateProperty")
     private lateinit var migrationJobService: org.octopusden.octopus.components.registry.server.service.MigrationJobService
 
@@ -66,9 +81,13 @@ class TeamcityResyncControllerTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
+    // ---------------------------------------------------------------------
+    // Legacy synchronous POST /resync (kept while portal switches; deleted in PR-D).
+    // ---------------------------------------------------------------------
+
     @Test
     @DisplayName("anonymous POST /admin/teamcity-project-ids/resync → 401, sync not invoked")
-    fun anonymous_returns401() {
+    fun resyncAnonymousReturns401() {
         mvc
             .perform(post("/rest/api/4/admin/teamcity-project-ids/resync"))
             .andExpect(status().isUnauthorized)
@@ -78,7 +97,7 @@ class TeamcityResyncControllerTest {
 
     @Test
     @DisplayName("editor JWT POST /admin/teamcity-project-ids/resync → 403, sync not invoked")
-    fun editor_returns403() {
+    fun resyncEditorReturns403() {
         mvc
             .perform(post("/rest/api/4/admin/teamcity-project-ids/resync").with(editorJwt()))
             .andExpect(status().isForbidden)
@@ -87,8 +106,8 @@ class TeamcityResyncControllerTest {
     }
 
     @Test
-    @DisplayName("admin JWT → 200 with full counts shape (incl. snake_case skipped_* keys)")
-    fun admin_returns200WithCounts() {
+    @DisplayName("admin POST /admin/teamcity-project-ids/resync → 200 with full counts shape (legacy path)")
+    fun resyncAdminReturns200WithCounts() {
         `when`(teamcitySyncService.resync()).thenReturn(
             TeamcitySyncResult(
                 scanned = 12,
@@ -112,6 +131,207 @@ class TeamcityResyncControllerTest {
 
         verify(teamcitySyncService, times(1)).resync()
     }
+
+    // ---------------------------------------------------------------------
+    // New async POST /sync — 202 newly-started, 409 same-kind attach, 409 cross-kind.
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("anonymous POST /admin/teamcity-project-ids/sync → 401, startAsync not invoked")
+    fun syncAnonymousReturns401() {
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/sync"))
+            .andExpect(status().isUnauthorized)
+
+        verify(teamcitySyncJobService, never()).startAsync()
+    }
+
+    @Test
+    @DisplayName("editor JWT POST /admin/teamcity-project-ids/sync → 403, startAsync not invoked")
+    fun syncEditorReturns403() {
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/sync").with(editorJwt()))
+            .andExpect(status().isForbidden)
+
+        verify(teamcitySyncJobService, never()).startAsync()
+    }
+
+    @Test
+    @DisplayName("admin POST /admin/teamcity-project-ids/sync newly-started → 202 with kind=job body")
+    fun syncAdminFreshReturns202() {
+        `when`(teamcitySyncJobService.startAsync())
+            .thenReturn(StartTeamcitySyncResult(runningState("job-1"), isNewlyStarted = true))
+
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/sync").with(adminJwt()))
+            .andExpect(status().isAccepted)
+            .andExpect(jsonPath("$.id").value("job-1"))
+            .andExpect(jsonPath("$.state").value(JobState.RUNNING.name))
+            .andExpect(jsonPath("$.kind").value("job"))
+            .andExpect(jsonPath("$.result").doesNotExist())
+
+        verify(teamcitySyncJobService, times(1)).startAsync()
+    }
+
+    @Test
+    @DisplayName("admin POST /admin/teamcity-project-ids/sync same-kind RUNNING → 409 with same job body")
+    fun syncAdminSameKindAttachReturns409() {
+        `when`(teamcitySyncJobService.startAsync())
+            .thenReturn(StartTeamcitySyncResult(runningState("job-existing"), isNewlyStarted = false))
+
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/sync").with(adminJwt()))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.id").value("job-existing"))
+            .andExpect(jsonPath("$.state").value(JobState.RUNNING.name))
+            .andExpect(jsonPath("$.kind").value("job"))
+    }
+
+    @Test
+    @DisplayName("admin POST /admin/teamcity-project-ids/sync cross-kind COMPONENTS → 409 with conflict envelope")
+    fun syncAdminCrossKindComponentsReturns409Conflict() {
+        `when`(teamcitySyncJobService.startAsync())
+            .thenThrow(
+                MigrationConflictException(
+                    MigrationLifecycleGate.ActiveJob(MigrationLifecycleGate.JobKind.COMPONENTS, "components-1"),
+                ),
+            )
+
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/sync").with(adminJwt()))
+            .andExpect(status().isConflict)
+            // kind="conflict" is the discriminator the SPA's parseSameKindAttach uses to
+            // distinguish a cross-kind envelope from a same-kind job body. Pin it here
+            // alongside the structural fields.
+            .andExpect(jsonPath("$.kind").value("conflict"))
+            .andExpect(jsonPath("$.code").value("components-migration-running"))
+            .andExpect(jsonPath("$.activeKind").value("COMPONENTS"))
+            .andExpect(jsonPath("$.activeJobId").value("components-1"))
+    }
+
+    @Test
+    @DisplayName("admin POST /admin/teamcity-project-ids/sync cross-kind HISTORY → 409 with conflict envelope")
+    fun syncAdminCrossKindHistoryReturns409Conflict() {
+        `when`(teamcitySyncJobService.startAsync())
+            .thenThrow(
+                MigrationConflictException(
+                    MigrationLifecycleGate.ActiveJob(MigrationLifecycleGate.JobKind.HISTORY, "history-1"),
+                ),
+            )
+
+        mvc
+            .perform(post("/rest/api/4/admin/teamcity-project-ids/sync").with(adminJwt()))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.kind").value("conflict"))
+            .andExpect(jsonPath("$.code").value("history-migration-running"))
+            .andExpect(jsonPath("$.activeKind").value("HISTORY"))
+            .andExpect(jsonPath("$.activeJobId").value("history-1"))
+    }
+
+    // ---------------------------------------------------------------------
+    // New async GET /sync/job — 200 when state is present, 404 when idle.
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("anonymous GET /admin/teamcity-project-ids/sync/job → 401")
+    fun getJobAnonymousReturns401() {
+        mvc
+            .perform(get("/rest/api/4/admin/teamcity-project-ids/sync/job"))
+            .andExpect(status().isUnauthorized)
+
+        verify(teamcitySyncJobService, never()).current()
+    }
+
+    @Test
+    @DisplayName("editor GET /admin/teamcity-project-ids/sync/job → 403")
+    fun getJobEditorReturns403() {
+        mvc
+            .perform(get("/rest/api/4/admin/teamcity-project-ids/sync/job").with(editorJwt()))
+            .andExpect(status().isForbidden)
+
+        verify(teamcitySyncJobService, never()).current()
+    }
+
+    @Test
+    @DisplayName("admin GET /admin/teamcity-project-ids/sync/job idle → 404")
+    fun getJobIdleReturns404() {
+        `when`(teamcitySyncJobService.current()).thenReturn(null)
+
+        mvc
+            .perform(get("/rest/api/4/admin/teamcity-project-ids/sync/job").with(adminJwt()))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    @DisplayName("admin GET /admin/teamcity-project-ids/sync/job FAILED → 200 with errorMessage, no result")
+    fun getJobFailedReturns200WithErrorMessage() {
+        `when`(teamcitySyncJobService.current())
+            .thenReturn(
+                TeamcitySyncJobState(
+                    id = "job-failed",
+                    state = JobState.FAILED,
+                    startedAt = Instant.parse("2026-05-06T10:00:00Z"),
+                    finishedAt = Instant.parse("2026-05-06T10:00:42Z"),
+                    result = null,
+                    errorMessage = "TC unavailable",
+                ),
+            )
+
+        mvc
+            .perform(get("/rest/api/4/admin/teamcity-project-ids/sync/job").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("job-failed"))
+            .andExpect(jsonPath("$.state").value(JobState.FAILED.name))
+            .andExpect(jsonPath("$.kind").value("job"))
+            .andExpect(jsonPath("$.errorMessage").value("TC unavailable"))
+            .andExpect(jsonPath("$.result").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("admin GET /admin/teamcity-project-ids/sync/job COMPLETED → 200 with result counts")
+    fun getJobCompletedReturns200WithResult() {
+        val result =
+            TeamcitySyncResult(
+                scanned = 5,
+                updated = 2,
+                unchanged = 3,
+                skippedNoMatch = 0,
+                skippedAmbiguous = 0,
+                errors = emptyList(),
+            )
+        `when`(teamcitySyncJobService.current())
+            .thenReturn(
+                TeamcitySyncJobState(
+                    id = "job-3",
+                    state = JobState.COMPLETED,
+                    startedAt = Instant.parse("2026-05-06T10:00:00Z"),
+                    finishedAt = Instant.parse("2026-05-06T10:00:42Z"),
+                    result = result,
+                    errorMessage = null,
+                ),
+            )
+
+        mvc
+            .perform(get("/rest/api/4/admin/teamcity-project-ids/sync/job").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("job-3"))
+            .andExpect(jsonPath("$.state").value(JobState.COMPLETED.name))
+            .andExpect(jsonPath("$.kind").value("job"))
+            .andExpect(jsonPath("$.result.scanned").value(5))
+            .andExpect(jsonPath("$.result.updated").value(2))
+            .andExpect(jsonPath("$.result.skipped_no_match").value(0))
+            .andExpect(jsonPath("$.result.skipped_ambiguous").value(0))
+    }
+
+    private fun runningState(jobId: String) =
+        TeamcitySyncJobState(
+            id = jobId,
+            state = JobState.RUNNING,
+            startedAt = Instant.parse("2026-05-06T10:00:00Z"),
+            finishedAt = null,
+            result = null,
+            errorMessage = null,
+        )
 
     companion object {
         @JvmStatic

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncSchedulerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncSchedulerTest.kt
@@ -1,0 +1,85 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import java.time.Instant
+
+/**
+ * Pins the contract that the weekly cron promises to operations:
+ *  - On a freshly-claimed slot it just kicks the job off and returns; the
+ *    actual sync runs on `migrationExecutor` and its outcome lands in the
+ *    job state, not in the cron call's stack.
+ *  - Same-kind attach (TC sync already RUNNING from an admin click): logged
+ *    + skipped, no exception escapes the @Scheduled tick.
+ *  - Cross-kind ([MigrationConflictException]): logged + skipped; same
+ *    no-throw guarantee.
+ *  - Any other RuntimeException from `startAsync` (typically
+ *    RejectedExecutionException on shutdown) is caught — Spring's
+ *    @Scheduled task scheduler considers `startAsync` failures fatal in
+ *    some configurations and would suppress further weekly fires.
+ */
+class TeamcitySyncSchedulerTest {
+    private fun startedState(jobId: String) =
+        TeamcitySyncJobState(
+            id = jobId,
+            state = JobState.RUNNING,
+            startedAt = Instant.now(),
+            finishedAt = null,
+            result = null,
+            errorMessage = null,
+        )
+
+    @Test
+    @DisplayName("weeklyResync calls startAsync and returns normally on isNewlyStarted=true")
+    fun startsFreshJob() {
+        val jobService = mock(TeamcitySyncJobService::class.java)
+        `when`(jobService.startAsync()).thenReturn(StartTeamcitySyncResult(startedState("job-1"), isNewlyStarted = true))
+
+        TeamcitySyncScheduler(jobService).weeklyResync()
+
+        verify(jobService, times(1)).startAsync()
+    }
+
+    @Test
+    @DisplayName("weeklyResync swallows isNewlyStarted=false (same-kind attach) without throwing")
+    fun swallowsSameKindAttach() {
+        val jobService = mock(TeamcitySyncJobService::class.java)
+        `when`(jobService.startAsync()).thenReturn(StartTeamcitySyncResult(startedState("job-2"), isNewlyStarted = false))
+
+        // Must NOT throw — catching the same-kind attach in @Scheduled is the entire point.
+        TeamcitySyncScheduler(jobService).weeklyResync()
+    }
+
+    @Test
+    @DisplayName("weeklyResync swallows MigrationConflictException (cross-kind) without throwing")
+    fun swallowsCrossKindConflict() {
+        val jobService = mock(TeamcitySyncJobService::class.java)
+        `when`(jobService.startAsync())
+            .thenThrow(
+                MigrationConflictException(
+                    MigrationLifecycleGate.ActiveJob(MigrationLifecycleGate.JobKind.HISTORY, "history-1"),
+                ),
+            )
+
+        // Must NOT propagate — Spring's @Scheduled would treat propagation as a fatal task failure.
+        TeamcitySyncScheduler(jobService).weeklyResync()
+    }
+
+    @Test
+    @DisplayName("weeklyResync swallows generic RuntimeException without throwing (back-compat)")
+    fun swallowsGenericRuntimeException() {
+        val jobService = mock(TeamcitySyncJobService::class.java)
+        `when`(jobService.startAsync()).thenThrow(RuntimeException("transient pool issue"))
+
+        // Pre-refactor scheduler had a catch-all — preserve that so a transient
+        // RejectedExecutionException doesn't suppress next week's fire.
+        TeamcitySyncScheduler(jobService).weeklyResync()
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
@@ -1,0 +1,207 @@
+package org.octopusden.octopus.components.registry.server.teamcity.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.service.JobState
+import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
+import org.springframework.core.task.SyncTaskExecutor
+import kotlin.test.assertFailsWith
+
+/**
+ * Pins the contract that `TeamcitySyncJobServiceImpl` promises to the
+ * controller and the weekly scheduler:
+ *  - Only one TC resync at a time. Same-kind 409 attach returns the existing
+ *    state with `isNewlyStarted=false`; cross-kind throws
+ *    [MigrationConflictException].
+ *  - Terminal transitions (COMPLETED / FAILED) populate finishedAt and
+ *    surface the underlying [TeamcitySyncResult] (or `errorMessage`) for
+ *    the SPA to render.
+ *  - Executor rejection rolls back the slot to FAILED with the standard
+ *    "Failed to submit teamcity resync: ..." prefix and releases the gate.
+ *
+ * [SyncTaskExecutor] runs the work inline so terminal state is observable
+ * the moment `startAsync` returns. [TeamcitySyncService] is mocked via
+ * Mockito here — `resync()` takes no arguments, so the Kotlin non-nullable
+ * arg trap that the migration-job tests work around with handwritten stubs
+ * does not apply.
+ */
+class TeamcitySyncJobServiceImplTest {
+    private val emptyResult =
+        TeamcitySyncResult(
+            scanned = 0,
+            updated = 0,
+            unchanged = 0,
+            skippedNoMatch = 0,
+            skippedAmbiguous = 0,
+            errors = emptyList(),
+        )
+
+    @Test
+    @DisplayName("current() is null before any job has been started")
+    fun currentIsNullBeforeFirstStart() {
+        val service = TeamcitySyncJobServiceImpl(mock(TeamcitySyncService::class.java), SyncTaskExecutor(), MigrationLifecycleGate())
+        assertNull(service.current())
+    }
+
+    @Test
+    @DisplayName("first startAsync claims gate, runs, completes")
+    fun firstStartCompletes() {
+        val populated =
+            TeamcitySyncResult(
+                scanned = 12,
+                updated = 3,
+                unchanged = 7,
+                skippedNoMatch = 1,
+                skippedAmbiguous = 1,
+                errors = listOf("oops on alpha"),
+            )
+        val syncService = mock(TeamcitySyncService::class.java)
+        `when`(syncService.resync()).thenReturn(populated)
+        val gate = MigrationLifecycleGate()
+        val service = TeamcitySyncJobServiceImpl(syncService, SyncTaskExecutor(), gate)
+
+        val result = service.startAsync()
+
+        assertTrue(result.isNewlyStarted, "fresh job should be newly-started")
+        // SyncTaskExecutor: by the time startAsync returns, the work has finished.
+        assertEquals(JobState.COMPLETED, result.state.state)
+        assertEquals(populated, result.state.result)
+        verify(syncService, times(1)).resync()
+        assertNull(gate.current(), "gate must be released on COMPLETED")
+    }
+
+    @Test
+    @DisplayName("second startAsync while RUNNING returns isNewlyStarted=false with same job state")
+    fun secondStartAttaches() {
+        val deferred = DeferredExecutor()
+        val syncService = mock(TeamcitySyncService::class.java)
+        `when`(syncService.resync()).thenReturn(emptyResult)
+        val service = TeamcitySyncJobServiceImpl(syncService, deferred, MigrationLifecycleGate())
+
+        val first = service.startAsync()
+        // DeferredExecutor: the work hasn't actually run yet, so the slot is RUNNING.
+        assertEquals(JobState.RUNNING, first.state.state)
+        assertTrue(first.isNewlyStarted)
+
+        val second = service.startAsync()
+
+        assertFalse(second.isNewlyStarted, "second start while RUNNING must NOT be flagged newly-started")
+        assertEquals(first.state.id, second.state.id, "second start must echo back the SAME job id")
+        assertEquals(1, deferred.taskCount, "executor must have been handed exactly one task")
+    }
+
+    @Test
+    @DisplayName("startAsync throws MigrationConflictException when COMPONENTS gate is held")
+    fun crossKindComponentsConflict() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(MigrationLifecycleGate.JobKind.COMPONENTS, "components-1")
+        val syncService = mock(TeamcitySyncService::class.java)
+
+        val service = TeamcitySyncJobServiceImpl(syncService, SyncTaskExecutor(), gate)
+
+        val ex = assertFailsWith<MigrationConflictException> { service.startAsync() }
+        assertEquals(MigrationLifecycleGate.JobKind.COMPONENTS, ex.active.kind)
+        assertEquals("components-1", ex.active.jobId)
+        verify(syncService, never()).resync()
+    }
+
+    @Test
+    @DisplayName("startAsync throws MigrationConflictException when HISTORY gate is held")
+    fun crossKindHistoryConflict() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(MigrationLifecycleGate.JobKind.HISTORY, "history-1")
+        val syncService = mock(TeamcitySyncService::class.java)
+
+        val service = TeamcitySyncJobServiceImpl(syncService, SyncTaskExecutor(), gate)
+
+        val ex = assertFailsWith<MigrationConflictException> { service.startAsync() }
+        assertEquals(MigrationLifecycleGate.JobKind.HISTORY, ex.active.kind)
+        assertEquals("history-1", ex.active.jobId)
+        verify(syncService, never()).resync()
+    }
+
+    @Test
+    @DisplayName("executor rejection transitions slot to FAILED and releases gate")
+    fun executorRejectionRollsBack() {
+        val syncService = mock(TeamcitySyncService::class.java)
+        val gate = MigrationLifecycleGate()
+        val service = TeamcitySyncJobServiceImpl(syncService, RejectingExecutor("pool shutting down"), gate)
+
+        val thrown = assertFailsWith<java.util.concurrent.RejectedExecutionException> { service.startAsync() }
+        assertEquals("pool shutting down", thrown.message)
+
+        val state = service.current()!!
+        assertEquals(JobState.FAILED, state.state)
+        assertNotNull(state.finishedAt)
+        assertEquals("Failed to submit teamcity resync: pool shutting down", state.errorMessage)
+        verify(syncService, never()).resync()
+        assertNull(gate.current(), "rejection must release the gate to avoid wedging follow-up runs")
+    }
+
+    @Test
+    @DisplayName("runtime exception inside resync transitions slot to FAILED, gate released")
+    fun resyncFailureTransitionsToFailed() {
+        val syncService = mock(TeamcitySyncService::class.java)
+        `when`(syncService.resync()).thenThrow(IllegalStateException("TC unavailable"))
+        val gate = MigrationLifecycleGate()
+        val service = TeamcitySyncJobServiceImpl(syncService, SyncTaskExecutor(), gate)
+
+        service.startAsync()
+        val state = service.current()!!
+
+        assertEquals(JobState.FAILED, state.state)
+        assertNotNull(state.finishedAt)
+        assertEquals("TC unavailable", state.errorMessage)
+        assertNull(state.result)
+        assertNull(gate.current(), "FAILED must release the gate to avoid wedging follow-up runs")
+    }
+
+    @Test
+    @DisplayName("after job COMPLETES the next startAsync starts a fresh job with a different id")
+    fun nextStartAfterCompleted() {
+        val syncService = mock(TeamcitySyncService::class.java)
+        `when`(syncService.resync()).thenReturn(emptyResult)
+        val service = TeamcitySyncJobServiceImpl(syncService, SyncTaskExecutor(), MigrationLifecycleGate())
+
+        val first = service.startAsync()
+        assertEquals(JobState.COMPLETED, first.state.state)
+
+        val second = service.startAsync()
+        assertTrue(second.isNewlyStarted)
+        assertTrue(first.state.id != second.state.id, "completed job should not block a new run")
+        verify(syncService, times(2)).resync()
+    }
+
+    // -- Test doubles -------------------------------------------------------
+
+    /** Capture-but-don't-run executor — observe RUNNING state without the work finishing. */
+    private class DeferredExecutor : org.springframework.core.task.TaskExecutor {
+        var taskCount: Int = 0
+            private set
+
+        override fun execute(task: Runnable) {
+            taskCount++
+            // Intentionally NOT running the task.
+        }
+    }
+
+    /** Always throws [java.util.concurrent.RejectedExecutionException] — simulates pod shutdown / queue full. */
+    private class RejectingExecutor(
+        private val reason: String,
+    ) : org.springframework.core.task.TaskExecutor {
+        override fun execute(task: Runnable): Unit = throw java.util.concurrent.RejectedExecutionException(reason)
+    }
+}


### PR DESCRIPTION
## Summary
- New async-job pair `POST /admin/teamcity-project-ids/sync` + `GET .../sync/job` — mirrors components / history migration pattern. Returns 202 on newly-started, 409 with same-kind job body on attach, 409 with `MigrationConflictResponse` envelope on cross-kind.
- Built on top of `AsyncJobLifecycle<TState>` from the just-merged refactor PR. `MigrationLifecycleGate.JobKind` extended with `TC_RESYNC` so all three async kinds share the same cross-kind gate.
- Legacy synchronous `POST /admin/teamcity-project-ids/resync` is **kept** (marked `@Deprecated`) so this PR can ship without coordinating portal deploy. Removed in follow-up PR-D after portal switches.
- `TeamcitySyncScheduler` now goes through `startAsync` so the weekly cron participates in the gate (skips the week instead of fighting an admin-clicked Resync or a migration in progress).

## Why now
Production `POST /resync` returns **504 Gateway Time-out** because TC sync issues one HTTP call per component (~150 components ≈ minutes of work). The async path returns 202 immediately and the SPA polls for the per-pass counter result.

## Rollout
- **Backend (this PR)** is back-compat — old portal continues to call `POST /resync` and gets the old 200 + counts shape.
- **Portal PR-C** switches to the new `/sync` endpoints — must deploy AFTER this backend lands on the same env (otherwise SPA gets 404 on the new URL).
- **PR-D** later: delete the legacy `/resync` endpoint and the legacy `useTeamCityResync` mutation-only hook in portal once PR-C is everywhere.

## Test plan
- [x] `TeamcitySyncJobServiceImplTest` — 8 tests covering claim/run/complete, same-kind attach, cross-kind COMPONENTS / HISTORY, executor rejection rollback, runtime failure, fresh start after COMPLETED.
- [x] `TeamcitySyncSchedulerTest` — 4 tests covering newly-started, same-kind attach skip, `MigrationConflictException` skip, generic `Throwable` swallow.
- [x] `TeamcityResyncControllerTest` extended — 401/403/202/409-attach (`kind="job"`), cross-kind 409 (`kind="conflict"` + `code` + `activeKind` + `activeJobId`), 200/404/FAILED-with-errorMessage polling. Legacy `/resync` 6-field shape preserved.
- [x] `AdminControllerV4SecurityTest` — `TeamcitySyncJobService` @MockBean added.
- [x] Full `./gradlew :components-registry-service-server:test` — green.
- [x] Full `./gradlew build` (with project-standard CI-only excludes) — green.
- [x] Independent code review (Sonnet) — addressed `kind="conflict"` test gap and FAILED poll test gap before pushing.
- [ ] CI on PR
- [ ] After merge: deploy to QA, smoke-test that `POST /sync` returns 202, `GET /sync/job` polls to COMPLETED, no 504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)