### PR TITLE
feat(security): add auth-server.disabled opt-out for FT/dev startup

### DIFF
--- a/components-registry-service-server/src/integrationTest/kotlin/org/octopusden/octopus/components/registry/server/FatJarAuthDisabledIntegrationTest.kt
+++ b/components-registry-service-server/src/integrationTest/kotlin/org/octopusden/octopus/components/registry/server/FatJarAuthDisabledIntegrationTest.kt
@@ -1,0 +1,232 @@
+package org.octopusden.octopus.components.registry.server
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import org.slf4j.LoggerFactory
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.ServerSocket
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+/**
+ * Tests the `auth-server.disabled` opt-out introduced for FT environments without a Keycloak.
+ *
+ * Two contracts are locked in here:
+ *  * [`fat jar with auth-server disabled starts and gates writes`] — disabled mode lets v1-v3 and
+ *    v4 reads through anonymously but `@PreAuthorize` still rejects v4 writes (403). If method
+ *    security ever silently breaks in disabled mode, FT pipelines would otherwise turn the
+ *    registry into an open delete surface.
+ *  * [`fat jar without auth-server config or disabled flag fails fast`] — production default
+ *    (`matchIfMissing = true` on `WebSecurityConfig`) must keep crashing at startup so a missing
+ *    `AUTH_SERVER_URL` env var in prod can never silently fall through to anonymous mode.
+ */
+class FatJarAuthDisabledIntegrationTest {
+    private val log = LoggerFactory.getLogger(FatJarAuthDisabledIntegrationTest::class.java)
+
+    @Test
+    @Timeout(120)
+    fun `fat jar with auth-server disabled starts and gates writes`(
+        @TempDir tempDir: Path,
+    ) {
+        val port = findRandomPort()
+        val process = startFatJar(
+            tempDir,
+            port,
+            extraJvmArgs = listOf("-Dauth-server.disabled=true"),
+        )
+
+        try {
+            Assertions.assertTrue(
+                waitForHealth(port, timeoutSeconds = 90),
+                "Application did not become healthy within timeout in auth-disabled mode. " +
+                    "Captured output should explain why; check stdout above.",
+            )
+
+            // v1-v3: legacy anonymous read. Deterministic — does not depend on imported fixture data.
+            assertHttpStatus("GET", "http://localhost:$port/rest/api/2/components-registry/service/ping", 200)
+
+            // The KEY assertion: a protected v4 write must be gated by @PreAuthorize even with
+            // permitAll() at the filter chain, because AnonymousSecurityConfig keeps method
+            // security enabled via @EnableMethodSecurity. ROLE_ANONYMOUS lacks DELETE_COMPONENTS,
+            // so this returns 403 — not 204, not 500. If method security ever silently breaks in
+            // disabled mode, this assertion catches it.
+            //
+            // Use a syntactically valid UUID; an invalid {id} would 400 at argument binding before
+            // method-security runs and would not actually exercise the contract.
+            //
+            // We deliberately do NOT assert on a v4 GET (e.g. /rest/api/4/components) here: the
+            // integration-test profile uses an embedded H2 with no migrations applied, so v4 list
+            // endpoints can fail with 500 from the data layer regardless of auth state. That is
+            // outside the scope of this test, which is about the security wiring.
+            assertHttpStatus(
+                "DELETE",
+                "http://localhost:$port/rest/api/4/components/00000000-0000-0000-0000-000000000000",
+                403,
+            )
+        } finally {
+            stopProcess(process)
+        }
+    }
+
+    @Test
+    @Timeout(60)
+    fun `fat jar without auth-server config or disabled flag fails fast`(
+        @TempDir tempDir: Path,
+    ) {
+        val port = findRandomPort()
+        val output = StringBuilder()
+        // No -Dauth-server.url, -Dauth-server.realm, or -Dauth-server.disabled — pure prod-default.
+        val process = startFatJar(tempDir, port, extraJvmArgs = emptyList(), capturedOutput = output)
+
+        try {
+            // 30s is well above CRS's normal context-refresh time on a healthy run. The contract
+            // is "fail before health goes green", so we explicitly assert that health never comes
+            // up. If it does, matchIfMissing = true was relaxed and prod is unprotected.
+            val becameHealthy = waitForHealth(port, timeoutSeconds = 30)
+            Assertions.assertFalse(
+                becameHealthy,
+                "Application went healthy without auth-server config — the prod fail-fast " +
+                    "contract is broken. Inspect WebSecurityConfig.@ConditionalOnProperty's " +
+                    "matchIfMissing and AnonymousSecurityConfig's condition.",
+            )
+
+            // Process must have exited (the eager OIDC discovery in AuthServerClient.init{} throws
+            // synchronously during context refresh, which Spring Boot translates to exit non-zero).
+            Assertions.assertTrue(
+                process.waitFor(15, TimeUnit.SECONDS),
+                "Process did not exit within 15s after health timeout. Likely hung instead of " +
+                    "fail-fast — check whether the OIDC discovery exception is being swallowed.",
+            )
+            Assertions.assertNotEquals(0, process.exitValue(), "Expected non-zero exit code, got 0.")
+
+            val logContent = synchronized(output) { output.toString() }
+            val matchedExpectedError = logContent.contains("OAuth2AuthenticationException") ||
+                logContent.contains("BeanInitializationException")
+            Assertions.assertTrue(
+                matchedExpectedError,
+                "Expected OAuth2AuthenticationException or BeanInitializationException in startup " +
+                    "log, but neither was found. The fail-fast trigger may have shifted to another " +
+                    "exception type — update this assertion or fix the regression.",
+            )
+        } finally {
+            stopProcess(process)
+        }
+    }
+
+    private fun startFatJar(
+        tempDir: Path,
+        port: Int,
+        extraJvmArgs: List<String>,
+        capturedOutput: StringBuilder = StringBuilder(),
+    ): Process {
+        val fatJarPath = System.getProperty("fatJar.path")
+            ?: throw IllegalStateException("fatJar.path system property not set")
+        val fatJar = File(fatJarPath)
+        Assertions.assertTrue(fatJar.exists(), "Fat jar not found at: $fatJarPath")
+
+        val testResourcesPath = System.getProperty("test.resources.path")
+            ?: throw IllegalStateException("test.resources.path system property not set")
+        val profilePath = File(testResourcesPath, "application-integration-test.yml")
+        Assertions.assertTrue(profilePath.exists(), "Integration test profile not found at: ${profilePath.absolutePath}")
+
+        val dslDir = setupDslFiles(tempDir, testResourcesPath)
+        val projectRegistryFile = tempDir.resolve("project-registry.json")
+        Files.writeString(projectRegistryFile, "{}")
+
+        val javaExecutable = File(System.getProperty("java.home"), "bin/java")
+        val command = mutableListOf(
+            javaExecutable.absolutePath,
+            "-Dspring.profiles.active=integration-test",
+            "-Dspring.config.additional-location=file:${profilePath.absolutePath}",
+            "-Dcomponents-registry.groovy-path=${dslDir.toAbsolutePath()}",
+            "-Dcomponents-registry.work-dir=${tempDir.toAbsolutePath()}",
+            "-Dcomponents-registry.project-registry-path=${projectRegistryFile.toAbsolutePath()}",
+            "-Dserver.port=$port",
+        )
+        command.addAll(extraJvmArgs)
+        command.add("-jar")
+        command.add(fatJar.absolutePath)
+
+        log.info("Starting application with extra args {} on port {}", extraJvmArgs, port)
+        val processBuilder = ProcessBuilder(command).redirectErrorStream(true)
+        val process = processBuilder.start()
+
+        thread(start = true, isDaemon = true) {
+            BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
+                var line: String?
+                while (reader.readLine().also { line = it } != null) {
+                    synchronized(capturedOutput) { capturedOutput.appendLine(line) }
+                    log.info("App output: {}", line)
+                }
+            }
+        }
+
+        return process
+    }
+
+    private fun stopProcess(process: Process) {
+        if (process.isAlive) {
+            process.destroy()
+            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+            }
+        }
+    }
+
+    private fun setupDslFiles(tempDir: Path, testResourcesPath: String): Path {
+        val dslDir = tempDir.resolve("dsl")
+        Files.createDirectories(dslDir)
+        val testDataDir = File(testResourcesPath, "test-data")
+        Assertions.assertTrue(testDataDir.exists(), "Test data directory not found at: ${testDataDir.absolutePath}")
+        File(testDataDir, "Aggregator.groovy").copyTo(dslDir.resolve("Aggregator.groovy").toFile())
+        File(testDataDir, "TestComponent.groovy").copyTo(dslDir.resolve("TestComponent.groovy").toFile())
+        File(testDataDir, "TestComponent.kts").copyTo(dslDir.resolve("TestComponent.kts").toFile())
+        return dslDir
+    }
+
+    private fun findRandomPort(): Int = ServerSocket(0).use { it.localPort }
+
+    private fun waitForHealth(port: Int, timeoutSeconds: Int): Boolean {
+        val endTime = System.currentTimeMillis() + (timeoutSeconds * 1000L)
+        val healthUrl = URI("http://localhost:$port/actuator/health").toURL()
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                with(healthUrl.openConnection() as HttpURLConnection) {
+                    requestMethod = "GET"
+                    connectTimeout = 1000
+                    readTimeout = 1000
+                    connect()
+                    if (responseCode == 200) return true
+                }
+            } catch (_: Exception) {
+                Thread.sleep(1000)
+            }
+        }
+        return false
+    }
+
+    private fun assertHttpStatus(method: String, url: String, expectedStatus: Int) {
+        val connection = URI(url).toURL().openConnection() as HttpURLConnection
+        try {
+            connection.requestMethod = method
+            connection.connectTimeout = 5000
+            connection.readTimeout = 5000
+            connection.connect()
+            Assertions.assertEquals(
+                expectedStatus,
+                connection.responseCode,
+                "$method $url: expected $expectedStatus, got ${connection.responseCode}",
+            )
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AnonymousSecurityConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AnonymousSecurityConfig.kt
@@ -44,6 +44,12 @@ class AnonymousSecurityConfig(
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
         http
             .authorizeHttpRequests { it.anyRequest().permitAll() }
+            // CSRF is intentionally disabled, mirroring WebSecurityConfig: the registry is a
+            // stateless OAuth2 resource server, so there is no session cookie a CSRF attacker
+            // could ride. AnonymousSecurityConfig only loads in FT/dev (auth-server.disabled=true)
+            // and the same browser-form-post threat model still does not apply. CodeQL
+            // "Disabled Spring CSRF protection" (java/spring-disabled-csrf-protection) is
+            // acknowledged here.
             .csrf { it.disable() }
             .cors { it.disable() }
             .build()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AnonymousSecurityConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AnonymousSecurityConfig.kt
@@ -1,0 +1,50 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import org.octopusden.cloud.commons.security.SecurityService
+import org.octopusden.cloud.commons.security.config.SecurityProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * FT/dev fallback that loads when `auth-server.disabled=true`. Production must keep
+ * the property unset — [WebSecurityConfig] then loads instead and preserves the
+ * fail-fast contract on missing `auth-server.url` / `auth-server.realm`.
+ *
+ * This config re-registers two pieces that disappear together with [WebSecurityConfig]
+ * because they live on its parent [org.octopusden.cloud.commons.security.config.CloudCommonWebSecurityConfig]:
+ *
+ *  1. The `SecurityService` `@Bean`. `PermissionEvaluator` and `AuthController` inject
+ *     it unconditionally — without it the application context fails to refresh, and
+ *     we'd just trade an OIDC-discovery crash for a missing-bean crash.
+ *  2. `@EnableMethodSecurity`. Without it `@PreAuthorize` becomes a no-op and v4
+ *     write handlers (e.g. `DELETE /rest/api/4/components/{id}`) would accept
+ *     anonymous traffic. With it active, `ROLE_ANONYMOUS` carries `ACCESS_COMPONENTS`
+ *     via the `octopus-security.roles` map and v4 reads pass; v4 writes return 403
+ *     because `ROLE_ANONYMOUS` lacks `DELETE_COMPONENTS` / `EDIT_COMPONENTS`.
+ *
+ * The HTTP filter chain itself is permissive (`anyRequest().permitAll()`); method
+ * security does the actual gating.
+ */
+@Configuration
+@ConditionalOnProperty(name = ["auth-server.disabled"], havingValue = "true")
+@EnableConfigurationProperties(SecurityProperties::class)
+@EnableMethodSecurity(prePostEnabled = true, securedEnabled = true)
+class AnonymousSecurityConfig(
+    private val securityProperties: SecurityProperties,
+) {
+    @Bean
+    fun securityService(): SecurityService = SecurityService(securityProperties)
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
+        http
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+            .csrf { it.disable() }
+            .cors { it.disable() }
+            .build()
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
@@ -10,6 +10,7 @@ import org.octopusden.cloud.commons.security.config.SecurityProperties
 import org.octopusden.cloud.commons.security.converter.UserInfoGrantedAuthoritiesConverter
 import org.octopusden.octopus.components.registry.core.dto.ErrorResponse
 import org.springframework.beans.factory.BeanInitializationException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -29,7 +30,15 @@ import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.AccessDeniedHandler
 
+/**
+ * Production / dev security wiring. Loaded by default; opt out by setting
+ * `auth-server.disabled=true`, which switches the application to [AnonymousSecurityConfig]
+ * for FT and local environments without a Keycloak. The disabled-mode flag must NEVER
+ * be set in production — `matchIfMissing = true` here keeps the existing fail-fast
+ * contract on `auth-server.url` / `auth-server.realm` (see [jwtDecoder]).
+ */
 @Configuration
+@ConditionalOnProperty(name = ["auth-server.disabled"], havingValue = "false", matchIfMissing = true)
 @Import(AuthServerClient::class)
 @EnableConfigurationProperties(SecurityProperties::class)
 class WebSecurityConfig(

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -20,6 +20,13 @@ teamcity:
 # Tests override with stub URLs in application-common.yml so the decoder bean can
 # be constructed without Keycloak running — MockMvc jwt() post-processor bypasses
 # the decoder entirely.
+#
+# auth-server.disabled (intentionally unset here): FT-only opt-out for environments
+# without a Keycloak. When set to true, WebSecurityConfig is skipped and
+# AnonymousSecurityConfig loads instead — see those classes for the contract.
+# Leaving the property unset preserves the production fail-fast guarantee, so do
+# NOT set it in any production profile. Set via env var AUTH_SERVER_DISABLED=true
+# or in profile-specific YAML mounted under /application-ft.yml.
 auth-server:
   url:
   realm:


### PR DESCRIPTION
## TL;DR

CRS currently fail-fasts at startup if `auth-server.url` / `auth-server.realm` are not set, because `octopus-security-common`'s `AuthServerClient.init{}` performs **eager OIDC discovery** during Spring context refresh. That is the right behaviour in production. But every FT pipeline that brings up CRS as a docker container without a Keycloak (releng, escrow-generator, octopus-release-management-service, octopus-dms-service) hits this and the registry never binds its port.

This PR adds a single opt-in property — `auth-server.disabled` — that lets FT/dev environments skip the eager discovery while **fully preserving the production fail-fast guarantee**. Default is `false`. When unset, behaviour is identical to before. When set to `true`, CRS swaps `WebSecurityConfig` for a permissive `AnonymousSecurityConfig` and starts without any auth server. Method-level security stays on, so v4 writes still return 403 even with the flag set.

## Why

CRS `2.0.84-3306` (current `v3` tip before this PR) crashes in every FT setup that does not run a Keycloak. Failure mode:

```
OAuth2AuthenticationException: Cannot get openid-configuration via /realms//.well-known/openid-configuration
Caused by: java.lang.IllegalArgumentException: URI is not absolute
```

The empty `/realms//` shows that `auth-server.url` and `auth-server.realm` are blank — the FT default — and `AuthServerClient.kt:39-57` (in `octopus-cloud-commons`) eagerly tries OIDC discovery anyway. The library has no built-in opt-out.

Confirmed broken by build [`Releng_2.3_Maven-CRM-Plugin_IT 8.5153`](https://teamcity.spb.openwaygroup.com) — every JIRA-side test died with `Connection refused localhost:10001` because the CRS container never finished starting. escrow-generator FT had the same symptom.

Existing tests, the build pipeline, and current deployments all assume CRS will fail fast on missing auth-server config (see the `WebSecurityConfig.jwtDecoder()` doc-comment "we'd rather crash at deploy time with a clear error"). This PR must not relax that.

## What changes

| Mode | Trigger | `WebSecurityConfig` | `AnonymousSecurityConfig` | `AuthServerClient` (eager OIDC) | Result |
|---|---|---|---|---|---|
| **Production (default)** | property unset, or `auth-server.disabled=false` | loaded | not loaded | created → discovery runs | unchanged: must succeed for context to refresh; missing `auth-server.url` still fail-fasts |
| **FT / dev** | `auth-server.disabled=true` | skipped | loaded | **never imported** | context refreshes without Keycloak; all HTTP reaches the controller layer |

`@ConditionalOnProperty` on `WebSecurityConfig` uses `matchIfMissing = true` — i.e. the property has to be **explicitly** set to `true` to flip into anonymous mode. A blank value, a missing key, or a typo all keep production behaviour.

### Why `AnonymousSecurityConfig` re-registers two beans

Skipping `WebSecurityConfig` also skips its parent `CloudCommonWebSecurityConfig`, which is the only producer of two things that the rest of CRS depends on:

1. **`SecurityService` `@Bean`** (`CloudCommonWebSecurityConfig.kt:67`) — injected unconditionally by `PermissionEvaluator` (`@Component`) and `AuthController` (`@Component`). Without it, the application context fails to refresh anyway. `AnonymousSecurityConfig.securityService()` re-creates it from `SecurityProperties`, no auth server involved.
2. **`@EnableMethodSecurity`** — without it `@PreAuthorize` becomes a no-op. v4 writes (e.g. `DELETE /rest/api/4/components/{id}` at `ComponentControllerV4.kt:129-139`) would silently accept anonymous traffic. `AnonymousSecurityConfig` re-applies `@EnableMethodSecurity(prePostEnabled = true, securedEnabled = true)`.

The HTTP filter chain in `AnonymousSecurityConfig` is `anyRequest().permitAll()`. Method security does the actual gating: `ROLE_ANONYMOUS` is granted `ACCESS_COMPONENTS` via the `octopus-security.roles` map (`application.yml:51-57`) but **not** `DELETE_COMPONENTS` / `EDIT_COMPONENTS` / `ARCHIVE_COMPONENTS`. So in disabled mode:
- v1-v3 endpoints — anonymous read OK (already `permitAll()` in the production chain too).
- v4 GETs — pass via `@PreAuthorize("hasPermission('ACCESS_COMPONENTS')")`.
- v4 writes — return **403**, not 204. This is asserted by an integration test below.

CSRF is disabled in `AnonymousSecurityConfig`, mirroring `WebSecurityConfig:109-116`. Same justification: stateless OAuth2 resource server, no session cookie surface, every state-changing call would carry a Bearer JWT in production. CodeQL alert #7 (`java/spring-disabled-csrf-protection`) was reviewed and dismissed as `won't fix`.

## Files

- `WebSecurityConfig.kt` — added `@ConditionalOnProperty(name = ["auth-server.disabled"], havingValue = "false", matchIfMissing = true)`.
- `AnonymousSecurityConfig.kt` (new) — sibling config, opposite condition.
- `application.yml` — doc comment next to the existing `auth-server:` block. No default value set.
- `FatJarAuthDisabledIntegrationTest.kt` (new) — locks in the two contracts below.

## Test plan

`./gradlew :components-registry-service-server:test :components-registry-service-server:integrationTest` — all green.

| | What it asserts | Why it matters |
|---|---|---|
| **Existing** `FatJarStartupIntegrationTest` (unchanged) | Production code path with WireMock-stubbed Keycloak still starts and serves health 200. | Confirms the conditional did not break the prod-default flow. |
| **New** `FatJarAuthDisabledIntegrationTest > fat jar with auth-server disabled starts and gates writes` | With `-Dauth-server.disabled=true` and no `auth-server.url`: `GET /actuator/health` → 200, `GET /rest/api/2/components-registry/service/ping` → 200, **`DELETE /rest/api/4/components/00000000-0000-0000-0000-000000000000` → 403**. | The 403 assertion is the key one: it proves method-level security is still active in disabled mode. If a future refactor accidentally drops `@EnableMethodSecurity` from `AnonymousSecurityConfig`, this test catches it before the registry becomes an open delete surface in any FT environment. Uses a syntactically valid UUID so 403 comes from method security, not 400 from argument binding. |
| **New** `FatJarAuthDisabledIntegrationTest > fat jar without auth-server config or disabled flag fails fast` | With **no** `auth-server.url`, **no** `auth-server.realm`, **no** `auth-server.disabled`: process must exit non-zero before health goes green; captured stderr must contain `OAuth2AuthenticationException` or `BeanInitializationException`. | Automates what was a manual smoke check. Protects the `matchIfMissing = true` semantics from being accidentally relaxed in a refactor: a misconfigured prod that forgets `AUTH_SERVER_URL` must keep crashing, not silently fall through to anonymous mode. |
| Existing unit tests | Unchanged; continue to use `@MockBean AuthServerClient` and stubbed `auth-server.url=http://localhost:0` from `application-common.yml`. The new conditional defaults to "auth on", so they never hit the anonymous path. | No test churn. |

CodeQL: alert #7 (`java/spring-disabled-csrf-protection` on `AnonymousSecurityConfig.kt:47`) reviewed and dismissed as `won't fix` — same rationale as the existing CSRF disable in `WebSecurityConfig:116`, now also documented inline.

## How consumers use it

After merge and a new CRS artifact, four repos add `auth-server.disabled: true` to the Spring config they mount into the CRS docker container in FT (a single-block YAML change per repo). The fifth, `octopus-rm-gradle-plugin`, only consumes the light client and does not run CRS — version bump only.

| Repo | Branch | Where the property goes |
|---|---|---|
| `releng` | `chore/crs-ft-db` | `ft/test-data/test-resources/docker/components-registry-service/application-ft.yml` |
| `escrow-generator` | `ESCR-1666/crs-ft-db` | `gradle-scripts/okd/application.yaml` (templated into `${APPLICATION_YAML_CONTENT}` for the OKD ConfigMap) |
| `octopus-release-management-service` | `chore/crs-ft-db` | `ft/docker/components-registry-service.yaml` |
| `octopus-dms-service` | `chore/crs-ft-db` | `test-common/src/main/config/components-registry-service.yaml` |
| `octopus-rm-gradle-plugin` | `chore/crs-ft-db` | (light client only, no FT runtime — no property change) |

releng and escrow-generator have already been bumped to `2.0.84-3312` (the artifact from this PR) on their respective branches with `auth-server.disabled: true` in place; the others will follow once this is merged.

**Production deployments must never set this flag.** Anywhere it is set, `AnonymousSecurityConfig` becomes the active security wiring; the value of `octopus-security.roles` no longer constrains anonymous read access via JWT.

## Follow-up

Filed octopusden/octopus-cloud-commons#45 to push the opt-out down into the library. The right long-term shape is for `octopus-security-common` to ship a first-class anonymous mode (lazy `AuthServerClient` + a built-in permissive chain that keeps `SecurityService` and `@EnableMethodSecurity` active). Once that lands, every consuming service gets the opt-out for free and this PR's `AnonymousSecurityConfig` becomes redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)