### PR TITLE
fix(test): restore ImportServiceImplVcsNameTest after merge ctor drift

### DIFF
--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImplVcsNameTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImplVcsNameTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mockito.mock
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
@@ -70,6 +71,7 @@ class ImportServiceImplVcsNameTest {
             componentLabelRepository = mock(ComponentLabelRepository::class.java),
             componentSystemRepository = mock(ComponentSystemRepository::class.java),
             componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+            componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
         )
 
         attachVcsEntriesMethod = ImportServiceImpl::class.java


### PR DESCRIPTION
## Summary

Build **3435 FAILED** on `:components-registry-service-server:compileTestKotlin`:

```
e: ImportServiceImplVcsNameTest.kt:72:13 No value passed for parameter 'componentBuildToolBeanRepository'
```

Merge artifact. `ImportServiceImplVcsNameTest` instantiates `ImportServiceImpl` directly with all named ctor args. The D+E PR added a 15th dependency (`componentBuildToolBeanRepository: ComponentBuildToolBeanRepository`) in the same release window as the VCS-name PR; merge order put D+E first, so when the VCS-name PR landed the ctor call was left one arg short. Neither subagent review caught it (D+E review didn't look at unmerged sibling tests; B review looked against a base that didn't yet have the new ctor param).

## Fix

One-line ctor arg + the import. Pure test-side; no production change.

## Test plan

- [x] `./gradlew :components-registry-service-server:compileTestKotlin` — green.
- [x] `./gradlew :components-registry-service-server:test --tests "*ImportServiceImplVcsNameTest*"` — all 3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)