### PR TITLE
fix(tc-sync): batch query via teamcity-client 2.0.90 to unblock 0/658 match

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClientConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClientConfig.kt
@@ -5,11 +5,19 @@ import org.octopusden.octopus.infrastructure.client.commons.ClientParametersProv
 import org.octopusden.octopus.infrastructure.client.commons.CredentialProvider
 import org.octopusden.octopus.infrastructure.client.commons.StandardBasicCredCredentialProvider
 import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClassicClient
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProject as ExternalTeamcityProject
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.locator.ProjectLocator
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.locator.PropertyLocator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.UUID
+
+private const val COMPONENT_NAME_PARAM = "COMPONENT_NAME"
+
+// `href` and `webUrl` are non-nullable on the library's TeamcityProject DTO, so the
+// fields spec MUST request them or Jackson throws on deserialisation. We don't read
+// `href` ourselves — it just has to round-trip through the client.
+private const val PROJECT_FIELDS = "project(id,name,webUrl,href,parameters(property(name,value)))"
 
 @Configuration
 class TeamcityClientConfig {
@@ -18,21 +26,27 @@ class TeamcityClientConfig {
 }
 
 /**
- * Adapter that queries TC per-component using the external teamcity-client
- * library. Each call issues one REST GET to find projects carrying
- * `parameter:(name:COMPONENT_NAME,value:<name>,matchType:equals)` — exact
- * value matching avoids false positives from TC's default contains semantics.
+ * Adapter that queries TC in a single batched GET for all projects carrying the
+ * `COMPONENT_NAME` parameter, then maps the response to UUIDs known to CRS by
+ * looking up each project's `COMPONENT_NAME` value in [componentsByName] (client-side
+ * grouping).
+ *
+ * Why batch instead of per-component:
+ * - One HTTP call vs. N (registry size).
+ * - Avoids version-specific behavior we previously hit where some TC builds silently
+ *   return an empty list for `parameter:(name:X,value:Y,matchType:equals)` queries.
+ *   The simple `parameter:(name:X)` filter is universally supported.
+ *
+ * Multiple TC projects sharing the same `COMPONENT_NAME` are all included in the
+ * `List<TcProject>` for that component — [TeamcitySyncService.applyMatches] treats
+ * `size > 1` as `skipped_ambiguous` and skips the row. Projects whose
+ * `COMPONENT_NAME` is unknown to CRS, missing, or blank are silently dropped.
  *
  * The client is lazily initialised so that a blank [TeamcityProperties.baseUrl]
  * does not attempt a connection until [findByComponentNames] is actually called.
- * The blank-URL check itself lives in [TeamcitySyncService] (before any DB or
- * HTTP work), so this adapter does not need to defend against it separately.
- *
- * Per-component TC errors are caught and logged: a single TC failure does not
- * abort the remainder of the sync. Components whose TC call fails are treated
- * as no-match for this run (their existing DB values are preserved).
+ * The blank-URL check itself lives in [TeamcitySyncService] (before any DB or HTTP
+ * work), so this adapter does not need to defend against it separately.
  */
-@Suppress("TooGenericExceptionCaught")
 internal class ExternalTcProjectFetcher(
     private val properties: TeamcityProperties,
 ) : TcProjectFetcher {
@@ -51,37 +65,49 @@ internal class ExternalTcProjectFetcher(
         )
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun findByComponentNames(componentsByName: Map<String, UUID>): Map<UUID, List<TcProject>> {
-        val result = mutableMapOf<UUID, MutableList<TcProject>>()
-        var tcErrors = 0
-        log.info { "TC sync: querying TC for ${componentsByName.size} components (per-component)" }
-        for ((name, uuid) in componentsByName) {
-            val locator =
-                ProjectLocator(
-                    parameter =
-                        listOf(
-                            PropertyLocator(
-                                name = "COMPONENT_NAME",
-                                value = name,
-                                matchType = PropertyLocator.MatchType.EQUALS,
-                            ),
-                        ),
-                )
-            try {
-                val response = client.getProjectsWithLocatorAndFields(locator, "project(id,name,webUrl)")
-                val projects = response.projects.orEmpty().map { p -> TcProject(id = p.id, webUrl = p.webUrl) }
-                if (projects.isNotEmpty()) {
-                    result.getOrPut(uuid) { mutableListOf() }.addAll(projects)
-                }
-            } catch (e: Exception) {
-                tcErrors++
-                log.warn(e) { "TC sync: failed to query TC for component '$name' (id=$uuid) — treating as no-match" }
+        if (componentsByName.isEmpty()) return emptyMap()
+
+        val locator = ProjectLocator(parameter = listOf(PropertyLocator(name = COMPONENT_NAME_PARAM)))
+        val response = try {
+            client.getProjectsWithLocatorAndFields(locator, PROJECT_FIELDS)
+        } catch (e: Exception) {
+            // Add fetcher-level context before the exception escapes to the admin endpoint
+            // (which sees a stack trace) or the scheduler (which logs-and-swallows). Without
+            // this line, the upstream message gives no hint that TC sync was the caller.
+            log.error(e) {
+                "TC sync: batch query failed against ${properties.baseUrl} " +
+                    "(${componentsByName.size} components scanned)"
             }
+            throw e
         }
-        log.info {
-            "TC sync: TC returned matches for ${result.size}/${componentsByName.size} components" +
-                if (tcErrors > 0) " ($tcErrors TC errors)" else ""
-        }
-        return result
+        val projects = response.projects.orEmpty()
+        log.info { "TC sync: TC returned ${projects.size} projects with $COMPONENT_NAME_PARAM parameter" }
+
+        return mapTcProjectsToComponentMatches(projects, componentsByName)
     }
 }
+
+/**
+ * Pure mapper, extracted for unit-testability. For each TC project, reads the
+ * `COMPONENT_NAME` parameter value, looks it up in [componentsByName], and groups
+ * the resulting [TcProject]s by component UUID. Projects without the parameter,
+ * with a blank value, or whose value is unknown to CRS are dropped.
+ */
+internal fun mapTcProjectsToComponentMatches(
+    projects: List<ExternalTeamcityProject>,
+    componentsByName: Map<String, UUID>,
+): Map<UUID, List<TcProject>> =
+    projects
+        .mapNotNull { project ->
+            val componentName = project.parameters?.properties
+                ?.firstOrNull { it.name == COMPONENT_NAME_PARAM }
+                ?.value
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?: return@mapNotNull null
+            val uuid = componentsByName[componentName] ?: return@mapNotNull null
+            uuid to TcProject(id = project.id, webUrl = project.webUrl)
+        }
+        .groupBy({ it.first }, { it.second })

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -15,9 +15,9 @@ import java.util.UUID
  *
  * One pass:
  * 1. Read all non-archived components.
- * 2. For each component, issue a TC REST call to find projects where
- *    `COMPONENT_NAME` parameter equals the component name (exact match,
- *    per-component query via [TcProjectFetcher]).
+ * 2. Single batched TC REST call via [TcProjectFetcher]: ask for every project
+ *    that carries a `COMPONENT_NAME` parameter (any value), then group the
+ *    response client-side by the parameter value.
  * 3. For each component:
  *      - 0 matches → leave nulls, count `skippedNoMatch`.
  *      - 1 match with non-blank webUrl → upsert id+url if changed; count
@@ -30,14 +30,11 @@ import java.util.UUID
  * emitted via existing [AuditEvent] flow when fields change so admins can
  * trace the source of writes.
  *
- * Error handling: the production [TcProjectFetcher] implementation
- * ([ExternalTcProjectFetcher]) isolates per-component TC failures — a single
- * HTTP error is logged as a warning and that component is treated as no-match,
- * leaving the rest of the batch unaffected. Only a failure that aborts the
- * fetcher entirely (e.g. an alternative implementation used in tests, or an
- * unrecoverable initialisation error) propagates out of [resync] — for the
- * admin endpoint that surfaces as 502/500, for the scheduled cron that is
- * logged-and-swallowed by the scheduler.
+ * Error handling: a fetcher failure (TC unreachable, auth refused, malformed
+ * response) propagates out of [resync] — for the admin endpoint that surfaces
+ * as 502/500, for the scheduled cron that is logged-and-swallowed by the
+ * scheduler. Per-write JPA failures inside the transaction template cause the
+ * whole transaction to roll back, leaving DB state untouched.
  */
 @Service
 class TeamcitySyncService(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/ExternalTcProjectFetcherTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/ExternalTcProjectFetcherTest.kt
@@ -1,0 +1,149 @@
+package org.octopusden.octopus.components.registry.server.teamcity
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperties
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperty
+import java.util.UUID
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProject as ExternalTeamcityProject
+
+/**
+ * Unit tests for the pure mapper inside [ExternalTcProjectFetcher]. The HTTP side
+ * is exercised separately by `teamcity-client/TeamcityClassicClientTest` against a
+ * real TC; here we cover only the mapping rules CRS layers on top.
+ */
+class ExternalTcProjectFetcherTest {
+
+    private val fooUuid = UUID.randomUUID()
+    private val barUuid = UUID.randomUUID()
+
+    @Test
+    @DisplayName("empty input -> empty output")
+    fun emptyInputEmptyOutput() {
+        val result = mapTcProjectsToComponentMatches(emptyList(), mapOf("foo" to fooUuid))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    @DisplayName("project with known COMPONENT_NAME maps to UUID")
+    fun knownComponentNameMaps() {
+        val projects = listOf(tcProject(id = "Tc_Foo", webUrl = "http://tc/foo", componentName = "foo"))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        assertEquals(mapOf(fooUuid to listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo"))), result)
+    }
+
+    @Test
+    @DisplayName("project whose COMPONENT_NAME is unknown to CRS is dropped")
+    fun unknownComponentNameDropped() {
+        val projects = listOf(tcProject(id = "Tc_Stranger", webUrl = "http://tc/x", componentName = "not-in-registry"))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    @DisplayName("project without parameters field is dropped")
+    fun missingParametersFieldDropped() {
+        val projects = listOf(
+            ExternalTeamcityProject(id = "Tc_Empty", name = "Empty", href = "/x", webUrl = "http://tc/empty"),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    @DisplayName("project with parameters but no COMPONENT_NAME among them is dropped")
+    fun parametersWithoutComponentNameDropped() {
+        val projects = listOf(
+            ExternalTeamcityProject(
+                id = "Tc_Other",
+                name = "Other",
+                href = "/x",
+                webUrl = "http://tc/other",
+                parameters = TeamcityProperties(properties = mutableListOf(TeamcityProperty(name = "OTHER", value = "y"))),
+            ),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    @DisplayName("project with whitespace-only COMPONENT_NAME value is dropped")
+    fun whitespaceOnlyValueDropped() {
+        val projects = listOf(tcProject(id = "Tc_Blank", webUrl = "http://tc/blank", componentName = "   "))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    @DisplayName("two projects with the same COMPONENT_NAME are grouped under one UUID")
+    fun twoProjectsSameNameGrouped() {
+        val projects = listOf(
+            tcProject(id = "Tc_Foo_A", webUrl = "http://tc/foo-a", componentName = "foo"),
+            tcProject(id = "Tc_Foo_B", webUrl = "http://tc/foo-b", componentName = "foo"),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        assertEquals(1, result.size)
+        assertEquals(2, result[fooUuid]!!.size)
+        assertEquals(setOf("Tc_Foo_A", "Tc_Foo_B"), result[fooUuid]!!.map { it.id }.toSet())
+    }
+
+    @Test
+    @DisplayName("value with surrounding whitespace is trimmed before matching")
+    fun whitespaceTrimmedBeforeMatching() {
+        val projects = listOf(tcProject(id = "Tc_Foo", webUrl = "http://tc/foo", componentName = "  foo  "))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        assertEquals(mapOf(fooUuid to listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo"))), result)
+    }
+
+    @Test
+    @DisplayName("when a project has multiple COMPONENT_NAME entries, the first one wins")
+    fun multipleComponentNameEntriesFirstWins() {
+        // TC shouldn't return more than one COMPONENT_NAME per project (parameter names are
+        // unique on a TC project), but pin the first-wins semantics so any future change to
+        // multi-value handling is caught.
+        val projects = listOf(
+            ExternalTeamcityProject(
+                id = "Tc_Dup",
+                name = "Dup",
+                href = "/x",
+                webUrl = "http://tc/dup",
+                parameters = TeamcityProperties(
+                    properties = mutableListOf(
+                        TeamcityProperty(name = "COMPONENT_NAME", value = "foo"),
+                        TeamcityProperty(name = "COMPONENT_NAME", value = "bar"),
+                    ),
+                ),
+            ),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid, "bar" to barUuid))
+        assertEquals(mapOf(fooUuid to listOf(TcProject(id = "Tc_Dup", webUrl = "http://tc/dup"))), result)
+    }
+
+    @Test
+    @DisplayName("mixed input - known, unknown, blank, missing - only known survives")
+    fun mixedInputOnlyKnownSurvives() {
+        val projects = listOf(
+            tcProject(id = "Tc_Foo", webUrl = "http://tc/foo", componentName = "foo"),
+            tcProject(id = "Tc_Stranger", webUrl = "http://tc/x", componentName = "not-in-registry"),
+            tcProject(id = "Tc_Bar", webUrl = "http://tc/bar", componentName = "bar"),
+            tcProject(id = "Tc_Blank", webUrl = "http://tc/blank", componentName = ""),
+            ExternalTeamcityProject(id = "Tc_NoParams", name = "NoParams", href = "/x", webUrl = "http://tc/np"),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid, "bar" to barUuid))
+        assertEquals(2, result.size)
+        assertEquals(listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo")), result[fooUuid])
+        assertEquals(listOf(TcProject(id = "Tc_Bar", webUrl = "http://tc/bar")), result[barUuid])
+    }
+
+    private fun tcProject(id: String, webUrl: String, componentName: String) = ExternalTeamcityProject(
+        id = id,
+        name = id,
+        href = "/$id",
+        webUrl = webUrl,
+        parameters = TeamcityProperties(
+            properties = mutableListOf(TeamcityProperty(name = "COMPONENT_NAME", value = componentName)),
+        ),
+    )
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/ExternalTcProjectFetcherTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/ExternalTcProjectFetcherTest.kt
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperties
-import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperty
-import java.util.UUID
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProject as ExternalTeamcityProject
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperties as ExternalTeamcityProperties
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperty as ExternalTeamcityProperty
+import java.util.UUID
 
 /**
  * Unit tests for the pure mapper inside [ExternalTcProjectFetcher]. The HTTP side
@@ -61,7 +61,7 @@ class ExternalTcProjectFetcherTest {
                 name = "Other",
                 href = "/x",
                 webUrl = "http://tc/other",
-                parameters = TeamcityProperties(properties = mutableListOf(TeamcityProperty(name = "OTHER", value = "y"))),
+                parameters = ExternalTeamcityProperties(properties = mutableListOf(ExternalTeamcityProperty(name = "OTHER", value = "y"))),
             ),
         )
         val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
@@ -109,10 +109,10 @@ class ExternalTcProjectFetcherTest {
                 name = "Dup",
                 href = "/x",
                 webUrl = "http://tc/dup",
-                parameters = TeamcityProperties(
+                parameters = ExternalTeamcityProperties(
                     properties = mutableListOf(
-                        TeamcityProperty(name = "COMPONENT_NAME", value = "foo"),
-                        TeamcityProperty(name = "COMPONENT_NAME", value = "bar"),
+                        ExternalTeamcityProperty(name = "COMPONENT_NAME", value = "foo"),
+                        ExternalTeamcityProperty(name = "COMPONENT_NAME", value = "bar"),
                     ),
                 ),
             ),
@@ -142,8 +142,8 @@ class ExternalTcProjectFetcherTest {
         name = id,
         href = "/$id",
         webUrl = webUrl,
-        parameters = TeamcityProperties(
-            properties = mutableListOf(TeamcityProperty(name = "COMPONENT_NAME", value = componentName)),
+        parameters = ExternalTeamcityProperties(
+            properties = mutableListOf(ExternalTeamcityProperty(name = "COMPONENT_NAME", value = componentName)),
         ),
     )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 # ow deps
-octopus-external-systems-clients.version=2.0.88
+octopus-external-systems-clients.version=2.0.90
 octopus-release-management.version=2.0.4
 octopus-employee-service.version=2.0.37
 octopus-oc-template.version=2.0.6


### PR DESCRIPTION
## Summary

Fixes the TC resync admin action that reports `658 scanned, 658 no match, 0 errors` on production: every per-component locator (`parameter:(name:COMPONENT_NAME,value:<name>,matchType:equals)`) was returning an empty list. Switches to a single batched query (`parameter:(name:COMPONENT_NAME)` plus `parameters(property(name,value))` in the fields spec) and groups by parameter value client-side.

The simpler batch shape became safe to use after the upstream library release of `octopus-external-systems-clients:teamcity-client:2.0.90` (PR octopusden/octopus-external-systems-client#131), which:
- makes `PropertyLocator.value` nullable so the value-less form compiles, and
- adds `@Param(encoded = true)` on query-string locators (plus URL-special escaping inside locator values in the expander) so TC receives `parameter:(name:X)` un-encoded rather than `parameter%3A%28name%3AX%29`.

## Changes

- `gradle.properties` — `octopus-external-systems-clients.version` `2.0.88 → 2.0.90`.
- `TeamcityClientConfig.kt` — single batch GET; mapper extracted as a top-level `internal` `mapTcProjectsToComponentMatches`. Fields spec includes `href` and `webUrl` because both are non-nullable on the library DTO.
- `TeamcitySyncService.kt` KDoc — updated to describe the new "one batched call → group client-side" flow, and to drop the stale "per-component error isolation" text that no longer applies.
- New `ExternalTcProjectFetcherTest.kt` — 10 unit cases on the mapper.

## Test plan

- [x] `./gradlew :components-registry-service-server:test` — green (existing `TeamcitySyncServiceTest` continues to pass; new mapper cases pass).
- [x] `AUTH_SERVER=stub ./gradlew build -x …` (full build with project-standard CI excludes) — green.
- [ ] CI on this PR.
- [ ] After merge: deploy to QA OKD, click Resync TC project IDs, confirm `Updated`/`Unchanged` are non-zero and `No match` decreases to the realistic count.

## Notes

- `ExternalTcProjectFetcher` no longer isolates per-component failures — the old code caught and counted them, but with a single batch GET there's nothing to isolate. Fetcher exceptions are logged with TC base URL context and rethrown.
- `TcProjectFetcher` interface and `TcProject` shape are unchanged. The higher-level sync logic (`applyMatches` ambiguous/no-match/updated counters) keeps working as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)