### PR TITLE
fix(schema-v2): preserve VCS root name end-to-end (RES-B)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/VcsSettingsEntryEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/VcsSettingsEntryEntity.kt
@@ -11,7 +11,9 @@ import jakarta.persistence.Table
 import java.util.UUID
 
 /**
- * Unified VCS model: SINGLE-VCS is a single row with `name = NULL`;
+ * Unified VCS model: all VCS entries carry a non-null `name`.
+ * Inline DSL form (`vcsUrl=` / `branch=` at module level) yields `name = "main"`;
+ * named-block form (`vcsSettings { key { ... } }`) yields `name = "<key>"`.
  * MULTI-VCS is N rows with distinct `name` values. No discriminator column.
  * `repository_type` carries the VCS engine (`GIT` / `MERCURIAL` / `CVS`);
  * typically `GIT`.
@@ -27,8 +29,8 @@ class VcsSettingsEntryEntity(
     @JoinColumn(name = "component_configuration_id", nullable = false)
     var componentConfiguration: ComponentConfigurationEntity,
 
-    @Column(name = "name")
-    var name: String? = null,
+    @Column(name = "name", nullable = false)
+    var name: String,
 
     @Column(name = "vcs_path", columnDefinition = "TEXT", nullable = false)
     var vcsPath: String = "",

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -587,7 +587,7 @@ internal fun List<VcsSettingsEntryEntity>.toVCSSettings(externalRegistry: String
     val roots =
         sorted.map { entry ->
             VersionControlSystemRoot.create(
-                entry.name ?: "main",
+                entry.name,
                 RepositoryType.valueOf(entry.repositoryType ?: "GIT"),
                 entry.vcsPath,
                 entry.tag,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -908,7 +908,7 @@ class ComponentManagementServiceImpl(
             config.vcsEntries.add(
                 VcsSettingsEntryEntity(
                     componentConfiguration = config,
-                    name = req.name,
+                    name = req.name ?: "main",
                     vcsPath = req.vcsPath,
                     branch = req.branch,
                     tag = req.tag,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1357,7 +1357,7 @@ class ImportServiceImpl(
         var sortOrder = 0
         for (root in roots) {
             val path = root.vcsPath ?: continue // skip roots with no path
-            val name = if (roots.size == 1 || root.name == "main") null else root.name
+            val name = root.name
             row.vcsEntries.add(
                 VcsSettingsEntryEntity(
                     componentConfiguration = row,

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -13,8 +13,8 @@
 --     the source-of-truth classifier; `overridden_attribute` is the payload
 --     discriminator for scalar/marker rows only. UNIQUE(component_id, version_range,
 --     overridden_attribute). Partial unique index ensures one base per component.
---   - Unified VCS: SINGLE = MULTI with one entry. All VCS scalars live on
---     `vcs_settings_entries` regardless of cardinality.
+--   - Unified VCS: SINGLE = MULTI with one entry. `name` is always non-null.
+--     All VCS scalars live on `vcs_settings_entries` regardless of cardinality.
 --   - Reference dictionaries: labels, systems, tools (admin-managed).
 --   - Aggregator groups: `component_groups` + `components.component_group_id`.
 --   - Distribution split into 4 specialized child tables (Maven/file-URL/Docker/packages).
@@ -315,11 +315,11 @@ CREATE UNIQUE INDEX uq_doc_links_null_major_version
 -- -----------------------------------------------------------------------------
 -- 1:N children of component_configurations (per-version-rangeable)
 -- -----------------------------------------------------------------------------
--- Unified VCS model: SINGLE-VCS = 1 entry (name=NULL); MULTI-VCS = N entries (named).
+-- Unified VCS model: all VCS entries have a non-null name.
 CREATE TABLE vcs_settings_entries (
     id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     component_configuration_id  UUID NOT NULL REFERENCES component_configurations(id) ON DELETE CASCADE,
-    name                        VARCHAR(255),                                -- NULL for single-VCS; named for multi-VCS
+    name                        VARCHAR(255) NOT NULL,                       -- DSL-assigned root name: 'main' for inline form, named-block key otherwise.
     vcs_path                    TEXT NOT NULL,
     branch                      TEXT,
     tag                         TEXT,

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
@@ -289,6 +289,7 @@ class ComponentDetailMapperTest {
         val vcsEntry = VcsSettingsEntryEntity(
             id = UUID.randomUUID(),
             componentConfiguration = cfg,
+            name = "main",
             vcsPath = "org/repo",
             sortOrder = 0,
         )

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentSummaryMapperTest.kt
@@ -183,6 +183,7 @@ class ComponentSummaryMapperTest {
             VcsSettingsEntryEntity(
                 id = UUID.randomUUID(),
                 componentConfiguration = cfg,
+                name = "main",
                 vcsPath = "org/repo",
                 sortOrder = 0,
             ),
@@ -201,6 +202,7 @@ class ComponentSummaryMapperTest {
             VcsSettingsEntryEntity(
                 id = UUID.randomUUID(),
                 componentConfiguration = cfg,
+                name = "main",
                 vcsPath = "",
                 sortOrder = 0,
             ),
@@ -226,12 +228,12 @@ class ComponentSummaryMapperTest {
         val cfg = baseConfigFor(component)
         cfg.vcsEntries.add(
             VcsSettingsEntryEntity(
-                id = UUID.randomUUID(), componentConfiguration = cfg, vcsPath = "org/repo-b", sortOrder = 2,
+                id = UUID.randomUUID(), componentConfiguration = cfg, name = "main", vcsPath = "org/repo-b", sortOrder = 2,
             ),
         )
         cfg.vcsEntries.add(
             VcsSettingsEntryEntity(
-                id = UUID.randomUUID(), componentConfiguration = cfg, vcsPath = "org/repo-a", sortOrder = 1,
+                id = UUID.randomUUID(), componentConfiguration = cfg, name = "main", vcsPath = "org/repo-a", sortOrder = 1,
             ),
         )
         component.configurations.add(cfg)
@@ -248,6 +250,7 @@ class ComponentSummaryMapperTest {
             VcsSettingsEntryEntity(
                 id = UUID.randomUUID(),
                 componentConfiguration = cfg,
+                name = "main",
                 vcsPath = "ssh://git@bitbucket.spb.example.com/neo/access-contol.git",
                 sortOrder = 0,
             ),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/DistributionEntityMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/DistributionEntityMapperTest.kt
@@ -391,6 +391,7 @@ class DistributionEntityMapperTest {
             VcsSettingsEntryEntity(
                 id = UUID.randomUUID(),
                 componentConfiguration = cfg,
+                name = "main",
                 vcsPath = "org/repo",
                 sortOrder = 0,
             ),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -22,6 +22,7 @@ import org.octopusden.octopus.components.registry.server.repository.ToolReposito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.nio.file.Paths
@@ -39,6 +40,7 @@ import java.nio.file.Paths
     classes = [ComponentRegistryServiceApplication::class],
 )
 @ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @Timeout(120)
 class MigrationIntegrationTest {
     @MockBean
@@ -259,14 +261,14 @@ class MigrationIntegrationTest {
     }
 
     // =========================================================================
-    // MIG-037: Unified VCS model (single row with name=null for single-VCS).
+    // MIG-037: Unified VCS model (VCS root name stored verbatim, never NULL).
     // =========================================================================
 
     @Test
     @Transactional
     @DisplayName(
-        "MIG-037: TEST_COMPONENT has single VCS entry with name=null " +
-            "(unified VCS model, no discriminator column)",
+        "MIG-037: TEST_COMPONENT has single VCS entry with name='main' " +
+            "(inline DSL form: vcsUrl= produces VersionControlSystemRoot.name='main')",
     )
     fun mig037_unifiedVcsModel_singleRoot() {
         val component = componentRepository.findByComponentKey("TEST_COMPONENT")
@@ -276,13 +278,14 @@ class MigrationIntegrationTest {
             configurationRepository.findBaseByComponentId(component!!.id!!)
         assertNotNull(baseRow, "TEST_COMPONENT must have a base row")
 
-        // TEST_COMPONENT has single vcsUrl = "ssh://hg@mercurial/test-component"
-        // → must produce one VcsSettingsEntryEntity with name=null
+        // TEST_COMPONENT uses inline DSL form: vcsUrl = "ssh://hg@mercurial/test-component"
+        // The Groovy DSL wraps this as VersionControlSystemRoot.create("main", ...).
+        // → entity name must be "main" (literal), NOT null.
         val vcsEntries = baseRow!!.vcsEntries
         assertTrue(vcsEntries.isNotEmpty(), "Must have at least one VCS entry")
         assertTrue(
-            vcsEntries.any { it.name == null },
-            "Single-VCS component must have a VCS entry with name=null (unified VCS model)",
+            vcsEntries.any { it.name == "main" },
+            "Inline DSL form must produce name='main'; found: ${vcsEntries.map { it.name }}",
         )
     }
 
@@ -306,7 +309,7 @@ class MigrationIntegrationTest {
             vcsEntries.size >= 2,
             "Multi-VCS component must have 2+ VCS entries, found: ${vcsEntries.size}",
         )
-        val distinctNames = vcsEntries.mapNotNull { it.name }.toSet()
+        val distinctNames = vcsEntries.map { it.name }.toSet()
         assertTrue(
             distinctNames.size >= 2,
             "Multi-VCS entries must have distinct non-null names, found: $distinctNames",

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
@@ -150,7 +150,7 @@ class DatabaseComponentRegistryResolverTest {
     private fun makeVcsEntry(
         config: ComponentConfigurationEntity,
         vcsPath: String,
-        name: String? = null,
+        name: String = "main",
         branch: String? = "master",
         sortOrder: Int = 0,
     ): VcsSettingsEntryEntity =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImplVcsNameTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImplVcsNameTest.kt
@@ -1,0 +1,167 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.lang.reflect.Method
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSystemRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.RepositoryType
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.model.VCSSettings
+import org.octopusden.octopus.escrow.model.VersionControlSystemRoot
+
+/**
+ * Unit tests for `ImportServiceImpl.attachVcsEntries` — verifies that VCS root
+ * names are stored verbatim in [VcsSettingsEntryEntity.name] without collapsing.
+ *
+ * Covers:
+ *   - Inline DSL form: `VersionControlSystemRoot` with name `"main"` (the default
+ *     produced by the Groovy DSL when vcsUrl/branch are used at module level) →
+ *     entity `name = "main"`.
+ *   - Named-block single root: custom name key → entity `name = "<key>"`.
+ *   - Named-block multi root: two roots with distinct keys → entities preserve
+ *     distinct names.
+ *
+ * `attachVcsEntries` is private; it is exercised via reflection.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class ImportServiceImplVcsNameTest {
+
+    private lateinit var service: ImportServiceImpl
+    private lateinit var attachVcsEntriesMethod: Method
+
+    @BeforeEach
+    fun setUp() {
+        // Instantiate ImportServiceImpl with all-mock dependencies.
+        // We only exercise the private `attachVcsEntries` method which has
+        // no dependency on any injected field.
+        service = ImportServiceImpl(
+            gitResolver = mock(ComponentRegistryResolverImpl::class.java),
+            dbResolver = mock(DatabaseComponentRegistryResolver::class.java),
+            componentSourceRepository = mock(ComponentSourceRepository::class.java),
+            sourceRegistry = mock(ComponentSourceRegistry::class.java),
+            configurationLoader = mock(EscrowConfigurationLoader::class.java),
+            registryConfigRepository = mock(RegistryConfigRepository::class.java),
+            componentRepository = mock(ComponentRepository::class.java),
+            configurationRepository = mock(ComponentConfigurationRepository::class.java),
+            componentGroupRepository = mock(ComponentGroupRepository::class.java),
+            systemRepository = mock(SystemRepository::class.java),
+            toolRepository = mock(ToolRepository::class.java),
+            labelRepository = mock(LabelRepository::class.java),
+            componentLabelRepository = mock(ComponentLabelRepository::class.java),
+            componentSystemRepository = mock(ComponentSystemRepository::class.java),
+            componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+        )
+
+        attachVcsEntriesMethod = ImportServiceImpl::class.java
+            .getDeclaredMethod("attachVcsEntries", ComponentConfigurationEntity::class.java, VCSSettings::class.java)
+        attachVcsEntriesMethod.isAccessible = true
+    }
+
+    private fun callAttachVcsEntries(row: ComponentConfigurationEntity, vcsSettings: VCSSettings?) {
+        attachVcsEntriesMethod.invoke(service, row, vcsSettings)
+    }
+
+    private fun baseRow(): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            id = UUID.randomUUID(),
+            component = ComponentEntity(id = UUID.randomUUID(), componentKey = "test"),
+            versionRange = ALL_VERSIONS,
+            overriddenAttribute = null,
+            rowType = "BASE",
+        )
+
+    // =========================================================================
+
+    @Test
+    @DisplayName("inline DSL form (root.name = 'main') → entity name = 'main'")
+    fun inlineDslForm_entityNameIsMain() {
+        // Inline DSL form: VersionControlSystemRoot.create() defaults name to "main".
+        val root = VersionControlSystemRoot.create(
+            "main",
+            RepositoryType.GIT,
+            "ssh://git@gitlab:project/repo.git",
+            null,
+            "main",
+            null,
+        )
+        val vcsSettings = VCSSettings.create(listOf(root))
+        val row = baseRow()
+
+        callAttachVcsEntries(row, vcsSettings)
+
+        assertEquals(1, row.vcsEntries.size, "Expected exactly one VCS entry")
+        assertEquals("main", row.vcsEntries[0].name, "Inline DSL root.name='main' must be stored as 'main'")
+    }
+
+    @Test
+    @DisplayName("named-block single root → entity name = configured key")
+    fun namedBlockSingleRoot_entityNameIsKey() {
+        val configuredKey = "my-component-distribution-vcs"
+        val root = VersionControlSystemRoot.create(
+            configuredKey,
+            RepositoryType.GIT,
+            "ssh://git@gitlab:project/repo.git",
+            null,
+            "main",
+            null,
+        )
+        val vcsSettings = VCSSettings.create(listOf(root))
+        val row = baseRow()
+
+        callAttachVcsEntries(row, vcsSettings)
+
+        assertEquals(1, row.vcsEntries.size, "Expected exactly one VCS entry")
+        assertEquals(configuredKey, row.vcsEntries[0].name, "Named-block root.name must be stored verbatim")
+    }
+
+    @Test
+    @DisplayName("named-block multi root → entities preserve distinct names")
+    fun namedBlockMultiRoot_entityNamesAreDistinct() {
+        val keyA = "cvs"
+        val keyB = "mercurial"
+        val rootA = VersionControlSystemRoot.create(
+            keyA,
+            RepositoryType.CVS,
+            "OctopusSource/COMPONENT",
+            null,
+            "MAIN",
+            null,
+        )
+        val rootB = VersionControlSystemRoot.create(
+            keyB,
+            RepositoryType.MERCURIAL,
+            "ssh://hg@mercurial/releng",
+            null,
+            "v2",
+            null,
+        )
+        val vcsSettings = VCSSettings.create(listOf(rootA, rootB))
+        val row = baseRow()
+
+        callAttachVcsEntries(row, vcsSettings)
+
+        assertEquals(2, row.vcsEntries.size, "Expected two VCS entries for multi-root")
+        val names = row.vcsEntries.map { it.name }.toSet()
+        assertEquals(setOf(keyA, keyB), names, "Multi-root entities must preserve distinct names $keyA and $keyB")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the schema-v2 compat regression in cluster **B**: `GET /versions/{v}/vcs-settings` returned the literal string `"main"` for `.versionControlSystemRoots[i].name` on 5 single-VCS components, where baseline returns the configured root name (e.g., a named-block key from the DSL).

Other fields (`vcsPath`, `type`, `tag`, `branch`) match — only `.name` was wrong.

## Root cause

Two cooperating bugs in the v2 VCS pipeline:

1. **Import side (`ImportServiceImpl.attachVcsEntries`)**: stored `null` for `name` whenever `roots.size == 1 || root.name == "main"`. This collapsed all single-root components to anonymous, conflating two DSL forms:
   - **Inline form** (`vcsUrl=`/`branch=` at module level) → DSL yields `name = "main"` (literal default).
   - **Named-block form** (`vcsSettings { foo { ... } }`) → DSL yields `name = "<key>"`.
2. **Read side (`EntityMappers.toVCSSettings`)**: substituted `?: "main"` when `entry.name` was `null`. So the configured key was lost on every single-root named-block component.

Schema-v2 isn't in prod yet (per memory policy: V1 in place + Groovy re-import). So we can tighten the model end-to-end.

## Approach (1-line core change + tighten model)

- **`ImportServiceImpl.attachVcsEntries`**: replace the conditional null-collapse with `val name = root.name`. Persist what the DSL gave us.
- **`EntityMappers.toVCSSettings`**: drop the `?: "main"` fallback. Emit `entry.name` directly.
- **`VcsSettingsEntryEntity.name`**: change `var name: String? = null` to `var name: String` (non-null end-to-end).
- **`V1__schema.sql` `vcs_settings_entries.name`**: change to `VARCHAR(255) NOT NULL`. Update comments to describe the new contract.
- **`ComponentManagementServiceImpl.replaceVcsEntries`** (V4 write path): fall back to `"main"` when V4 caller omits the name (`req.name ?: "main"`) — keeps the V4 API back-compat unchanged (the DTO `VcsEntryRequest.name` stays `String? = null`).
- Sweep audit: 4 existing test fixtures (`ComponentDetailMapperTest`, `ComponentSummaryMapperTest`, `DistributionEntityMapperTest`, `DatabaseComponentRegistryResolverTest`) updated to pass explicit `name = "main"` on single-VCS fixtures that previously relied on `null`.
- `@DirtiesContext(BEFORE_CLASS)` added to `MigrationIntegrationTest` (PR-B branched from `feat/schema-v2-sql` tip BEFORE the PR #208 fix landed; re-applied here for order-independence in single-JVM CI).

## Test plan

- [x] New `ImportServiceImplVcsNameTest` — 3 tests (red → green):
  - Inline DSL form (single root, default DSL `name = "main"`) → entity `name = "main"`.
  - Named-block single root → entity `name = "<configured-key>"`.
  - Named-block multi root → entities preserve distinct names.
- [x] Updated `MigrationIntegrationTest.mig037_unifiedVcsModel_singleRoot` — now asserts `name = "main"` instead of `name == null`. Multi-root subtest semantically unchanged.
- [x] Full local build `./gradlew build -x dockerBuildImage -x ocCi -x :components-registry-automation:test` — **BUILD SUCCESSFUL** (173 tasks, all tests green).

## TDD chain

2 commits, test-first:
1. `test:` `ImportServiceImplVcsNameTest` + `MigrationIntegrationTest.mig037_*` updated assertion (red against current `attachVcsEntries` null-collapse).
2. `fix:` core 1-line + model tightening (entity non-null, schema NOT NULL, mapper fallback removed) + V4 write back-compat + 4 fixture sweep (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)