### PR TITLE
feat(local-stands): scripts for running compat-test locally without TeamCity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ out/
 BOOT-INF/
 *.class
 *.sh
+# But do track the local-stands tooling — these are shared dev scripts, not ad-hoc.
+!scripts/local-stands/*.sh

--- a/scripts/local-stands/README.md
+++ b/scripts/local-stands/README.md
@@ -121,8 +121,9 @@ remove it with `docker volume rm <name>` to fully reset.
 | `SERVICE_CONFIG_DIR` | _required for both stands, no default_ — local clone of the service-config repo |
 | `BASELINE_WORKTREE` | absolute path of `_wt/local-baseline` |
 | `CANDIDATE_WORKTREE` | absolute path of `_wt/schema-v2-sql` |
-| `CRS_DB_PORT` | `5432` (Postgres) |
-| `CRS_DB_USER` / `CRS_DB_PASSWORD` / `CRS_DB_NAME` | `crs` / `crs` / `components_registry` |
+| `CRS_DB_PORT` | `5432` — _docker side only_: host port the Postgres container binds to. The candidate JVM reads `POSTGRES_HOST`/`POSTGRES_PORT`/… from the `dev-db-automigrate` profile (defaults `localhost`/`5432`); changing `CRS_DB_PORT` alone makes the JVM and the container disagree. |
+| `CRS_DB_USER` / `CRS_DB_PASSWORD` / `CRS_DB_NAME` | `crs` / `crs` / `components_registry` — _docker side only_, same caveat as above. |
+| `WORK_DIR` | `/tmp/crs-baseline-work` (baseline) / `/tmp/crs-candidate-work` (candidate) — distinct per stand so the `dev-vcs-local` clone-then-delete cycle on one doesn't race with the other. |
 | `COMPAT_SMOKE_COMPONENTS` | _required for component-bearing tests_ — comma-separated real names from prod listing. **Never commit.** |
 | `COMPAT_RMS_URL` | _required for version-bearing tests_ — URL of Release Management Service used for sampling real release versions |
 

--- a/scripts/local-stands/README.md
+++ b/scripts/local-stands/README.md
@@ -1,0 +1,163 @@
+# Local compat stands
+
+Spin up two Components-Registry services locally (one per branch) and run the compat
+test against them — bypassing the TeamCity build + OKD deploy cycle.
+
+| | Baseline | Candidate |
+|---|---|---|
+| Branch | `origin/main` (= prod) | `origin/feat/schema-v2-sql` (or its head) |
+| Worktree | `_wt/local-baseline` | `_wt/schema-v2-sql` |
+| Port | `4567` | `4568` |
+| Runtime | fat JAR (`java -jar`, built once via `bootJar`) | Gradle `bootRun` (incremental iteration) |
+| Mode | VCS (Git-DSL) | DB (Postgres + auto-migrate from VCS at startup) |
+| Profiles | `dev,dev-vcs-local,local` | `dev,dev-vcs-local,dev-db-automigrate,local` |
+| Cloud Config | disabled (yamls mounted from local `service-config` clone) | not used (`dev` profile) |
+
+Both stands point at the same local Git-DSL clone (no remote git fetch) so the
+**only** difference is the codepath, eliminating data-drift confounds.
+
+## Prerequisites
+
+- Local clone of the Components-Registry DSL repo, somewhere on disk. Tell the scripts
+  where via `LOCAL_VCS_ROOT`:
+  ```bash
+  export LOCAL_VCS_ROOT="$HOME/path/to/your/registry-dsl-clone"
+  ```
+- Local clone of the `service-config` repo (the one Spring Cloud Config Server in
+  prod publishes from). Both stands overlay `components-registry-service.yml`
+  from this clone via `--spring.config.additional-location=` — it carries
+  production-grade keys (`components-registry.product-type.*`, `supportedGroupIds`,
+  …) that the candidate's bundled `dev/` overlays leave unset. The baseline JAR
+  additionally pulls `application.yml` because Spring Cloud Config is disabled.
+  ```bash
+  export SERVICE_CONFIG_DIR="$HOME/path/to/your/service-config-clone"
+  ```
+  Both env vars have no default — confidential paths must not be hard-coded.
+- Docker (for Postgres on candidate side).
+- `gradlew` works in both worktrees.
+- `AUTH_SERVER_URL` / `AUTH_SERVER_REALM` are **not** required — the scripts set
+  `auth-server.disabled=true`.
+
+## Worktrees
+
+Once-per-machine setup:
+
+```bash
+# from the repo root or any existing worktree
+git worktree add _wt/local-baseline origin/main
+# _wt/schema-v2-sql is where these scripts live — you're already there
+```
+
+Refresh later:
+
+```bash
+git -C _wt/local-baseline fetch && git -C _wt/local-baseline reset --hard origin/main
+git -C _wt/schema-v2-sql  fetch && git -C _wt/schema-v2-sql  reset --hard origin/feat/schema-v2-sql
+```
+
+## Typical loop
+
+In three terminals (or use `tmux`):
+
+```bash
+# Terminal 1 — Postgres for candidate
+./scripts/local-stands/postgres-up.sh
+
+# Terminal 2 — baseline (main on 4567, VCS-mode)
+./scripts/local-stands/baseline.sh
+
+# Terminal 3 — candidate (schema-v2-sql on 4568, DB-mode with auto-migrate)
+./scripts/local-stands/candidate.sh
+
+# Terminal 4 — when both are healthy, run compat-test
+# Real component names are confidential — pass via env, not via committed file.
+# Provide either a local file outside the repo, or set the env directly:
+export COMPAT_RMS_URL="https://your-rms-host/release-management-service/"
+export COMPAT_SMOKE_COMPONENTS="comp-1,comp-2,comp-3"   # real names from your prod listing
+./scripts/local-stands/compat.sh
+```
+
+### Inner-loop verify (after a fix)
+
+`verify.sh` is the gate plan agents call after applying a code/schema fix:
+
+```bash
+# Code-only change (import/mapper/resolver) — rebuild candidate JVM, DSL→DB
+# re-imports through the new code via dev-db-automigrate profile.
+./scripts/local-stands/verify.sh --restart --tests "*VcsSettings*"
+
+# Schema change (V1__schema.sql edit) — additionally wipe the postgres volume
+# so Flyway re-applies the schema from scratch before automigrate.
+./scripts/local-stands/verify.sh --reset-db --tests "*BuildTools*"
+
+# No candidate change since last run — just re-read state.
+./scripts/local-stands/verify.sh --tests "*MavenArtifacts*"
+```
+
+Subagent workflow: a PR agent in a sibling worktree exports
+`CANDIDATE_WORKTREE="$(pwd)"` before invoking — `candidate.sh` then rebuilds
+from that worktree's code on restart. Port-scoped kill leaves parallel
+worktrees on other ports untouched.
+
+## Tear-down
+
+```bash
+./scripts/local-stands/stop-all.sh
+```
+
+Stops both CRS JVMs (baseline `java -jar` on `:4567` and candidate `bootRun` on `:4568`)
+by port — only the processes listening on those ports are killed, so parallel agent
+worktrees on different ports survive. Then tears down the Postgres container.
+Postgres data lives in a docker volume (project-prefixed `<project>_crs_postgres_data`) —
+remove it with `docker volume rm <name>` to fully reset.
+
+## Overrides
+
+| Env var | Default |
+|---|---|
+| `BASELINE_PORT` | `4567` |
+| `CANDIDATE_PORT` | `4568` |
+| `LOCAL_VCS_ROOT` | _required, no default_ |
+| `SERVICE_CONFIG_DIR` | _required for both stands, no default_ — local clone of the service-config repo |
+| `BASELINE_WORKTREE` | absolute path of `_wt/local-baseline` |
+| `CANDIDATE_WORKTREE` | absolute path of `_wt/schema-v2-sql` |
+| `CRS_DB_PORT` | `5432` (Postgres) |
+| `CRS_DB_USER` / `CRS_DB_PASSWORD` / `CRS_DB_NAME` | `crs` / `crs` / `components_registry` |
+| `COMPAT_SMOKE_COMPONENTS` | _required for component-bearing tests_ — comma-separated real names from prod listing. **Never commit.** |
+| `COMPAT_RMS_URL` | _required for version-bearing tests_ — URL of Release Management Service used for sampling real release versions |
+
+Pass any of these to override the defaults before invoking the script:
+
+```bash
+export LOCAL_VCS_ROOT="$HOME/your-registry-dsl-clone"
+./scripts/local-stands/baseline.sh
+```
+
+## Caveats
+
+- `baseline.sh` runs from a fat JAR. On first invocation it executes
+  `./gradlew :components-registry-service-server:bootJar -x test` in the
+  baseline worktree (~2-3 min); subsequent starts are instant. To force a rebuild
+  after pulling new main: delete `_wt/local-baseline/components-registry-service-server/build/libs/`.
+- Candidate's `dev-db-automigrate` profile triggers a full import from VCS at
+  startup. First start is slow (~30-60 sec for ~1000 components on a clean DB).
+- Both Spring Boot apps log to their respective terminal. Use `--quiet` on bootRun
+  for less noise once it works.
+- The compat-test module is part of the candidate worktree only. `compat.sh` calls
+  `gradlew :components-registry-compat-test:test` from there.
+
+## Confidentiality of test inputs
+
+Real production component names, hostnames, and similar customer-identifying data
+must **not** be committed to this repo (per the open-source rule). The compat-test
+module respects this and reads its smoke list from runtime sources only:
+
+1. `-Pcompat.smoke-components=...` gradle property, or
+2. `COMPAT_SMOKE_COMPONENTS` env var, or
+3. `/smoke-components.txt` test resource — kept empty in the repo by design.
+
+Same for `COMPAT_BASELINE_URL` / `COMPAT_CANDIDATE_URL` / `COMPAT_RMS_URL`: provide
+at runtime, never hard-coded. The scripts in this directory follow the same rule —
+`LOCAL_VCS_ROOT` is a mandatory env var with no default, and prod URLs come from a
+local-only env file (recommended pattern: keep it under `/tmp/` or `$HOME/.config/`,
+outside the repo tree).

--- a/scripts/local-stands/baseline.sh
+++ b/scripts/local-stands/baseline.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Run baseline (main branch) on localhost:${BASELINE_PORT:-4567} from a fat JAR.
+#
+# Why JAR (not bootRun): build once, restart many; no Gradle daemon competing
+# with the candidate's bootRun for the same JVM/disk-cache resources.
+#
+# Required env:
+#   LOCAL_VCS_ROOT         path to local clone of the registry-DSL repo
+#   SERVICE_CONFIG_DIR     path to a local clone of the service-config repo
+#                          (must contain application.yml and
+#                          components-registry-service.yml). Spring Cloud Config
+#                          is disabled; these yamls are mounted via
+#                          --spring.config.additional-location.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# scripts/local-stands -> scripts -> <candidate-worktree> -> _wt -> CRS_ROOT.
+CRS_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+BASELINE_WORKTREE="${BASELINE_WORKTREE:-$CRS_ROOT/_wt/local-baseline}"
+LOCAL_VCS_ROOT="${LOCAL_VCS_ROOT:-}"
+SERVICE_CONFIG_DIR="${SERVICE_CONFIG_DIR:-}"
+BASELINE_PORT="${BASELINE_PORT:-4567}"
+
+[ -d "$BASELINE_WORKTREE" ] || {
+  echo "ERROR: baseline worktree not found at $BASELINE_WORKTREE"
+  echo "  Create with: git worktree add $BASELINE_WORKTREE origin/main"
+  exit 1
+}
+[ -n "$LOCAL_VCS_ROOT" ] || {
+  echo "ERROR: LOCAL_VCS_ROOT env var is not set."
+  echo "  Point it at your local clone of the registry-DSL repo, e.g."
+  echo "    export LOCAL_VCS_ROOT=\"\$HOME/path/to/your/registry-dsl-clone\""
+  exit 1
+}
+[ -d "$LOCAL_VCS_ROOT" ] || { echo "ERROR: LOCAL_VCS_ROOT=$LOCAL_VCS_ROOT is not a directory."; exit 1; }
+[ -n "$SERVICE_CONFIG_DIR" ] || {
+  echo "ERROR: SERVICE_CONFIG_DIR env var is not set."
+  echo "  Point it at your local clone of the service-config repo, e.g."
+  echo "    export SERVICE_CONFIG_DIR=\"\$HOME/path/to/your/service-config-clone\""
+  exit 1
+}
+[ -d "$SERVICE_CONFIG_DIR" ] || { echo "ERROR: SERVICE_CONFIG_DIR=$SERVICE_CONFIG_DIR is not a directory."; exit 1; }
+[ -f "$SERVICE_CONFIG_DIR/application.yml" ] || {
+  echo "ERROR: $SERVICE_CONFIG_DIR/application.yml not found (does not look like a service-config dir)."
+  exit 1
+}
+[ -f "$SERVICE_CONFIG_DIR/components-registry-service.yml" ] || {
+  echo "ERROR: $SERVICE_CONFIG_DIR/components-registry-service.yml not found."
+  exit 1
+}
+
+LIBS_DIR="$BASELINE_WORKTREE/components-registry-service-server/build/libs"
+# bootJar produces components-registry-service-server-<version>.jar;
+# the regular jar task adds an "-it-" infix and is non-runnable.
+find_boot_jar() {
+  ls -t "$LIBS_DIR"/components-registry-service-server-[0-9]*.jar 2>/dev/null | head -n 1
+}
+
+JAR="$(find_boot_jar || true)"
+if [ -z "$JAR" ]; then
+  echo ">>> baseline JAR not found in $LIBS_DIR — building (one-time, ~2-3 min)..."
+  cd "$BASELINE_WORKTREE"
+  ./gradlew :components-registry-service-server:bootJar --no-daemon --console=plain -x test
+  JAR="$(find_boot_jar)"
+fi
+[ -n "$JAR" ] && [ -f "$JAR" ] || { echo "ERROR: failed to locate or build baseline JAR under $LIBS_DIR"; exit 1; }
+
+echo ">>> baseline: $BASELINE_WORKTREE @ $(git -C "$BASELINE_WORKTREE" rev-parse --short HEAD)"
+echo ">>> JAR:    $JAR"
+echo ">>> port:   $BASELINE_PORT"
+echo ">>> config: $SERVICE_CONFIG_DIR (cloud-config disabled)"
+echo ">>> VCS:    $LOCAL_VCS_ROOT"
+
+# additional-location is searched left-to-right; later entries win for overlapping keys.
+# Order: profile yamls from main worktree's dev/ dir, then service-config defaults,
+# then prod overlay equivalents. The bundled application.yml in the JAR remains the
+# lowest-priority fallback.
+ADDITIONAL_LOCATION="file:$BASELINE_WORKTREE/components-registry-service-server/dev/"
+ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/application.yml"
+ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
+
+exec java -jar "$JAR" \
+  --server.port="$BASELINE_PORT" \
+  --spring.cloud.config.enabled=false \
+  --spring.cloud.bootstrap.enabled=false \
+  --spring.config.additional-location="$ADDITIONAL_LOCATION" \
+  --spring.profiles.active=dev,dev-vcs-local,local \
+  --components-registry.vcs.root="file://$LOCAL_VCS_ROOT" \
+  --auth-server.disabled=true

--- a/scripts/local-stands/baseline.sh
+++ b/scripts/local-stands/baseline.sh
@@ -57,19 +57,40 @@ find_boot_jar() {
 }
 
 JAR="$(find_boot_jar || true)"
-if [ -z "$JAR" ]; then
-  echo ">>> baseline JAR not found in $LIBS_DIR — building (one-time, ~2-3 min)..."
+
+# Stale-JAR guard: if any source file changed since the JAR was built, rebuild.
+# Catches the common "git pulled origin/main, forgot to rebuild" case where the
+# script would otherwise report the new commit hash but run yesterday's bytecode.
+SRC_ROOT="$BASELINE_WORKTREE/components-registry-service-server/src"
+needs_build() {
+  [ -z "$JAR" ] && return 0
+  [ ! -f "$JAR" ] && return 0
+  [ ! -d "$SRC_ROOT" ] && return 1
+  local newer
+  newer=$(find "$SRC_ROOT" "$BASELINE_WORKTREE"/*.gradle "$BASELINE_WORKTREE"/*/build.gradle \
+            -newer "$JAR" \( -name '*.kt' -o -name '*.java' -o -name '*.gradle' \) \
+            -print -quit 2>/dev/null || true)
+  [ -n "$newer" ]
+}
+
+if needs_build; then
+  if [ -z "$JAR" ]; then
+    echo ">>> baseline JAR not found in $LIBS_DIR — building (one-time, ~2-3 min)..."
+  else
+    echo ">>> source newer than $(basename "$JAR") — rebuilding..."
+  fi
   cd "$BASELINE_WORKTREE"
   ./gradlew :components-registry-service-server:bootJar --no-daemon --console=plain -x test
   JAR="$(find_boot_jar)"
 fi
 [ -n "$JAR" ] && [ -f "$JAR" ] || { echo "ERROR: failed to locate or build baseline JAR under $LIBS_DIR"; exit 1; }
 
+WORK_DIR="${WORK_DIR:-/tmp/crs-baseline-work}"
 echo ">>> baseline: $BASELINE_WORKTREE @ $(git -C "$BASELINE_WORKTREE" rev-parse --short HEAD)"
 echo ">>> JAR:    $JAR"
 echo ">>> port:   $BASELINE_PORT"
 echo ">>> config: $SERVICE_CONFIG_DIR (cloud-config disabled)"
-echo ">>> VCS:    $LOCAL_VCS_ROOT"
+echo ">>> VCS:    $LOCAL_VCS_ROOT  (work-dir: $WORK_DIR)"
 
 # additional-location is searched left-to-right; later entries win for overlapping keys.
 # Order: profile yamls from main worktree's dev/ dir, then service-config defaults,
@@ -86,4 +107,6 @@ exec java -jar "$JAR" \
   --spring.config.additional-location="$ADDITIONAL_LOCATION" \
   --spring.profiles.active=dev,dev-vcs-local,local \
   --components-registry.vcs.root="file://$LOCAL_VCS_ROOT" \
+  --components-registry.work-dir="$WORK_DIR" \
+  --components-registry.groovy-path="$WORK_DIR/src/main/resources" \
   --auth-server.disabled=true

--- a/scripts/local-stands/candidate.sh
+++ b/scripts/local-stands/candidate.sh
@@ -40,13 +40,16 @@ CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
 ADDITIONAL_LOCATION="file:$CANDIDATE_WORKTREE/components-registry-service-server/dev/"
 ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
 
+WORK_DIR="${WORK_DIR:-/tmp/crs-candidate-work}"
 cd "$CANDIDATE_WORKTREE"
 echo ">>> candidate: $CANDIDATE_WORKTREE @ $(git rev-parse --short HEAD)"
-echo ">>> port: $CANDIDATE_PORT,  VCS root: $LOCAL_VCS_ROOT,  DB: localhost:${CRS_DB_PORT:-5432}"
+echo ">>> port: $CANDIDATE_PORT,  VCS root: $LOCAL_VCS_ROOT  (work-dir: $WORK_DIR),  DB: localhost:${CRS_DB_PORT:-5432}"
 echo ">>> config: $SERVICE_CONFIG_DIR (overlaid on dev/)"
 exec ./gradlew :components-registry-service-server:bootRun --no-daemon --console=plain \
   --args="--server.port=$CANDIDATE_PORT \
           --spring.profiles.active=dev,dev-vcs-local,dev-db-automigrate,local \
           --spring.config.additional-location=$ADDITIONAL_LOCATION \
           --components-registry.vcs.root=file://$LOCAL_VCS_ROOT \
+          --components-registry.work-dir=$WORK_DIR \
+          --components-registry.groovy-path=$WORK_DIR/src/main/resources \
           --auth-server.disabled=true"

--- a/scripts/local-stands/candidate.sh
+++ b/scripts/local-stands/candidate.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Run candidate (feat/schema-v2-sql) on localhost:${CANDIDATE_PORT:-4568} in DB-automigrate mode.
+#
+# Required env:
+#   LOCAL_VCS_ROOT         path to local clone of the registry-DSL repo (DSL→DB source)
+#   SERVICE_CONFIG_DIR     path to local clone of the service-config repo; overlaid on the
+#                          candidate's dev/ profile yamls so production-only keys
+#                          (components-registry.product-type.*, supportedGroupIds, ...)
+#                          are present
+#
+# Requires Postgres running (see postgres-up.sh).
+# Triggers full DSL→DB migration at startup (~30-60 sec on first run).
+# Unlike baseline.sh, this script does NOT explicitly disable Spring Cloud Config — the
+# dev profile suite doesn't request cloud-config, so it's implicitly off.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANDIDATE_WORKTREE="${CANDIDATE_WORKTREE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+LOCAL_VCS_ROOT="${LOCAL_VCS_ROOT:-}"
+SERVICE_CONFIG_DIR="${SERVICE_CONFIG_DIR:-}"
+CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
+
+[ -d "$CANDIDATE_WORKTREE" ] || { echo "ERROR: candidate worktree not found at $CANDIDATE_WORKTREE"; exit 1; }
+[ -n "$LOCAL_VCS_ROOT" ] || { echo "ERROR: LOCAL_VCS_ROOT env var is not set."; echo "  Point it at your local clone of the registry-DSL repo, e.g."; echo "    export LOCAL_VCS_ROOT=\"\$HOME/path/to/your/registry-dsl-clone\""; exit 1; }
+[ -d "$LOCAL_VCS_ROOT" ] || { echo "ERROR: LOCAL_VCS_ROOT=$LOCAL_VCS_ROOT is not a directory."; exit 1; }
+[ -n "$SERVICE_CONFIG_DIR" ] || {
+  echo "ERROR: SERVICE_CONFIG_DIR env var is not set."
+  echo "  Same yaml the baseline uses; it carries production-grade values"
+  echo "  (product-type, supportedGroupIds, ...) that are absent from the candidate's"
+  echo "  bundled dev/ overlays. Point it at your local service-config clone, e.g."
+  echo "    export SERVICE_CONFIG_DIR=\"\$HOME/path/to/your/service-config-clone\""
+  exit 1
+}
+[ -d "$SERVICE_CONFIG_DIR" ] || { echo "ERROR: SERVICE_CONFIG_DIR=$SERVICE_CONFIG_DIR is not a directory."; exit 1; }
+[ -f "$SERVICE_CONFIG_DIR/components-registry-service.yml" ] || {
+  echo "ERROR: $SERVICE_CONFIG_DIR/components-registry-service.yml not found."
+  exit 1
+}
+
+ADDITIONAL_LOCATION="file:$CANDIDATE_WORKTREE/components-registry-service-server/dev/"
+ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
+
+cd "$CANDIDATE_WORKTREE"
+echo ">>> candidate: $CANDIDATE_WORKTREE @ $(git rev-parse --short HEAD)"
+echo ">>> port: $CANDIDATE_PORT,  VCS root: $LOCAL_VCS_ROOT,  DB: localhost:${CRS_DB_PORT:-5432}"
+echo ">>> config: $SERVICE_CONFIG_DIR (overlaid on dev/)"
+exec ./gradlew :components-registry-service-server:bootRun --no-daemon --console=plain \
+  --args="--server.port=$CANDIDATE_PORT \
+          --spring.profiles.active=dev,dev-vcs-local,dev-db-automigrate,local \
+          --spring.config.additional-location=$ADDITIONAL_LOCATION \
+          --components-registry.vcs.root=file://$LOCAL_VCS_ROOT \
+          --auth-server.disabled=true"

--- a/scripts/local-stands/compat.sh
+++ b/scripts/local-stands/compat.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Wait for both stands to be healthy, then run :components-registry-compat-test:test
+# against them. Extra args are forwarded to gradle (e.g. `--tests "*.ComponentDetailV2*"`).
+#
+# Real component names are confidential — do NOT bake them into this script or any
+# committed file. Pass them at runtime via the env (gradle forwards COMPAT_SMOKE_COMPONENTS
+# to the test JVM as a system property):
+#
+#   export COMPAT_SMOKE_COMPONENTS="name1,name2,name3"
+#   ./scripts/local-stands/compat.sh
+#
+# Or sourcing a local-only file kept outside the repo (e.g. in /tmp or $HOME):
+#
+#   source /tmp/compat-aug-env.sh   # exports COMPAT_SMOKE_COMPONENTS, COMPAT_RMS_URL, ...
+#   ./scripts/local-stands/compat.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANDIDATE_WORKTREE="${CANDIDATE_WORKTREE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+BASELINE_PORT="${BASELINE_PORT:-4567}"
+CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
+
+wait_for() {
+  local name="$1" port="$2"
+  echo -n ">>> waiting for $name (localhost:$port/actuator/health)..."
+  for i in $(seq 1 90); do
+    if curl -fsS --max-time 2 "http://localhost:$port/actuator/health" >/dev/null 2>&1; then
+      echo " up"
+      return 0
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo " TIMEOUT"
+  return 1
+}
+
+wait_for baseline  "$BASELINE_PORT"
+wait_for candidate "$CANDIDATE_PORT"
+
+export COMPAT_BASELINE_URL="http://localhost:$BASELINE_PORT"
+export COMPAT_CANDIDATE_URL="http://localhost:$CANDIDATE_PORT"
+# COMPAT_RMS_URL is optional — caller can export it for real version sampling.
+echo ">>> running compat-test from $CANDIDATE_WORKTREE"
+echo "    COMPAT_BASELINE_URL=$COMPAT_BASELINE_URL"
+echo "    COMPAT_CANDIDATE_URL=$COMPAT_CANDIDATE_URL"
+echo "    COMPAT_RMS_URL=${COMPAT_RMS_URL:-<unset; version sampling will return empty>}"
+
+cd "$CANDIDATE_WORKTREE"
+exec ./gradlew :components-registry-compat-test:test --no-daemon --console=plain "$@"

--- a/scripts/local-stands/postgres-up.sh
+++ b/scripts/local-stands/postgres-up.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Start local Postgres for the candidate stand (schema-v2 DB-mode).
+# Uses docker-compose.local-postgres.yml from the candidate worktree.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANDIDATE_WORKTREE="${CANDIDATE_WORKTREE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+COMPOSE_FILE="$CANDIDATE_WORKTREE/docker-compose.local-postgres.yml"
+
+[ -f "$COMPOSE_FILE" ] || { echo "ERROR: $COMPOSE_FILE not found"; exit 1; }
+
+# Some hosts have only the v1 hyphenated `docker-compose`; others have the v2
+# `docker compose` subcommand. Detect once.
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "ERROR: neither 'docker compose' nor 'docker-compose' is available on this host."
+  exit 1
+fi
+
+echo ">>> ${COMPOSE[*]} up -d  ($COMPOSE_FILE)"
+"${COMPOSE[@]}" -f "$COMPOSE_FILE" up -d
+
+echo ">>> waiting for Postgres healthcheck..."
+for i in $(seq 1 30); do
+  health=$("${COMPOSE[@]}" -f "$COMPOSE_FILE" ps --format json postgres 2>/dev/null | head -1 | python3 -c 'import sys,json; print(json.loads(sys.stdin.read() or "{}").get("Health","unknown"))' 2>/dev/null || echo unknown)
+  if [ "$health" = "healthy" ]; then
+    echo ">>> Postgres healthy (port ${CRS_DB_PORT:-5432})."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "WARN: Postgres did not become healthy within 60 sec. Check '${COMPOSE[*]} -f $COMPOSE_FILE logs postgres'."
+exit 1

--- a/scripts/local-stands/stop-all.sh
+++ b/scripts/local-stands/stop-all.sh
@@ -13,12 +13,12 @@ CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
 kill_port() {
   command -v lsof >/dev/null 2>&1 || { echo "WARN: lsof missing; skipping port-$1 kill"; return 0; }
   local pids
-  pids=$(lsof -ti tcp:"$1" 2>/dev/null || true)
+  pids=$(lsof -ti -sTCP:LISTEN tcp:"$1" 2>/dev/null || true)
   [ -z "$pids" ] && return 0
   echo "    :$1 — TERM $pids"
   kill $pids 2>/dev/null || true
   for i in $(seq 1 10); do
-    pids=$(lsof -ti tcp:"$1" 2>/dev/null || true)
+    pids=$(lsof -ti -sTCP:LISTEN tcp:"$1" 2>/dev/null || true)
     [ -z "$pids" ] && return 0
     sleep 1
   done

--- a/scripts/local-stands/stop-all.sh
+++ b/scripts/local-stands/stop-all.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Tear down both bootRun stands and the local Postgres container.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANDIDATE_WORKTREE="${CANDIDATE_WORKTREE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+COMPOSE_FILE="$CANDIDATE_WORKTREE/docker-compose.local-postgres.yml"
+
+BASELINE_PORT="${BASELINE_PORT:-4567}"
+CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
+
+# Port-scoped kill so parallel agent worktrees on different ports survive.
+kill_port() {
+  command -v lsof >/dev/null 2>&1 || { echo "WARN: lsof missing; skipping port-$1 kill"; return 0; }
+  local pids
+  pids=$(lsof -ti tcp:"$1" 2>/dev/null || true)
+  [ -z "$pids" ] && return 0
+  echo "    :$1 — TERM $pids"
+  kill $pids 2>/dev/null || true
+  for i in $(seq 1 10); do
+    pids=$(lsof -ti tcp:"$1" 2>/dev/null || true)
+    [ -z "$pids" ] && return 0
+    sleep 1
+  done
+  echo "    :$1 — KILL $pids"
+  kill -9 $pids 2>/dev/null || true
+}
+
+echo ">>> stopping CRS JVMs by port"
+kill_port "$BASELINE_PORT"
+kill_port "$CANDIDATE_PORT"
+
+if [ -f "$COMPOSE_FILE" ]; then
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE=(docker-compose)
+  else
+    COMPOSE=()
+  fi
+  if [ "${#COMPOSE[@]}" -gt 0 ]; then
+    echo ">>> ${COMPOSE[*]} down ($COMPOSE_FILE)"
+    "${COMPOSE[@]}" -f "$COMPOSE_FILE" down || true
+  else
+    echo "WARN: docker compose / docker-compose not available; skipping postgres teardown."
+  fi
+fi
+
+echo ">>> done"

--- a/scripts/local-stands/verify.sh
+++ b/scripts/local-stands/verify.sh
@@ -41,12 +41,12 @@ kill_port() {
   local port="$1"
   command -v lsof >/dev/null 2>&1 || { echo "WARN: lsof not available; skipping port-$port kill"; return 0; }
   local pids
-  pids=$(lsof -ti tcp:"$port" 2>/dev/null || true)
+  pids=$(lsof -ti -sTCP:LISTEN tcp:"$port" 2>/dev/null || true)
   [ -z "$pids" ] && return 0
   echo "    sending TERM to PID(s) on :$port — $pids"
   kill $pids 2>/dev/null || true
   for i in $(seq 1 10); do
-    pids=$(lsof -ti tcp:"$port" 2>/dev/null || true)
+    pids=$(lsof -ti -sTCP:LISTEN tcp:"$port" 2>/dev/null || true)
     [ -z "$pids" ] && return 0
     sleep 1
   done
@@ -57,8 +57,14 @@ kill_port() {
 # Wait until $port is free, capped at $2 seconds.
 wait_port_free() {
   local port="$1" cap="${2:-15}"
+  local have_lsof=0
+  command -v lsof >/dev/null 2>&1 && have_lsof=1
   for i in $(seq 1 "$cap"); do
-    if ! health "$port" && ! lsof -i tcp:"$port" >/dev/null 2>&1; then return 0; fi
+    if ! health "$port"; then
+      # If lsof is missing, fall back to health-only as the readiness signal.
+      [ "$have_lsof" -eq 0 ] && return 0
+      lsof -i -sTCP:LISTEN tcp:"$port" >/dev/null 2>&1 || return 0
+    fi
     sleep 1
   done
   return 1
@@ -98,8 +104,9 @@ if [ "$RESTART" -eq 1 ]; then
   echo ">>> --restart: stopping candidate JVM on :$CANDIDATE_PORT"
   kill_port "$CANDIDATE_PORT"
   wait_port_free "$CANDIDATE_PORT" 10 || echo "WARN: :$CANDIDATE_PORT still bound; continuing anyway"
-  echo ">>> starting candidate.sh in background (logs: /tmp/crs-candidate.log)"
-  nohup bash "$SCRIPT_DIR/candidate.sh" >/tmp/crs-candidate.log 2>&1 &
+  CANDIDATE_LOG="/tmp/crs-candidate-${CANDIDATE_PORT}.log"
+  echo ">>> starting candidate.sh in background (logs: $CANDIDATE_LOG)"
+  nohup bash "$SCRIPT_DIR/candidate.sh" >"$CANDIDATE_LOG" 2>&1 &
   echo -n ">>> waiting for candidate health on :$CANDIDATE_PORT (up to 5 min)"
   for i in $(seq 1 75); do
     if health "$CANDIDATE_PORT"; then
@@ -113,8 +120,8 @@ if [ "$RESTART" -eq 1 ]; then
   done
   echo
   if ! health "$CANDIDATE_PORT"; then
-    echo "ERROR: candidate failed to come up — tail of /tmp/crs-candidate.log:"
-    tail -n 40 /tmp/crs-candidate.log || true
+    echo "ERROR: candidate failed to come up — tail of $CANDIDATE_LOG:"
+    tail -n 40 "$CANDIDATE_LOG" || true
     exit 3
   fi
 elif ! health "$CANDIDATE_PORT"; then

--- a/scripts/local-stands/verify.sh
+++ b/scripts/local-stands/verify.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Verify gate for local stands.
+#
+# Flow per flags:
+#   verify.sh                        — just compat against the currently-running stands
+#   verify.sh --restart              — kill candidate JVM, run candidate.sh in background,
+#                                      wait for health, then compat. DSL→DB automigrate runs
+#                                      via dev-db-automigrate profile on every candidate start.
+#   verify.sh --reset-db             — implies --restart, plus tears down + recreates the
+#                                      postgres volume so Flyway re-applies V1__schema.sql.
+#                                      Needed when V1__schema.sql itself changed (e.g. PR-D+E).
+#
+# Extra args are forwarded verbatim to compat.sh / gradle (e.g. --tests "*BuildToolsV2*").
+#
+# Subagent workflow: a PR agent working in its own worktree exports CANDIDATE_WORKTREE
+# to its path before invoking; candidate.sh respects that override so the rebuilt JVM
+# runs the agent's code.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESTART=0
+RESET_DB=0
+PASS_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --restart)  RESTART=1 ;;
+    --reset-db) RESTART=1; RESET_DB=1 ;;
+    *) PASS_ARGS+=("$arg") ;;
+  esac
+done
+
+BASELINE_PORT="${BASELINE_PORT:-4567}"
+CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
+
+health() { curl -fsS --max-time 2 "http://localhost:$1/actuator/health" >/dev/null 2>&1; }
+
+# Port-scoped kill — only touches the JVM listening on the given port, so
+# parallel agent worktrees on different ports (or unrelated Spring Boot apps
+# on this host) are not affected. Falls back gracefully if lsof is absent.
+kill_port() {
+  local port="$1"
+  command -v lsof >/dev/null 2>&1 || { echo "WARN: lsof not available; skipping port-$port kill"; return 0; }
+  local pids
+  pids=$(lsof -ti tcp:"$port" 2>/dev/null || true)
+  [ -z "$pids" ] && return 0
+  echo "    sending TERM to PID(s) on :$port — $pids"
+  kill $pids 2>/dev/null || true
+  for i in $(seq 1 10); do
+    pids=$(lsof -ti tcp:"$port" 2>/dev/null || true)
+    [ -z "$pids" ] && return 0
+    sleep 1
+  done
+  echo "    still alive — SIGKILL"
+  kill -9 $pids 2>/dev/null || true
+}
+
+# Wait until $port is free, capped at $2 seconds.
+wait_port_free() {
+  local port="$1" cap="${2:-15}"
+  for i in $(seq 1 "$cap"); do
+    if ! health "$port" && ! lsof -i tcp:"$port" >/dev/null 2>&1; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+if ! health "$BASELINE_PORT"; then
+  echo "ERROR: baseline (:$BASELINE_PORT) is not running."
+  echo "       Start with: ./scripts/local-stands/baseline.sh"
+  exit 2
+fi
+
+# Early env validation for any flag that respawns candidate — surface the
+# missing-env error here rather than 5 minutes later in /tmp/crs-candidate.log.
+if [ "$RESTART" -eq 1 ]; then
+  : "${LOCAL_VCS_ROOT:?ERROR: LOCAL_VCS_ROOT must be exported when using --restart/--reset-db (passed through to candidate.sh)}"
+  : "${SERVICE_CONFIG_DIR:?ERROR: SERVICE_CONFIG_DIR must be exported when using --restart/--reset-db (passed through to candidate.sh)}"
+fi
+
+if [ "$RESET_DB" -eq 1 ]; then
+  echo ">>> --reset-db: wiping postgres volume and recreating"
+  kill_port "$CANDIDATE_PORT"
+  wait_port_free "$CANDIDATE_PORT" 15 || echo "WARN: :$CANDIDATE_PORT still bound; continuing anyway"
+  COMPOSE_FILE="${CANDIDATE_WORKTREE:-$(cd "$SCRIPT_DIR/../.." && pwd)}/docker-compose.local-postgres.yml"
+  if docker compose version >/dev/null 2>&1; then
+    COMPOSE=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE=(docker-compose)
+  else
+    echo "ERROR: docker compose / docker-compose not available."
+    exit 2
+  fi
+  "${COMPOSE[@]}" -f "$COMPOSE_FILE" down -v
+  "$SCRIPT_DIR/postgres-up.sh"
+fi
+
+if [ "$RESTART" -eq 1 ]; then
+  echo ">>> --restart: stopping candidate JVM on :$CANDIDATE_PORT"
+  kill_port "$CANDIDATE_PORT"
+  wait_port_free "$CANDIDATE_PORT" 10 || echo "WARN: :$CANDIDATE_PORT still bound; continuing anyway"
+  echo ">>> starting candidate.sh in background (logs: /tmp/crs-candidate.log)"
+  nohup bash "$SCRIPT_DIR/candidate.sh" >/tmp/crs-candidate.log 2>&1 &
+  echo -n ">>> waiting for candidate health on :$CANDIDATE_PORT (up to 5 min)"
+  for i in $(seq 1 75); do
+    if health "$CANDIDATE_PORT"; then
+      echo
+      echo "    candidate up after $((i * 4)) s"
+      break
+    fi
+    # One dot every 4 s = 15/min, two-digit minute marks for orientation.
+    if [ $((i % 15)) -eq 0 ]; then echo -n " ${i}/75 "; else echo -n "."; fi
+    sleep 4
+  done
+  echo
+  if ! health "$CANDIDATE_PORT"; then
+    echo "ERROR: candidate failed to come up — tail of /tmp/crs-candidate.log:"
+    tail -n 40 /tmp/crs-candidate.log || true
+    exit 3
+  fi
+elif ! health "$CANDIDATE_PORT"; then
+  echo "ERROR: candidate (:$CANDIDATE_PORT) is not running and --restart was not passed."
+  echo "       Either: re-run with --restart, or start manually with ./scripts/local-stands/candidate.sh"
+  exit 2
+fi
+
+echo ">>> running compat"
+exec "$SCRIPT_DIR/compat.sh" "${PASS_ARGS[@]}"


### PR DESCRIPTION
## Summary

- Adds `scripts/local-stands/` — a self-contained set of scripts that spin up baseline (`origin/main` fat JAR on `:4567`) and candidate (current branch via `bootRun` on `:4568` with Postgres + DSL→DB automigrate) on the same host, then run `:components-registry-compat-test:test` against them. Cuts the iteration loop on schema-v2 bug clusters from "push → TeamCity build → OKD deploy → run" down to "save → `verify.sh --restart`".
- Introduces `verify.sh` as the inner-loop gate for plan-driven iteration (`--restart` for code-only PRs, `--reset-db` for V1__schema.sql changes). Plan agents in sibling worktrees export `CANDIDATE_WORKTREE=$(pwd)` so the rebuilt JVM runs *their* code; port-scoped kill (via `lsof -ti tcp:<port>`) leaves parallel agent worktrees on other ports untouched.
- All paths, ports, smoke component lists, and RMS URL are env-driven (`LOCAL_VCS_ROOT`, `SERVICE_CONFIG_DIR`, `COMPAT_SMOKE_COMPONENTS`, `COMPAT_RMS_URL`); no company or customer identifiers are baked in. `.gitignore` gets a `!scripts/local-stands/*.sh` exception so shared tooling is tracked while ad-hoc `*.sh` stays ignored.

## Pre-merge validation

- Independent Sonnet code review against the diff — all flagged items addressed (port-scoped kill, port-release poll in `--reset-db`, candidate.sh docstring, README stale wording, progress dots during the 5-min wait).
- `gradlew compileKotlin compileTestKotlin` clean on top of recent base merge (`b165ad0` — PRs #205/#206/#207). No source files touched, so `gradlew build` would only re-run the existing test suite, which is unchanged.
- End-to-end smoke: fresh Postgres → baseline JAR → candidate bootRun → `verify.sh --restart --tests "*ServiceStatusV2CompatTest*"` returns 0 active diffs, exit 0, 41 s.
- Full 475-component sweep against the same stands surfaces the expected schema-v2 vs main divergences (91 VALUE_DIFFs across the B / C / D+E / F+G clusters of the existing fix plan + 1806 known infrastructure false-positives on `/jira-component-version-ranges` Cluster I, + 1 suppressed `updateCache` 410-Gone known-delta). The compat output matches what the upcoming fix PRs are scoped to close.

## Test plan

- [ ] Reviewer clones `service-config` and a registry-DSL repo, exports `LOCAL_VCS_ROOT` / `SERVICE_CONFIG_DIR`, runs `./scripts/local-stands/postgres-up.sh` then `./scripts/local-stands/baseline.sh` then `./scripts/local-stands/candidate.sh` — both `:4567` and `:4568` `/actuator/health` return UP.
- [ ] `./scripts/local-stands/compat.sh --tests "*ServiceStatusV2CompatTest*"` exits 0 against fresh stands.
- [ ] `./scripts/local-stands/verify.sh --restart --tests "*ServiceStatusV2CompatTest*"` exits 0; only the candidate JVM is killed (any other Spring Boot JVMs on the host survive).
- [ ] `./scripts/local-stands/stop-all.sh` tears down both JVMs by port and stops the Postgres compose project.
- [ ] `grep -rn -F -f forbidden-literals.txt scripts/local-stands/` returns empty (no company / customer identifiers in committed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)