### PR TITLE
fix(import): preserve Defaults.requiredTools on schema-v2 import

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -502,6 +502,28 @@ class ImportServiceImpl(
         }
     }
 
+    /**
+     * Common-defaults tools (`Defaults.groovy` → `build { requiredTools = "..." }`),
+     * lazy-loaded once per `ImportServiceImpl` instance and reused as a fallback
+     * when a component's own merged `buildConfiguration.tools` came back empty
+     * (the Groovy loader drops Defaults-inherited tools whenever the component
+     * declares its own `build { ... }` block — see `importModule` for context).
+     *
+     * Limitation: this fallback cannot distinguish "loader merge dropped tools"
+     * from "component explicitly cleared tools" — both surface as an empty list
+     * on `EscrowModuleConfig.buildConfiguration.tools`. A future opt-out for
+     * components that want NO tools would require loader changes (preserve the
+     * null-vs-empty distinction). No current DSL component exercises that case.
+     */
+    private val commonDefaultsToolsCache: List<org.octopusden.octopus.escrow.model.Tool> by lazy {
+        configurationLoader
+            .loadCommonDefaults(emptyMap())
+            .buildParameters
+            ?.tools
+            ?.toList()
+            ?: emptyList()
+    }
+
     private fun preupsertToolsFromLoader(
         @Suppress("UNUSED_PARAMETER") fullConfig: org.octopusden.octopus.escrow.configuration.model.EscrowConfiguration,
     ) {
@@ -647,28 +669,33 @@ class ImportServiceImpl(
         // until the session closes, so mutations after persist are invisible to
         // the flush.
         //
-        // Required tools MUST be stored as a dedicated BUILD_REQUIRED_TOOLS marker
-        // row (overriddenAttribute = "build.requiredTools", row_type = MARKER), NOT
-        // on the base config row.  EntityMappers.toBuildParameters reads tools only
-        // from markerOverrides (rows pre-filtered by rowType == "MARKER" upstream);
-        // the BASE row is excluded.
+        // Base required-tools junctions are attached DIRECTLY to the base row
+        // (not a separate BUILD_REQUIRED_TOOLS marker). EntityMappers.toBuildParameters
+        // falls back to `base.requiredToolJunctions` when no per-range marker
+        // matches, which is the correct semantic for tools inherited via
+        // `Defaults.groovy`. The previous design wrote a marker row at
+        // `savedBase.versionRange`, but for synthetic-base components that range
+        // is the DSL's first explicit range (e.g. `(,1.0.107)`) and would not
+        // match version queries against any other range — collapsing
+        // `buildParameters.tools` to `[]` for those versions. Per-range tool
+        // overrides still get a dedicated marker via `emitMarkerOverrides`.
         val baseRow = buildBaseConfigRow(saved, baseConfig, isSyntheticBase)
         attachVcsEntries(baseRow, baseConfig.vcsSettings)
         attachDistribution(baseRow, baseConfig.distribution)
         val savedBase = configurationRepository.save(baseRow)
-        // Store base-config required tools as a marker row so EntityMappers can find them.
-        val baseTools = baseConfig.buildConfiguration?.tools
-        if (!baseTools.isNullOrEmpty()) {
-            val toolMarkerRow =
-                ComponentConfigurationEntity(
-                    component = saved,
-                    versionRange = savedBase.versionRange,
-                    overriddenAttribute = MarkerAttributes.BUILD_REQUIRED_TOOLS,
-                    rowType = "MARKER",
-                    isSyntheticBase = false,
-                )
-            configurationRepository.save(toolMarkerRow)
-            attachRequiredTools(toolMarkerRow, baseTools)
+        // The Groovy loader's per-range merge drops `requiredTools` inherited
+        // from `Defaults.groovy` whenever the component declares its OWN
+        // `build { ... }` block (the block REPLACES Defaults' build, so an
+        // inherited `requiredTools` is lost from the per-range merged config —
+        // observed reproducibly on multi-range components with a top-level
+        // `build {}` block). The legacy Git resolver compensates with a
+        // Defaults fallback at request time; restore parity here by reading
+        // common-defaults tools when the per-config merge came back empty.
+        val baseTools =
+            baseConfig.buildConfiguration?.tools.takeUnless { it.isNullOrEmpty() }
+                ?: commonDefaultsToolsCache
+        if (baseTools.isNotEmpty()) {
+            attachRequiredTools(savedBase, baseTools)
         }
 
         // For synthetic-base components, the base row's versionRange is the
@@ -1035,10 +1062,17 @@ class ImportServiceImpl(
             }?.let { saved += it }
         }
 
-        // Required tools override (junction rows need the config ID; handled inside)
-        val baseTools = base.buildConfiguration?.tools?.map { it.name }?.toSet() ?: emptySet()
+        // Required tools override (junction rows need the config ID; handled inside).
+        // Use the same effective base tools that were attached to the BASE row in
+        // `importModule` (loader merge + common-defaults fallback) so that an
+        // override range whose tools match the effective base does NOT produce a
+        // redundant marker row.
+        val effectiveBaseToolNames =
+            (base.buildConfiguration?.tools.takeUnless { it.isNullOrEmpty() } ?: commonDefaultsToolsCache)
+                .mapNotNull { it.name }
+                .toSet()
         val overTools = override.buildConfiguration?.tools?.map { it.name }?.toSet() ?: emptySet()
-        if (baseTools != overTools) {
+        if (effectiveBaseToolNames != overTools) {
             saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.BUILD_REQUIRED_TOOLS) { row ->
                 // Required tool junctions use the config ID explicitly, so we must
                 // persist the marker row first (to get the ID), then attach tools.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/GitVsDbValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/GitVsDbValidationTest.kt
@@ -494,10 +494,11 @@ class GitVsDbValidationTest {
         "VAL-011: Defaults.requiredTools (BuildEnv) survives DB import — Git baseline vs DB candidate parity",
     )
     fun `VAL-011 defaults requiredTools git vs db parity`() {
-        // Pick every multi-range / top-level component in production-like that does NOT
-        // declare its own `requiredTools` block and compare Git vs DB responses.
-        // production-like/Defaults.groovy sets `build { requiredTools = "BuildEnv" }`,
-        // so Git baseline must always emit BuildEnv. Any divergence is the bug.
+        // Hand-picked candidates representative of the broken-on-prod pattern plus
+        // historically-working control cases. production-like/Defaults.groovy sets
+        // `build { requiredTools = "BuildEnv" }`, so the Git baseline must always
+        // emit BuildEnv for these components. Any Git-vs-DB divergence in
+        // `buildParameters.tools` is the bug.
         val candidates =
             listOf(
                 // Synthetic fixture mirroring the real-world broken pattern: multi-range
@@ -534,7 +535,6 @@ class GitVsDbValidationTest {
             val dbTools =
                 objectMapper.readTree(dbBody).path("buildParameters").path("tools").map { it.path("name").asText() }
 
-            System.err.println("VAL-011 [$name@$version] git=$gitTools db=$dbTools")
             if (gitTools.toSet() != dbTools.toSet()) {
                 failures.add("[$name@$version] git=$gitTools db=$dbTools")
             }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/GitVsDbValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/GitVsDbValidationTest.kt
@@ -463,6 +463,87 @@ class GitVsDbValidationTest {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // VAL-011: Tools inherited from Defaults.requiredTools must persist on migration.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Regression: multi-range components that don't declare their own
+     * `build.requiredTools` but inherit `BuildEnv` via `Defaults.groovy` lose
+     * the tool when migrated to schema-v2. The Groovy resolver still emits it
+     * in `buildParameters.tools` (Defaults merge at resolve time), but the
+     * DB-backed resolver returns an empty list — import never persists the
+     * inherited junction because, for synthetic-base components, `baseConfig`
+     * is `configs.first()` (the first range block) and the Defaults merge
+     * doesn't propagate `tools` into per-range configs the same way it does
+     * into a top-level config.
+     *
+     * `cache-service` in `production-like/Components.groovy` has only
+     * top-level scalars + two version-range blocks (`(,2.0)` and `[2.0,)`),
+     * neither of which declares `requiredTools`. Production-like
+     * `Defaults.groovy` sets `build { requiredTools = "BuildEnv" }`. The DB-
+     * source response for `cache-service/versions/{version}` must contain
+     * `BuildEnv` in `buildParameters.tools` — same as the Groovy baseline.
+     *
+     * Mirrors a real production pattern observed on multi-range components
+     * that declare their own top-level `build { ... }` block (with scalars
+     * such as `javaVersion`) but no `requiredTools` of their own.
+     */
+    @Test
+    @DisplayName(
+        "VAL-011: Defaults.requiredTools (BuildEnv) survives DB import — Git baseline vs DB candidate parity",
+    )
+    fun `VAL-011 defaults requiredTools git vs db parity`() {
+        // Pick every multi-range / top-level component in production-like that does NOT
+        // declare its own `requiredTools` block and compare Git vs DB responses.
+        // production-like/Defaults.groovy sets `build { requiredTools = "BuildEnv" }`,
+        // so Git baseline must always emit BuildEnv. Any divergence is the bug.
+        val candidates =
+            listOf(
+                // Synthetic fixture mirroring the real-world broken pattern: multi-range
+                // with empty first range, top-level `build {}` block, no own
+                // `requiredTools` (must inherit from Defaults). This is the case where
+                // the Groovy baseline emits BuildEnv but the DB-backed resolver was
+                // returning `[]`. Probe both sides of the `1.0.107` range boundary so
+                // both the empty first range and the override second range exercise
+                // the base-row junction fallback path.
+                "legacy-multi-range-tool-inherit" to "1.0.107",
+                "legacy-multi-range-tool-inherit" to "1.0.106",
+                // Other multi-range / single-range candidates (control cases that have
+                // historically worked end-to-end).
+                "cache-service" to "1.0.0",
+                "auth-service" to "1.0.0",
+                "payment-gateway" to "1.0.0",
+            )
+
+        val failures = mutableListOf<String>()
+        for ((name, version) in candidates) {
+            sourceRegistry.setComponentSource(name, "git")
+            val gitBody =
+                mvc
+                    .perform(get("/rest/api/2/components/$name/versions/$version").accept(APPLICATION_JSON))
+                    .andReturn().response.contentAsString
+            val gitTools =
+                objectMapper.readTree(gitBody).path("buildParameters").path("tools").map { it.path("name").asText() }
+
+            sourceRegistry.setComponentSource(name, "db")
+            val dbBody =
+                mvc
+                    .perform(get("/rest/api/2/components/$name/versions/$version").accept(APPLICATION_JSON))
+                    .andReturn().response.contentAsString
+            val dbTools =
+                objectMapper.readTree(dbBody).path("buildParameters").path("tools").map { it.path("name").asText() }
+
+            System.err.println("VAL-011 [$name@$version] git=$gitTools db=$dbTools")
+            if (gitTools.toSet() != dbTools.toSet()) {
+                failures.add("[$name@$version] git=$gitTools db=$dbTools")
+            }
+        }
+        if (failures.isNotEmpty()) {
+            fail<Unit>("Git vs DB buildParameters.tools divergence:\n${failures.joinToString("\n")}")
+        }
+    }
+
     companion object {
         @JvmStatic
         val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }

--- a/test-common/src/test/resources/components-registry/production-like/Components.groovy
+++ b/test-common/src/test/resources/components-registry/production-like/Components.groovy
@@ -2384,3 +2384,49 @@ import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
         }
     }
 }
+
+// VAL-011 regression fixture: synthetic shape mirroring a real-world component
+// reported broken on the schema-v2 candidate — multi-range, top-level `build {}`
+// block with NO own `requiredTools` (must inherit `BuildEnv` from Defaults),
+// first range empty, second range with jira override + tag at the range level.
+// Distinct from cache-service (no top-level `build {}`) and auth-service
+// (single-range): this is the exact pattern where the Groovy baseline emits
+// BuildEnv but the DB-backed resolver returned `[]` on real production data.
+"legacy-multi-range-tool-inherit" {
+    componentDisplayName = "Legacy Multi-Range Tool Inherit"
+    componentOwner = "owner-i"
+    securityChampion = "champion-i"
+    releaseManager = "manager-i"
+    groupId = "org.octopusden.octopus.legacy"
+    artifactId = "legacy-multi-range-tool"
+    buildSystem = MAVEN
+    jira {
+        projectKey = "PROJ_I"
+    }
+    build {
+        javaVersion = "1.8"
+    }
+    vcsSettings {
+        vcsUrl = "ssh://git@git.example.com/team/legacy-multi-range.git"
+        tag = 'legacy-$version'
+    }
+    distribution {
+        explicit = true
+        external = true
+        GAV = "org.octopusden.octopus.legacy:legacy-multi-range-tool:war"
+        securityGroups {
+            read = "team-i#legacy-rd"
+        }
+    }
+
+    "(,1.0.107)" {
+
+    }
+
+    "[1.0.107,)" {
+        jira {
+            releaseVersionFormat = '$major.$minor.$service-$fix'
+        }
+        tag = 'legacy-tool-$version'
+    }
+}


### PR DESCRIPTION
## Summary
- Components that don't declare own `build.requiredTools` but inherit `BuildEnv` from `Defaults.groovy` returned empty `buildParameters.tools` on the schema-v2 DB candidate (Git baseline kept `[BuildEnv]`).
- Two root causes (both fixed): (a) the Groovy loader's per-range merge drops Defaults-inherited `requiredTools` when the component declares its own top-level `build { ... }` block; (b) the import previously wrote a `BUILD_REQUIRED_TOOLS` marker at `savedBase.versionRange`, which for synthetic-base / multi-range components is only the DSL's first range — version queries against any other range silently bypassed it.
- Fix: attach base required-tools junctions directly to the BASE row (reader already falls back to `base.requiredToolJunctions`); fall back to `Defaults`' tools when the per-component merge came back empty; align `emitMarkerOverrides` "tools differ?" comparison to use the same effective base.

## Regression test
- `GitVsDbValidationTest.VAL-011 defaults requiredTools git vs db parity` — switches each candidate between Git and DB sources, compares `buildParameters.tools`, fails on any divergence.
- Reproduced on new synthetic fixture `legacy-multi-range-tool-inherit` (multi-range, top-level `build { javaVersion }`, no own `requiredTools`). Pre-fix: `git=[BuildEnv] db=[]`. Post-fix: parity on both sides of the `1.0.107` range boundary. Existing single-range / no-top-level-build components keep passing.

## Acknowledged limitation
The Defaults fallback can't distinguish "loader merge dropped tools" from "component explicitly cleared tools" — both surface as an empty list at the same call site. No current DSL component exercises the latter; preserving that distinction would need loader changes (kdoc note inline).

## Test plan
- [x] `AUTH_SERVER_URL=http://localhost:9999 AUTH_SERVER_REALM=octopus ./gradlew build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test` exits 0
- [x] VAL-011 reproduced pre-fix, green post-fix on both probe versions
- [x] Independent Sonnet subagent review pre-push; both P2 findings (redundant marker on per-range tool overrides + extra range-boundary probe) addressed in the same commit
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)