### PR TITLE
feat(api): domain-named meta endpoints for option lists

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -1,5 +1,8 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.core.dto.BuildSystem
+import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
+import org.octopusden.octopus.components.registry.core.dto.RepositoryType
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentDetailResponse
@@ -48,6 +51,25 @@ class ComponentControllerV4(
     @GetMapping("/meta/owners")
     @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
     fun getDistinctOwners(): List<String> = componentRepository.findDistinctOwners()
+
+    // Domain-named option lists for the three free-form aspect string fields
+    // (buildSystem, repositoryType, generation). The portal's EnumSelect uses
+    // these to populate dropdowns when the admin field-config registry has no
+    // explicit options[] seeded. The endpoint names are domain-named, not
+    // implementation-named (no `/meta/enums`), so the wire surface survives
+    // a future move of the option source from a Kotlin enum to a config
+    // table or admin-editable registry.
+    @GetMapping("/meta/build-systems")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getBuildSystems(): List<String> = BuildSystem.values().map { it.name }
+
+    @GetMapping("/meta/repository-types")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getRepositoryTypes(): List<String> = RepositoryType.values().map { it.name }
+
+    @GetMapping("/meta/escrow-generations")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getEscrowGenerations(): List<String> = EscrowGenerationMode.values().map { it.name }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
@@ -1,0 +1,106 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.core.dto.BuildSystem
+import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
+import org.octopusden.octopus.components.registry.core.dto.RepositoryType
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+
+/**
+ * Domain-named meta endpoints that expose the canonical option lists for the
+ * three free-form string aspect fields that schema-v2 opened up (buildSystem,
+ * repositoryType, generation). The Portal calls these to populate its
+ * EnumSelect dropdowns when the admin field-config registry has no
+ * options[] seeded for the matching field.
+ *
+ * The endpoint names are domain-named (NOT `/meta/enums`) so the wire
+ * surface does not pre-commit to "values come from a Java enum" — the
+ * source is free to migrate to a config table or admin-editable registry
+ * without breaking the contract.
+ *
+ * See Portal `frontend/src/hooks/useFieldOptions.ts` and Portal TD-005
+ * item #10 for the call-site context.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(60)
+class MetaOptionsEndpointsTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    init {
+        val testResourcesPath =
+            Paths.get(MetaOptionsEndpointsTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("GET /meta/build-systems returns canonical BuildSystem values")
+    fun buildSystems_returnsCanonicalSet() {
+        val expected = BuildSystem.values().map { it.name }
+        val result =
+            mvc
+                .perform(get("/rest/api/4/components/meta/build-systems").with(viewerJwt()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").isArray)
+                .andExpect(jsonPath("$.length()").value(expected.size))
+        expected.forEachIndexed { idx, value ->
+            result.andExpect(jsonPath("$[$idx]").value(value))
+        }
+    }
+
+    @Test
+    @DisplayName("GET /meta/repository-types returns canonical RepositoryType values")
+    fun repositoryTypes_returnsCanonicalSet() {
+        val expected = RepositoryType.values().map { it.name }
+        val result =
+            mvc
+                .perform(get("/rest/api/4/components/meta/repository-types").with(viewerJwt()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").isArray)
+                .andExpect(jsonPath("$.length()").value(expected.size))
+        expected.forEachIndexed { idx, value ->
+            result.andExpect(jsonPath("$[$idx]").value(value))
+        }
+    }
+
+    @Test
+    @DisplayName("GET /meta/escrow-generations returns canonical EscrowGenerationMode values")
+    fun escrowGenerations_returnsCanonicalSet() {
+        val expected = EscrowGenerationMode.values().map { it.name }
+        val result =
+            mvc
+                .perform(get("/rest/api/4/components/meta/escrow-generations").with(viewerJwt()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").isArray)
+                .andExpect(jsonPath("$.length()").value(expected.size))
+        expected.forEachIndexed { idx, value ->
+            result.andExpect(jsonPath("$[$idx]").value(value))
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Schema-v2 left three aspect string fields free-form on the wire — `BuildAspect.buildSystem`, `VcsEntry.repositoryType`, `Escrow.generation` are now `string`, not enum. The canonical valid-token sets still live as Kotlin enums but are no longer reachable through the v4 typed contract, so admin and portal users have no way to discover them.

This PR adds three GET endpoints under `/rest/api/4/components/meta/*` that return the option lists:

| Endpoint | Source |
|---|---|
| `GET /meta/build-systems` | `BuildSystem.values()` (9 values: GRADLE, MAVEN, WHISKEY, …) |
| `GET /meta/repository-types` | `RepositoryType.values()` (3: GIT, MERCURIAL, CVS) |
| `GET /meta/escrow-generations` | `EscrowGenerationMode.values()` (3: AUTO, MANUAL, UNSUPPORTED) |

Names are domain-named, NOT implementation-named (no `/meta/enums`), so the wire surface survives a future move of the option source from a Kotlin enum to a config table or admin-editable registry.

All three require `ACCESS_COMPONENTS` via `@PreAuthorize`, matching the existing `/meta/owners` pattern.

## Portal context

Portal-side wiring already landed on the schema-v2 feature branch (`feature/crs-schema-v2`, commit `6ad8876`): a new `useFieldOptions` hook calls these endpoints when the admin field-config registry has no explicit `options[]` seeded. Until this PR merges, the hook 404s gracefully and `EnumSelect` collapses to a degenerate "None + current value" dropdown — users on a fresh CRS install cannot change Build System on a component once it has a value set.

Cross-repo TD record: portal `docs/tech-debt/TD-005-schema-v2-followups.md` item #10.

## Stack

Based on `feat/schema-v2-phase5b-6` (PR #193). Will rebase to `v3` after the schema-v2 stack merges.

## Test plan

- [x] `MetaOptionsEndpointsTest` — three parameterized cases asserting each endpoint returns the canonical enum value set in declaration order, under the `ft-db` profile
- [x] Full `:components-registry-service-server:test` suite green
- [ ] Manual smoke once portal feature branch is rebased: open `/components/{id}` Build tab, confirm dropdown lists all 9 build systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)