### PR TITLE
Schema v2: design artifacts (docs only)

### DIFF
--- a/docs/db-migration/adr/010-schema-extensibility.md
+++ b/docs/db-migration/adr/010-schema-extensibility.md
@@ -1,7 +1,15 @@
 # ADR-010: Schema Extensibility — Hybrid Columns + JSONB Strategy
 
 ## Status
-Proposed
+**Superseded by [ADR-014](014-schema-v2.md)**
+
+The Tier-3 JSONB extensibility envisioned here was never used in practice: empirical audit found zero PostgreSQL-specific JSONB features in the codebase, no GIN index hits, and no `@>`/`->`/`?` operators. All seven JSONB `metadata` columns store known stable fields and have been promoted to typed columns in v2.
+
+The extensibility friction this ADR sought to address (DDL change per new field) remains, but is now considered acceptable: empirically, new fields are added in scheduled batches (V6 added six fields at once) rather than continuously. The historical evolution cadence does not justify the trade-offs of polymorphic JSON storage.
+
+Original content preserved below for historical context.
+
+---
 
 ## Context
 

--- a/docs/db-migration/adr/014-schema-v2.md
+++ b/docs/db-migration/adr/014-schema-v2.md
@@ -106,7 +106,8 @@ Wide typed `component_configurations` with base + sparse single-attribute overri
 
 Phases tracked in `implementation-progress.md` under "Schema v2 refactor":
 
-1. `V1__schema.sql` baseline (this ADR; replaces V1..V6) — **done**.
+1a. Design artifacts (this ADR, `schema-spec.md`) — **done**.
+1b. `V1__schema.sql` baseline (replaces V1..V6) — **pending**, bundled with Phase 2 entity refactor to keep DB and JPA aligned in one merge.
 2. Entity refactor (≈16 → ≈22 classes due to dictionaries + distribution split).
 3. Mapper / resolver rewrite.
 4. v4 DTO update.

--- a/docs/db-migration/adr/014-schema-v2.md
+++ b/docs/db-migration/adr/014-schema-v2.md
@@ -1,0 +1,118 @@
+# ADR-014: CRS Schema v2 Redesign
+
+**Status:** Proposed
+**Supersedes:** ADR-010 (Schema Extensibility — JSONB-based metadata)
+**Related:** ADR-001 (Storage: PostgreSQL), ADR-007 (Dual-read migration)
+**Detailed reference:** `docs/db-migration/schema-spec.md`
+
+## Context
+
+The current schema (V1..V6) carries several issues uncovered during MIG-029 investigation and a cross-installation DSL audit:
+
+- **Polymorphic FK pairs** (`component_id` + `component_version_id`) on six configuration tables (build, escrow, jira, vcs, distribution, artifact_ids). One must be NULL — fragile and forces awkward queries.
+- **JSONB `metadata` columns** on eight tables store known stable fields via Hibernate Map serialization. Audit found zero PostgreSQL-specific JSONB features used (no `@>`, `->`, `?` operators; GIN indexes never hit). Seven of these belong as explicit typed columns.
+- **MIG-029**: `EntityMappers.toEscrowModule()` unconditionally synthesises an `(,0),[0,)` config for every component. For DSL components whose definitions consist only of version-range blocks (no top-level fields), this surfaces a spurious row in legacy variants-Map endpoints (`GET /rest/api/3/components`). The `hasDefaultConfig` flag computed in `toComponentEntity()` is never persisted.
+- **`text[]`** for `system` and `labels` (PostgreSQL-only; no array containment queries used).
+- **`component_versions` table** holds little beyond a range string + JSONB metadata; doesn't earn its existence.
+- **No per-attribute version-range model** despite DSL allowing single-attribute overrides per range.
+- **Cross-installation assumptions** baked into the schema (e.g., `system = "CLASSIC"` is single-installation; other installations are known to use a different set of system codes).
+
+Project is not yet in production; QA/dev databases are wiped and recreated on each deploy.
+
+## Decision
+
+Replace V1..V6 with a single consolidated `V1__schema.sql` baseline implementing **Model A'** — a wide typed `component_configurations` table with three row shapes (base, scalar override, marker override), plus dictionary tables, child relationships, and an aggregator grouping concept.
+
+Highlights:
+
+1. **No polymorphic FKs.** All per-version data lives on `component_configurations` (single FK to `components`).
+2. **No JSONB metadata.** Seven JSONB columns promoted to typed columns; five legitimate JSON values (`audit_log`, `registry_config`) kept as TEXT via Hibernate `@JdbcTypeCode(SqlTypes.JSON)`.
+3. **Per-attribute version-range overrides.** Each override is a row keyed by `(component_id, version_range, overridden_attribute)`. Three shapes: NULL (base), `'aspect.field'` (scalar), or marker name (replacement of a child collection).
+4. **`is_synthetic_base` flag** on the base row identifies bases populated purely from `Defaults.groovy`. Legacy enumeration endpoints skip synthetic bases — eliminates MIG-029 structurally; hot-path single-version resolve still uses base as fallback.
+5. **Unified VCS model.** SINGLE-VCS is the special case "1 entry, name=NULL" in `vcs_settings_entries`. No discriminator; no scalar VCS columns on `component_configurations`.
+6. **Distribution split into four typed tables** (Maven coords, file URLs, Docker images, DEB/RPM packages). Per-family `sort_order` preserves DSL CSV order within each family; mapper concatenates families canonically for v1-v3 responses.
+7. **Reference dictionaries** for `labels`, `systems`, `tools` (admin-managed). Auto-discovered or seeded from `validation-config.yaml` during migration.
+8. **Aggregator grouping** via `component_groups`. Detection at migration: an aggregator is REAL when it has its own valid (non-placeholder) `vcsUrl`; otherwise FAKE. REAL aggregator has its own `components` row + group; FAKE has only the group; sub-components reference the group.
+9. **Two FK columns on `components`**: `parent_component_id` (DSL `parentComponent` reference between top-level peers) and `component_group_id` (aggregator membership) — orthogonal.
+10. **Targeted DB CHECK constraints** for marker rows (one CHECK per marker name). Full structural validation (scalar override = exactly one non-NULL column) lives in the service layer.
+11. **Partial unique index** ensures one base row per component.
+
+Total: 23 tables.
+
+### Migration approach
+
+- No data migration; QA/dev recreate from `V1__schema.sql`.
+- `POST /admin/migrate` rewritten to write the new shape from DSL via `EscrowConfigurationLoader.loadFullConfiguration`.
+- Two-pass for `parentComponent` resolution (string → FK by `component_key`).
+- Two-pass for aggregator groups (1st pass: discover + create groups + REAL aggregator components; 2nd pass: link sub-components).
+- Pre-pass discovery for `systems` and `tools` dictionaries (upsert distinct values from DSL).
+- `labels` dictionary seeded from installation's `validation-config.yaml`.
+
+### v1-v3 backward compatibility
+
+All v1-v3 endpoints continue to return semantically identical responses, served via a thin mapper layer over the new schema. Five effectively-dead endpoints (≤2 calls/2 prod days) are formalised as dropped or stubbed (kill-list in `schema-spec.md`).
+
+## Consequences
+
+### Positive
+- DB-level type safety on every persisted value.
+- MIG-029 structurally impossible (no synthesis path in resolver; legacy mapper skips synthetic base).
+- Per-attribute override matches DSL grammar and empirical data (≈14% of multi-variant components have aspect-divergent version ranges).
+- Schema portable: no JSONB-specific features; one PG-specific feature is `pgcrypto.gen_random_uuid()` (replaceable).
+- Reduced row count for static-value components (no need to duplicate constants across N range rows when a single attribute changes).
+- Aggregator relationships preserved through migration (currently flattened and lost).
+- Cross-installation friendly: dictionaries (`systems`, `tools`) are auto-discovered; `labels` are seeded per-installation from yaml.
+
+### Negative / breaking
+- Sparse override rows have many NULL columns (storage: cheap via PG null bitmap; query: trivial).
+- Two row shapes in one table (scalar vs marker) require service-layer validation in addition to CHECK constraints.
+- Migration code grows ≈2× (per-aspect diff, marker rows, dictionary discovery, distribution family split).
+- v4 DTOs change shape (no more generic `metadata: Map<String, Any?>`); v4 client (Portal) must be updated.
+- Five v1-v3 endpoints dropped or stubbed (all had ≤2 calls in 2 prod days; full kill-list with HTTP-code mapping in `schema-spec.md`).
+
+## Alternatives Considered
+
+### Model A — single consolidated wide table (full snapshot per range)
+
+One row per (component, version_range), all aspect fields populated each row.
+
+**Rejected.** No per-attribute independent override; heavy duplication for components where only one field changes per range. Real data shows 14% of multi-variant components have aspect-divergent ranges (build changes at one boundary, jira at another, vcs at a third); single shared range-axis cannot model this without lossy collapse.
+
+### Model B — separate aspect tables
+
+`build_configurations`, `escrow_configurations`, `jira_component_configs`, `vcs_settings` — each with own version_range column and typed fields.
+
+**Rejected.** Solves aspect-level independence but not attribute-level. Four tables per resolve; v4 CRUD splits into four resources. Migration must shard a single DSL config across four entity types. Empirically, the dominant override pattern is "one DSL block changes one field" — aspect-level granularity is unnecessarily coarse.
+
+### Model C — full EAV (single attribute-value table)
+
+`component_attribute_values(component_id, attribute_path, version_range, value TEXT/JSON)`. Every value is a row.
+
+**Rejected.** Loses DB-level type safety. Validation moves entirely to application. v4 API model becomes "table of facts" rather than object. Resolve verbose (filter by attribute_path prefix, merge in app). Indexing strategy harder. Flexibility (no DDL for new attributes) is not load-bearing — `requirements-migration.md` history shows fields are added in scheduled batches, not ad-hoc.
+
+### Model D — typed `components` defaults + `field_overrides` for overrides
+
+`components` is the wide table; sparse `field_overrides(field_path, version_range, value JSON)` carry per-range deltas.
+
+**Rejected.** Close to A' in shape but loses type safety on overrides (JSON polymorphic value). For components without top-level DSL fields, `components` defaults are either synthesised or empty — semantically confusing. Two storage layouts to merge at read time.
+
+### Model A' — chosen
+
+Wide typed `component_configurations` with base + sparse single-attribute overrides + marker rows for child-collection replacement.
+
+**Why selected.** Keeps everything typed (defaults AND overrides). Per-attribute independent ranges first-class. One table — simple JPA mapping. Single resolve query returns base + matching overrides; merge per field. Adding new fields is a typed `ALTER TABLE`, acceptable for the historical batch cadence of schema evolution. Marker rows cover child collections cleanly with full-replacement semantics matching DSL grammar.
+
+## Implementation notes
+
+Phases tracked in `implementation-progress.md` under "Schema v2 refactor":
+
+1. `V1__schema.sql` baseline (this ADR; replaces V1..V6) — **done**.
+2. Entity refactor (≈16 → ≈22 classes due to dictionaries + distribution split).
+3. Mapper / resolver rewrite.
+4. v4 DTO update.
+5. Migration service rewrite.
+6. Test suite (synthetic DSL fixtures + integration tests; real-data baselines kept in internal CI only).
+7. QA recreate + full `gradlew build`.
+8. ADR updates (this file, supersede 010).
+
+Each phase ends with subagent review (Sonnet by default) per team convention.

--- a/docs/db-migration/implementation-progress.md
+++ b/docs/db-migration/implementation-progress.md
@@ -159,5 +159,22 @@ Driven by MIG-029 investigation + cross-installation DSL audit. See [ADR-014](ad
 | 6 | Test suite (Layer 1 synthetic fixtures; Layer 2 env-gated integration; Layer 3 internal-CI baselines) | 🚧 Pending | MIG-029..MIG-038 coverage |
 | 7 | QA DB recreate + full `gradlew build` | 🚧 Pending | Requires `AUTH_SERVER` env + standard excludes |
 | 8 | Supersede ADR-010 | ✅ Done | ADR-010 marked superseded; ADR-014 active |
+| 9 | Final docs cleanup (mandatory before merging the refactor into `main`) | 🚧 Pending | See "Final docs cleanup scope" below. |
 
 Requirements traceability: MIG-029..MIG-038 in [`requirements-migration.md`](requirements-migration.md). Each phase ends with an independent subagent review (Sonnet default).
+
+### Final docs cleanup scope (Phase 9)
+
+Once Phases 1b–7 land, the refactor narrative ("V1..V6 → V2", MIG-029 investigation, phase tracking) stops being useful. The permanent reference docs are rewritten to describe the new state from the perspective of a reader who never knew V1..V6 existed. The intermediate Flyway evolution was never released; it should not appear in the final documentation.
+
+**Rewrite (kept as canonical reference):**
+- `adr/014-schema-v2.md` — reframe as **"Storage redesign: Groovy DSL → PostgreSQL"**. Context = portal needs DB-backed CRUD over the Component Registry. Remove all references to V1..V6, polymorphic FKs, JSONB extensibility, MIG-029 investigation. Keep the alternative-models section (A, B, C, D, A') — that is the value of the ADR.
+- `schema-spec.md` — strip "current schema (V1..V6)" framing; drop the resolve-algorithm reference to "synthetic base for legacy variants-Map" once enumeration endpoints are formally retired. Becomes a pure column-by-column reference of the live schema.
+
+**Delete (transient implementation aids, no permanent value):**
+- `implementation-progress.md` — phase tracking is done.
+- `requirements-migration.md` — MIG-029..MIG-038 acceptance criteria were implementation gates; their structural fixes live in the schema itself.
+- `technical-design.md` — the "how to migrate from V1..V6" guide is no longer needed.
+- `adr/010-schema-extensibility.md` — never implemented; superseded; remove rather than leave a tombstone.
+
+Phase 9 ships as a single PR titled "docs: clean up DB migration artifacts" once Phases 1b–7 are merged and the refactor is observably working in QA.

--- a/docs/db-migration/implementation-progress.md
+++ b/docs/db-migration/implementation-progress.md
@@ -141,3 +141,23 @@ The original 4-test smoke pack at `components-registry-ui/e2e/smoke.spec.ts` was
 - TLS migration to Ingress + shared wildcard Secret on Portal side — Portal `TD-004`.
 - OpenAPI v4 spec generation + sharing with Portal — TD-003 (CRS) / Portal TD-002.
 - Cutover Phase 5: drop `component_source` table and remove Git resolver / JGit dependency once stability is confirmed — see [ADR-013](adr/013-cutover-strategy.md) (Proposed).
+
+---
+
+## Schema v2 Refactor
+
+Driven by MIG-029 investigation + cross-installation DSL audit. See [ADR-014](adr/014-schema-v2.md) and [`schema-spec.md`](schema-spec.md). Project not yet in production; QA/dev databases recreate from baseline.
+
+| Phase | Task | Status | Notes |
+|---|---|---|---|
+| 1a | Design artifacts: ADR-014, `schema-spec.md`, MIG-030..MIG-038, supersede ADR-010 | ✅ Done | This PR (docs-only). Canonical reference for v2 schema. |
+| 1b | Land `V1__schema.sql` baseline (replaces V1..V6) in Flyway path | 🚧 Pending | 23 tables; Model A'. Held back from docs-only PR; ships alongside Phase 2 to avoid Hibernate `validate` startup crash. |
+| 2 | Refactor entities & repositories (delete `ComponentVersionEntity` + polymorphic FK pairs; introduce `ComponentGroupEntity`, distribution-split entities, etc.) | 🚧 Pending | ≈16 → ≈22 entity classes. Bundled with Phase 1b so DB and JPA align in one merge. |
+| 3 | Rewrite `EntityMappers` + `DatabaseComponentRegistryResolver` (base + override merge; marker rows; synthetic-base handling; doc-links resolution; unified VCS mapping) | 🚧 Pending | |
+| 4 | Update v4 DTOs + `ComponentControllerV4` (replace `metadata: Map` with explicit fields; surface group membership; doc links as `docs[]`) | 🚧 Pending | |
+| 5 | Rewrite `ImportServiceImpl` + `MigrationServiceImpl` (pre-pass dictionary discovery; aggregator detection; two-pass `parentComponent`; per-attribute override emission; distribution family split) | 🚧 Pending | |
+| 6 | Test suite (Layer 1 synthetic fixtures; Layer 2 env-gated integration; Layer 3 internal-CI baselines) | 🚧 Pending | MIG-029..MIG-038 coverage |
+| 7 | QA DB recreate + full `gradlew build` | 🚧 Pending | Requires `AUTH_SERVER` env + standard excludes |
+| 8 | Supersede ADR-010 | ✅ Done | ADR-010 marked superseded; ADR-014 active |
+
+Requirements traceability: MIG-029..MIG-038 in [`requirements-migration.md`](requirements-migration.md). Each phase ends with an independent subagent review (Sonnet default).

--- a/docs/db-migration/requirements-migration.md
+++ b/docs/db-migration/requirements-migration.md
@@ -39,6 +39,15 @@
 | MIG-027 | POST /admin/migrate is async; 202 new / 409 re-run guard / GET /admin/migrate/job polling | High | integration-test | ✅ Tested |
 | MIG-028 | Async migration job state survives pod restart | Medium | design | ❌ Open |
 | MIG-029 | DB → EscrowModule round-trip preserves the absence of a default ALL_VERSIONS config for version-range-only components | High | integration-test | ❌ Not tested |
+| MIG-030 | Polymorphic FK pairs removed; all per-version data on `component_configurations` | High | integration-test | ❌ Not tested |
+| MIG-031 | JSONB `metadata` columns promoted to typed columns | High | unit-test | ❌ Not tested |
+| MIG-032 | Reference dictionaries for `labels`, `systems`, `tools` | Medium | integration-test | ❌ Not tested |
+| MIG-033 | Distribution split into four specialized child tables | Medium | unit-test | ❌ Not tested |
+| MIG-034 | `component_doc_links` M:N with `major_version` | Medium | unit-test | ❌ Not tested |
+| MIG-035 | Aggregator groups (`component_groups`) | High | integration-test | ❌ Not tested |
+| MIG-036 | Per-attribute version-range overrides via Model A' | High | integration-test | ❌ Not tested |
+| MIG-037 | Unified VCS model (no discriminator) | Medium | unit-test | ❌ Not tested |
+| MIG-038 | Endpoint kill-list (5 endpoints dropped/stubbed) | Low | integration-test | ❌ Not tested |
 
 ---
 
@@ -890,3 +899,148 @@ The criteria therefore cover both real shapes:
 - Test data already covers the version-range-only shape via `TEST_COMPONENT3`; add a focused MIG-029 test method in `MigrationIntegrationTest`.
 
 **Test method:** `MigrationIntegrationTest.MIG-029 version-range-only component does not produce a synthetic ALL_VERSIONS config in toEscrowModule`
+
+> **Note on suggested implementation sketch above:** v2 schema (ADR-014) supersedes the `has_default_config` proposal. The structural fix uses `component_configurations.is_synthetic_base BOOLEAN` on the base row; legacy variants-Map mappers skip rows with `is_synthetic_base = true`. See `schema-spec.md` §3.4.
+
+---
+
+### MIG-030: Polymorphic FK pairs removed; all per-version data on `component_configurations`
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ❌ Not tested
+
+Schema v2 removes the `component_id` / `component_version_id` polymorphic FK pair from all configuration tables. Per-version data lives on `component_configurations` with a single FK to `components`. The `component_versions` table is gone.
+
+**Acceptance criteria:**
+1. `V1__schema.sql` contains no `component_version_id` column.
+2. JPA entity inventory has no `ComponentVersionEntity` class.
+3. Resolve queries succeed without referencing any polymorphic CHECK constraint.
+
+---
+
+### MIG-031: JSONB `metadata` columns promoted to typed columns
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ❌ Not tested
+
+Seven JSONB columns from V1..V6 are replaced with explicit typed columns on `components` and `component_configurations`. Legitimate polymorphic JSON (audit_log, registry_config) is stored as TEXT with `@JdbcTypeCode(SqlTypes.JSON)`.
+
+**Acceptance criteria:**
+1. No `columnDefinition = "jsonb"` annotations remain on any entity.
+2. `metadata["X"]` field accesses replaced with typed column reads in mappers and services.
+3. v1-v3 API responses for unchanged components match a prod-aligned fixture suite byte-for-byte.
+
+---
+
+### MIG-032: Reference dictionaries for `labels`, `systems`, `tools`
+
+**Priority:** Medium
+**Test layer:** integration-test
+**Status:** ❌ Not tested
+
+After migration, three dictionary tables exist:
+- `labels` — seeded from installation's `validation-config.yaml`.
+- `systems` — auto-discovered from DSL `system = "X,Y"` values.
+- `tools` — auto-discovered from DSL top-level `Tools { ToolName { ... } ... }` block.
+
+Component-to-dictionary relationships via M:N junctions (`component_labels`, `component_systems`, `component_required_tools`).
+
+**Acceptance criteria:**
+1. After migration, `systems` contains exactly the union of distinct `system` tokens from DSL.
+2. `tools` contains exactly the tools defined by `Tools { ... }` blocks.
+3. `labels` matches `validation-config.yaml` content.
+4. Component create/update via v4 rejects unknown label/system/tool references with 400.
+
+---
+
+### MIG-033: Distribution split into four specialized child tables
+
+**Priority:** Medium
+**Test layer:** unit-test
+**Status:** ❌ Not tested
+
+DSL `distribution { GAV, docker, DEB, RPM, securityGroups }` decomposes into four child tables of `component_configurations` plus `distribution_security_groups` on `components`. Per-family `sort_order` preserves DSL CSV order within each family; mapper concatenates families canonically (Maven, then file-URL) for v1-v3 responses.
+
+**Acceptance criteria:**
+1. DSL `GAV = "g:a:ext:cls, file://url?artifactId=X"` produces 1 row in `distribution_maven_artifacts` (sort_order=0) and 1 in `distribution_file_url_artifacts` (sort_order=0).
+2. DSL `docker = "img1, img2:flavor"` produces 2 rows in `distribution_docker_images` with `flavor` set only on the second (sort_order 0, 1).
+3. v1-v3 `GAV` response CSV recomposes correctly from per-family ordered reads.
+
+---
+
+### MIG-034: `component_doc_links` M:N with `major_version`
+
+**Priority:** Medium
+**Test layer:** unit-test
+**Status:** ❌ Not tested
+
+DSL `doc { component = "X"; majorVersion = "Y" }` maps to a row in `component_doc_links`. Schema supports multiple links per component (v4 API may create more even though DSL allows one block per component).
+
+**Acceptance criteria:**
+1. Migration of a component with `doc { component = "X" }` produces exactly one `component_doc_links` row.
+2. v1-v3 mapper for `doc: { component, majorVersion }` applies major-version rule: for requested version `X.Y.Z`, pick row WHERE `major_version = 'X.Y'`; else WHERE `major_version IS NULL`; else null.
+3. v4 API exposes the full list as `docs[]`.
+
+---
+
+### MIG-035: Aggregator groups (`component_groups`)
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ❌ Not tested
+
+DSL nested `components { ... }` block creates a `component_groups` row. Detection rule classifies as REAL (own valid vcsUrl) or FAKE (no/placeholder vcsUrl or fake artifactId marker).
+
+**Acceptance criteria:**
+1. Standalone component (no nested block) produces 0 rows in `component_groups`; its `components.component_group_id IS NULL`.
+2. REAL aggregator produces 1 `component_groups` row with `is_fake = false` + 1 `components` row for the aggregator + N rows for sub-components, all linked to the same group.
+3. FAKE aggregator (artifactId or vcsUrl matches fake markers) produces 1 `component_groups` row with `is_fake = true` + N sub-component rows linked to the group; NO `components` row for the aggregator itself.
+4. v1-v3 responses do not expose group membership.
+
+---
+
+### MIG-036: Per-attribute version-range overrides via Model A'
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ❌ Not tested
+
+DSL version-range blocks produce override rows on `component_configurations`. Each scalar attribute change is a separate row (`overridden_attribute = 'aspect.field'`); each child-collection replacement is a marker row.
+
+**Acceptance criteria:**
+1. DSL `"[1,2)" { build { javaVersion = "11" } }` produces one scalar override row with `overridden_attribute = 'build.javaVersion'`, `java_version = '11'`, all other typed columns NULL.
+2. DSL `"[1,2)" { vcsSettings { "name1" { ... } } }` produces one marker row with `overridden_attribute = 'vcs.settings'`, all typed scalars NULL, plus corresponding `vcs_settings_entries` child rows.
+3. Resolve at version V applies the matching override per attribute; falls back to base row values for non-overridden fields.
+4. Transitional non-overlap constraint enforced at create/update: partial range overlap rejected with 400.
+
+---
+
+### MIG-037: Unified VCS model
+
+**Priority:** Medium
+**Test layer:** unit-test
+**Status:** ❌ Not tested
+
+All VCS data lives in `vcs_settings_entries`. `component_configurations` has no VCS columns.
+
+**Acceptance criteria:**
+1. SINGLE-VCS DSL component produces 1 row in `vcs_settings_entries` with `name IS NULL`.
+2. MULTI-VCS DSL component produces N rows with `name` populated.
+3. v1-v3 API `vcs.type` mapper computes correctly: `EXTERNAL` when `components.vcs_external_registry IS NOT NULL`; `null` when no entries; `GIT` (or repository_type) otherwise.
+
+---
+
+### MIG-038: Endpoint kill-list
+
+**Priority:** Low
+**Test layer:** integration-test
+**Status:** ❌ Not tested
+
+Five effectively-dead endpoints (≤2 calls in 2 production days) are removed or stubbed per `schema-spec.md` §5.1.
+
+**Acceptance criteria:**
+1. `GET /rest/api/3/components` returns 410 Gone.
+2. `PUT /rest/api/2/components-registry/service/updateCache` returns 410 Gone (matches deployed behaviour).
+3. `GET /rest/api/2/components` (no params), `GET /rest/api/2/projects/{k}/jira-component-version-ranges`, `GET /rest/api/1/components` (no filter) each return 200 with empty array.

--- a/docs/db-migration/schema-spec.md
+++ b/docs/db-migration/schema-spec.md
@@ -1,7 +1,7 @@
 # CRS Schema v2 — Specification
 
 **Status:** Proposed (see [ADR-014](adr/014-schema-v2.md))
-**Implementation:** [`V1__schema.sql`](../../components-registry-service-server/src/main/resources/db/migration/V1__schema.sql)
+**Implementation status:** specified here; the Flyway baseline (`V1__schema.sql`) ships in Phase 1b alongside the entity refactor (see [`implementation-progress.md`](implementation-progress.md)).
 
 This document is the canonical reference for the v2 schema. ADR-014 records the decision and alternatives; this file specifies the exact shape, semantics, and intended usage of every table.
 

--- a/docs/db-migration/schema-spec.md
+++ b/docs/db-migration/schema-spec.md
@@ -1,0 +1,469 @@
+# CRS Schema v2 — Specification
+
+**Status:** Proposed (see [ADR-014](adr/014-schema-v2.md))
+**Implementation:** [`V1__schema.sql`](../../components-registry-service-server/src/main/resources/db/migration/V1__schema.sql)
+
+This document is the canonical reference for the v2 schema. ADR-014 records the decision and alternatives; this file specifies the exact shape, semantics, and intended usage of every table.
+
+## 1. Overview
+
+23 tables across 7 groups:
+
+| Group | Tables | Count |
+|---|---|---:|
+| Core | `components`, `component_configurations` | 2 |
+| Aggregator grouping | `component_groups` | 1 |
+| Dictionaries | `labels`, `systems`, `tools` | 3 |
+| M:N junctions | `component_labels`, `component_systems`, `component_required_tools` | 3 |
+| Children of `components` | `component_artifact_ids`, `distribution_security_groups`, `component_teamcity_projects`, `component_doc_links` | 4 |
+| Children of `component_configurations` | `vcs_settings_entries`, `distribution_maven_artifacts`, `distribution_file_url_artifacts`, `distribution_docker_images`, `distribution_packages` | 5 |
+| Cross-cutting | `audit_log`, `registry_config`, `component_source`, `dependency_mappings`, `git_history_import_state` | 5 |
+
+## 2. ER overview
+
+```
+                                           ┌─────────────────────┐
+                                           │  component_groups   │
+                                           │  group_key UNIQUE   │
+                                           │  is_fake            │
+                                           └──────────┬──────────┘
+                                                      │ 1:N (group → its components)
+                ┌─────────────────────┐               │
+                │     components      ├───────────────┘
+                │  component_key PK   │  ← parent_component_id (self-FK, DSL parentComponent)
+                │  component_group_id │  ← FK to component_groups; NULL = standalone
+                └─────────┬───────────┘
+                          │
+        ┌──────┬──────┬───┴──┬──────┬──────┬──────┬──────────────┐
+        │M:N   │M:N   │1:N   │1:N   │1:N   │1:N   │1:N           │
+        ▼      ▼      ▼      ▼      ▼      ▼      ▼              ▼
+  component_  component_  component_  distribution_  component_  component_   component_
+  labels      systems    artifact_   security_       teamcity_   doc_         configurations
+                          ids        groups         projects    links         │
+   │          │                                                       ┌───────┼─────────────────┐
+   ▼          ▼                                                       │1:N    │1:N each         │M:N
+ labels    systems                                                    ▼       ▼                 ▼
+                                              vcs_settings_entries  4× distribution_*        component_required_tools
+                                                                          (maven, file_url,            │
+                                                                           docker, packages)           ▼
+                                                                                                    tools
+
+────  cross-cutting  ────
+   audit_log     registry_config     component_source     dependency_mappings     git_history_import_state
+```
+
+## 3. Core model: Model A' override taxonomy
+
+`component_configurations` holds three row shapes per component. Each row is keyed by `(component_id, version_range, overridden_attribute)` with a UNIQUE constraint and a partial unique index ensuring at most one base per component.
+
+### 3.1 Base row
+- `overridden_attribute IS NULL`
+- All typed columns may carry values (defaults for that component)
+- `is_synthetic_base = true` when populated from `Defaults.groovy` only (DSL has no top-level fields); otherwise `false`
+
+### 3.2 Scalar override row
+- `overridden_attribute = '<aspect.field>'` (e.g., `build.javaVersion`, `escrow.generation`, `jira.projectKey`)
+- **Exactly one typed column non-NULL** — the column matching the attribute path
+- No attached child rows
+- Service-layer validation enforces single non-NULL; DB CHECK not used here (verbose with 30+ columns)
+
+### 3.3 Marker (child-collection replacement) row
+- `overridden_attribute` is one of the marker names:
+
+| Marker | Replaces |
+|---|---|
+| `vcs.settings` | `vcs_settings_entries` |
+| `distribution.maven` | `distribution_maven_artifacts` |
+| `distribution.fileUrl` | `distribution_file_url_artifacts` |
+| `distribution.docker` | `distribution_docker_images` |
+| `distribution.packages` | `distribution_packages` |
+| `build.requiredTools` | `component_required_tools` |
+
+- **All typed scalar columns must be NULL** — enforced by DB CHECK (one per marker)
+- Child rows attached via FK to this marker row's `id`
+- Semantics: full replacement of the corresponding collection for matching version range
+
+### 3.4 Resolve algorithm
+
+For request `(component, version V)`:
+
+1. Load base row + all matching override rows: `WHERE component_id = X AND (overridden_attribute IS NULL OR range_contains(version_range, V))`.
+2. Start with base row scalar values; for each scalar override row matching V, set its single non-NULL column on the merged result.
+3. For child collections, pick the most-specific marker override row whose `version_range` contains V; if found, its children REPLACE base children (full replacement). If no marker matches, use base children.
+4. Transitional constraint: version_range of override rows within one component MUST NOT partially overlap (equal ranges are blocked by UNIQUE; strict containment and disjoint allowed; partial overlap rejected at write-time). Under this constraint, at most one override per attribute matches V — no runtime tiebreaker needed.
+5. For the legacy variants-Map endpoints, skip emitting the base row entry if `is_synthetic_base = true` (this is the MIG-029 fix). For single-version resolve (hot path), synthetic base is always used as fallback.
+
+## 4. Table specifications
+
+### 4.1 `components`
+
+Identity + fields that never vary per version range.
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| `id` | UUID | PK | |
+| `component_key` | VARCHAR(255) | NOT NULL, UNIQUE | DSL key; exposed as `name` in v1-v3 API, `componentKey` in v4 |
+| `component_owner` | VARCHAR(255) | nullable | |
+| `display_name` | VARCHAR(255) | nullable | DSL `componentDisplayName` |
+| `product_type` | VARCHAR(20) | nullable | App-validated against `ProductTypes` enum (PT_K/PT_C/PT_D_DB/PT_D) |
+| `client_code` | VARCHAR(255) | nullable | |
+| `archived` | BOOLEAN | NOT NULL DEFAULT false | |
+| `solution` | BOOLEAN | nullable | |
+| `parent_component_id` | UUID | FK → components(id) | DSL `parentComponent = "X"` reference between peers |
+| `component_group_id` | UUID | FK → component_groups(id) | Aggregator membership; NULL for standalone components |
+| `release_manager` | VARCHAR(255) | nullable | |
+| `security_champion` | VARCHAR(255) | nullable | |
+| `copyright` | TEXT | nullable | |
+| `releases_in_default_branch` | BOOLEAN | nullable | |
+| `jira_display_name` | VARCHAR(255) | nullable | jira.displayName — never varies per version per audit |
+| `jira_hotfix_version_format` | VARCHAR(255) | nullable | jira.componentVersionFormat.hotfixVersionFormat — UI read-only (inherited from Defaults) |
+| `vcs_external_registry` | TEXT | nullable | vcsSettings.externalRegistry — per-component (audit assertion enforced at migration) |
+| `distribution_explicit` | BOOLEAN | nullable | |
+| `distribution_external` | BOOLEAN | nullable | |
+| `version` | BIGINT | NOT NULL DEFAULT 0 | `@Version` optimistic locking |
+| `created_at` | TIMESTAMP WITH TIME ZONE | NOT NULL DEFAULT now() | |
+| `updated_at` | TIMESTAMP WITH TIME ZONE | NOT NULL DEFAULT now() | |
+
+Indexes: `archived`, `product_type`, `parent_component_id`, `component_group_id`, partial `component_key WHERE archived = false`.
+
+### 4.2 `component_configurations`
+
+Per-(component, version_range) typed rows; the spine of Model A'.
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | UUID | PK | |
+| `component_id` | UUID | NOT NULL, FK → components(id) ON DELETE CASCADE | |
+| `version_range` | VARCHAR(255) | NOT NULL | DSL range string, e.g., `(,0),[0,)`, `[1.0,2.0)` |
+| `overridden_attribute` | VARCHAR(50) | nullable | NULL = base; non-NULL = scalar or marker override |
+| `is_synthetic_base` | BOOLEAN | NOT NULL DEFAULT false | true only on base rows synthesised from Defaults.groovy |
+| Build aspect | | | |
+| `build_system` | VARCHAR(50) | | MAVEN/GRADLE/ESCROW_PROVIDED_MANUALLY/PROVIDED/etc. |
+| `build_system_version` | VARCHAR(50) | | |
+| `java_version` | VARCHAR(50) | | |
+| `maven_version` | VARCHAR(50) | | |
+| `gradle_version` | VARCHAR(50) | | |
+| `build_file_path` | TEXT | | |
+| `deprecated` | BOOLEAN | | |
+| `required_project` | BOOLEAN | | |
+| `project_version` | VARCHAR(255) | | |
+| `system_properties` | TEXT | | |
+| `build_tasks` | TEXT | | Used for both build and escrow process; legacy `escrow.buildTask` consolidated here |
+| Escrow aspect | | | |
+| `escrow_provided_dependencies` | TEXT | | Comma-separated |
+| `escrow_reusable` | BOOLEAN | | |
+| `escrow_generation` | VARCHAR(50) | | AUTO/MANUAL/UNSUPPORTED |
+| `escrow_disk_space` | VARCHAR(50) | | |
+| `escrow_additional_sources` | TEXT | | Comma-separated |
+| `escrow_gradle_include_configurations` | TEXT | | |
+| `escrow_gradle_exclude_configurations` | TEXT | | |
+| `escrow_gradle_include_test_configurations` | BOOLEAN | | |
+| Jira aspect | | | |
+| `jira_project_key` | VARCHAR(50) | | |
+| `jira_technical` | BOOLEAN | | |
+| `jira_major_version_format` | VARCHAR(255) | | |
+| `jira_release_version_format` | VARCHAR(255) | | |
+| `jira_build_version_format` | VARCHAR(255) | | |
+| `jira_line_version_format` | VARCHAR(255) | | |
+| `jira_version_prefix` | VARCHAR(255) | | jira.customer.versionPrefix |
+| `jira_version_format` | VARCHAR(255) | | jira.customer.versionFormat |
+| Timestamps | | | |
+| `created_at` | TIMESTAMP WITH TIME ZONE | NOT NULL DEFAULT now() | |
+| `updated_at` | TIMESTAMP WITH TIME ZONE | NOT NULL DEFAULT now() | |
+
+Constraints:
+- `UNIQUE (component_id, version_range, overridden_attribute)`
+- Partial `UNIQUE INDEX uq_component_configurations_one_base ON component_configurations(component_id) WHERE overridden_attribute IS NULL`
+- Six DB CHECK constraints (one per marker) enforcing "all typed scalars NULL when overridden_attribute = '<marker>'"
+
+Indexes: `(component_id, version_range)`, `jira_project_key WHERE NOT NULL`, `updated_at`.
+
+VCS fields are absent on this table — see unified VCS model below (`vcs_settings_entries`).
+
+### 4.3 `component_groups`
+
+Aggregator grouping. An aggregator is a DSL component with a nested `components { ... }` block.
+
+| Column | Type | Constraints |
+|---|---|---|
+| `id` | UUID | PK |
+| `group_key` | VARCHAR(255) | NOT NULL, UNIQUE |
+| `is_fake` | BOOLEAN | NOT NULL DEFAULT false |
+| `created_at`, `updated_at` | TIMESTAMP WITH TIME ZONE | NOT NULL DEFAULT now() |
+
+Semantics:
+- **REAL aggregator** (`is_fake = false`): aggregator is itself a deployable component. Has its own row in `components` whose `component_group_id` points to this group. All sub-components also link to this group.
+- **FAKE aggregator** (`is_fake = true`): grouping-only entity. **No row in `components` for the aggregator itself.** Only sub-components link to the group.
+
+Detection rule at migration:
+
+```kotlin
+fun isFakeAggregator(cfg: EscrowModuleConfig): Boolean {
+    val vcsUrl = cfg.firstVcsUrlAcrossAllForms()    // form 1, 2, or 3
+    val artifactId = cfg.artifactIdPattern ?: ""
+    return vcsUrl.isNullOrBlank()
+        || isFakeVcsUrl(vcsUrl)
+        || isFakeArtifactId(artifactId)
+}
+
+fun isFakeVcsUrl(url: String) =
+    "/fake/" in url || "/dummy/" in url ||
+    url.endsWith("fake.git") || url.endsWith("dummy.git") || url.endsWith("stub.git")
+
+fun isFakeArtifactId(aid: String): Boolean {
+    val lower = aid.lowercase().trim()
+    if (lower in setOf("fake", "dummy", "stub")) return true
+    return Regex("(^|-)(fake|dummy|stub)(-|$|,)").containsMatchIn(lower)
+}
+```
+
+### 4.4 Dictionaries
+
+`labels`, `systems`, `tools` share a common shape: `code/name VARCHAR PK + description TEXT + timestamps`. `tools` additionally has `escrow_env_variable VARCHAR(255), target_location TEXT, source_location TEXT, install_script TEXT`.
+
+Seeding:
+- `labels` — from installation's `validation-config.yaml` at first migration.
+- `systems` — auto-discovered from DSL `system = "X,Y"` values during migration (UPSERT each distinct token).
+- `tools` — auto-discovered from DSL top-level `Tools { name { ... } ... }` block during migration.
+
+### 4.5 M:N junctions
+
+Each junction has composite PK `(component_X_id, target_code)`.
+
+| Junction | Connects | FK targets |
+|---|---|---|
+| `component_labels` | `components` ↔ `labels` | components(id), labels(code) |
+| `component_systems` | `components` ↔ `systems` | components(id), systems(code) |
+| `component_required_tools` | `component_configurations` ↔ `tools` | component_configurations(id), tools(name) |
+
+`component_required_tools` is per-version-rangeable; replacement at a specific range uses the `build.requiredTools` marker row.
+
+### 4.6 Children of `components` (never per-version)
+
+| Table | Key fields | Notes |
+|---|---|---|
+| `component_artifact_ids` | `group_pattern, artifact_pattern` | Used by `find-by-artifact` hot endpoint; indexed `(group_pattern, artifact_pattern)` |
+| `distribution_security_groups` | `group_type ∈ {read, write}, group_name` | Audit confirms never per-version |
+| `component_teamcity_projects` | `project_id, sort_order` | Multi-id supported |
+| `component_doc_links` | `doc_component_key, major_version, sort_order` | Soft-reference; target may be archived or out-of-installation; UNIQUE `(component_id, doc_component_key, major_version)` |
+
+### 4.7 Children of `component_configurations` (per-version-rangeable)
+
+#### Unified VCS — `vcs_settings_entries`
+
+SINGLE-VCS is "1 entry with `name = NULL`"; MULTI-VCS is "N entries with names". No discriminator column.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | |
+| `component_configuration_id` | UUID FK | |
+| `name` | VARCHAR(255), nullable | NULL for single-VCS; named for multi-VCS |
+| `vcs_path` | TEXT NOT NULL | |
+| `branch` | TEXT | |
+| `tag` | TEXT | |
+| `hotfix_branch` | TEXT | |
+| `repository_type` | VARCHAR(20) | GIT/MERCURIAL/CVS (Java enum); typically GIT |
+| `sort_order` | INT NOT NULL DEFAULT 0 | |
+
+`vcs.type` (GIT/EXTERNAL/null) computed at API layer:
+- `components.vcs_external_registry IS NOT NULL` → `EXTERNAL`
+- else `vcs_settings_entries` count = 0 → `null` (no VCS)
+- else → `GIT` (or other repository_type from entries[0])
+
+#### Distribution split (4 specialized tables)
+
+DSL `distribution { GAV = "...", docker = "...", DEB = "...", RPM = "..." }` decomposes into four families. `sort_order` is **per-family** within a `component_configuration_id`.
+
+| Table | Distinct columns |
+|---|---|
+| `distribution_maven_artifacts` | `group_pattern, artifact_pattern, extension, classifier` |
+| `distribution_file_url_artifacts` | `url, artifact_id, classifier` |
+| `distribution_docker_images` | `image_name, flavor` (flavor = OW build variant, NOT a Docker registry tag) |
+| `distribution_packages` | `package_type ∈ {DEB, RPM}, package_name` |
+
+API mapper recomposes the v1-v3 `GAV` CSV by reading Maven entries (sort_order), then file-URL entries (sort_order), concatenating canonically. `docker`, `DEB`, `RPM` are separate DSL fields; each family's order is preserved by its own `sort_order`.
+
+### 4.8 Cross-cutting
+
+| Table | PK | Purpose |
+|---|---|---|
+| `audit_log` | `id BIGSERIAL` | Entity history; `old_value/new_value/change_diff` are TEXT (JSON via Hibernate) |
+| `registry_config` | `key` | Global config blob (component-defaults, field-config); value TEXT (JSON) |
+| `component_source` | `component_key` | Per-component flag git\|db for dual-read routing |
+| `dependency_mappings` | `alias` | alias → component_key lookup |
+| `git_history_import_state` | `import_key` | Async migration job state |
+
+## 5. API mapping (v1-v3 backward compatibility)
+
+All v1-v3 endpoints implemented as adapters over the new schema. Mapper rules:
+
+| API field / shape | New schema source |
+|---|---|
+| `name` (v1-v3) | `components.component_key` (rename in mapper) |
+| `componentKey` (v4) | `components.component_key` direct |
+| `repositoryType` | `vcs_settings_entries.repository_type`; NULL → default GIT |
+| `teamcityProjectUrl` | Computed at mapper: `<teamcity-base>/buildConfiguration/<project_id>` |
+| `hotfixVersionFormat` (jira) | `components.jira_hotfix_version_format`; UI read-only |
+| `escrow.buildTask` (legacy) | `component_configurations.build_tasks` (consolidated) |
+| `doc: {component, majorVersion}` (singular) | `component_doc_links` filtered: for requested version X.Y.Z, pick row WHERE `major_version = 'X.Y'`; else fall back to row WHERE `major_version IS NULL`; else null |
+| `docs[]` (v4 plural) | `component_doc_links` full list |
+| `vcs.versionControlSystems` (v3 legacy) | Not produced — only emitted by dropped `GET /api/3/components` endpoint |
+| `GAV` csv (v1-v3) | `distribution_maven_artifacts` ORDER BY sort_order, then `distribution_file_url_artifacts` ORDER BY sort_order; canonical concat |
+| `docker` csv (v1-v3) | `distribution_docker_images` ORDER BY sort_order; format `image:flavor` when `flavor IS NOT NULL`, else `image` |
+| Legacy variants-Map shape | Skip base row in enumeration when `is_synthetic_base = true` — fixes MIG-029 |
+
+### 5.1 Endpoint kill-list
+
+Effectively-dead endpoints (≤2 calls in 2 production days) are dropped or stubbed:
+
+| Endpoint | Calls/2d | New behavior | HTTP code |
+|---|---:|---|---:|
+| `GET /api/3/components` | 0 | Remove handler | 410 Gone |
+| `PUT /api/2/components-registry/service/updateCache` | 2 | Remove handler | 410 Gone (matches deployed) |
+| `GET /api/2/components` (no params) | 2 | Return `[]` | 200 |
+| `GET /api/2/projects/{k}/jira-component-version-ranges` | 1 | Return `[]` | 200 |
+| `GET /api/1/components` (no filter) | 1 | Return `[]` | 200 |
+
+All other v1-v3 endpoints preserve byte-for-byte response shape for unchanged components, validated against the prod-aligned fixture suite.
+
+## 6. Migration approach
+
+`POST /admin/migrate` is rewritten to populate the new schema from DSL. Async-job semantics (MIG-027/028) are unchanged.
+
+### 6.1 Pre-pass discovery
+
+1. Parse all DSL files via `EscrowConfigurationLoader.loadFullConfiguration` (unresolved form — preserves raw distribution strings with `${version}` placeholders).
+2. Collect distinct `system` values → upsert `systems`.
+3. Collect `Tools { name { ... } ... }` block contents → upsert `tools`.
+4. Seed `labels` from installation's `validation-config.yaml`.
+
+### 6.2 Per-component import (two-pass for `parentComponent` and aggregators)
+
+**Pass 1** — create all components with `parent_component_id = NULL`:
+
+```kotlin
+val pendingParentByKey = mutableMapOf<String, String>()
+for (dslComponent in allDslComponents) {
+    val entity = mapToComponentEntity(dslComponent)
+    entity.parentComponentId = null
+    componentRepository.save(entity)
+    dslComponent.parentComponentName?.let { parentKey ->
+        pendingParentByKey[dslComponent.componentKey] = parentKey
+    }
+}
+```
+
+**Pass 2** — resolve `parentComponent` references and link aggregators:
+
+```kotlin
+for ((childKey, parentKey) in pendingParentByKey) {
+    val parent = componentRepository.findByComponentKey(parentKey)
+    if (parent == null) {
+        log.warn("parentComponent='$parentKey' referenced by '$childKey' not found; leaving null")
+        continue
+    }
+    val child = componentRepository.findByComponentKey(childKey)!!
+    child.parentComponentId = parent.id
+    componentRepository.save(child)
+}
+```
+
+Missing parent references are tolerated (WARN log) — referenced component may be archived or in a different installation.
+
+### 6.3 Aggregator handling
+
+For each top-level DSL component:
+1. If no nested `components { }` block → STANDALONE; create one `components` row with `component_group_id = NULL`.
+2. Else (aggregator):
+   - Classify REAL vs FAKE per the detection rule (§4.3).
+   - Create `component_groups` row.
+   - REAL: also create `components` row for the aggregator itself with `component_group_id` pointing to its own group.
+   - For each sub-component (`EscrowConfigurationLoader` resolves parent defaults into the sub config): create `components` row with `component_group_id` pointing to the group.
+
+### 6.4 Base row determination
+
+For each component:
+- If DSL has any top-level fields (vcsUrl, jira, build, escrow, distribution, etc.) → base row from those values, `is_synthetic_base = false`.
+- If DSL has only version-range blocks (no top-level fields) → base row populated purely from `Defaults.groovy` resolved values, `is_synthetic_base = true`.
+
+### 6.5 Override row generation
+
+For each version-range block in DSL:
+- For each scalar attribute whose value differs from the base row: emit scalar override row (`overridden_attribute = 'aspect.field'`, single column set).
+- For each child-collection change (multi-VCS, distribution_*, requiredTools): emit marker row (`overridden_attribute = '<marker>'`, all typed scalars NULL) + child rows attached.
+
+Override detection deduplicates: a row is emitted only when the resolved value differs from the base row's resolved value.
+
+### 6.6 Distribution parsing
+
+`distribution { GAV = "csv1,csv2", docker = "img1,img2:flavor", DEB = "p1,p2", RPM = "p" }`:
+- Split `GAV` CSV; for each entry:
+  - Starts with `file://`/`http(s)://` → `distribution_file_url_artifacts` row (parse query string for `artifactId`, `classifier`); per-family sort_order counter.
+  - Else parse `group:artifact[:ext[:classifier]]` → `distribution_maven_artifacts` row; per-family sort_order counter.
+- Split `docker` CSV; parse `image[:flavor]` (split on last `:`; flavor is the OW build variant, not a Docker registry tag); warn if flavor matches a version pattern.
+- Split `DEB`, `RPM` CSV; one `distribution_packages` row per entry.
+
+### 6.7 Tools and required tools
+
+- Discover `Tools { ToolName { escrowEnvironmentVariable, targetLocation, sourceLocation, installScript } ... }` at top of any DSL file → upsert into `tools`.
+- For each component's `build.requiredTools = "BuildEnv,Whiskey"` csv: split and link `component_required_tools` rows.
+- Missing tool reference (referenced tool not in registry) → WARN log; relationship skipped.
+
+### 6.8 `${version}` placeholders
+
+DSL strings containing `${version}`, `${env.X}`, `${major}`, etc. are stored **verbatim** in the database. Placeholder expansion happens at runtime by the consumer (build tooling), not at migration time.
+
+## 7. Validation rules
+
+`ComponentManagementServiceImpl.create / update` enforces:
+
+- Base row: at least one typed column may be filled; child rows allowed.
+- Scalar override row: `overridden_attribute` is a known `aspect.field`; exactly one matching typed column non-NULL; no child rows.
+- Marker override row: `overridden_attribute` ∈ marker set; all typed scalar columns NULL (DB CHECK also enforces this); child rows attached.
+- Version_range overlap (transitional): override rows within one component must not partially overlap (equal ranges blocked by UNIQUE; strict containment and disjoint allowed).
+
+DB-level CHECK constraints defend against migration / bulk-load bypassing the service layer (one CHECK per marker name).
+
+## 8. Test strategy
+
+### 8.1 Layer 1: synthetic DSL fixtures (committed to repo)
+
+Handcrafted fixtures in `src/test/resources/dsl-fixtures/` cover each pattern with anonymized names:
+
+```
+real-aggregator-multi-vcs.groovy        — multi-VCS named entries, real URL
+real-aggregator-single-vcs.groovy       — single-VCS form 1 or form 3
+fake-aggregator-no-vcs.groovy           — no vcsUrl at all
+fake-aggregator-placeholder-url.groovy  — vcsUrl = ".../fake/fake.git"
+fake-aggregator-stub-marker.groovy      — artifactId = "X-stub"
+fake-aggregator-fake-marker.groovy      — artifactId = "fake"
+standalone-component.groovy             — no nested components block
+version-range-only.groovy               — no top-level DSL fields; tests is_synthetic_base
+multi-aspect-divergence.groovy          — build, vcs, jira, escrow each change at different ranges
+all-distribution-families.groovy        — Maven + fileUrl + Docker + DEB/RPM together
+```
+
+Unit tests assert per-pattern classification using synthetic names only.
+
+### 8.2 Layer 2: integration against real DSL (env-gated)
+
+```kotlin
+@EnabledIfEnvironmentVariable(named = "CRS_DSL_PATH", matches = ".+")
+@Test
+fun `migration on full DSL produces expected aggregator structure`() {
+    runMigration(System.getenv("CRS_DSL_PATH"))
+    // property-based, not name-specific:
+    assertThat(componentGroupRepository.findAll()).isNotEmpty
+    // ...
+}
+```
+
+Disabled in public CI; runs in internal CI with private-DSL access.
+
+### 8.3 Layer 3: prod-aligned baselines (internal CI only)
+
+Baseline JSON files in internal artifact storage record exact counts per installation. Internal CI asserts Layer-2 outputs against these baselines.
+
+## 9. Anonymization
+
+This document and all artifacts published to the public repository use anonymized names and structural descriptions. Real component names from production DSL appear only in internal working notes (kept outside the repository).

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -98,9 +98,9 @@ The JPA entity layout for schema v2 is specified in [`schema-spec.md`](schema-sp
 
 ## 5. API Design
 
-### 5.1 Existing API (unchanged)
+### 5.1 Existing API
 
-All 34 endpoints across v1/v2/v3 remain identical. The only change is the backing `ComponentRegistryResolver` implementation.
+All non-kill-listed v1/v2/v3 endpoints preserve response shape; the backing `ComponentRegistryResolver` implementation changes under the hood. See [`schema-spec.md`](schema-spec.md) §5.1 for the list of dropped/stubbed low-traffic endpoints under schema v2.
 
 ### 5.2 New API v4
 

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -70,77 +70,27 @@ CREATE TABLE component_source (
 
 ## 3. Database Schema
 
-### 3.1 Entity-Relationship Overview
+**Schema v2 is the authoritative model.** See [`schema-spec.md`](schema-spec.md) for the full reference (22 tables, column-by-column inventory, resolve algorithm, API mapping, migration approach) and [ADR-014](adr/014-schema-v2.md) for the decision record and rejected alternatives.
 
-```
-components (1) ──→ (N) component_versions
-    │                       │
-    ├──→ build_configurations ←──┤
-    ├──→ escrow_configurations ←─┤
-    ├──→ vcs_settings ←──────────┤
-    ├──→ distributions ←─────────┤
-    ├──→ jira_component_configs ←┤
-    │
-    ├──→ component_artifact_ids
-    └──→ components (self-ref: parent_component_id)
+### 3.1 Summary
 
-distributions (1) ──→ (N) distribution_artifacts
-                  ──→ (N) distribution_security_groups
+Schema v2 (Model A') replaces the V1..V6 polymorphic-FK / JSONB-metadata model:
 
-vcs_settings (1) ──→ (N) vcs_settings_entries (for MULTIPLY type)
+- **Polymorphic FK pairs removed.** All per-version data lives on `component_configurations` with a single FK to `components`.
+- **No JSONB metadata.** Typed columns for all known fields; legitimate polymorphic JSON (audit_log, registry_config) kept as TEXT via `@JdbcTypeCode(SqlTypes.JSON)`.
+- **`component_versions` table removed.** Version_range lives directly on `component_configurations` rows.
+- **Per-attribute version-range overrides.** Each override is a row keyed by `(component_id, version_range, overridden_attribute)`: NULL (base), `'aspect.field'` (scalar), or marker (replacement of a child collection).
+- **Unified VCS model.** SINGLE-VCS = 1 entry in `vcs_settings_entries` with `name = NULL`; MULTI-VCS = N named entries.
+- **Distribution split** into four specialized child tables (Maven coords, file URLs, Docker images, DEB/RPM packages).
+- **Aggregator grouping.** `component_groups` table + `components.component_group_id` FK preserve the DSL `components { ... }` nesting relationship that was previously lost in migration.
+- **Reference dictionaries** for `labels`, `systems`, `tools` (admin-managed).
+- **MIG-029 fixed.** `is_synthetic_base` flag on base rows; legacy variants enumeration skips synthetic bases.
 
-audit_log (standalone, indexed by entity_type + entity_id, source ∈ {api, git-history})
-dependency_mappings (standalone key-value)
-git_history_import_state (single-row idempotency state for /admin/migrate-history)
-field_overrides (per-component per-field per-version-range overrides)
-component_artifact_ids (owner XOR: component_id OR component_version_id, V4)
-```
+22 tables total. See `schema-spec.md` §2 for the ER diagram, §3 for resolve semantics, and §6 for migration approach.
 
-### 3.2 Polymorphic Owner Pattern
+### 3.2 Flyway
 
-Build, escrow, VCS, distribution, and Jira configs can belong to either a **component** (defaults) or a **component_version** (overrides). This uses a CHECK constraint:
-
-```sql
-CONSTRAINT chk_owner CHECK (
-    (component_id IS NOT NULL AND component_version_id IS NULL) OR
-    (component_id IS NULL AND component_version_id IS NOT NULL)
-)
-```
-
-> **Note — per-field version overrides:** The schema will support independent version ranges per parameter field (e.g., `buildSystem` overridden for `[1.0, 2.0)` while `jiraProjectKey` is overridden for `[1.5, 2.5)`). Overlapping ranges across different fields are allowed; overlapping ranges for the same field are forbidden. The final schema design for per-field overrides is deferred to implementation.
-
-### 3.3 Schema Extensibility
-
-Component properties are classified into three tiers by stability. See [ADR-010](adr/010-schema-extensibility.md) for full rationale.
-
-| Tier | Storage | Fields | Adding new field |
-|------|---------|--------|------------------|
-| 1 — Stable core | Columns | `name`, `component_owner`, `archived`, `system`, `product_type`, `client_code`, `solution`, `parent_component_id` | Flyway + Entity + Mapper + DTO |
-| 2 — Domain configs | Separate tables | build, escrow, VCS, distribution, jira | Flyway + Entity + Mapper + DTO |
-| 3 — Extensible metadata | `metadata JSONB` | `releaseManager`, `securityChampion`, `labels`, `doc`, `copyright`, `releasesInDefaultBranch` | DTO only |
-
-```sql
--- metadata column on components table
-ALTER TABLE components ADD COLUMN metadata JSONB NOT NULL DEFAULT '{}';
-CREATE INDEX idx_components_metadata ON components USING GIN (metadata);
-```
-
-**Promotion path:** if a Tier 3 field becomes critical for performance or joins, it can be promoted to a Tier 1 column via Flyway migration + backfill from JSONB.
-
-### 3.4 Full DDL
-
-Complete DDL is maintained in Flyway migration files (see §3.1 ERD above for entity relationships). The full SQL will be finalized at implementation start and placed in:
-
-
-Flyway migration files live at `components-registry-service-server/src/main/resources/db/migration/`:
-
-| Version | File | Purpose |
-|---|---|---|
-| V1 | `V1__initial_schema.sql` | Initial schema — components, versions, build/escrow/vcs/distribution/jira configs, audit_log, field_overrides, component_artifact_ids, etc. |
-| V2 | `V2__indexes.sql` | Performance indexes on hot lookup paths. |
-| V3 | `V3__text_columns.sql` | Widen VARCHAR(500) columns to TEXT to fix overflow regressions. |
-| V4 | `V4__artifact_ids_version_level.sql` | Allow `component_artifact_ids` to belong to either a component or a `component_version` (XOR `CHECK` + nullable `component_id`, new nullable `component_version_id`). Mirrors the polymorphic owner pattern used by other config tables. |
-| V5 | `V5__audit_source_and_history_state.sql` | Add `audit_log.source VARCHAR(20) NOT NULL DEFAULT 'api'` (distinguishes runtime API events from synthetic backfill rows produced by `/admin/migrate-history`); plain `CREATE INDEX idx_audit_source` (acceptable while the table is small — see file header for the CONCURRENTLY workaround if replayed against a large table). Create `git_history_import_state` (single-row idempotency state, no resume support; PK `import_key`, fields `target_ref`, `target_sha`, `status`, `updated_at`). |
+Single consolidated baseline `V1__schema.sql` replaces V1..V6 (project not yet in production; databases recreated). Hibernate runs in `validate` mode against the baseline. Tests use `ddl-auto: create-drop` directly from JPA annotations.
 
 ## 4. JPA Entities
 

--- a/docs/db-migration/technical-design.md
+++ b/docs/db-migration/technical-design.md
@@ -70,7 +70,7 @@ CREATE TABLE component_source (
 
 ## 3. Database Schema
 
-**Schema v2 is the authoritative model.** See [`schema-spec.md`](schema-spec.md) for the full reference (22 tables, column-by-column inventory, resolve algorithm, API mapping, migration approach) and [ADR-014](adr/014-schema-v2.md) for the decision record and rejected alternatives.
+**Schema v2 is the authoritative model.** See [`schema-spec.md`](schema-spec.md) for the full reference (column-by-column inventory of all tables, resolve algorithm, API mapping, migration approach) and [ADR-014](adr/014-schema-v2.md) for the decision record and rejected alternatives.
 
 ### 3.1 Summary
 
@@ -86,7 +86,7 @@ Schema v2 (Model A') replaces the V1..V6 polymorphic-FK / JSONB-metadata model:
 - **Reference dictionaries** for `labels`, `systems`, `tools` (admin-managed).
 - **MIG-029 fixed.** `is_synthetic_base` flag on base rows; legacy variants enumeration skips synthetic bases.
 
-22 tables total. See `schema-spec.md` §2 for the ER diagram, §3 for resolve semantics, and §6 for migration approach.
+See `schema-spec.md` §1 for the full table count and grouping, §2 for the ER diagram, §3 for resolve semantics, and §6 for migration approach.
 
 ### 3.2 Flyway
 
@@ -94,72 +94,7 @@ Single consolidated baseline `V1__schema.sql` replaces V1..V6 (project not yet i
 
 ## 4. JPA Entities
 
-### 4.1 Core Entity Example (Kotlin)
-
-```kotlin
-@Entity
-@Table(name = "components")
-class ComponentEntity(
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    var id: UUID? = null,
-
-    // name is the public API identifier (Component.id in v1/v2/v3 is the component name)
-    @Column(nullable = false, unique = true)
-    val name: String,
-
-    // Tier 1 — stable core (columns)
-    @Column(name = "component_owner", nullable = false)
-    var componentOwner: String,
-
-    var productType: String? = null,
-    // NOTE: current model uses Set<String> for system (Component.system: Set<String>)
-    // DB: stored as array or join table; mapped to Set<String> in DTO
-    @Column(columnDefinition = "text[]")
-    var system: Set<String> = emptySet(),
-    var clientCode: String? = null,
-    var archived: Boolean = false,
-    var solution: Boolean? = null,
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_component_id")
-    var parentComponent: ComponentEntity? = null,
-
-    // Tier 3 — extensible metadata (JSONB)
-    // Contains: displayName, releaseManager, securityChampion,
-    //           labels, doc, copyright, releasesInDefaultBranch, and future fields
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(columnDefinition = "jsonb")
-    var metadata: MutableMap<String, Any?> = mutableMapOf(),
-
-    // Tier 2 — domain configs (separate tables, via relations)
-    @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val versions: MutableList<ComponentVersionEntity> = mutableListOf(),
-
-    @Version
-    var version: Long = 0,  // optimistic locking
-
-    @CreationTimestamp
-    @Column(updatable = false)
-    val createdAt: Instant? = null,
-
-    @UpdateTimestamp
-    var updatedAt: Instant? = null
-)
-```
-
-### 4.2 Repository Example
-
-```kotlin
-interface ComponentRepository : JpaRepository<ComponentEntity, UUID> {
-    fun findByName(name: String): ComponentEntity?
-    fun findBySystem(system: String): List<ComponentEntity>
-    fun findByArchivedFalse(): List<ComponentEntity>
-
-    @Query("SELECT c FROM ComponentEntity c LEFT JOIN FETCH c.versions WHERE c.name = :name")
-    fun findByNameWithVersions(@Param("name") name: String): ComponentEntity?
-}
-```
+The JPA entity layout for schema v2 is specified in [`schema-spec.md`](schema-spec.md) (column-by-column inventory of every table) and lands in Phase 2 (entity refactor). See [`implementation-progress.md`](implementation-progress.md) for current phase status.
 
 ## 5. API Design
 


### PR DESCRIPTION
## Summary

This PR lands the planning artifacts for the v2 schema redesign. **Docs only** — the actual `V1__schema.sql` baseline and the JPA entity refactor ship together in a follow-up PR (`feat/schema-v2-sql` + Phase 2 work). Splitting was necessary because dropping a new SQL baseline into the Flyway path without aligning entities would crash Hibernate `validate` at startup.

### What's included

- **`schema-spec.md`** — canonical reference. 23 tables across 7 groups; column-by-column inventory; resolve algorithm; v1-v3 API mapping (with kill-list of dead endpoints); migration approach; three-layer test strategy.
- **`adr/014-schema-v2.md`** — decision record. Model A' (wide typed `component_configurations` with one base row + sparse override rows; three row shapes). Records rejected alternatives (Model A, B, C, D) and consequences.
- **`adr/010-schema-extensibility.md`** — marked **superseded** by ADR-014. Tier-3 JSONB extensibility never materialised; empirical audit found zero PG-specific JSONB use.
- **`requirements-migration.md`** — MIG-030..MIG-038 acceptance criteria for the v2 refactor. MIG-029 implementation sketch updated to the `is_synthetic_base` flag approach.
- **`technical-design.md`** §3 — redirects to `schema-spec.md`.
- **`implementation-progress.md`** — Schema v2 Refactor section. Phase 1a (this PR) done; Phases 1b–8 pending and explicitly bundled.

### Background

- Project not yet in production; QA/dev databases will recreate from the v2 baseline once Phase 1b lands.
- Driven by MIG-029 investigation, 2-day production traffic analysis (216k requests), QA REST API audit (948 components), and cross-installation DSL comparison.
- Anonymised examples throughout (no real component names committed).

### Stacked follow-up

`feat/schema-v2-sql` (held back, not yet open) contains the `V1__schema.sql` baseline + V1..V6 deletion. It will open as a Draft alongside the Phase 2 entity refactor so DB and JPA align in one merge.

## Test plan

- [ ] Reviewers verify `schema-spec.md` covers every column claimed in ADR-014.
- [ ] ADR-014 alternatives section is balanced (each rejected model has a stated reason).
- [ ] No real component names / org identifiers in committed text.
- [ ] Markdown renders correctly in GitHub UI (ER diagram block + tables).
- [ ] `implementation-progress.md` phase table accurately reflects what's done in this PR vs. what's pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)