### PR TITLE
fix(controller): null-safe vcs-path filter on /rest/api/2/components

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/BaseComponentController.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/BaseComponentController.kt
@@ -40,11 +40,16 @@ abstract class BaseComponentController<T : Component> {
                 .filter { module ->
                     module.moduleConfigurations.any { config ->
 
+                        // `config.vcsSettings` is a Java/Groovy platform type and can be
+                        // null for components that declare no VCS roots and no externalRegistry
+                        // (e.g. some library components in the DB-backed resolver). A non-null
+                        // `vcs-path` query parameter must filter such components out, not 500.
                         val vcsPathEquals =
                             vcsPath?.let { vcsPathValue ->
                                 config.vcsSettings
-                                    .versionControlSystemRoots
-                                    .any { vcsPathValue.equals(it.vcsPath, true) }
+                                    ?.versionControlSystemRoots
+                                    ?.any { vcsPathValue.equals(it.vcsPath, true) }
+                                    ?: false
                             } ?: true
 
                         val buildSystemEquals =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.components.registry.server.support.adminJwt
@@ -103,6 +105,29 @@ class DbBackedComponentsRegistryServiceControllerTest : MockMvcRegistryTestSuppo
             "only). Tracked in docs/db-migration/todo.md under 'Schema v2 known limitations' (RES-014).",
     )
     override fun testGetBuildTools() = super.testGetBuildTools()
+
+    /**
+     * Regression: components migrated from a DSL with no `vcsSettings` block at all
+     * (no VCS roots and no externalRegistry) resolve to `EscrowModuleConfig.vcsSettings == null`.
+     * `BaseComponentController.getAllComponents` used to dereference
+     * `config.vcsSettings.versionControlSystemRoots` unconditionally inside the
+     * `vcs-path` filter lambda, NPE-ing the whole request to a 500 whenever the
+     * query parameter was present and at least one component had a null
+     * `vcsSettings`. After the fix the request must succeed and just filter
+     * those components out.
+     */
+    @Test
+    @DisplayName(
+        "GET /rest/api/2/components?vcs-path=<any> returns 200 (no NPE on null vcsSettings)",
+    )
+    fun getAllComponents_vcsPathFilter_doesNotNpeOnNullVcsSettings() {
+        mvc
+            .perform(
+                get("/rest/api/2/components")
+                    .param("vcs-path", "ssh://hg@mercurial/__no_such_component__")
+                    .accept(APPLICATION_JSON),
+            ).andExpect(status().isOk)
+    }
 
     companion object {
         @JvmStatic


### PR DESCRIPTION
## Summary
- `GET /rest/api/2/components?vcs-path=<any>` returned **500** on the schema-v2 candidate for every value of the query parameter, while the legacy Groovy baseline returned **200** (`count=0`).
- Root cause: `BaseComponentController.getAllComponents` dereferenced `config.vcsSettings.versionControlSystemRoots` unconditionally inside the filter lambda. `EscrowModuleConfig.vcsSettings` is a Java/Groovy platform type and can be \`null\` for components with no VCS roots and no externalRegistry — surfaced naturally now that the DB-backed resolver emits null `vcsSettings` for such components (after Stream B narrowed when `vcsSettings` is constructed).
- Fix: safe-call the chain (`?.versionControlSystemRoots?.any { ... } ?: false`). Components with no VCS roots fail the filter — matching the baseline.

## Reproduction
Pre-fix baseline-vs-candidate comparison from the QA env:

| | Baseline (main) | Candidate (schema-v2) |
|---|---|---|
| `/rest/api/2/components` (no param) | 200, 948 components | 200 |
| `?vcs-path=ansible/` | 200, count=0 | **500** |
| `?vcs-path=ai/aini` | 200, count=0 | **500** |
| `?vcs-path=f1/tv-frontend` | 200, count=0 | **500** |
| `?vcs-path=nonexistent-prefix-xyz` | 200, count=0 | **500** |
| `?vcs-path=ssh://hg` | 200, count=0 | **500** |

(Note: `count=0` on baseline for `ssh://hg` reflects the controller's existing exact-equals semantics — separate from this fix.)

## Test plan
- [x] Regression test `getAllComponents_vcsPathFilter_doesNotNpeOnNullVcsSettings` — added before fix, **fails with 500** on pre-fix code, **passes with 200** after the fix.
- [x] `AUTH_SERVER_URL=http://localhost:9999 AUTH_SERVER_REALM=octopus ./gradlew build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test` exits 0.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)