### PR TITLE
feat(api): domain-named meta endpoints for option lists

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -1,9 +1,9 @@
 package org.octopusden.octopus.components.registry.server.controller
 
-import org.octopusden.octopus.components.registry.core.dto.BuildSystem
-import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
-import org.octopusden.octopus.components.registry.core.dto.RepositoryType
+import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.escrow.BuildSystem
+import org.octopusden.octopus.escrow.RepositoryType
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentDetailResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
@@ -55,10 +55,17 @@ class ComponentControllerV4(
     // Domain-named option lists for the three free-form aspect string fields
     // (buildSystem, repositoryType, generation). The portal's EnumSelect uses
     // these to populate dropdowns when the admin field-config registry has no
-    // explicit options[] seeded. The endpoint names are domain-named, not
+    // explicit options[] seeded. Endpoint names are domain-named, not
     // implementation-named (no `/meta/enums`), so the wire surface survives
     // a future move of the option source from a Kotlin enum to a config
     // table or admin-editable registry.
+    //
+    // The enums sourced here are the *persistence-layer* ones used by
+    // `EntityMappers` on read/write — NOT the `core.dto.*` mirrors. The DTO
+    // variant of `BuildSystem` carries `NOT_SUPPORTED` while
+    // `EntityMappers.safeParseBuildSystem` calls `BuildSystem.valueOf` on
+    // the escrow variant (which has `ESCROW_NOT_SUPPORTED`). Advertising the
+    // DTO token would silently drop that value on save.
     @GetMapping("/meta/build-systems")
     @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
     fun getBuildSystems(): List<String> = BuildSystem.values().map { it.name }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -1,5 +1,8 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.core.dto.BuildSystem
+import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
+import org.octopusden.octopus.components.registry.core.dto.RepositoryType
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentDetailResponse
@@ -48,6 +51,25 @@ class ComponentControllerV4(
     @GetMapping("/meta/owners")
     @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
     fun getDistinctOwners(): List<String> = componentRepository.findDistinctOwners()
+
+    // Domain-named option lists for the three free-form aspect string fields
+    // (buildSystem, repositoryType, generation). The portal's EnumSelect uses
+    // these to populate dropdowns when the admin field-config registry has no
+    // explicit options[] seeded. The endpoint names are domain-named, not
+    // implementation-named (no `/meta/enums`), so the wire surface survives
+    // a future move of the option source from a Kotlin enum to a config
+    // table or admin-editable registry.
+    @GetMapping("/meta/build-systems")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getBuildSystems(): List<String> = BuildSystem.values().map { it.name }
+
+    @GetMapping("/meta/repository-types")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getRepositoryTypes(): List<String> = RepositoryType.values().map { it.name }
+
+    @GetMapping("/meta/escrow-generations")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getEscrowGenerations(): List<String> = EscrowGenerationMode.values().map { it.name }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -2,8 +2,6 @@ package org.octopusden.octopus.components.registry.server.controller
 
 import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
-import org.octopusden.octopus.escrow.BuildSystem
-import org.octopusden.octopus.escrow.RepositoryType
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentDetailResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
@@ -14,6 +12,8 @@ import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideRes
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpdateRequest
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
+import org.octopusden.octopus.escrow.BuildSystem
+import org.octopusden.octopus.escrow.RepositoryType
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -60,12 +60,17 @@ class ComponentControllerV4(
     // a future move of the option source from a Kotlin enum to a config
     // table or admin-editable registry.
     //
-    // The enums sourced here are the *persistence-layer* ones used by
-    // `EntityMappers` on read/write — NOT the `core.dto.*` mirrors. The DTO
-    // variant of `BuildSystem` carries `NOT_SUPPORTED` while
+    // For buildSystem and repositoryType the *persistence-layer* enums
+    // (`org.octopusden.octopus.escrow.BuildSystem` / `RepositoryType`) are
+    // sourced rather than the `core.dto.*` mirrors. The DTO variant of
+    // `BuildSystem` carries `NOT_SUPPORTED` while
     // `EntityMappers.safeParseBuildSystem` calls `BuildSystem.valueOf` on
-    // the escrow variant (which has `ESCROW_NOT_SUPPORTED`). Advertising the
-    // DTO token would silently drop that value on save.
+    // the escrow variant (which has `ESCROW_NOT_SUPPORTED`); advertising
+    // the DTO token would silently drop that value on save. For generation
+    // there is only one canonical source in `components-registry-api`'s
+    // `EscrowGenerationMode` (the `core.dto.EscrowGenerationMode` mirror
+    // has the same token set; we use the API enum because `Mappers.toDTO`
+    // reads it directly off the escrow model).
     @GetMapping("/meta/build-systems")
     @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
     fun getBuildSystems(): List<String> = BuildSystem.values().map { it.name }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
@@ -4,10 +4,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
-import org.octopusden.octopus.components.registry.core.dto.BuildSystem
-import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
-import org.octopusden.octopus.components.registry.core.dto.RepositoryType
+import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.escrow.BuildSystem
+import org.octopusden.octopus.escrow.RepositoryType
 import org.octopusden.octopus.components.registry.server.support.viewerJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -27,6 +27,24 @@ import java.nio.file.Paths
  * repositoryType, generation). The Portal calls these to populate its
  * EnumSelect dropdowns when the admin field-config registry has no
  * options[] seeded for the matching field.
+ *
+ * Canonical-set choice — the persistence-layer enums (NOT the DTO enums)
+ * are the source of truth, so the values the endpoint advertises are
+ * exactly the values that round-trip through write/read via
+ * `EntityMappers`:
+ *   - `org.octopusden.octopus.escrow.BuildSystem` — used by
+ *     `EntityMappers.safeParseBuildSystem`. Differs from the
+ *     `core.dto.BuildSystem` enum on a single token: persistence has
+ *     `ESCROW_NOT_SUPPORTED`, DTO has `NOT_SUPPORTED`. Advertising the
+ *     DTO token would silently drop user input on save because the
+ *     mapper's `BuildSystem.valueOf(value)` would throw and
+ *     `safeParseBuildSystem` returns null.
+ *   - `org.octopusden.octopus.escrow.RepositoryType` — used by
+ *     `EntityMappers.vcsRoot(...)`. Token set is identical to the DTO
+ *     enum (GIT/MERCURIAL/CVS) but we still source from persistence
+ *     so the choice is unambiguous.
+ *   - `org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode`
+ *     — what `Mappers.toDTO()` reads off the escrow model.
  *
  * The endpoint names are domain-named (NOT `/meta/enums`) so the wire
  * surface does not pre-commit to "values come from a Java enum" — the
@@ -86,6 +104,20 @@ class MetaOptionsEndpointsTest {
         expected.forEachIndexed { idx, value ->
             result.andExpect(jsonPath("$[$idx]").value(value))
         }
+    }
+
+    @Test
+    @DisplayName("GET /meta/build-systems uses persistence enum tokens (ESCROW_NOT_SUPPORTED, not NOT_SUPPORTED)")
+    fun buildSystems_advertisesPersistenceTokens() {
+        // Pins the choice of persistence-layer enum over the DTO enum. If a
+        // future refactor accidentally reverts the controller to
+        // `core.dto.BuildSystem`, this test catches it because that enum has
+        // `NOT_SUPPORTED` (which would NOT round-trip through EntityMappers).
+        mvc
+            .perform(get("/rest/api/4/components/meta/build-systems").with(viewerJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$").value(org.hamcrest.Matchers.hasItem("ESCROW_NOT_SUPPORTED")))
+            .andExpect(jsonPath("$").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem("NOT_SUPPORTED"))))
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
 import org.octopusden.octopus.escrow.BuildSystem
 import org.octopusden.octopus.escrow.RepositoryType
-import org.octopusden.octopus.components.registry.server.support.viewerJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -28,10 +28,11 @@ import java.nio.file.Paths
  * EnumSelect dropdowns when the admin field-config registry has no
  * options[] seeded for the matching field.
  *
- * Canonical-set choice — the persistence-layer enums (NOT the DTO enums)
- * are the source of truth, so the values the endpoint advertises are
- * exactly the values that round-trip through write/read via
- * `EntityMappers`:
+ * Canonical-set choice — for buildSystem and repositoryType the
+ * persistence-layer enums (NOT the `core.dto.*` mirrors) are the source,
+ * so the values the endpoint advertises are exactly the values that
+ * round-trip through write/read via `EntityMappers`. The generation
+ * enum has a single canonical source in the API module:
  *   - `org.octopusden.octopus.escrow.BuildSystem` — used by
  *     `EntityMappers.safeParseBuildSystem`. Differs from the
  *     `core.dto.BuildSystem` enum on a single token: persistence has
@@ -44,7 +45,10 @@ import java.nio.file.Paths
  *     enum (GIT/MERCURIAL/CVS) but we still source from persistence
  *     so the choice is unambiguous.
  *   - `org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode`
- *     — what `Mappers.toDTO()` reads off the escrow model.
+ *     — the API-module enum that `Mappers.toDTO()` reads off the escrow
+ *     model. The `core.dto.EscrowGenerationMode` mirror has the same
+ *     token set; sourcing from the API enum keeps the mapping path
+ *     direct.
  *
  * The endpoint names are domain-named (NOT `/meta/enums`) so the wire
  * surface does not pre-commit to "values come from a Java enum" — the

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
@@ -1,0 +1,106 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.core.dto.BuildSystem
+import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
+import org.octopusden.octopus.components.registry.core.dto.RepositoryType
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+
+/**
+ * Domain-named meta endpoints that expose the canonical option lists for the
+ * three free-form string aspect fields that schema-v2 opened up (buildSystem,
+ * repositoryType, generation). The Portal calls these to populate its
+ * EnumSelect dropdowns when the admin field-config registry has no
+ * options[] seeded for the matching field.
+ *
+ * The endpoint names are domain-named (NOT `/meta/enums`) so the wire
+ * surface does not pre-commit to "values come from a Java enum" — the
+ * source is free to migrate to a config table or admin-editable registry
+ * without breaking the contract.
+ *
+ * See Portal `frontend/src/hooks/useFieldOptions.ts` and Portal TD-005
+ * item #10 for the call-site context.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(60)
+class MetaOptionsEndpointsTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    init {
+        val testResourcesPath =
+            Paths.get(MetaOptionsEndpointsTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("GET /meta/build-systems returns canonical BuildSystem values")
+    fun buildSystems_returnsCanonicalSet() {
+        val expected = BuildSystem.values().map { it.name }
+        val result =
+            mvc
+                .perform(get("/rest/api/4/components/meta/build-systems").with(viewerJwt()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").isArray)
+                .andExpect(jsonPath("$.length()").value(expected.size))
+        expected.forEachIndexed { idx, value ->
+            result.andExpect(jsonPath("$[$idx]").value(value))
+        }
+    }
+
+    @Test
+    @DisplayName("GET /meta/repository-types returns canonical RepositoryType values")
+    fun repositoryTypes_returnsCanonicalSet() {
+        val expected = RepositoryType.values().map { it.name }
+        val result =
+            mvc
+                .perform(get("/rest/api/4/components/meta/repository-types").with(viewerJwt()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").isArray)
+                .andExpect(jsonPath("$.length()").value(expected.size))
+        expected.forEachIndexed { idx, value ->
+            result.andExpect(jsonPath("$[$idx]").value(value))
+        }
+    }
+
+    @Test
+    @DisplayName("GET /meta/escrow-generations returns canonical EscrowGenerationMode values")
+    fun escrowGenerations_returnsCanonicalSet() {
+        val expected = EscrowGenerationMode.values().map { it.name }
+        val result =
+            mvc
+                .perform(get("/rest/api/4/components/meta/escrow-generations").with(viewerJwt()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").isArray)
+                .andExpect(jsonPath("$.length()").value(expected.size))
+        expected.forEachIndexed { idx, value ->
+            result.andExpect(jsonPath("$[$idx]").value(value))
+        }
+    }
+
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaOptionsEndpointsTest.kt
@@ -77,8 +77,8 @@ class MetaOptionsEndpointsTest {
     }
 
     @Test
-    @DisplayName("GET /meta/build-systems returns canonical BuildSystem values")
-    fun buildSystems_returnsCanonicalSet() {
+    @DisplayName("SYS-038: GET /meta/build-systems returns canonical BuildSystem values")
+    fun `SYS-038 GET meta build-systems returns canonical BuildSystem values`() {
         val expected = BuildSystem.values().map { it.name }
         val result =
             mvc
@@ -92,8 +92,8 @@ class MetaOptionsEndpointsTest {
     }
 
     @Test
-    @DisplayName("GET /meta/repository-types returns canonical RepositoryType values")
-    fun repositoryTypes_returnsCanonicalSet() {
+    @DisplayName("SYS-038: GET /meta/repository-types returns canonical RepositoryType values")
+    fun `SYS-038 GET meta repository-types returns canonical RepositoryType values`() {
         val expected = RepositoryType.values().map { it.name }
         val result =
             mvc
@@ -107,8 +107,8 @@ class MetaOptionsEndpointsTest {
     }
 
     @Test
-    @DisplayName("GET /meta/build-systems uses persistence enum tokens (ESCROW_NOT_SUPPORTED, not NOT_SUPPORTED)")
-    fun buildSystems_advertisesPersistenceTokens() {
+    @DisplayName("SYS-038: /meta/build-systems uses persistence enum tokens (ESCROW_NOT_SUPPORTED, not NOT_SUPPORTED)")
+    fun `SYS-038 GET meta build-systems uses persistence enum tokens not DTO mirror`() {
         // Pins the choice of persistence-layer enum over the DTO enum. If a
         // future refactor accidentally reverts the controller to
         // `core.dto.BuildSystem`, this test catches it because that enum has
@@ -121,8 +121,8 @@ class MetaOptionsEndpointsTest {
     }
 
     @Test
-    @DisplayName("GET /meta/escrow-generations returns canonical EscrowGenerationMode values")
-    fun escrowGenerations_returnsCanonicalSet() {
+    @DisplayName("SYS-038: GET /meta/escrow-generations returns canonical EscrowGenerationMode values")
+    fun `SYS-038 GET meta escrow-generations returns canonical EscrowGenerationMode values`() {
         val expected = EscrowGenerationMode.values().map { it.name }
         val result =
             mvc

--- a/docs/db-migration/implementation-progress.md
+++ b/docs/db-migration/implementation-progress.md
@@ -82,6 +82,7 @@ Backend tasks (B2, B3) live in this repo. Frontend tasks (U4, U5) moved to Porta
 | V5 schema | ✅ Done | `V5__audit_source_and_history_state.sql` — `audit_log.source` (api / git-history) + `git_history_import_state` table. |
 | `ft-db` profile | ✅ Done | H2 + auto-migrate for downstream FT testing. PR #148 (commit `7733f83`). Contracts: SYS-026, SYS-027. |
 | UI extracted to Portal | ✅ Done | `components-registry-ui/` module + `SpaWebConfig.kt` removed; UI now lives in `octopus-components-management-portal`. PR #147 (commit `26278f2`). Decision recorded in [ADR-012](adr/012-portal-architecture.md), supersedes ADR-009. |
+| Meta option-list endpoints | ✅ Done | `ComponentControllerV4.getBuildSystems()` / `getRepositoryTypes()` / `getEscrowGenerations()` — domain-named meta endpoints sourced from persistence (`escrow.BuildSystem` / `escrow.RepositoryType`) and API (`api.enums.EscrowGenerationMode`) enums. Portal's `useFieldOptions` consumes these as the fallback when admin field-config has no `options[]` seeded. PR #202. Contract: SYS-038. |
 
 ## Known Bugs Fixed During Development
 

--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -1136,3 +1136,44 @@ The existing v2 read endpoint (`GET /rest/api/2/common/dependency-aliases`) rema
 - Bulk import/replace-all (single-entry operations are sufficient; bulk is handled by `/admin/migrate-history`).
 - Portal UI — not planned; the v2 read endpoint and direct API calls cover the use cases.
 - Pagination — the mapping set is small enough for a flat list response.
+
+---
+
+### SYS-038: Domain-named meta endpoints for free-form aspect option lists
+
+**Priority:** Medium
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+Schema-v2 (PR #192) reshaped the v4 contract such that `BuildAspect.buildSystem`, `VcsEntry.repositoryType`, and `Escrow.generation` are now free-form `string` fields rather than enum-typed. The canonical valid-token sets still live as Kotlin enums (used by `EntityMappers` on write parsing and read mapping) but are no longer reachable from the v4 typed contract. On a fresh CRS install the Portal's `EnumSelect` dropdown for these fields collapses to "None + current value" because no field-config seed is shipped, leaving users unable to change Build System / Repository Type / Escrow Generation after a value has been set.
+
+**Description:**
+Add three GET endpoints under `/rest/api/4/components/meta/*` that return the canonical option lists as `string[]`. Names are domain-named — NOT implementation-named (no `/meta/enums`) — so the wire surface survives a future move of the option source from a Kotlin enum to a config table or admin-editable registry without breaking the contract.
+
+| Endpoint | Source enum |
+|---|---|
+| `GET /rest/api/4/components/meta/build-systems` | `org.octopusden.octopus.escrow.BuildSystem` |
+| `GET /rest/api/4/components/meta/repository-types` | `org.octopusden.octopus.escrow.RepositoryType` |
+| `GET /rest/api/4/components/meta/escrow-generations` | `org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode` |
+
+The enums sourced are the **persistence-layer** ones used by `EntityMappers` on read/write — NOT the `core.dto.*` mirrors. The DTO variant of `BuildSystem` carries `NOT_SUPPORTED` while persistence carries `ESCROW_NOT_SUPPORTED`; advertising the DTO token would silently drop user input on save because `EntityMappers.safeParseBuildSystem` calls `BuildSystem.valueOf` against the escrow variant.
+
+Auth: `@PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")` — same gate as `/meta/owners`.
+
+**Preconditions:**
+- Caller authenticated with `ACCESS_COMPONENTS`.
+- No DB state required — endpoint reads from compile-time enum metadata.
+
+**Acceptance criteria:**
+1. `GET /meta/build-systems` returns HTTP 200 with a JSON array equal to `escrow.BuildSystem.values().map { it.name }` in declaration order.
+2. The returned array MUST contain `ESCROW_NOT_SUPPORTED` and MUST NOT contain `NOT_SUPPORTED` — guards against accidental reversion to the DTO-mirror enum.
+3. `GET /meta/repository-types` returns HTTP 200 with a JSON array equal to `escrow.RepositoryType.values().map { it.name }` in declaration order (CVS, MERCURIAL, GIT).
+4. `GET /meta/escrow-generations` returns HTTP 200 with a JSON array equal to `api.enums.EscrowGenerationMode.values().map { it.name }` in declaration order (AUTO, MANUAL, UNSUPPORTED).
+
+**Test method:** `MetaOptionsEndpointsTest` — four cases covering criteria 1–4 against the live controller on the `ft-db` profile.
+
+**Out of scope:**
+- Admin write API for the option lists (the field-config registry `options[]` already exists; SYS-038 only addresses the canonical-set advertisement when admin has not seeded explicit options).
+- Portal UI for editing the option lists (admin field-config write surface is unchanged).
+- A 4th endpoint for `productType` — the existing flat-flat `field-config.options[]` channel is sufficient there.

--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -1158,12 +1158,12 @@ Add three GET endpoints under `/rest/api/4/components/meta/*` that return the ca
 | `GET /rest/api/4/components/meta/repository-types` | `org.octopusden.octopus.escrow.RepositoryType` |
 | `GET /rest/api/4/components/meta/escrow-generations` | `org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode` |
 
-The enums sourced are the **persistence-layer** ones used by `EntityMappers` on read/write — NOT the `core.dto.*` mirrors. The DTO variant of `BuildSystem` carries `NOT_SUPPORTED` while persistence carries `ESCROW_NOT_SUPPORTED`; advertising the DTO token would silently drop user input on save because `EntityMappers.safeParseBuildSystem` calls `BuildSystem.valueOf` against the escrow variant.
+For `buildSystem` and `repositoryType` the **persistence-layer** enums (NOT the `core.dto.*` mirrors) are the source. The DTO variant of `BuildSystem` carries `NOT_SUPPORTED` while persistence carries `ESCROW_NOT_SUPPORTED`; advertising the DTO token would silently drop user input on save because `EntityMappers.safeParseBuildSystem` calls `BuildSystem.valueOf` against the escrow variant. For `generation` the source is `components-registry-api`'s `EscrowGenerationMode` (the `core.dto.EscrowGenerationMode` mirror has the same token set; the API enum is the one `Mappers.toDTO()` reads off the escrow model).
 
-Auth: `@PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")` — same gate as `/meta/owners`.
+Auth: `@PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")` — same gate as `/meta/owners`. `ACCESS_COMPONENTS` is granted to `ROLE_ANONYMOUS` in the current security config, matching the rest of the v4 component-read surface, so anonymous callers can read the option lists.
 
 **Preconditions:**
-- Caller authenticated with `ACCESS_COMPONENTS`.
+- Caller has `ACCESS_COMPONENTS` (granted to `ROLE_ANONYMOUS` by default — no JWT required).
 - No DB state required — endpoint reads from compile-time enum metadata.
 
 **Acceptance criteria:**

--- a/docs/db-migration/requirements-common.md
+++ b/docs/db-migration/requirements-common.md
@@ -47,6 +47,7 @@
 | SYS-035 | GET /components?owner=&lt;username&gt; filters by componentOwner exact match | High | integration-test | ✅ Tested |
 | SYS-036 | GET /audit/recent accepts entityType/entityId/changedBy/source/action/from/to filter params | High | integration-test | ✅ Tested |
 | SYS-037 | v4 CRUD API for dependency mappings (alias → componentName) | Medium | integration-test | ❌ Not implemented |
+| SYS-038 | Domain-named meta endpoints for free-form aspect option lists (buildSystem / repositoryType / generation) | Medium | integration-test | ✅ Tested |
 
 ---
 


### PR DESCRIPTION
## Summary

Schema-v2 left three aspect string fields free-form on the wire — `BuildAspect.buildSystem`, `VcsEntry.repositoryType`, `Escrow.generation` are now `string`, not enum. The canonical valid-token sets still live as Kotlin enums but are no longer reachable through the v4 typed contract, so admin and portal users have no way to discover them.

This PR adds three GET endpoints under `/rest/api/4/components/meta/*` that return the option lists:

| Endpoint | Source |
|---|---|
| `GET /meta/build-systems` | `BuildSystem.values()` (9 values: GRADLE, MAVEN, WHISKEY, …) |
| `GET /meta/repository-types` | `RepositoryType.values()` (3: GIT, MERCURIAL, CVS) |
| `GET /meta/escrow-generations` | `EscrowGenerationMode.values()` (3: AUTO, MANUAL, UNSUPPORTED) |

Names are domain-named, NOT implementation-named (no `/meta/enums`), so the wire surface survives a future move of the option source from a Kotlin enum to a config table or admin-editable registry.

All three require `ACCESS_COMPONENTS` via `@PreAuthorize`, matching the existing `/meta/owners` pattern.

## Portal context

Portal-side wiring already landed on the schema-v2 feature branch (`feature/crs-schema-v2`, commit `6ad8876`): a new `useFieldOptions` hook calls these endpoints when the admin field-config registry has no explicit `options[]` seeded. Until this PR merges, the hook 404s gracefully and `EnumSelect` collapses to a degenerate "None + current value" dropdown — users on a fresh CRS install cannot change Build System on a component once it has a value set.

Cross-repo TD record: portal `docs/tech-debt/TD-005-schema-v2-followups.md` item #10.

## History

Originally opened as #201 stacked on PR #193 (`feat/schema-v2-phase5b-6`). After #193 merged into `feat/schema-v2-sql` the base branch was deleted and #201 auto-closed. This is a clean re-open against `feat/schema-v2-sql` (PR #192), with the single endpoint commit rebased on the new base.

## Test plan

- [x] `MetaOptionsEndpointsTest` — three cases asserting each endpoint returns the canonical enum value set in declaration order, under the `ft-db` profile
- [x] Full `:components-registry-service-server:test` suite green
- [ ] Manual smoke once portal feature branch is rebased: open `/components/{id}` Build tab, confirm dropdown lists all 9 build systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)