### PR TITLE
chore(tc-sync): remove deprecated synchronous /resync endpoint

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -15,8 +15,6 @@ import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
-import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
-import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -36,7 +34,6 @@ class AdminControllerV4(
     private val importService: ImportService,
     private val migrationJobService: MigrationJobService,
     private val historyMigrationJobService: HistoryMigrationJobService,
-    private val teamcitySyncService: TeamcitySyncService,
     private val teamcitySyncJobService: TeamcitySyncJobService,
 ) {
     @PostMapping("/migrate-component/{name}")
@@ -152,27 +149,6 @@ class AdminControllerV4(
                     ),
                 )
         }
-
-    /**
-     * **Deprecated** — synchronous TC resync. Kept for backwards-compatibility
-     * with portal builds that haven't switched to the async pair yet
-     * (`POST /teamcity-project-ids/sync` + `GET .../sync/job`). Once the portal
-     * deploy is complete in all envs, this endpoint is removed in a follow-up.
-     *
-     * Reuses the IMPORT_DATA permission (locked design decision — see PR plan
-     * §A5 rationale: a separate SYNC_TC_PROJECTS permission would require new
-     * constants across CRS, cloud-commons, the automation repo's role yaml,
-     * the portal `auth.ts`, and every admin UI consumer; for "admin bulk
-     * operation" the existing IMPORT_DATA semantic is the right scope).
-     *
-     * Synchronous and gateway-blocking: TC sync issues one REST call per
-     * non-archived component, so on registries past ~150 components the round
-     * trip exceeds typical gateway HTTP read timeouts and returns 504. The
-     * async pair below was added specifically to fix that.
-     */
-    @Deprecated("Use POST /teamcity-project-ids/sync (async). This endpoint is removed once portal switches.")
-    @PostMapping("/teamcity-project-ids/resync")
-    fun resyncTeamcityProjectIds(): ResponseEntity<TeamcitySyncResult> = ResponseEntity.ok(teamcitySyncService.resync())
 
     /**
      * Async TC resync — kicks off the run on the background executor.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncJobService.kt
@@ -40,12 +40,9 @@ data class StartTeamcitySyncResult(
  * Async wrapper around [TeamcitySyncService.resync]. Mirrors
  * `MigrationJobService` for the components flow.
  *
- * The synchronous endpoint `POST /admin/teamcity-project-ids/resync` is kept for
- * backwards-compatibility (deprecated; will be removed once portal is on the
- * async path) and delegates to [TeamcitySyncService] directly. The new async
- * endpoint pair `POST /admin/teamcity-project-ids/sync` + `GET .../sync/job`
- * goes through this service so callers can poll instead of holding an HTTP
- * connection through TC's per-component REST roundtrip storm.
+ * The endpoint pair `POST /admin/teamcity-project-ids/sync` + `GET .../sync/job`
+ * goes through this service so callers poll instead of holding an HTTP
+ * connection while TC is being scanned.
  */
 interface TeamcitySyncJobService {
     /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
@@ -3,9 +3,11 @@ package org.octopusden.octopus.components.registry.server.teamcity
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
- * Wire shape of the resync admin endpoint response. Field names match the
- * plan (snake_case via @JsonProperty so the Kotlin property names stay
- * idiomatic).
+ * Wire shape of one TC resync run's result. Embedded as `result` in
+ * [TeamcitySyncJobState] once a job COMPLETES, and surfaced over HTTP via
+ * `GET /admin/teamcity-project-ids/sync/job` inside [TeamcitySyncJobResponse].
+ * Field names use snake_case via @JsonProperty so the Kotlin property names
+ * stay idiomatic.
  *
  * - `scanned`     — number of components considered (= number of non-archived
  *                   components in the registry at the moment of the call).
@@ -13,9 +15,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * - `unchanged`   — components matched and already correct (no DB write).
  * - `skippedNoMatch`   — components with no TC project carrying the parameter.
  * - `skippedAmbiguous` — components matched by ≥2 TC projects (skipped by policy).
- * - `errors`      — component-level error messages (TC API failures, etc.).
- *                   A top-level TC API failure aborts the whole sync and is
- *                   surfaced via HTTP error, not via this list.
+ * - `errors`      — component-level error messages caught during the post-fetch
+ *                   `applyMatches` loop. A fetch-level TC API failure aborts the
+ *                   whole sync and is surfaced via the job's `errorMessage`, not
+ *                   via this list.
  */
 data class TeamcitySyncResult(
     val scanned: Int,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -82,8 +82,9 @@ class TeamcitySyncService(
         val matches = tcProjectFetcher.findByComponentNames(componentsByName)
 
         // CurrentUserResolver returns "system" when there is no auth context
-        // (the scheduled cron path), or the JWT's preferred_username when an
-        // admin invokes the resync endpoint. Either way it never returns null.
+        // (the scheduled cron path), or the JWT's preferred_username captured
+        // from the admin request that started the async resync job. Either way
+        // it never returns null.
         val changedBy = currentUserResolver.currentUsername()
 
         // execute() returns the callback's value; applyMatches never returns

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -17,7 +17,6 @@ import org.octopusden.octopus.components.registry.server.service.MigrationPhase
 import org.octopusden.octopus.components.registry.server.service.StartMigrationResult
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.octopusden.octopus.components.registry.server.support.editorJwt
-import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -69,19 +68,10 @@ class AdminControllerV4SecurityTest {
     private lateinit var historyMigrationJobService: HistoryMigrationJobService
 
     /**
-     * Mocked so the new /teamcity-project-ids/resync endpoint's collaborator
-     * is satisfied without standing up the real TC client. Same rationale as
-     * the migration-job mocks above: keep this test purely about the security
-     * gates on AdminControllerV4.
-     */
-    @MockBean
-    @Suppress("UnusedPrivateProperty")
-    private lateinit var teamcitySyncService: TeamcitySyncService
-
-    /**
-     * Mocked too — the controller wires this in for the async TC resync pair
-     * (`POST /sync` + `GET /sync/job`). Same isolation rationale as the other
-     * job-service mocks.
+     * Mocked so the controller's TC-resync collaborator is satisfied without
+     * standing up the real TC client. Same rationale as the migration-job
+     * mocks above: keep this test purely about the security gates on
+     * AdminControllerV4.
      */
     @MockBean
     @Suppress("UnusedPrivateProperty")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
@@ -18,7 +18,6 @@ import org.octopusden.octopus.components.registry.server.teamcity.StartTeamcityS
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobState
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
-import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -35,20 +34,18 @@ import java.time.Instant
 
 /**
  * Pins the auth + response-shape contract of the TeamCity resync endpoints
- * (legacy synchronous `POST /resync`, new async pair `POST /sync` + `GET
- * /sync/job`).
+ * (`POST /sync` + `GET /sync/job`).
  *
  * Both gates that protect the endpoints are exercised:
  *   - WebSecurityConfig URL-level rule → 401 for anonymous callers.
  *   - AdminControllerV4 class-level @PreAuthorize("@permissionEvaluator.canImport()")
  *     → 403 for authenticated callers without IMPORT_DATA.
  *
- * Both TeamcitySyncService and TeamcitySyncJobService are @MockBean'd so the
- * test does not pull in the TeamcityClient bean wiring (which would attempt
- * outbound HTTP if base-url were ever set). The legacy path verifies the
- * 6-field counts shape including the snake_case `skipped_no_match` /
- * `skipped_ambiguous` keys; the async path verifies 202/409 attach, 200/404
- * polling, and the cross-kind 409 envelope.
+ * TeamcitySyncJobService is @MockBean'd so the test does not pull in the
+ * TeamcityClient bean wiring (which would attempt outbound HTTP if base-url
+ * were ever set). Asserts cover 202/409 attach + 409 cross-kind envelope on
+ * POST, and 200/404 polling on GET, including the snake_case
+ * `skipped_no_match` / `skipped_ambiguous` keys in the COMPLETED `result`.
  *
  * Other migration job services are @MockBean'd to keep this test scoped to
  * the resync paths — same convention as AdminControllerV4SecurityTest.
@@ -65,9 +62,6 @@ class TeamcityResyncControllerTest {
     private lateinit var authServerClient: AuthServerClient
 
     @MockBean
-    private lateinit var teamcitySyncService: TeamcitySyncService
-
-    @MockBean
     private lateinit var teamcitySyncJobService: TeamcitySyncJobService
 
     @MockBean
@@ -82,58 +76,7 @@ class TeamcityResyncControllerTest {
     private lateinit var mvc: MockMvc
 
     // ---------------------------------------------------------------------
-    // Legacy synchronous POST /resync (kept while portal switches; deleted in PR-D).
-    // ---------------------------------------------------------------------
-
-    @Test
-    @DisplayName("anonymous POST /admin/teamcity-project-ids/resync → 401, sync not invoked")
-    fun resyncAnonymousReturns401() {
-        mvc
-            .perform(post("/rest/api/4/admin/teamcity-project-ids/resync"))
-            .andExpect(status().isUnauthorized)
-
-        verify(teamcitySyncService, never()).resync()
-    }
-
-    @Test
-    @DisplayName("editor JWT POST /admin/teamcity-project-ids/resync → 403, sync not invoked")
-    fun resyncEditorReturns403() {
-        mvc
-            .perform(post("/rest/api/4/admin/teamcity-project-ids/resync").with(editorJwt()))
-            .andExpect(status().isForbidden)
-
-        verify(teamcitySyncService, never()).resync()
-    }
-
-    @Test
-    @DisplayName("admin POST /admin/teamcity-project-ids/resync → 200 with full counts shape (legacy path)")
-    fun resyncAdminReturns200WithCounts() {
-        `when`(teamcitySyncService.resync()).thenReturn(
-            TeamcitySyncResult(
-                scanned = 12,
-                updated = 3,
-                unchanged = 7,
-                skippedNoMatch = 1,
-                skippedAmbiguous = 1,
-                errors = listOf("oops on alpha"),
-            ),
-        )
-
-        mvc
-            .perform(post("/rest/api/4/admin/teamcity-project-ids/resync").with(adminJwt()))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.scanned").value(12))
-            .andExpect(jsonPath("$.updated").value(3))
-            .andExpect(jsonPath("$.unchanged").value(7))
-            .andExpect(jsonPath("$.skipped_no_match").value(1))
-            .andExpect(jsonPath("$.skipped_ambiguous").value(1))
-            .andExpect(jsonPath("$.errors[0]").value("oops on alpha"))
-
-        verify(teamcitySyncService, times(1)).resync()
-    }
-
-    // ---------------------------------------------------------------------
-    // New async POST /sync — 202 newly-started, 409 same-kind attach, 409 cross-kind.
+    // POST /sync — 202 newly-started, 409 same-kind attach, 409 cross-kind.
     // ---------------------------------------------------------------------
 
     @Test
@@ -229,7 +172,7 @@ class TeamcityResyncControllerTest {
     }
 
     // ---------------------------------------------------------------------
-    // New async GET /sync/job — 200 when state is present, 404 when idle.
+    // GET /sync/job — 200 when state is present, 404 when idle.
     // ---------------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Summary

The async pair (\`POST /admin/teamcity-project-ids/sync\` + \`GET .../sync/job\`) has been live on QA, the portal is on the new path, and the 0/658 batch fix is in (PR #184). Drop the now-orphaned legacy synchronous endpoint and its tests.

## Removed

- \`AdminControllerV4.resyncTeamcityProjectIds()\` (was \`@Deprecated\`).
- \`teamcitySyncService: TeamcitySyncService\` constructor parameter on \`AdminControllerV4\` — only the deleted method used it. The async path goes through \`TeamcitySyncJobService\`, which still depends on \`TeamcitySyncService\` internally.
- 3 legacy /resync test cases in \`TeamcityResyncControllerTest\` (anon → 401, editor → 403, admin → 200 with counts shape) plus the corresponding @MockBean. Auth + response-shape coverage of the remaining pair (\`/sync\`, \`/sync/job\`) is unchanged.
- \`teamcitySyncService\` @MockBean and KDoc paragraph in \`AdminControllerV4SecurityTest\`.

## Stays

- \`TeamcitySyncService.resync()\` — the sync engine; called by \`TeamcitySyncJobService\` (admin) and \`TeamcitySyncScheduler\` (cron).
- \`TeamcitySyncResult\` — embedded in \`TeamcitySyncJobState.result\` and surfaced via \`GET /sync/job\` once a job COMPLETES.

## Test plan

- [x] \`./gradlew :components-registry-service-server:test\` — green.
- [x] \`AUTH_SERVER=stub ./gradlew build -x …\` (full build) — green.
- [ ] CI on this PR.
- [ ] After merge: confirm portal in all environments has been on the async path long enough that no caller will hit a 404 on the removed URL. (Already true on QA / prod per PR-C deploy.)

## Notes

Subagent code review was clean (no P1/P2). Two P3 KDoc nits flagged were folded into the same commit:
- \`TeamcitySyncResult\` KDoc rephrased to describe the async-job embedded form.
- Inline comment in \`TeamcitySyncService.resync()\` updated — was referring to "admin invokes the resync endpoint" (now removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)