### PR TITLE
fix(schema-v2): per-range maven-artifacts override leak (RES-C)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -17,6 +17,8 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentRep
 import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
 import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
 import org.octopusden.octopus.components.registry.server.util.formatVersion
+import org.octopusden.octopus.components.registry.server.util.parseMavenGavEntry
+import org.octopusden.octopus.components.registry.server.util.splitCsv
 import org.octopusden.octopus.escrow.MavenArtifactMatcher
 import org.octopusden.octopus.escrow.ModelConfigPostProcessor
 import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
@@ -266,22 +268,58 @@ class DatabaseComponentRegistryResolver(
         val componentEntity =
             componentRepository.findByComponentKey(component)
                 ?: throw NotFoundException("Component '$component' is not found")
-        val artifactIds = componentEntity.artifactIds.toList()
-        if (artifactIds.isEmpty()) return emptyMap()
-        // Reconstruct the original multi-artifact patterns: all rows share the same groupPattern;
-        // artifactPattern values are joined back into a CSV to match Git resolver output.
-        val groupPattern = artifactIds.first().groupPattern
-        val artifactPattern = artifactIds.joinToString(",") { it.artifactPattern }
-        val pair = ComponentArtifactConfiguration(groupPattern, artifactPattern)
 
-        // Enumerate distinct version_ranges (base + override rows) to surface the
-        // same shape the Git resolver returned, keyed by version_range string.
-        val ranges =
-            componentEntity.configurations
-                .map { it.versionRange }
-                .distinct()
-                .ifEmpty { listOf(ALL_VERSIONS) }
-        return ranges.associateWith { pair }
+        // Component-level fallback: the top-level groupId/artifactId rows imported from DSL.
+        val artifactIdRows = componentEntity.artifactIds.toList()
+        val componentLevelFallback =
+            if (artifactIdRows.isEmpty()) {
+                null
+            } else {
+                ComponentArtifactConfiguration(
+                    artifactIdRows.first().groupPattern,
+                    artifactIdRows.joinToString(",") { it.artifactPattern },
+                )
+            }
+
+        // Walk the per-range EscrowModule view so that DISTRIBUTION_MAVEN marker
+        // overrides are respected: each EscrowModuleConfig already has the correct
+        // per-range distribution.GAV() after pickMarkerChildren applied the markers.
+        val module = componentEntity.toEscrowModule(versionRangeFactory, numericVersionFactory)
+
+        if (module.moduleConfigurations.isEmpty()) {
+            // No configurations at all — return empty map (preserves previous contract)
+            return emptyMap()
+        }
+
+        return module.moduleConfigurations
+            .associate { config ->
+                val rangeKey = config.versionRangeString ?: ALL_VERSIONS
+                val gavCsv = config.distribution?.GAV()
+                val artifact =
+                    if (!gavCsv.isNullOrBlank()) {
+                        // Per-range GAV present: parse maven entries (skip URL entries).
+                        val coords =
+                            splitCsv(gavCsv)
+                                .filterNot {
+                                    it.startsWith("file://") ||
+                                        it.startsWith("http://") ||
+                                        it.startsWith("https://")
+                                }
+                                .mapNotNull { parseMavenGavEntry(it) }
+                        if (coords.isNotEmpty()) {
+                            ComponentArtifactConfiguration(
+                                coords.first().groupId,
+                                coords.joinToString(",") { it.artifactId },
+                            )
+                        } else {
+                            componentLevelFallback
+                        }
+                    } else {
+                        componentLevelFallback
+                    }
+                rangeKey to (artifact ?: ComponentArtifactConfiguration("", ""))
+            }
+            .filterValues { it.groupPattern.isNotEmpty() || it.artifactPattern.isNotEmpty() }
     }
 
     override fun getDependencyMapping(): Map<String, String> =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -43,6 +43,9 @@ import org.octopusden.octopus.components.registry.server.service.MigrationProgre
 import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
+import org.octopusden.octopus.components.registry.server.util.MavenCoords
+import org.octopusden.octopus.components.registry.server.util.parseMavenGavEntry
+import org.octopusden.octopus.components.registry.server.util.splitCsv
 import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
 import org.octopusden.octopus.escrow.configuration.model.EscrowModule
 import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
@@ -1676,29 +1679,9 @@ class ImportServiceImpl(
     }
 
     // =========================================================================
-    // Distribution parsing helpers
+    // Distribution parsing helpers (splitCsv / MavenCoords / parseMavenGavEntry
+    // are now in util/GavParsing.kt and imported at the top of this file)
     // =========================================================================
-
-    private fun splitCsv(csv: String): List<String> =
-        csv.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-
-    private data class MavenCoords(
-        val groupId: String,
-        val artifactId: String,
-        val extension: String?,
-        val classifier: String?,
-    )
-
-    private fun parseMavenGavEntry(entry: String): MavenCoords? {
-        val parts = entry.split(":").map { it.trim() }
-        if (parts.size < 2) return null
-        val group = parts[0]
-        val artifact = parts[1]
-        if (group.isEmpty() || artifact.isEmpty()) return null
-        val extension = parts.getOrNull(2)?.takeIf { it.isNotEmpty() }
-        val classifier = parts.getOrNull(3)?.takeIf { it.isNotEmpty() }
-        return MavenCoords(group, artifact, extension, classifier)
-    }
 
     private data class FileUrlCoords(
         val url: String,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/GavParsing.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/GavParsing.kt
@@ -1,0 +1,44 @@
+package org.octopusden.octopus.components.registry.server.util
+
+/**
+ * Parsed Maven GAV coordinates extracted from a single CSV entry.
+ *
+ * @param groupId    Maven groupId (first `:` segment)
+ * @param artifactId Maven artifactId (second `:` segment)
+ * @param extension  Optional type/extension (third `:` segment), null when absent
+ * @param classifier Optional classifier (fourth `:` segment), null when absent
+ */
+internal data class MavenCoords(
+    val groupId: String,
+    val artifactId: String,
+    val extension: String?,
+    val classifier: String?,
+)
+
+/**
+ * Splits a comma-separated value string into trimmed, non-empty tokens.
+ *
+ * Shared between [ImportServiceImpl] (write path) and
+ * [DatabaseComponentRegistryResolver] (read path) to ensure consistent tokenisation.
+ */
+internal fun splitCsv(csv: String): List<String> =
+    csv.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+
+/**
+ * Parses a single Maven GAV entry of the form `groupId:artifactId[:extension[:classifier]]`.
+ *
+ * Returns null when the entry has fewer than two `:` segments or when either the
+ * groupId or artifactId segment is blank.  URL-format entries (`file://`, `http://`,
+ * `https://`) are NOT filtered here — callers are responsible for skipping them
+ * before invoking this function so that the parser remains pure.
+ */
+internal fun parseMavenGavEntry(entry: String): MavenCoords? {
+    val parts = entry.split(":").map { it.trim() }
+    if (parts.size < 2) return null
+    val group = parts[0]
+    val artifact = parts[1]
+    if (group.isEmpty() || artifact.isEmpty()) return null
+    val extension = parts.getOrNull(2)?.takeIf { it.isNotEmpty() }
+    val classifier = parts.getOrNull(3)?.takeIf { it.isNotEmpty() }
+    return MavenCoords(group, artifact, extension, classifier)
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/GitVsDbValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/GitVsDbValidationTest.kt
@@ -356,6 +356,9 @@ class GitVsDbValidationTest {
                 "platform-commons",
                 "data-mapper",
                 "logging-service",
+                // RES-C regression guard: per-range DISTRIBUTION_MAVEN marker override
+                // (tokenization-service has (,2.0) → zip and [2.0,) → tgz extension).
+                "tokenization-service",
             )
         val failures = mutableListOf<String>()
         for (name in sampleComponents) {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -1,0 +1,240 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * TDD regression tests for RES-C: getMavenArtifactParameters must return per-range
+ * groupPattern/artifactPattern by walking the EscrowModule view rather than
+ * returning the component-level artifactIds for every range.
+ *
+ * Bug: when a component has DISTRIBUTION_MAVEN marker rows overriding the GAV per
+ * range, the old implementation ignored the overrides and returned the same
+ * component-level artifact IDs for every range. The fixed implementation consults
+ * config.distribution?.GAV() per EscrowModuleConfig, falling back to component-level
+ * artifactIds only when no per-range GAV is present.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
+
+    // ========================================================================
+    // Infrastructure
+    // ========================================================================
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    // ========================================================================
+    // Entity helpers
+    // ========================================================================
+
+    private fun makeComponent(key: String): ComponentEntity =
+        ComponentEntity(id = UUID.randomUUID(), componentKey = key)
+
+    private fun makeBase(
+        component: ComponentEntity,
+        versionRange: String = ALL_VERSIONS,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            deprecated = false,
+        )
+
+    private fun makeMarkerRow(
+        component: ComponentEntity,
+        versionRange: String,
+        attribute: String,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = attribute,
+            rowType = "MARKER",
+        )
+
+    private fun addMavenArtifact(
+        config: ComponentConfigurationEntity,
+        groupPattern: String,
+        artifactPattern: String,
+        sortOrder: Int = 0,
+    ) {
+        config.mavenArtifacts.add(
+            DistributionMavenArtifactEntity(
+                componentConfiguration = config,
+                groupPattern = groupPattern,
+                artifactPattern = artifactPattern,
+                sortOrder = sortOrder,
+            ),
+        )
+    }
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    // ========================================================================
+    // Tests
+    // ========================================================================
+
+    @Test
+    @DisplayName(
+        "RES-C-001: per-range DISTRIBUTION_MAVEN marker overrides groupPattern " +
+            "(bug-C-component-A shape: two ranges with distinct groupId per range)",
+    )
+    fun `RES-C-001 getMavenArtifactParameters returns per-range groupPattern from marker override`() {
+        // bug-C-component-A shape:
+        //   BASE at [1.1,) with maven artifact (com.example.ic, bug-C-component-A)
+        //   MARKER distribution.maven at [1.0,1.1) with maven artifact (com.example, bug-C-component-A)
+        val comp = makeComponent("bug-C-component-A-like")
+        comp.distributionExplicit = true
+
+        val base = makeBase(comp, "[1.1,)")
+        addMavenArtifact(base, "com.example.ic", "bug-C-component-A")
+
+        val markerOld = makeMarkerRow(comp, "[1.0,1.1)", "distribution.maven")
+        addMavenArtifact(markerOld, "com.example", "bug-C-component-A")
+
+        comp.configurations.addAll(listOf(base, markerOld))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("bug-C-component-A-like")
+
+        assertEquals(2, result.size, "Expected two range entries")
+
+        val rangeOld = result["[1.0,1.1)"]
+        assertNotNull(rangeOld, "[1.0,1.1) entry must be present")
+        assertEquals("com.example", rangeOld!!.groupPattern, "[1.0,1.1) groupPattern must be com.example")
+        assertEquals("bug-C-component-A", rangeOld.artifactPattern, "[1.0,1.1) artifactPattern must be bug-C-component-A")
+
+        val rangeNew = result["[1.1,)"]
+        assertNotNull(rangeNew, "[1.1,) entry must be present")
+        assertEquals(
+            "com.example.ic",
+            rangeNew!!.groupPattern,
+            "[1.1,) groupPattern must be com.example.ic",
+        )
+        assertEquals("bug-C-component-A", rangeNew.artifactPattern, "[1.1,) artifactPattern must be bug-C-component-A")
+    }
+
+    @Test
+    @DisplayName(
+        "RES-C-002: per-range DISTRIBUTION_MAVEN marker override with multiple artifacts " +
+            "(bug-C-component-B shape: multi-artifact CSV, two ranges)",
+    )
+    fun `RES-C-002 getMavenArtifactParameters handles multi-artifact CSV override`() {
+        // bug-C-component-B shape:
+        //   BASE at [03.51.29.15,) with maven artifact (com.example.cardsmodel2.dummy, bug-C-component-B)
+        //   MARKER distribution.maven at (,03.51.29.15) with two artifacts:
+        //     (com.example.cardsmodel2, bug-C-fixture-v2) and (com.example.cardsmodel, bug-C-fixture-legacy)
+        val comp = makeComponent("bug-C-fixture-B-shape")
+        comp.distributionExplicit = true
+
+        val base = makeBase(comp, "[03.51.29.15,)")
+        addMavenArtifact(base, "com.example.cardsmodel2.dummy", "bug-C-component-B", sortOrder = 0)
+
+        val markerOld = makeMarkerRow(comp, "(,03.51.29.15)", "distribution.maven")
+        addMavenArtifact(markerOld, "com.example.cardsmodel2", "bug-C-fixture-v2", sortOrder = 0)
+        addMavenArtifact(markerOld, "com.example.cardsmodel", "bug-C-fixture-legacy", sortOrder = 1)
+
+        comp.configurations.addAll(listOf(base, markerOld))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("bug-C-fixture-B-shape")
+
+        assertEquals(2, result.size, "Expected two range entries")
+
+        val rangeOld = result["(,03.51.29.15)"]
+        assertNotNull(rangeOld, "(,03.51.29.15) entry must be present")
+        // groupPattern = first artifact's groupId
+        assertEquals(
+            "com.example.cardsmodel2",
+            rangeOld!!.groupPattern,
+            "(,03.51.29.15) groupPattern must be first artifact's groupId",
+        )
+        // artifactPattern = CSV join of all artifact IDs in sort order
+        assertEquals(
+            "bug-C-fixture-v2,bug-C-fixture-legacy",
+            rangeOld.artifactPattern,
+            "(,03.51.29.15) artifactPattern must be CSV of both artifact IDs",
+        )
+
+        val rangeNew = result["[03.51.29.15,)"]
+        assertNotNull(rangeNew, "[03.51.29.15,) entry must be present")
+        assertEquals(
+            "com.example.cardsmodel2.dummy",
+            rangeNew!!.groupPattern,
+            "[03.51.29.15,) groupPattern must be com.example.cardsmodel2.dummy",
+        )
+        assertEquals("bug-C-component-B", rangeNew.artifactPattern, "[03.51.29.15,) artifactPattern must be bug-C-component-B")
+    }
+
+    @Test
+    @DisplayName(
+        "RES-C-003: component with single ALL_VERSIONS range and no marker overrides " +
+            "falls back to component-level artifactIds",
+    )
+    fun `RES-C-003 getMavenArtifactParameters falls back to component-level artifactIds when no GAV override`() {
+        // No per-range overrides: only a BASE row with maven artifact at ALL_VERSIONS
+        val comp = makeComponent("simple-component")
+        comp.distributionExplicit = true
+
+        val base = makeBase(comp, ALL_VERSIONS)
+        addMavenArtifact(base, "com.example", "simple-lib")
+
+        comp.configurations.add(base)
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("simple-component")
+
+        assertEquals(1, result.size, "Expected one range entry for ALL_VERSIONS")
+        val entry = result[ALL_VERSIONS]
+        assertNotNull(entry, "ALL_VERSIONS entry must be present")
+        assertEquals("com.example", entry!!.groupPattern, "groupPattern must be com.example")
+        assertEquals("simple-lib", entry.artifactPattern, "artifactPattern must be simple-lib")
+    }
+
+    // ========================================================================
+    // Companion
+    // ========================================================================
+
+    companion object {
+        /** Must match EscrowConfigurationLoader.ALL_VERSIONS */
+        private const val ALL_VERSIONS = "(,0),[0,)"
+    }
+}

--- a/docs/db-migration/implementation-progress.md
+++ b/docs/db-migration/implementation-progress.md
@@ -209,6 +209,8 @@ If any other test class fails to compile once Phase 5 lands, add it here with th
 
 **Stream B (externalRegistry fix)** patched `EntityMappers.toEscrowModule` to emit `vcsSettings` whenever `component.vcsExternalRegistry != null` (not only when VCS roots are non-empty). Components declared in DSL as `vcsSettings { externalRegistry = "..." }` with no VCS roots now round-trip correctly. Re-enabled `DbBackedComponentsRegistryServiceControllerTest.testGetAllJiraComponentVersionRanges`. VAL-010 stays @Disabled — recount empirically once the remaining FAKE-aggregator residual is addressed.
 
+**PR-C (RES-C maven-artifacts per-range override fix)** rewrote `DatabaseComponentRegistryResolver.getMavenArtifactParameters` to walk the EscrowModule per-range view instead of returning component-level `artifactIds` unchanged for every range. The old implementation ignored `DISTRIBUTION_MAVEN` marker overrides, causing 30 components to return the wrong `groupPattern` for one or more ranges (latest range's group bled into earlier ranges). Fix: use `config.distribution?.GAV()` per `EscrowModuleConfig` (already has per-range markers applied); fall back to component-level `artifactIds` only when GAV is null/blank. Extracted `splitCsv`/`MavenCoords`/`parseMavenGavEntry` from `ImportServiceImpl` into shared `util/GavParsing.kt`. Added 3 new unit tests (`DatabaseComponentRegistryResolverMavenArtifactsRangeTest`: two-range shape, multi-artifact CSV shape, single-range fallback). Extended VAL-006 with `tokenization-service` for regression guard. ✅ Full build PASS.
+
 Two method-level `@Disabled` markers remain for known v2-vs-v1 semantic deltas:
 
 | Test method | Reason | Tracked in todo.md |


### PR DESCRIPTION
## Summary

Closes the schema-v2 compat regression where `GET /rest/api/2/components/{component}/maven-artifacts` returned the same `(groupPattern, artifactPattern)` for every version range — ignoring per-range `DISTRIBUTION_MAVEN` marker rows. Affects **30 components** in the prod-503 set (cluster C in the compat-test report); clearest case is the two-range shape:

| Range | Baseline `.groupPattern` | Pre-fix candidate |
|---|---|---|
| `[1.0,1.1)` | `<group-A>` | `<group-B>` ← wrong, bled from `[1.1,)` |
| `[1.1,)`   | `<group-B>` | `<group-B>` |

## Approach

- Extract private GAV helpers from `ImportServiceImpl` to new top-level `util/GavParsing.kt` (`splitCsv`, `parseMavenGavEntry`, `MavenCoords` — all `internal`). No behavior change.
- Rewrite `DatabaseComponentRegistryResolver.getMavenArtifactParameters` to walk `EscrowModule.moduleConfigurations` per range. Reads `config.distribution?.GAV()` first (which already reflects `DISTRIBUTION_MAVEN` marker overrides via `pickMarkerChildren`), falls back to component-level `artifactIds` only when GAV is null/blank.
- Mirrors v1's collapse semantic: first coord's `groupId` as `groupPattern`; CSV-joined `artifactId`s in sort order as `artifactPattern`.

## Test plan

- [x] `DatabaseComponentRegistryResolverMavenArtifactsRangeTest` — three unit tests:
  - **RES-C-001**: two-range case — distinct `groupPattern` per range
  - **RES-C-002**: multi-artifact CSV case — `artifactPattern` is CSV in `sortOrder`
  - **RES-C-003**: single-range fallback — confirms GAV-parse path on the BASE-row's maven artifacts
- [x] `VAL-006 maven-artifacts` extended with `tokenization-service` (per-range GAV split: `(,2.0)`→zip, `[2.0,)`→tgz). Already not `@Disabled` on base (PR #194 Stream A re-enabled it); this commit strengthens the regression guard.
- [x] All existing `ImportServiceImpl`-related tests pass after the helper extraction (refactor confirmed behavior-preserving).
- [x] Full local build `./gradlew build -x dockerBuildImage -x ocCi -x :components-registry-automation:test` — **PASS** (5m 51s).

## TDD chain

5 commits, test→refactor→fix→test order:
1. `test:` failing resolver tests for per-range override (red)
2. `refactor:` extract `splitCsv`/`MavenCoords`/`parseMavenGavEntry` to `util/GavParsing.kt`
3. `fix:` `getMavenArtifactParameters` walks per-range `EscrowModule` view (green)
4. `test:` extend VAL-006 with regression-guard fixture
5. `docs:` `implementation-progress.md` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)