### PR TITLE
fix(error-handler): map bad-input exceptions to 4xx ErrorResponse

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
@@ -173,10 +173,11 @@ class ControllerExceptionHandler {
     @ExceptionHandler(ResponseStatusException::class)
     fun responseStatusExceptionHandler(e: ResponseStatusException): ResponseEntity<ErrorResponse> {
         log.warn("Mapped HTTP exception: {} {}", e.statusCode, e.reason)
-        // `e.reason` is the explicit reason phrase passed at the throw site;
-        // `e.message` adds the status prefix. Fall back to a numeric-only
-        // message so we never echo Spring's internal status enum name.
-        val body = e.reason ?: e.message ?: "HTTP ${e.statusCode.value()}"
+        // Use only the explicit reason phrase (set at the throw site) — never
+        // `e.message`, which is prefixed with Spring's status enum name
+        // (e.g. "409 CONFLICT \"reason\""). Fall back to a numeric-only string
+        // so a caller-facing body never leaks framework formatting.
+        val body = e.reason ?: "HTTP ${e.statusCode.value()}"
         return ResponseEntity.status(e.statusCode).body(ErrorResponse(body))
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
@@ -9,10 +9,12 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.client.RestClientException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @ControllerAdvice
 class ControllerExceptionHandler {
@@ -97,12 +99,100 @@ class ControllerExceptionHandler {
         return HttpEntity(ErrorResponse(e.localizedMessage ?: "Operation not implemented"))
     }
 
+    /**
+     * Spring Data throws this when a `Pageable.sort` or query-derived method
+     * references a property the entity doesn't declare — e.g. `?sort=name,asc`
+     * on `ComponentEntity` (which has `componentKey`, not `name`). Without an
+     * explicit mapping this propagated as a 500. The list endpoints translate
+     * known API-facing field names to entity properties (see
+     * `ComponentManagementServiceImpl.translateSort`), so reaching this handler
+     * means the caller asked for a truly unknown property — 400 with the
+     * offender name is the right shape.
+     */
+    @ExceptionHandler(org.springframework.data.mapping.PropertyReferenceException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun propertyReferenceExceptionHandler(
+        e: org.springframework.data.mapping.PropertyReferenceException,
+    ): HttpEntity<ErrorResponse> {
+        log.warn("Unknown property in sort/filter: {}", e.localizedMessage)
+        return HttpEntity(ErrorResponse("Unknown sort/filter property: '${e.propertyName}'"))
+    }
+
+    /**
+     * Malformed JSON request body — Spring's default resolver maps this to 400
+     * but with `DefaultErrorAttributes` body shape (`{timestamp,status,error,...}`),
+     * which is inconsistent with our `ErrorResponse` envelope. Re-map so clients
+     * see the same shape regardless of who detected the bad input.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun httpMessageNotReadableExceptionHandler(e: HttpMessageNotReadableException): HttpEntity<ErrorResponse> {
+        log.warn("Malformed request body: {}", e.localizedMessage)
+        return HttpEntity(ErrorResponse("Malformed request body"))
+    }
+
+    /**
+     * Type-mismatch on `@RequestParam` / `@PathVariable` (e.g. non-UUID `{id}`,
+     * `?archived=notabool`). Spring's default returns 400 — we override only to
+     * unify the body shape with the rest of the API.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun methodArgumentTypeMismatchExceptionHandler(e: MethodArgumentTypeMismatchException): HttpEntity<ErrorResponse> {
+        val type = e.requiredType?.simpleName ?: "expected type"
+        log.warn("Type mismatch on '{}': {}", e.name, e.localizedMessage)
+        return HttpEntity(ErrorResponse("Parameter '${e.name}' could not be converted to $type"))
+    }
+
+    /**
+     * Future-proof: Jakarta Validation throws this when a `@Validated` controller
+     * sees a `@RequestParam` / `@PathVariable` that violates a constraint. Today
+     * no V4 controller uses `@Validated`, so this never fires — but absent a
+     * handler, the moment one is added bad input would surface as 500.
+     */
+    @ExceptionHandler(jakarta.validation.ConstraintViolationException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun constraintViolationExceptionHandler(e: jakarta.validation.ConstraintViolationException): HttpEntity<ErrorResponse> {
+        val errors = e.constraintViolations.joinToString(", ") { "${it.propertyPath}: ${it.message}" }
+        log.warn("Constraint violation: {}", errors)
+        return HttpEntity(ErrorResponse("Validation failed: $errors"))
+    }
+
     // Note: AccessDeniedException and AuthenticationException are intercepted by Spring
     // Security's ExceptionTranslationFilter BEFORE they ever reach @ControllerAdvice.
     // Consistent JSON 401/403 bodies are produced by the AuthenticationEntryPoint /
     // AccessDeniedHandler wired in WebSecurityConfig — see those for the actual envelope.
     // Do not re-add @ExceptionHandler entries for the security exceptions here; they
     // would silently never fire and create a false sense of coverage.
+
+    /**
+     * Catch-all for anything not matched by a more specific handler. Without this,
+     * uncaught exceptions surface as Boot's whitelabel 500 (`DefaultErrorAttributes`
+     * body shape), inconsistent with `ErrorResponse`. We log the full stack at ERROR
+     * level for operator triage but return a generic, non-leaking message — exception
+     * type names and messages may include schema or library internals the caller
+     * shouldn't see. Declared last so Spring's most-specific-handler dispatch leaves
+     * the dedicated 4xx handlers above untouched.
+     *
+     * **Security carve-out:** `AccessDeniedException` (incl. Spring Security 6's
+     * `AuthorizationDeniedException`) and `AuthenticationException` are thrown at
+     * method-invocation time by `@PreAuthorize` / authentication interceptors and
+     * propagate UP through DispatcherServlet — which means they would otherwise be
+     * caught here BEFORE Spring Security's `ExceptionTranslationFilter` ever sees
+     * them, silently downgrading 401/403 to 500. Re-throw them so the security
+     * filter chain produces the canonical envelope (see WebSecurityConfig).
+     */
+    @ExceptionHandler(Throwable::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun fallbackExceptionHandler(e: Throwable): HttpEntity<ErrorResponse> {
+        if (e is org.springframework.security.access.AccessDeniedException ||
+            e is org.springframework.security.core.AuthenticationException
+        ) {
+            throw e
+        }
+        log.error("Unhandled exception", e)
+        return HttpEntity(ErrorResponse("Internal server error"))
+    }
 
     companion object {
         val log: Logger = LoggerFactory.getLogger(ControllerExceptionHandler::class.java)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
@@ -9,12 +9,15 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.ErrorResponseException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.client.RestClientException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ResponseStatusException
 
 @ControllerAdvice
 class ControllerExceptionHandler {
@@ -158,6 +161,25 @@ class ControllerExceptionHandler {
         return HttpEntity(ErrorResponse("Validation failed: $errors"))
     }
 
+    /**
+     * Service code (e.g. `GitHistoryImportServiceImpl.preflight`) intentionally
+     * throws `ResponseStatusException` with non-500 statuses (409 for concurrent
+     * import claim). Without this explicit handler the `Throwable` catch-all
+     * below would intercept it and downgrade to 500 — because Spring's
+     * `ExceptionHandlerExceptionResolver` runs ahead of `ResponseStatusExceptionResolver`
+     * and the first matching `@ExceptionHandler` wins. Map back to the caller's
+     * declared status code while keeping the `ErrorResponse` envelope.
+     */
+    @ExceptionHandler(ResponseStatusException::class)
+    fun responseStatusExceptionHandler(e: ResponseStatusException): ResponseEntity<ErrorResponse> {
+        log.warn("Mapped HTTP exception: {} {}", e.statusCode, e.reason)
+        // `e.reason` is the explicit reason phrase passed at the throw site;
+        // `e.message` adds the status prefix. Fall back to a numeric-only
+        // message so we never echo Spring's internal status enum name.
+        val body = e.reason ?: e.message ?: "HTTP ${e.statusCode.value()}"
+        return ResponseEntity.status(e.statusCode).body(ErrorResponse(body))
+    }
+
     // Note: AccessDeniedException and AuthenticationException are intercepted by Spring
     // Security's ExceptionTranslationFilter BEFORE they ever reach @ControllerAdvice.
     // Consistent JSON 401/403 bodies are produced by the AuthenticationEntryPoint /
@@ -174,19 +196,34 @@ class ControllerExceptionHandler {
      * shouldn't see. Declared last so Spring's most-specific-handler dispatch leaves
      * the dedicated 4xx handlers above untouched.
      *
-     * **Security carve-out:** `AccessDeniedException` (incl. Spring Security 6's
-     * `AuthorizationDeniedException`) and `AuthenticationException` are thrown at
-     * method-invocation time by `@PreAuthorize` / authentication interceptors and
-     * propagate UP through DispatcherServlet — which means they would otherwise be
-     * caught here BEFORE Spring Security's `ExceptionTranslationFilter` ever sees
-     * them, silently downgrading 401/403 to 500. Re-throw them so the security
-     * filter chain produces the canonical envelope (see WebSecurityConfig).
+     * **Re-throw carve-outs.** This `Throwable` catch-all is broad enough to
+     * intercept exceptions that other resolvers/filters are responsible for —
+     * silently downgrading their canonical 4xx/401/403 into a 500. Re-throw to
+     * let the right machinery handle them:
+     *
+     *  - `AccessDeniedException` (incl. Spring Security 6's `AuthorizationDeniedException`)
+     *    and `AuthenticationException` — thrown at method-invocation time by
+     *    `@PreAuthorize` / authentication interceptors; Spring Security's
+     *    `ExceptionTranslationFilter` produces the canonical 401/403 envelope
+     *    (see WebSecurityConfig).
+     *  - `ErrorResponseException` — Spring 6+ base for many MVC framework
+     *    exceptions (and any explicit `ResponseStatusException` not caught by the
+     *    handler above). `DefaultHandlerExceptionResolver` maps these to their
+     *    declared status codes.
+     *  - `jakarta.servlet.ServletException` — older Spring MVC framework
+     *    exceptions: `HttpRequestMethodNotSupportedException` (405),
+     *    `HttpMediaTypeNotSupportedException` (415),
+     *    `MissingServletRequestParameterException` (400),
+     *    `NoHandlerFoundException` (404). These predate `ErrorResponseException`
+     *    and are still classified via Spring's resolver chain.
      */
     @ExceptionHandler(Throwable::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     fun fallbackExceptionHandler(e: Throwable): HttpEntity<ErrorResponse> {
         if (e is org.springframework.security.access.AccessDeniedException ||
-            e is org.springframework.security.core.AuthenticationException
+            e is org.springframework.security.core.AuthenticationException ||
+            e is ErrorResponseException ||
+            e is jakarta.servlet.ServletException
         ) {
             throw e
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -397,7 +397,11 @@ class ComponentManagementServiceImpl(
             Sort.by(
                 pageable.sort.map { order ->
                     when (order.property) {
-                        "name" -> Sort.Order(order.direction, "componentKey", order.nullHandling)
+                        "name" ->
+                            // 4-arg ctor — preserves `ignoreCase` alongside direction
+                            // and null-handling. The 3-arg variant defaults
+                            // ignoreCase to false and would silently drop the flag.
+                            Sort.Order(order.direction, "componentKey", order.isIgnoreCase, order.nullHandling)
                         else -> order
                     }
                 }.toList(),

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -61,7 +61,9 @@ import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProper
 import org.octopusden.releng.versions.VersionRangeFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -371,7 +373,37 @@ class ComponentManagementServiceImpl(
         filter: ComponentFilter,
         pageable: Pageable,
     ): Page<ComponentSummaryResponse> =
-        componentRepository.findAll(buildSpecification(filter), pageable).map { it.toSummaryResponse(teamcityProperties.baseUrl) }
+        componentRepository
+            .findAll(buildSpecification(filter), translateSort(pageable))
+            .map { it.toSummaryResponse(teamcityProperties.baseUrl) }
+
+    /**
+     * Translate API-facing sort field names to `ComponentEntity` property names.
+     * The v4 `ComponentSummaryResponse` exposes `name` (mapped from `componentKey`),
+     * so a natural `?sort=name,asc` from the Portal would otherwise raise
+     * `PropertyReferenceException` ("no property 'name' on ComponentEntity") and
+     * surface as a 500. Other summary fields (`id`, `displayName`, `componentOwner`,
+     * `productType`, `archived`, `updatedAt`) already match entity properties
+     * 1:1 and need no translation. Derived/joined fields on the summary
+     * (`systems`, `labels`, `buildSystem`, etc.) intentionally have NO translation
+     * — sorting on them would still raise `PropertyReferenceException` and end
+     * up as a clean 400, which is the right answer until and unless someone
+     * adds a dedicated query for those. Unknown fields fall through to Spring
+     * Data and end up as a clean 400 via `ControllerExceptionHandler`.
+     */
+    private fun translateSort(pageable: Pageable): Pageable {
+        if (pageable.sort.isUnsorted) return pageable
+        val translated =
+            Sort.by(
+                pageable.sort.map { order ->
+                    when (order.property) {
+                        "name" -> Sort.Order(order.direction, "componentKey", order.nullHandling)
+                        else -> order
+                    }
+                }.toList(),
+            )
+        return PageRequest.of(pageable.pageNumber, pageable.pageSize, translated)
+    }
 
     // ============================================================
     // Field overrides — backed by `component_configurations`

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ErrorHandlingHardeningTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ErrorHandlingHardeningTest.kt
@@ -1,0 +1,143 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * Error-handler hardening: clients hitting the V4 API with malformed input must get
+ * a `4xx` with a consistent `ErrorResponse { errorMessage }` body, not a `500` and
+ * not Boot's default `/error` envelope (which has a different shape).
+ *
+ * Covers the gaps identified after the `sort=name,asc → 500` report:
+ *   - `PropertyReferenceException` from Spring Data (unknown sort field) → 400
+ *   - lenient API↔entity sort translation so `sort=name` works (mapped to `componentKey`)
+ *   - malformed JSON request body (`HttpMessageNotReadableException`) → 400
+ *   - bad path-variable type (`MethodArgumentTypeMismatchException`) → 400
+ *   - all of the above return `ErrorResponse` shape, not Boot's `DefaultErrorAttributes`
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+class ErrorHandlingHardeningTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(ErrorHandlingHardeningTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("sort=name,asc is translated to componentKey and returns 200")
+    fun listComponents_sortByApiFieldName_translatesToComponentKey() {
+        val a = "errhard_a_${UUID.randomUUID().toString().take(8)}"
+        val b = "errhard_b_${UUID.randomUUID().toString().take(8)}"
+        createComponent(b)
+        createComponent(a)
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/components")
+                        .with(viewerJwt())
+                        .param("size", "200")
+                        .param("sort", "name,asc"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+        val names =
+            objectMapper.readTree(body)["content"]
+                .map { it["name"].asText() }
+                .filter { it.startsWith("errhard_") }
+        assert(names.indexOf(a) < names.indexOf(b)) {
+            "expected '$a' to come before '$b' under sort=name,asc, got $names"
+        }
+    }
+
+    @Test
+    @DisplayName("sort=<unknown> returns 400 ErrorResponse, not 500")
+    fun listComponents_sortByUnknownField_returns400ErrorResponse() {
+        mvc
+            .perform(
+                get("/rest/api/4/components")
+                    .with(viewerJwt())
+                    .param("sort", "doesNotExist,asc"),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage").exists())
+            .andExpect(jsonPath("$.errorMessage", containsSubstring("doesNotExist")))
+    }
+
+    @Test
+    @DisplayName("malformed JSON body on POST returns 400 ErrorResponse, not Boot's /error envelope")
+    fun createComponent_malformedJson_returns400ErrorResponse() {
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "broken", """),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage").exists())
+    }
+
+    @Test
+    @DisplayName("non-UUID path variable on PATCH returns 400 ErrorResponse")
+    fun patchComponent_nonUuidPath_returns400ErrorResponse() {
+        mvc
+            .perform(
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                    .patch("/rest/api/4/components/not-a-uuid")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"displayName":"x"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage").exists())
+    }
+
+    private fun createComponent(name: String) {
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"$name"}"""),
+            ).andExpect(status().isCreated)
+    }
+
+    private fun containsSubstring(needle: String) =
+        org.hamcrest.Matchers.containsString(needle)
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ErrorHandlingHardeningTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ErrorHandlingHardeningTest.kt
@@ -11,7 +11,6 @@ import org.octopusden.octopus.components.registry.server.support.viewerJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
@@ -166,9 +165,10 @@ class ErrorHandlingHardeningTest {
      * full DispatcherServlet → `@ControllerAdvice` chain. Service-layer code
      * (e.g. `GitHistoryImportServiceImpl.preflight`) throws `ResponseStatusException`
      * with a non-500 status; the broad `@ExceptionHandler(Throwable::class)`
-     * catch-all must NOT swallow it back into a 500.
+     * catch-all must NOT swallow it back into a 500. Registered via `@Import`
+     * on the test class — a plain `@RestController` bean, not a `@TestConfiguration`,
+     * to avoid CGLIB proxying of an MVC controller.
      */
-    @TestConfiguration
     @RestController
     @RequestMapping("/test-error-helpers")
     class TestThrowingController {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ErrorHandlingHardeningTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ErrorHandlingHardeningTest.kt
@@ -11,7 +11,10 @@ import org.octopusden.octopus.components.registry.server.support.viewerJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
@@ -20,6 +23,10 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import java.nio.file.Paths
 import java.util.UUID
 
@@ -43,6 +50,7 @@ import java.util.UUID
 @ActiveProfiles("common", "ft-db")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Timeout(120)
+@Import(ErrorHandlingHardeningTest.TestThrowingController::class)
 class ErrorHandlingHardeningTest {
     @MockBean
     @Suppress("UnusedPrivateProperty")
@@ -115,6 +123,18 @@ class ErrorHandlingHardeningTest {
     }
 
     @Test
+    @DisplayName("ResponseStatusException(CONFLICT) is preserved as 409, not collapsed to 500 by Throwable catch-all")
+    fun responseStatusException_preservesOriginalStatusCode() {
+        mvc
+            .perform(
+                get("/test-error-helpers/response-status-conflict")
+                    .with(viewerJwt()),
+            ).andExpect(status().isConflict)
+            .andExpect(jsonPath("$.errorMessage").exists())
+            .andExpect(jsonPath("$.errorMessage", containsSubstring("synthetic conflict")))
+    }
+
+    @Test
     @DisplayName("non-UUID path variable on PATCH returns 400 ErrorResponse")
     fun patchComponent_nonUuidPath_returns400ErrorResponse() {
         mvc
@@ -140,4 +160,20 @@ class ErrorHandlingHardeningTest {
 
     private fun containsSubstring(needle: String) =
         org.hamcrest.Matchers.containsString(needle)
+
+    /**
+     * Test-only controller used to drive a `ResponseStatusException` through the
+     * full DispatcherServlet → `@ControllerAdvice` chain. Service-layer code
+     * (e.g. `GitHistoryImportServiceImpl.preflight`) throws `ResponseStatusException`
+     * with a non-500 status; the broad `@ExceptionHandler(Throwable::class)`
+     * catch-all must NOT swallow it back into a 500.
+     */
+    @TestConfiguration
+    @RestController
+    @RequestMapping("/test-error-helpers")
+    class TestThrowingController {
+        @GetMapping("/response-status-conflict")
+        fun conflict(): Nothing =
+            throw ResponseStatusException(HttpStatus.CONFLICT, "synthetic conflict for handler test")
+    }
 }


### PR DESCRIPTION
## Summary

- `GET /rest/api/4/components?sort=name,asc` returned **500** — Spring Data raised `PropertyReferenceException` because the v4 API exposes `name` but `ComponentEntity` only has `componentKey`, and no `@ExceptionHandler` claimed it.
- Audited the broader picture: malformed JSON, type-mismatched query/path params, `ResponseStatusException` from service code, and any unhandled `Throwable` were either landing on Boot's whitelabel error envelope (shape divergent from `ErrorResponse`) or surfacing as 500.

## Changes

- **`ControllerExceptionHandler`** — new handlers for `PropertyReferenceException`, `HttpMessageNotReadableException`, `MethodArgumentTypeMismatchException`, `ConstraintViolationException`, and `ResponseStatusException`. Each returns the appropriate status with `ErrorResponse { errorMessage }` body. `Throwable` catch-all returns `ErrorResponse` **500** (full stack logged) and re-throws Spring Security exceptions, `ErrorResponseException`, and `jakarta.servlet.ServletException` so the security filter chain and Spring's resolvers still produce canonical 401/403/4xx for those classes.
- **`ComponentManagementServiceImpl.listComponents`** — `translateSort()` maps the API-facing sort field `name` → entity property `componentKey` before `findAll`, preserving `direction`, `ignoreCase`, and null-handling. Unknown sort fields keep falling through to the 400 handler.
- **`ErrorHandlingHardeningTest`** — 5 MockMvc tests: `sort=name` happy path, `sort=unknown` 400, malformed JSON 400, non-UUID path 400, and `ResponseStatusException(CONFLICT)` preservation via a `@TestConfiguration`-imported stub controller.

## Test plan

- [x] `ErrorHandlingHardeningTest` passes (5 tests).
- [x] Full `gradlew build` green (server unit + integration tests, all other modules).
- [x] Security tests still pass after `Throwable` catch-all re-throws security exceptions (`AdminControllerV4SecurityTest`, `TeamcityResyncControllerTest`, `UserInfoConverterIntegrationTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)