### PR TITLE
fix(v4): expose escrow.buildTask through the V4 editor API

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
@@ -83,6 +83,7 @@ data class EscrowAspectResponse(
     val gradleIncludeConfigurations: String? = null,
     val gradleExcludeConfigurations: String? = null,
     val gradleIncludeTestConfigurations: Boolean? = null,
+    val buildTask: String? = null,
 )
 
 data class JiraAspectResponse(
@@ -186,6 +187,7 @@ data class EscrowAspectRequest(
     val gradleIncludeConfigurations: String? = null,
     val gradleExcludeConfigurations: String? = null,
     val gradleIncludeTestConfigurations: Boolean? = null,
+    val buildTask: String? = null,
 )
 
 data class JiraAspectRequest(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
@@ -36,6 +36,7 @@ internal val SCALAR_ATTRIBUTE_PATHS: Set<String> =
         "escrow.gradleIncludeConfigurations",
         "escrow.gradleExcludeConfigurations",
         "escrow.gradleIncludeTestConfigurations",
+        "escrow.buildTask",
         "jira.projectKey",
         "jira.technical",
         "jira.majorVersionFormat",
@@ -82,6 +83,7 @@ internal fun ComponentConfigurationEntity.extractScalarValue(): Any? =
         "escrow.gradleIncludeConfigurations" -> escrowGradleIncludeConfigurations
         "escrow.gradleExcludeConfigurations" -> escrowGradleExcludeConfigurations
         "escrow.gradleIncludeTestConfigurations" -> escrowGradleIncludeTestConfigurations
+        "escrow.buildTask" -> escrowBuildTask
         "jira.projectKey" -> jiraProjectKey
         "jira.technical" -> jiraTechnical
         "jira.majorVersionFormat" -> jiraMajorVersionFormat
@@ -139,6 +141,7 @@ internal fun ComponentConfigurationEntity.applyScalarValue(
         "escrow.gradleIncludeConfigurations" -> escrowGradleIncludeConfigurations = requireString(attributePath, value)
         "escrow.gradleExcludeConfigurations" -> escrowGradleExcludeConfigurations = requireString(attributePath, value)
         "escrow.gradleIncludeTestConfigurations" -> escrowGradleIncludeTestConfigurations = requireBoolean(attributePath, value)
+        "escrow.buildTask" -> escrowBuildTask = requireString(attributePath, value)
         "jira.projectKey" -> jiraProjectKey = requireString(attributePath, value)
         "jira.technical" -> jiraTechnical = requireBoolean(attributePath, value)
         "jira.majorVersionFormat" -> jiraMajorVersionFormat = requireString(attributePath, value)
@@ -171,6 +174,7 @@ private fun ComponentConfigurationEntity.clearAllScalarColumns() {
     escrowGradleIncludeConfigurations = null
     escrowGradleExcludeConfigurations = null
     escrowGradleIncludeTestConfigurations = null
+    escrowBuildTask = null
     jiraProjectKey = null
     jiraTechnical = null
     jiraMajorVersionFormat = null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -263,6 +263,7 @@ private fun ComponentConfigurationEntity.escrowAspectResponse(): EscrowAspectRes
         gradleIncludeConfigurations = escrowGradleIncludeConfigurations,
         gradleExcludeConfigurations = escrowGradleExcludeConfigurations,
         gradleIncludeTestConfigurations = escrowGradleIncludeTestConfigurations,
+        buildTask = escrowBuildTask,
     )
 
 private fun ComponentConfigurationEntity.jiraAspectResponse(): JiraAspectResponse =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -801,6 +801,7 @@ class ComponentManagementServiceImpl(
             config.escrowGradleIncludeConfigurations = e.gradleIncludeConfigurations
             config.escrowGradleExcludeConfigurations = e.gradleExcludeConfigurations
             config.escrowGradleIncludeTestConfigurations = e.gradleIncludeTestConfigurations
+            config.escrowBuildTask = e.buildTask
         }
         request.jira?.let { j ->
             config.jiraProjectKey = j.projectKey
@@ -853,6 +854,7 @@ class ComponentManagementServiceImpl(
             e.gradleIncludeConfigurations?.let { config.escrowGradleIncludeConfigurations = it }
             e.gradleExcludeConfigurations?.let { config.escrowGradleExcludeConfigurations = it }
             e.gradleIncludeTestConfigurations?.let { config.escrowGradleIncludeTestConfigurations = it }
+            e.buildTask?.let { config.escrowBuildTask = it }
         }
         patch.jira?.let { j ->
             j.projectKey?.let { config.jiraProjectKey = it }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/EscrowBuildTaskV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/EscrowBuildTaskV4Test.kt
@@ -1,0 +1,127 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+
+/**
+ * SYS-039 / RES-008 — `escrow.buildTask` must round-trip the V4 editor API.
+ *
+ * The Groovy DSL exposes `escrow { buildTask = "..." }`, the schema-v2
+ * `escrow_build_task` column persists it, and `EntityMappers` applies it to
+ * `EscrowModuleConfig.escrow.buildTask` on the resolver path. Pre-fix, the V4
+ * surface dropped the value entirely: the editor `EscrowAspect{Request,Response}`
+ * DTOs had no `buildTask` field, `V4Mappers.escrowAspectResponse()` ignored
+ * the `escrowBuildTask` column, and `escrow.buildTask` was missing from
+ * `SCALAR_ATTRIBUTE_PATHS` — so `GET /rest/api/4/components/{id}` returned no
+ * buildTask, and `POST .../field-overrides { "overriddenAttribute":
+ * "escrow.buildTask" }` returned 400 as an unknown attribute.
+ *
+ * TESTONE (`common/TestComponents.kts:8-19`) declares
+ * `escrow { buildTask = "clean build -x test" }` at the top level. After
+ * auto-migrate the DB-backed v4 detail endpoint must surface that exact value
+ * on the BASE configuration row's `escrow.buildTask`, and a field-override
+ * with `overriddenAttribute = "escrow.buildTask"` must persist successfully.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@Timeout(120)
+class EscrowBuildTaskV4Test {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(EscrowBuildTaskV4Test::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("RES-008 GET /v4/components/{TESTONE}: escrow.buildTask survives DB round-trip")
+    fun escrowBuildTask_baseConfiguration_exposedOnV4Detail() {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components/TESTONE").with(editorJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val detail = objectMapper.readTree(body)
+        val baseConfig =
+            detail
+                .path("configurations")
+                .firstOrNull { it.path("rowType").asText() == "BASE" }
+                ?: error("TESTONE detail must include a BASE configuration row; got: ${detail.path("configurations")}")
+        val buildTask = baseConfig.path("escrow").path("buildTask")
+        assertTrue(
+            !buildTask.isMissingNode && !buildTask.isNull,
+            "Expected configurations[BASE].escrow.buildTask to be populated; full response was $body",
+        )
+        assertEquals(
+            "clean build -x test",
+            buildTask.asText(),
+            "configurations[BASE].escrow.buildTask must equal the DSL value",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "RES-008 POST /v4/components/{TESTONE}/field-overrides with escrow.buildTask is accepted",
+    )
+    fun escrowBuildTask_fieldOverride_acceptedAsScalar() {
+        // Resolve TESTONE id first — field-override endpoints take UUID, not name.
+        val detail =
+            objectMapper.readTree(
+                mvc
+                    .perform(get("/rest/api/4/components/TESTONE").with(editorJwt()))
+                    .andExpect(status().isOk)
+                    .andReturn()
+                    .response.contentAsString,
+            )
+        val id = detail["id"].asText()
+        val payload =
+            """
+            {
+              "overriddenAttribute": "escrow.buildTask",
+              "versionRange": "[99.0.0,)",
+              "value": "build -x test -PskipEscrow"
+            }
+            """.trimIndent()
+
+        mvc
+            .perform(
+                post("/rest/api/4/components/$id/field-overrides")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(status().is2xxSuccessful)
+    }
+}


### PR DESCRIPTION
## Summary
\`escrow.buildTask\` is persisted at DB level (\`escrow_build_task\` column) and applied by \`EntityMappers\` at the resolver layer, but the V4 editor API silently dropped it on every surface:

- GET \`/rest/api/4/components/{id}\` returned an \`escrow\` object **without** \`buildTask\`.
- POST \`/rest/api/4/components/{id}/field-overrides\` with \`overriddenAttribute = "escrow.buildTask"\` returned **400** as an unknown scalar attribute path.
- PATCH \`baseConfiguration.escrow.buildTask\` was silently ignored (DTO had no field; service-layer apply didn't propagate).

Six wiring points fixed:
- \`EscrowAspectRequest\` / \`EscrowAspectResponse\` — add nullable \`buildTask\`.
- \`V4Mappers.escrowAspectResponse()\` — map \`escrowBuildTask\` → \`buildTask\`.
- \`SCALAR_ATTRIBUTE_PATHS\` + \`extractScalarValue\` + \`applyScalarValue\` + \`clearAllScalarColumns\` — add \`escrow.buildTask\` case.
- \`ComponentManagementServiceImpl.applyBaseConfigurationCreate\` / \`…Patch\` — propagate \`request.escrow.buildTask\` to \`config.escrowBuildTask\`.

DTO addition is additive (default \`null\`); existing clients are unaffected.

## Why now
Blocker for merging the schema-v2 stack (PR #193): \`requirements-migration.md\` mandates that V4 returns \`escrow.buildTask\`.

## Regression test
\`EscrowBuildTaskV4Test\`:
- GET asserts \`configurations[BASE].escrow.buildTask = "clean build -x test"\` (the TESTONE DSL value). Pre-fix the field was missing from the JSON.
- POST asserts a field-override with \`overriddenAttribute = "escrow.buildTask"\` is accepted with 2xx. Pre-fix it returned 400.

## Test plan
- [x] \`AUTH_SERVER_URL=http://localhost:9999 AUTH_SERVER_REALM=octopus ./gradlew build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test\` exits 0
- [x] \`EscrowBuildTaskV4Test\` — 2/2 green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)