### PR TITLE
feat(tc-sync): auto-pick CDRelease project on ambiguous matches

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TcProjectFetcher.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TcProjectFetcher.kt
@@ -2,7 +2,21 @@ package org.octopusden.octopus.components.registry.server.teamcity
 
 import java.util.UUID
 
-data class TcProject(val id: String, val webUrl: String)
+/**
+ * @property hasCdReleaseBuild true when this TC project owns at least one
+ *  buildType inheriting from the configured CDRelease template
+ *  (see [TeamcityProperties.SyncProperties.cdReleaseTemplateId]). Used by
+ *  [TeamcitySyncService] as the tie-breaker when several TC projects carry
+ *  the same `COMPONENT_NAME` parameter — the only one (or the lexicographically
+ *  smallest of several) flagged `true` wins. Computed once by the fetcher
+ *  from the same batch response that resolves the projects, so the field is a
+ *  static fact about that response, not a re-query trigger.
+ */
+data class TcProject(
+    val id: String,
+    val webUrl: String,
+    val hasCdReleaseBuild: Boolean,
+)
 
 fun interface TcProjectFetcher {
     fun findByComponentNames(componentsByName: Map<String, UUID>): Map<UUID, List<TcProject>>

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClientConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityClientConfig.kt
@@ -17,7 +17,19 @@ private const val COMPONENT_NAME_PARAM = "COMPONENT_NAME"
 // `href` and `webUrl` are non-nullable on the library's TeamcityProject DTO, so the
 // fields spec MUST request them or Jackson throws on deserialisation. We don't read
 // `href` ourselves — it just has to round-trip through the client.
-private const val PROJECT_FIELDS = "project(id,name,webUrl,href,parameters(property(name,value)))"
+//
+// `buildTypes(buildType(id,template(id),templates(buildType(id))))` powers the
+// CDRelease tie-breaker for ambiguous matches: we only need each buildType id and
+// its template ancestry. Both `template` (legacy single, TC <2018) and `templates`
+// (multi, TC2018+) are requested because TC populates only one of the two
+// depending on installation/version; checking both keeps the detection robust at
+// negligible cost (one extra id per buildType). Direct buildTypes only — sub-projects
+// are not walked, on the convention that the project carrying COMPONENT_NAME also
+// owns the release build.
+private const val PROJECT_FIELDS =
+    "project(id,name,webUrl,href," +
+        "parameters(property(name,value))," +
+        "buildTypes(buildType(id,template(id),templates(buildType(id)))))"
 
 @Configuration
 class TeamcityClientConfig {
@@ -38,9 +50,10 @@ class TeamcityClientConfig {
  *   The simple `parameter:(name:X)` filter is universally supported.
  *
  * Multiple TC projects sharing the same `COMPONENT_NAME` are all included in the
- * `List<TcProject>` for that component — [TeamcitySyncService.applyMatches] treats
- * `size > 1` as `skipped_ambiguous` and skips the row. Projects whose
- * `COMPONENT_NAME` is unknown to CRS, missing, or blank are silently dropped.
+ * `List<TcProject>` for that component; each carries `hasCdReleaseBuild` derived
+ * from the same response so [TeamcitySyncService.applyMatches] can pick the
+ * release-flagged one without an extra round-trip. Projects whose `COMPONENT_NAME`
+ * is unknown to CRS, missing, or blank are silently dropped.
  *
  * The client is lazily initialised so that a blank [TeamcityProperties.baseUrl]
  * does not attempt a connection until [findByComponentNames] is actually called.
@@ -85,7 +98,11 @@ internal class ExternalTcProjectFetcher(
         val projects = response.projects.orEmpty()
         log.info { "TC sync: TC returned ${projects.size} projects with $COMPONENT_NAME_PARAM parameter" }
 
-        return mapTcProjectsToComponentMatches(projects, componentsByName)
+        return mapTcProjectsToComponentMatches(
+            projects,
+            componentsByName,
+            properties.sync.cdReleaseTemplateId,
+        )
     }
 }
 
@@ -94,10 +111,17 @@ internal class ExternalTcProjectFetcher(
  * `COMPONENT_NAME` parameter value, looks it up in [componentsByName], and groups
  * the resulting [TcProject]s by component UUID. Projects without the parameter,
  * with a blank value, or whose value is unknown to CRS are dropped.
+ *
+ * `hasCdReleaseBuild` is computed per-project from the same response: true iff
+ * any direct [ExternalTeamcityProject.buildTypes] entry inherits — through either
+ * the legacy single `template` or the multi `templates` link — from the
+ * configured [cdReleaseTemplateId]. Inheritance is checked **only** at the
+ * project carrying the COMPONENT_NAME parameter; sub-projects are not walked.
  */
 internal fun mapTcProjectsToComponentMatches(
     projects: List<ExternalTeamcityProject>,
     componentsByName: Map<String, UUID>,
+    cdReleaseTemplateId: String,
 ): Map<UUID, List<TcProject>> =
     projects
         .mapNotNull { project ->
@@ -108,6 +132,16 @@ internal fun mapTcProjectsToComponentMatches(
                 ?.takeIf { it.isNotEmpty() }
                 ?: return@mapNotNull null
             val uuid = componentsByName[componentName] ?: return@mapNotNull null
-            uuid to TcProject(id = project.id, webUrl = project.webUrl)
+            val hasCdRelease = projectHasCdReleaseBuild(project, cdReleaseTemplateId)
+            uuid to TcProject(id = project.id, webUrl = project.webUrl, hasCdReleaseBuild = hasCdRelease)
         }
         .groupBy({ it.first }, { it.second })
+
+private fun projectHasCdReleaseBuild(
+    project: ExternalTeamcityProject,
+    cdReleaseTemplateId: String,
+): Boolean =
+    project.buildTypes?.buildTypes?.any { bt ->
+        bt.template?.id == cdReleaseTemplateId ||
+            bt.templates?.buildTypes?.any { it.id == cdReleaseTemplateId } == true
+    } == true

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcityProperties.kt
@@ -40,5 +40,15 @@ class TeamcityProperties(
          * Spring cron expression for the weekly resync. Default: Sunday 04:00 UTC.
          */
         val cron: String = "0 0 4 * * SUN",
+        /**
+         * TeamCity build-template id used as the tie-breaker when several TC
+         * projects share the same `COMPONENT_NAME` parameter: the project that
+         * owns a buildType inheriting from this template wins. If none of the
+         * tied projects has it, the component is left unchanged (counted as
+         * `skipped_ambiguous`). Configurable via
+         * `teamcity.sync.cd-release-template-id` for envs where the template
+         * carries a different id.
+         */
+        val cdReleaseTemplateId: String = "CDRelease",
     )
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
@@ -15,7 +15,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
  *                   both single-candidate matches and ambiguous rows resolved
  *                   by the CDRelease tie-break).
  * - `unchanged`   — components matched and already correct (no DB write).
- * - `skippedNoMatch`   — components with no TC project carrying the parameter.
+ * - `skippedNoMatch`   — components with no TC project carrying the parameter,
+ *                        plus single-candidate / tie-broken matches dropped by
+ *                        the URL guard (blank or non-http(s) `webUrl` cannot
+ *                        be linked, so the row falls through to no-match).
  * - `skippedAmbiguous` — components matched by ≥2 TC projects where the
  *                        CDRelease tie-break could not pick a winner (no
  *                        candidate owns a release build). Manual override is the

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncResult.kt
@@ -11,10 +11,19 @@ import com.fasterxml.jackson.annotation.JsonProperty
  *
  * - `scanned`     — number of components considered (= number of non-archived
  *                   components in the registry at the moment of the call).
- * - `updated`     — components where either id or url actually changed.
+ * - `updated`     — components where either id or url actually changed (counts
+ *                   both single-candidate matches and ambiguous rows resolved
+ *                   by the CDRelease tie-break).
  * - `unchanged`   — components matched and already correct (no DB write).
  * - `skippedNoMatch`   — components with no TC project carrying the parameter.
- * - `skippedAmbiguous` — components matched by ≥2 TC projects (skipped by policy).
+ * - `skippedAmbiguous` — components matched by ≥2 TC projects where the
+ *                        CDRelease tie-break could not pick a winner (no
+ *                        candidate owns a release build). Manual override is the
+ *                        escape hatch.
+ * - `ambiguousAutoResolved` — sub-counter of `updated`+`unchanged`: how many of
+ *                              those rows came from a CDRelease tie-break on a
+ *                              multi-candidate match. Lets ops see whether the
+ *                              auto-resolve path is firing without grepping logs.
  * - `errors`      — component-level error messages caught during the post-fetch
  *                   `applyMatches` loop. A fetch-level TC API failure aborts the
  *                   whole sync and is surfaced via the job's `errorMessage`, not
@@ -26,5 +35,6 @@ data class TeamcitySyncResult(
     val unchanged: Int,
     @JsonProperty("skipped_no_match") val skippedNoMatch: Int,
     @JsonProperty("skipped_ambiguous") val skippedAmbiguous: Int,
+    @JsonProperty("ambiguous_auto_resolved") val ambiguousAutoResolved: Int,
     val errors: List<String>,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -228,9 +228,10 @@ class TeamcitySyncService(
         }
         // String.compareTo on TC ids: TC project ids are conventionally
         // [A-Za-z0-9_], so ASCII-lexicographic order is total and
-        // case-insensitivity is moot. minBy returns the first occurrence on
-        // a tie; ties on id can't happen (TC enforces unique project ids).
-        val pick = withCdRelease.minBy { it.id }
+        // case-insensitivity is moot. !! is safe: we returned above when
+        // withCdRelease was empty, so minByOrNull cannot return null here.
+        // (Kotlin 1.9.x deprecated `minBy` in favour of `minByOrNull`.)
+        val pick = withCdRelease.minByOrNull { it.id }!!
         if (withCdRelease.size == 1) {
             log.info {
                 "TC sync: ambiguous match for component '${component.name}' " +

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -200,6 +200,16 @@ class TeamcitySyncService(
      * then pick the lexicographically smallest by id so the choice is stable
      * across reruns. Returns null when no candidate has a release build — caller
      * counts that as `skippedAmbiguous` (manual override is the escape hatch).
+     *
+     * Log-level policy:
+     *  - `withCdRelease.size == 1` → INFO. The auto-pick is the *intended*
+     *    outcome — exactly one project carries the release build, the other
+     *    candidates are typically legacy/archived duplicates of the
+     *    COMPONENT_NAME. Ops want this counted, not paged on.
+     *  - `withCdRelease.size > 1` → WARN. Genuine ambiguity (multiple "release"
+     *    projects share the same COMPONENT_NAME) where lexicographic tie-break
+     *    is just a deterministic last-resort; the row needs a TC cleanup.
+     *  - `withCdRelease.isEmpty()` → WARN. Skipped, ops should fix in TC.
      */
     private fun resolveAmbiguous(
         component: ComponentEntity,
@@ -216,15 +226,26 @@ class TeamcitySyncService(
             }
             return null
         }
+        // String.compareTo on TC ids: TC project ids are conventionally
+        // [A-Za-z0-9_], so ASCII-lexicographic order is total and
+        // case-insensitivity is moot. minBy returns the first occurrence on
+        // a tie; ties on id can't happen (TC enforces unique project ids).
         val pick = withCdRelease.minBy { it.id }
-        log.warn {
-            // WARN, not INFO: the row needs a manual fix in TC long-term, the
-            // auto-pick is a temporary escape hatch (see TODO in class KDoc).
-            "TC sync: ambiguous match for component '${component.name}' " +
-                "(id=$componentId): ${candidates.size} TC projects share " +
-                "COMPONENT_NAME=${component.name}, ${withCdRelease.size} have a CDRelease build " +
-                "(${withCdRelease.joinToString { it.id }}); auto-picking '${pick.id}' " +
-                "(lexicographically smallest)."
+        if (withCdRelease.size == 1) {
+            log.info {
+                "TC sync: ambiguous match for component '${component.name}' " +
+                    "(id=$componentId): ${candidates.size} TC projects share " +
+                    "COMPONENT_NAME=${component.name}, exactly one has a CDRelease build " +
+                    "(${pick.id}); auto-picking it."
+            }
+        } else {
+            log.warn {
+                "TC sync: ambiguous match for component '${component.name}' " +
+                    "(id=$componentId): ${candidates.size} TC projects share " +
+                    "COMPONENT_NAME=${component.name}, ${withCdRelease.size} have a CDRelease build " +
+                    "(${withCdRelease.joinToString { it.id }}); auto-picking '${pick.id}' " +
+                    "(lexicographically smallest) — TC cleanup recommended."
+            }
         }
         return pick
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -23,8 +23,15 @@ import java.util.UUID
  *      - 1 match with non-blank webUrl → upsert id+url if changed; count
  *        `updated` or `unchanged`.
  *      - 1 match with blank webUrl → treat as no-match (cannot link).
- *      - 2+ matches → skip, count `skippedAmbiguous`. Manual override is
- *        the escape hatch.
+ *      - 2+ matches → CDRelease tie-break:
+ *          - filter to projects with `hasCdReleaseBuild = true`;
+ *          - if filtered is empty → leave nulls, count `skippedAmbiguous`
+ *            (no release build → no automated way to pick the right project);
+ *          - if non-empty → pick the lexicographically smallest by id (stable
+ *            across runs), apply the match, count it under `updated`/`unchanged`
+ *            and bump `ambiguousAutoResolved` for visibility.
+ *        Manual override remains the escape hatch for rows that still skip.
+ *        TODO: properly support multiple TC projects per component (DTO/UI work).
  *
  * Idempotent: only writes when `id` or `url` actually changes. Audit log
  * emitted via existing [AuditEvent] flow when fields change so admins can
@@ -93,7 +100,7 @@ class TeamcitySyncService(
         return transactionTemplate.execute { _ -> applyMatches(components, matches, changedBy) }!!
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "LongMethod")
     private fun applyMatches(
         components: List<ComponentEntity>,
         matches: Map<UUID, List<TcProject>>,
@@ -104,45 +111,61 @@ class TeamcitySyncService(
         var unchanged = 0
         var skippedNoMatch = 0
         var skippedAmbiguous = 0
+        var ambiguousAutoResolved = 0
         val errors = mutableListOf<String>()
 
         for (component in components) {
             val componentId = component.id ?: continue
             try {
                 val candidates = matches[componentId].orEmpty()
+                val pick: TcProject?
+                val pickedFromAmbiguous: Boolean
+                when {
+                    candidates.isEmpty() -> {
+                        pick = null
+                        pickedFromAmbiguous = false
+                    }
+                    candidates.size == 1 -> {
+                        pick = candidates.single()
+                        pickedFromAmbiguous = false
+                    }
+                    else -> {
+                        pick = resolveAmbiguous(component, componentId, candidates)
+                        pickedFromAmbiguous = pick != null
+                    }
+                }
+
                 when {
                     candidates.isEmpty() -> {
                         skippedNoMatch++
                     }
-                    candidates.size > 1 -> {
-                        // Don't pick a winner silently. Manual override is
-                        // the documented escape hatch for genuinely-duplicated
-                        // TC setups.
-                        log.warn {
-                            "TC sync: ambiguous match for component '${component.name}' " +
-                                "(id=$componentId): ${candidates.size} TC projects share " +
-                                "COMPONENT_NAME=${component.name} — skipping."
-                        }
+                    pick == null -> {
+                        // Ambiguous and none of the candidates owns a CDRelease build —
+                        // tie-break failed, fall through to skipped_ambiguous.
                         skippedAmbiguous++
                     }
                     else -> {
-                        val match = candidates.single()
                         val isUsableUrl =
-                            match.webUrl.isNotBlank() &&
-                                (match.webUrl.startsWith("http://") || match.webUrl.startsWith("https://"))
+                            pick.webUrl.isNotBlank() &&
+                                (pick.webUrl.startsWith("http://") || pick.webUrl.startsWith("https://"))
                         if (!isUsableUrl) {
                             // webUrl missing, blank, or non-http → cannot render
                             // a safe link. Treat as no-match: leave nulls, count it.
+                            // ambiguousAutoResolved is NOT incremented here — the row is
+                            // counted as skipped_no_match, not as a successful auto-resolve,
+                            // so the result KDoc invariant "sub-counter of updated+unchanged"
+                            // holds.
                             log.warn {
                                 "TC sync: component '${component.name}' (id=$componentId) " +
-                                    "matched TC project '${match.id}' but webUrl " +
-                                    "'${match.webUrl}' is blank or not http/https; " +
+                                    "matched TC project '${pick.id}' but webUrl " +
+                                    "'${pick.webUrl}' is blank or not http/https; " +
                                     "treating as no-match."
                             }
                             skippedNoMatch++
                         } else {
-                            val didChange = applyMatch(component, match, changedBy)
+                            val didChange = applyMatch(component, pick, changedBy)
                             if (didChange) updated++ else unchanged++
+                            if (pickedFromAmbiguous) ambiguousAutoResolved++
                         }
                     }
                 }
@@ -159,7 +182,7 @@ class TeamcitySyncService(
         log.info {
             "TC sync done: scanned=$scanned, updated=$updated, unchanged=$unchanged, " +
                 "skippedNoMatch=$skippedNoMatch, skippedAmbiguous=$skippedAmbiguous, " +
-                "errors=${errors.size}"
+                "ambiguousAutoResolved=$ambiguousAutoResolved, errors=${errors.size}"
         }
         return TeamcitySyncResult(
             scanned = scanned,
@@ -167,8 +190,43 @@ class TeamcitySyncService(
             unchanged = unchanged,
             skippedNoMatch = skippedNoMatch,
             skippedAmbiguous = skippedAmbiguous,
+            ambiguousAutoResolved = ambiguousAutoResolved,
             errors = errors.toList(),
         )
+    }
+
+    /**
+     * Tie-break for `candidates.size > 1`: keep only those with a CDRelease build,
+     * then pick the lexicographically smallest by id so the choice is stable
+     * across reruns. Returns null when no candidate has a release build — caller
+     * counts that as `skippedAmbiguous` (manual override is the escape hatch).
+     */
+    private fun resolveAmbiguous(
+        component: ComponentEntity,
+        componentId: UUID,
+        candidates: List<TcProject>,
+    ): TcProject? {
+        val withCdRelease = candidates.filter { it.hasCdReleaseBuild }
+        if (withCdRelease.isEmpty()) {
+            log.warn {
+                "TC sync: ambiguous match for component '${component.name}' " +
+                    "(id=$componentId): ${candidates.size} TC projects share " +
+                    "COMPONENT_NAME=${component.name} but none has a CDRelease build " +
+                    "(${candidates.joinToString { it.id }}) — skipping."
+            }
+            return null
+        }
+        val pick = withCdRelease.minBy { it.id }
+        log.warn {
+            // WARN, not INFO: the row needs a manual fix in TC long-term, the
+            // auto-pick is a temporary escape hatch (see TODO in class KDoc).
+            "TC sync: ambiguous match for component '${component.name}' " +
+                "(id=$componentId): ${candidates.size} TC projects share " +
+                "COMPONENT_NAME=${component.name}, ${withCdRelease.size} have a CDRelease build " +
+                "(${withCdRelease.joinToString { it.id }}); auto-picking '${pick.id}' " +
+                "(lexicographically smallest)."
+        }
+        return pick
     }
 
     /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
@@ -85,13 +85,14 @@ class TeamcitySyncJobServiceImpl(
             }
             LOG.info(
                 "TC resync job {} COMPLETED: scanned={}, updated={}, unchanged={}, " +
-                    "skippedNoMatch={}, skippedAmbiguous={}, errors={}",
+                    "skippedNoMatch={}, skippedAmbiguous={}, ambiguousAutoResolved={}, errors={}",
                 jobId,
                 result.scanned,
                 result.updated,
                 result.unchanged,
                 result.skippedNoMatch,
                 result.skippedAmbiguous,
+                result.ambiguousAutoResolved,
                 result.errors.size,
             )
         } catch (

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
@@ -45,7 +45,8 @@ import java.time.Instant
  * TeamcityClient bean wiring (which would attempt outbound HTTP if base-url
  * were ever set). Asserts cover 202/409 attach + 409 cross-kind envelope on
  * POST, and 200/404 polling on GET, including the snake_case
- * `skipped_no_match` / `skipped_ambiguous` keys in the COMPLETED `result`.
+ * `skipped_no_match` / `skipped_ambiguous` / `ambiguous_auto_resolved` keys in
+ * the COMPLETED `result`.
  *
  * Other migration job services are @MockBean'd to keep this test scoped to
  * the resync paths — same convention as AdminControllerV4SecurityTest.
@@ -240,6 +241,7 @@ class TeamcityResyncControllerTest {
                 unchanged = 3,
                 skippedNoMatch = 0,
                 skippedAmbiguous = 0,
+                ambiguousAutoResolved = 0,
                 errors = emptyList(),
             )
         `when`(teamcitySyncJobService.current())
@@ -264,6 +266,7 @@ class TeamcityResyncControllerTest {
             .andExpect(jsonPath("$.result.updated").value(2))
             .andExpect(jsonPath("$.result.skipped_no_match").value(0))
             .andExpect(jsonPath("$.result.skipped_ambiguous").value(0))
+            .andExpect(jsonPath("$.result.ambiguous_auto_resolved").value(0))
     }
 
     private fun runningState(jobId: String) =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/ExternalTcProjectFetcherTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/ExternalTcProjectFetcherTest.kt
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuildType as ExternalTeamcityBuildType
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuildTypes as ExternalTeamcityBuildTypes
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProject as ExternalTeamcityProject
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperties as ExternalTeamcityProperties
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperty as ExternalTeamcityProperty
@@ -18,11 +20,12 @@ class ExternalTcProjectFetcherTest {
 
     private val fooUuid = UUID.randomUUID()
     private val barUuid = UUID.randomUUID()
+    private val cdReleaseTemplateId = "CDRelease"
 
     @Test
     @DisplayName("empty input -> empty output")
     fun emptyInputEmptyOutput() {
-        val result = mapTcProjectsToComponentMatches(emptyList(), mapOf("foo" to fooUuid))
+        val result = mapTcProjectsToComponentMatches(emptyList(), mapOf("foo" to fooUuid), cdReleaseTemplateId)
         assertTrue(result.isEmpty())
     }
 
@@ -30,15 +33,18 @@ class ExternalTcProjectFetcherTest {
     @DisplayName("project with known COMPONENT_NAME maps to UUID")
     fun knownComponentNameMaps() {
         val projects = listOf(tcProject(id = "Tc_Foo", webUrl = "http://tc/foo", componentName = "foo"))
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
-        assertEquals(mapOf(fooUuid to listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo"))), result)
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
+        assertEquals(
+            mapOf(fooUuid to listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo", hasCdReleaseBuild = false))),
+            result,
+        )
     }
 
     @Test
     @DisplayName("project whose COMPONENT_NAME is unknown to CRS is dropped")
     fun unknownComponentNameDropped() {
         val projects = listOf(tcProject(id = "Tc_Stranger", webUrl = "http://tc/x", componentName = "not-in-registry"))
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
         assertTrue(result.isEmpty())
     }
 
@@ -48,7 +54,7 @@ class ExternalTcProjectFetcherTest {
         val projects = listOf(
             ExternalTeamcityProject(id = "Tc_Empty", name = "Empty", href = "/x", webUrl = "http://tc/empty"),
         )
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
         assertTrue(result.isEmpty())
     }
 
@@ -64,7 +70,7 @@ class ExternalTcProjectFetcherTest {
                 parameters = ExternalTeamcityProperties(properties = mutableListOf(ExternalTeamcityProperty(name = "OTHER", value = "y"))),
             ),
         )
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
         assertTrue(result.isEmpty())
     }
 
@@ -72,7 +78,7 @@ class ExternalTcProjectFetcherTest {
     @DisplayName("project with whitespace-only COMPONENT_NAME value is dropped")
     fun whitespaceOnlyValueDropped() {
         val projects = listOf(tcProject(id = "Tc_Blank", webUrl = "http://tc/blank", componentName = "   "))
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
         assertTrue(result.isEmpty())
     }
 
@@ -83,7 +89,7 @@ class ExternalTcProjectFetcherTest {
             tcProject(id = "Tc_Foo_A", webUrl = "http://tc/foo-a", componentName = "foo"),
             tcProject(id = "Tc_Foo_B", webUrl = "http://tc/foo-b", componentName = "foo"),
         )
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
         assertEquals(1, result.size)
         assertEquals(2, result[fooUuid]!!.size)
         assertEquals(setOf("Tc_Foo_A", "Tc_Foo_B"), result[fooUuid]!!.map { it.id }.toSet())
@@ -93,8 +99,11 @@ class ExternalTcProjectFetcherTest {
     @DisplayName("value with surrounding whitespace is trimmed before matching")
     fun whitespaceTrimmedBeforeMatching() {
         val projects = listOf(tcProject(id = "Tc_Foo", webUrl = "http://tc/foo", componentName = "  foo  "))
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid))
-        assertEquals(mapOf(fooUuid to listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo"))), result)
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
+        assertEquals(
+            mapOf(fooUuid to listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo", hasCdReleaseBuild = false))),
+            result,
+        )
     }
 
     @Test
@@ -117,8 +126,15 @@ class ExternalTcProjectFetcherTest {
                 ),
             ),
         )
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid, "bar" to barUuid))
-        assertEquals(mapOf(fooUuid to listOf(TcProject(id = "Tc_Dup", webUrl = "http://tc/dup"))), result)
+        val result = mapTcProjectsToComponentMatches(
+            projects,
+            mapOf("foo" to fooUuid, "bar" to barUuid),
+            cdReleaseTemplateId,
+        )
+        assertEquals(
+            mapOf(fooUuid to listOf(TcProject(id = "Tc_Dup", webUrl = "http://tc/dup", hasCdReleaseBuild = false))),
+            result,
+        )
     }
 
     @Test
@@ -131,13 +147,104 @@ class ExternalTcProjectFetcherTest {
             tcProject(id = "Tc_Blank", webUrl = "http://tc/blank", componentName = ""),
             ExternalTeamcityProject(id = "Tc_NoParams", name = "NoParams", href = "/x", webUrl = "http://tc/np"),
         )
-        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid, "bar" to barUuid))
+        val result = mapTcProjectsToComponentMatches(
+            projects,
+            mapOf("foo" to fooUuid, "bar" to barUuid),
+            cdReleaseTemplateId,
+        )
         assertEquals(2, result.size)
-        assertEquals(listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo")), result[fooUuid])
-        assertEquals(listOf(TcProject(id = "Tc_Bar", webUrl = "http://tc/bar")), result[barUuid])
+        assertEquals(listOf(TcProject(id = "Tc_Foo", webUrl = "http://tc/foo", hasCdReleaseBuild = false)), result[fooUuid])
+        assertEquals(listOf(TcProject(id = "Tc_Bar", webUrl = "http://tc/bar", hasCdReleaseBuild = false)), result[barUuid])
     }
 
-    private fun tcProject(id: String, webUrl: String, componentName: String) = ExternalTeamcityProject(
+    @Test
+    @DisplayName("CDRelease via legacy single template field is detected")
+    fun cdReleaseDetectedViaLegacyTemplate() {
+        val projects = listOf(
+            tcProject(
+                id = "Tc_Rel",
+                webUrl = "http://tc/rel",
+                componentName = "foo",
+                buildTypes = listOf(buildType(id = "Build1", legacyTemplateId = "CDRelease")),
+            ),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
+        assertEquals(true, result[fooUuid]!!.single().hasCdReleaseBuild)
+    }
+
+    @Test
+    @DisplayName("CDRelease via plural templates link is detected")
+    fun cdReleaseDetectedViaPluralTemplates() {
+        val projects = listOf(
+            tcProject(
+                id = "Tc_Rel",
+                webUrl = "http://tc/rel",
+                componentName = "foo",
+                buildTypes = listOf(buildType(id = "Build1", pluralTemplateIds = listOf("Other", "CDRelease"))),
+            ),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
+        assertEquals(true, result[fooUuid]!!.single().hasCdReleaseBuild)
+    }
+
+    @Test
+    @DisplayName("CDRelease present on any of multiple buildTypes flips the flag")
+    fun cdReleaseAnyBuildType() {
+        val projects = listOf(
+            tcProject(
+                id = "Tc_Rel",
+                webUrl = "http://tc/rel",
+                componentName = "foo",
+                buildTypes = listOf(
+                    buildType(id = "Build1", legacyTemplateId = "Unrelated"),
+                    buildType(id = "Build2", legacyTemplateId = "CDRelease"),
+                ),
+            ),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
+        assertEquals(true, result[fooUuid]!!.single().hasCdReleaseBuild)
+    }
+
+    @Test
+    @DisplayName("project with buildTypes but none inheriting from CDRelease has hasCdReleaseBuild=false")
+    fun cdReleaseAbsentWhenUnrelatedTemplates() {
+        val projects = listOf(
+            tcProject(
+                id = "Tc_Foo",
+                webUrl = "http://tc/foo",
+                componentName = "foo",
+                buildTypes = listOf(
+                    buildType(id = "Build1", legacyTemplateId = "Unrelated"),
+                    buildType(id = "Build2", pluralTemplateIds = listOf("AnotherTemplate")),
+                    buildType(id = "Build3"), // no template at all
+                ),
+            ),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId)
+        assertEquals(false, result[fooUuid]!!.single().hasCdReleaseBuild)
+    }
+
+    @Test
+    @DisplayName("template id comparison honors a custom configured cdReleaseTemplateId")
+    fun customTemplateIdHonored() {
+        val projects = listOf(
+            tcProject(
+                id = "Tc_Rel",
+                webUrl = "http://tc/rel",
+                componentName = "foo",
+                buildTypes = listOf(buildType(id = "Build1", legacyTemplateId = "CustomReleaseTpl")),
+            ),
+        )
+        val result = mapTcProjectsToComponentMatches(projects, mapOf("foo" to fooUuid), cdReleaseTemplateId = "CustomReleaseTpl")
+        assertEquals(true, result[fooUuid]!!.single().hasCdReleaseBuild)
+    }
+
+    private fun tcProject(
+        id: String,
+        webUrl: String,
+        componentName: String,
+        buildTypes: List<ExternalTeamcityBuildType> = emptyList(),
+    ) = ExternalTeamcityProject(
         id = id,
         name = id,
         href = "/$id",
@@ -145,5 +252,30 @@ class ExternalTcProjectFetcherTest {
         parameters = ExternalTeamcityProperties(
             properties = mutableListOf(ExternalTeamcityProperty(name = "COMPONENT_NAME", value = componentName)),
         ),
+        buildTypes = if (buildTypes.isEmpty()) {
+            null
+        } else {
+            ExternalTeamcityBuildTypes(buildTypes = buildTypes)
+        },
+    )
+
+    private fun buildType(
+        id: String,
+        legacyTemplateId: String? = null,
+        pluralTemplateIds: List<String>? = null,
+    ): ExternalTeamcityBuildType = ExternalTeamcityBuildType(
+        id = id,
+        name = id,
+        projectId = "P",
+        projectName = "P",
+        href = "/$id",
+        template = legacyTemplateId?.let {
+            ExternalTeamcityBuildType(id = it, name = it, projectId = "P", projectName = "P", href = "/$it")
+        },
+        templates = pluralTemplateIds?.let { ids ->
+            ExternalTeamcityBuildTypes(
+                buildTypes = ids.map { ExternalTeamcityBuildType(id = it, name = it, projectId = "P", projectName = "P", href = "/$it") },
+            )
+        },
     )
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -74,7 +74,7 @@ class TeamcitySyncServiceTest {
         val fetcher =
             stubFetcher(
                 mapOf(
-                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build")),
+                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build", hasCdReleaseBuild = false)),
                 ),
             )
         val repo = StubComponentRepository(components)
@@ -121,7 +121,7 @@ class TeamcitySyncServiceTest {
         val fetcher =
             stubFetcher(
                 mapOf(
-                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build")),
+                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build", hasCdReleaseBuild = false)),
                 ),
             )
         val repo = StubComponentRepository(components)
@@ -138,16 +138,16 @@ class TeamcitySyncServiceTest {
     }
 
     @Test
-    @DisplayName("ambiguous: 2+ matches → skip + count, no write")
-    fun ambiguousSkipped() {
+    @DisplayName("ambiguous + nobody has CDRelease build → skip + count, no write")
+    fun ambiguousNoCdReleaseSkipped() {
         val components = listOf(component(alice, "alpha"))
         val fetcher =
             stubFetcher(
                 mapOf(
                     "alpha" to
                         listOf(
-                            TcProject("Project_A", "https://teamcity.example.com/project/A"),
-                            TcProject("Project_B", "https://teamcity.example.com/project/B"),
+                            TcProject("Project_A", "https://teamcity.example.com/project/A", hasCdReleaseBuild = false),
+                            TcProject("Project_B", "https://teamcity.example.com/project/B", hasCdReleaseBuild = false),
                         ),
                 ),
             )
@@ -161,9 +161,98 @@ class TeamcitySyncServiceTest {
         assertEquals(0, result.updated)
         assertEquals(0, result.unchanged)
         assertEquals(1, result.skippedAmbiguous)
+        assertEquals(0, result.ambiguousAutoResolved)
         assertNull(components[0].teamcityProjectId, "ambiguous → no write")
         assertNull(components[0].teamcityProjectUrl, "ambiguous → no write")
         assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    @DisplayName("ambiguous + exactly one has CDRelease → tie-break to that one, count auto-resolved")
+    fun ambiguousSingleCdReleaseAutoResolved() {
+        val components = listOf(component(alice, "alpha"))
+        val fetcher =
+            stubFetcher(
+                mapOf(
+                    "alpha" to
+                        listOf(
+                            TcProject("Project_A_NoRelease", "https://tc/a", hasCdReleaseBuild = false),
+                            TcProject("Project_B_Release", "https://tc/b", hasCdReleaseBuild = true),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val svc = service(repo, fetcher, publisher, fixedUser("admin"))
+
+        val result = svc.resync()
+
+        assertEquals(1, result.scanned)
+        assertEquals(1, result.updated)
+        assertEquals(0, result.skippedAmbiguous)
+        assertEquals(1, result.ambiguousAutoResolved)
+        assertEquals("Project_B_Release", components[0].teamcityProjectId)
+        assertEquals("https://tc/b", components[0].teamcityProjectUrl)
+        assertEquals(1, publisher.events.filterIsInstance<AuditEvent>().size)
+    }
+
+    @Test
+    @DisplayName("ambiguous + multiple have CDRelease → pick lexicographically smallest by id")
+    fun ambiguousMultipleCdReleasePickFirstById() {
+        val components = listOf(component(alice, "alpha"))
+        // "Project_A_Release" < "Project_B_Release" lexicographically; both have CDRelease.
+        // Order in the list is intentionally inverted so the tie-break is by id, not by input order.
+        val fetcher =
+            stubFetcher(
+                mapOf(
+                    "alpha" to
+                        listOf(
+                            TcProject("Project_B_Release", "https://tc/b", hasCdReleaseBuild = true),
+                            TcProject("Project_A_Release", "https://tc/a", hasCdReleaseBuild = true),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val svc = service(repo, fetcher, publisher, fixedUser("admin"))
+
+        val result = svc.resync()
+
+        assertEquals(1, result.updated)
+        assertEquals(0, result.skippedAmbiguous)
+        assertEquals(1, result.ambiguousAutoResolved)
+        assertEquals("Project_A_Release", components[0].teamcityProjectId)
+        assertEquals("https://tc/a", components[0].teamcityProjectUrl)
+    }
+
+    @Test
+    @DisplayName("ambiguous tie-break to a CDRelease project with blank webUrl → no-match, ambiguousAutoResolved stays 0")
+    fun ambiguousTieBreakBlankUrlIsNoMatch() {
+        val components = listOf(component(alice, "alpha"))
+        val fetcher =
+            stubFetcher(
+                mapOf(
+                    "alpha" to
+                        listOf(
+                            TcProject("Project_NoUrl", "", hasCdReleaseBuild = true),
+                            TcProject("Project_Other", "https://tc/other", hasCdReleaseBuild = false),
+                        ),
+                ),
+            )
+        val repo = StubComponentRepository(components)
+        val publisher = RecordingPublisher()
+        val svc = service(repo, fetcher, publisher, fixedUser("admin"))
+
+        val result = svc.resync()
+
+        // Tie-break selected the CDRelease one, but its webUrl is unusable → counts as no-match.
+        // ambiguousAutoResolved is a sub-counter of `updated`+`unchanged` (per the result KDoc), so
+        // it must NOT increment for rows that ultimately fall into skipped_no_match.
+        assertEquals(1, result.skippedNoMatch)
+        assertEquals(0, result.updated)
+        assertEquals(0, result.skippedAmbiguous)
+        assertEquals(0, result.ambiguousAutoResolved)
+        assertNull(components[0].teamcityProjectId)
     }
 
     @Test
@@ -192,7 +281,7 @@ class TeamcitySyncServiceTest {
         val fetcher =
             stubFetcher(
                 mapOf(
-                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build")),
+                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build", hasCdReleaseBuild = false)),
                 ),
             )
         val repo = StubComponentRepository(components)
@@ -212,7 +301,7 @@ class TeamcitySyncServiceTest {
     @DisplayName("blank webUrl: treated as no-match")
     fun blankWebUrlIsNoMatch() {
         val components = listOf(component(alice, "alpha"))
-        val fetcher = stubFetcher(mapOf("alpha" to listOf(TcProject("Project_A", ""))))
+        val fetcher = stubFetcher(mapOf("alpha" to listOf(TcProject("Project_A", "", hasCdReleaseBuild = false))))
         val repo = StubComponentRepository(components)
         val publisher = RecordingPublisher()
         val svc = service(repo, fetcher, publisher, fixedUser("admin"))
@@ -274,8 +363,8 @@ class TeamcitySyncServiceTest {
         val fetcher =
             stubFetcher(
                 mapOf(
-                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build")),
-                    "beta" to listOf(TcProject("Beta_Build", "https://teamcity.example.com/project/Beta_Build")),
+                    "alpha" to listOf(TcProject("Alpha_Build", "https://teamcity.example.com/project/Alpha_Build", hasCdReleaseBuild = false)),
+                    "beta" to listOf(TcProject("Beta_Build", "https://teamcity.example.com/project/Beta_Build", hasCdReleaseBuild = false)),
                 ),
             )
         val repo = StubComponentRepository(components)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
@@ -46,6 +46,7 @@ class TeamcitySyncJobServiceImplTest {
             unchanged = 0,
             skippedNoMatch = 0,
             skippedAmbiguous = 0,
+            ambiguousAutoResolved = 0,
             errors = emptyList(),
         )
 
@@ -66,6 +67,7 @@ class TeamcitySyncJobServiceImplTest {
                 unchanged = 7,
                 skippedNoMatch = 1,
                 skippedAmbiguous = 1,
+                ambiguousAutoResolved = 0,
                 errors = listOf("oops on alpha"),
             )
         val syncService = mock(TeamcitySyncService::class.java)


### PR DESCRIPTION
## Summary
- TC resync: when 2+ TC projects share `COMPONENT_NAME`, tie-break by CDRelease build inheritance instead of always skipping. Pick the candidate whose direct buildTypes inherit from the configured release template (default `CDRelease`); lex-smallest by id when several do; fall through to `skipped_ambiguous` only when none qualifies. Single-candidate behavior unchanged.
- New configurable `teamcity.sync.cd-release-template-id` (default `CDRelease`).
- Single batch fields-spec extended to fetch each project's direct buildTypes + template ancestry (legacy `template` and TC2018+ `templates`); detection is client-side, no extra round-trip. Sub-projects intentionally not walked.
- New `ambiguous_auto_resolved` counter in `TeamcitySyncResult` — sub-counter of `updated`+`unchanged` so ops can see whether the auto-resolve path is firing without grepping logs.

## Why
QA last week confirmed 458/658 updated, 120 stuck on `skipped_ambiguous`. Most of those are legacy + active TC project pairs sharing `COMPONENT_NAME`, where only one carries a CDRelease build. Tie-breaking on that lets us auto-resolve the bulk without operator intervention; the rest still need manual TC cleanup, and the legacy escape hatch (manual override + ambiguity counter) is preserved. TODO long-term: support multiple TC projects per component end-to-end (DTO/UI work, not in this PR).

## Test plan
- [x] New unit tests in `ExternalTcProjectFetcherTest` for CDRelease detection: legacy single `template`, TC2018+ plural `templates`, mixed multi-buildType, none, custom-id config.
- [x] New unit tests in `TeamcitySyncServiceTest`: ambiguous + nobody-has-CDRelease → still skipped; ambiguous + exactly-one-CDRelease → auto-resolved; ambiguous + multi-CDRelease → lex-smallest by id; ambiguous tie-break to a CDRelease project with blank webUrl → no-match (counter NOT bumped, preserving the `updated`+`unchanged` invariant).
- [x] `TeamcitySyncResult`/`TeamcityResyncControllerTest` cover the new wire field `ambiguous_auto_resolved`.
- [x] Full `gradlew build` green (excluding `:components-registry-automation:test` per CI conventions).
- [ ] Smoke against real TC after deploy: trigger resync, verify `ambiguous_auto_resolved > 0`, `skipped_ambiguous` drops.
- [ ] SPA PR (separate, against `octopus-components-management-portal`) to render the new tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)