### PR TITLE
feat(local-stands): polluted-run guard in verify.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,22 @@ What it does, per flag:
 |---|---|---|
 | `--restart` | code-only change (import / mapper / resolver) | port-scoped kill of the candidate JVM, respawn from `$CANDIDATE_WORKTREE` via `candidate.sh`, wait `/actuator/health` UP, run `:components-registry-compat-test:test`. DSL→DB automigrate re-runs through the new code on every restart. |
 | `--reset-db` | edit to `V1__schema.sql` | implies `--restart`, plus `docker compose down -v` so Flyway re-applies the schema from scratch before automigrate. |
+| `--allow-partial-migration` | targeted smoke knowingly excluding failed components | after restart, the gate parses the auto-migrate summary; without this flag, any `failed > 0` makes verify exit `4` (POLLUTED RUN). With it, the gate prints the warning + failed-component list but proceeds. Only use when your test filter skips the failed set. |
 | _(no flag)_ | re-read state | runs compat against the existing stands without touching them. |
+
+**Exit codes:** `0` clean / `2` baseline down or env missing / `3` candidate failed to come up / `4` polluted run / `*` gradle exit code from compat.
+
+**Polluted run — how to recognize one from the diff signature alone:**
+
+If you have a `summary.md` and don't know whether the run was polluted (e.g. you didn't see the verify banner):
+
+- `STATUS_CODE_DIFF` dominated by `200 → 500` (not `200 → 404`) — endpoints crash on missing-component refs.
+- `NULL_VS_EMPTY` on `GET /rest/api/3/components` for many distinct `componentId=` — those components weren't imported.
+- `VALUE_DIFF` count is small or zero while `STRUCTURAL_DIFF` and `STATUS_CODE_DIFF` are huge.
+
+This combination is the characteristic signature of a partially-migrated DB. **Do not classify these diffs as your cluster's regressions** without first ruling out the polluted-state hypothesis — re-run with `--restart` (which always invokes the migration health-check) or grep the candidate log for `Failed to migrate component '`. The no-flag path of `verify.sh` does NOT invoke the health-check (it has no fresh log to look at), so a polluted candidate started by an earlier `--restart` could keep serving stale state until the next restart-flagged run.
+
+**When `--reset-db` surfaces an upstream import regression:** if the gate exits `4` and the failed components are not in *your* cluster (B / C / D+E / F+G), the regression belongs to an earlier merged PR — file it separately, don't fold the fix into your cluster PR. To continue validating *your* cluster while the upstream fix is in flight, use `--allow-partial-migration` together with a smoke filter (`COMPAT_SMOKE_COMPONENTS=` or `--tests`) that excludes the failed components.
 
 **Env contract** (verify.sh fails fast with a clear message if any required var is missing when a restart-flag is used):
 

--- a/scripts/local-stands/README.md
+++ b/scripts/local-stands/README.md
@@ -134,6 +134,19 @@ export LOCAL_VCS_ROOT="$HOME/your-registry-dsl-clone"
 ./scripts/local-stands/baseline.sh
 ```
 
+## Polluted-run guard
+
+`verify.sh --restart` (and `--reset-db`) parses the candidate log right after
+health-up for the auto-migrate summary line. If any component failed to import,
+it exits `4` with a `POLLUTED RUN` banner and the failed-component list — the
+following compat diffs would be dominated by `NULL_VS_EMPTY` / `200→500` noise
+on the missing components rather than real backward-compat regressions.
+
+Override with `--allow-partial-migration` only when you're running a targeted
+smoke that explicitly excludes the failed set (e.g. via `COMPAT_SMOKE_COMPONENTS=`
+or `--tests`). See `AGENTS.md` § "Compatibility Verification" for the cluster
+classification rule of thumb.
+
 ## Caveats
 
 - `baseline.sh` runs from a fat JAR. On first invocation it executes

--- a/scripts/local-stands/verify.sh
+++ b/scripts/local-stands/verify.sh
@@ -2,13 +2,34 @@
 # Verify gate for local stands.
 #
 # Flow per flags:
-#   verify.sh                        — just compat against the currently-running stands
-#   verify.sh --restart              — kill candidate JVM, run candidate.sh in background,
-#                                      wait for health, then compat. DSL→DB automigrate runs
-#                                      via dev-db-automigrate profile on every candidate start.
-#   verify.sh --reset-db             — implies --restart, plus tears down + recreates the
-#                                      postgres volume so Flyway re-applies V1__schema.sql.
-#                                      Needed when V1__schema.sql itself changed (e.g. PR-D+E).
+#   verify.sh                              — just compat against the currently-running stands
+#   verify.sh --restart                    — kill candidate JVM, run candidate.sh in background,
+#                                            wait for health, then compat. DSL→DB automigrate
+#                                            runs via dev-db-automigrate profile on every
+#                                            candidate start.
+#   verify.sh --reset-db                   — implies --restart, plus tears down + recreates
+#                                            the postgres volume so Flyway re-applies
+#                                            V1__schema.sql. Needed when V1__schema.sql itself
+#                                            changed (e.g. PR-D+E).
+#   verify.sh --allow-partial-migration    — after restart, the gate parses the candidate log
+#                                            for the auto-migrate summary; if any components
+#                                            failed to import, it exits 4 (POLLUTED RUN). With
+#                                            this flag the gate prints the same warning but
+#                                            proceeds — use it only for targeted smoke that
+#                                            knowingly excludes the failed components.
+#                                            Has no effect without --restart/--reset-db: the
+#                                            guard only fires after the gate itself spawned the
+#                                            candidate (and therefore knows which log file holds
+#                                            the migration summary). If a candidate that was
+#                                            started polluted is still running, re-run with
+#                                            --restart to surface the issue.
+#
+# Exit codes:
+#   0  — compat run finished cleanly, gradle exit 0
+#   2  — baseline not running, or env-vars missing for --restart
+#   3  — candidate failed to come up after --restart
+#   4  — POLLUTED RUN: auto-migrate reported failures; compat result is unreliable
+#   *  — gradle exit code from compat.sh otherwise
 #
 # Extra args are forwarded verbatim to compat.sh / gradle (e.g. --tests "*BuildToolsV2*").
 #
@@ -20,12 +41,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESTART=0
 RESET_DB=0
+ALLOW_PARTIAL=0
 PASS_ARGS=()
 for arg in "$@"; do
   case "$arg" in
-    --restart)  RESTART=1 ;;
-    --reset-db) RESTART=1; RESET_DB=1 ;;
-    *) PASS_ARGS+=("$arg") ;;
+    --restart)                  RESTART=1 ;;
+    --reset-db)                 RESTART=1; RESET_DB=1 ;;
+    --allow-partial-migration)  ALLOW_PARTIAL=1 ;;
+    *)                          PASS_ARGS+=("$arg") ;;
   esac
 done
 
@@ -52,6 +75,71 @@ kill_port() {
   done
   echo "    still alive — SIGKILL"
   kill -9 $pids 2>/dev/null || true
+}
+
+# Parse the candidate log for the auto-migrate summary. If any component failed
+# to import, the candidate is serving a partially-migrated DB — any compat diff
+# count will be dominated by NULL_VS_EMPTY and STATUS_CODE 200→500 on the missing
+# components, not by real backward-compat regressions. Fail-fast (exit 4) unless
+# the caller passed --allow-partial-migration (targeted smoke that knowingly
+# excludes the failed set).
+check_migration_health() {
+  local log="$1"
+  [ -f "$log" ] || return 0
+  local line total migrated failed skipped
+  # Prefer the inner structured ImportServiceImpl marker
+  #   "Migration complete: total=X, migrated=Y, failed=Z, skipped=W"
+  # and fall back to the outer ComponentsRegistryServiceImpl wrapper
+  #   "Auto-migrate complete: X migrated, Y skipped, Z failed".
+  line=$(grep -E 'Migration complete: total=' "$log" 2>/dev/null | tail -n 1 || true)
+  if [ -n "$line" ]; then
+    total=$(echo    "$line" | sed -E 's/.*total=([0-9]+).*/\1/')
+    migrated=$(echo "$line" | sed -E 's/.*migrated=([0-9]+).*/\1/')
+    failed=$(echo   "$line" | sed -E 's/.*failed=([0-9]+).*/\1/')
+    skipped=$(echo  "$line" | sed -E 's/.*skipped=([0-9]+).*/\1/')
+  else
+    line=$(grep -E 'Auto-migrate complete:' "$log" 2>/dev/null | tail -n 1 || true)
+    if [ -z "$line" ]; then
+      echo ">>> migration summary: not found in $log (candidate may not run auto-migrate; skipping check)"
+      return 0
+    fi
+    # Anchor each capture against its full surrounding template — the obvious
+    # `.*([0-9]+) keyword.*` form is greedy-left and silently loses the last
+    # digit of any multi-digit number ending in 0 (e.g. "10 failed" → "0").
+    local pat='Auto-migrate complete: ([0-9]+) migrated, ([0-9]+) skipped, ([0-9]+) failed'
+    migrated=$(echo "$line" | sed -E "s/.*$pat.*/\1/")
+    skipped=$(echo  "$line" | sed -E "s/.*$pat.*/\2/")
+    failed=$(echo   "$line" | sed -E "s/.*$pat.*/\3/")
+    total=$((migrated + skipped + failed))
+  fi
+
+  echo ">>> migration summary: total=$total migrated=$migrated failed=$failed skipped=$skipped"
+
+  if [ "$failed" -gt 0 ]; then
+    echo
+    echo "  ⚠️  POLLUTED RUN: $failed of $total components failed to import."
+    echo "      Compat diffs will be dominated by NULL_VS_EMPTY on the missing"
+    echo "      components and STATUS_CODE 200→500 on endpoints referencing them —"
+    echo "      NOT real backward-compat regressions of the current branch."
+    echo
+    echo "      Failed components (from $log):"
+    grep -E "Failed to migrate component '" "$log" 2>/dev/null \
+      | sed -E "s/.*Failed to migrate component '([^']+)'.*/        - \1/" \
+      | sort -u \
+      || echo "        (no per-component error lines — check $log directly)"
+    echo
+    if [ "$ALLOW_PARTIAL" -eq 1 ]; then
+      echo "      --allow-partial-migration set; proceeding despite the warning."
+      echo "      Make sure your test filter / smoke list excludes the failed components,"
+      echo "      otherwise the polluted state will leak into your diff classification."
+      echo
+    else
+      echo "      Resolve the upstream import regression first, then re-run."
+      echo "      To force-proceed with a targeted smoke that excludes the failures:"
+      echo "          ./scripts/local-stands/verify.sh --restart --allow-partial-migration ..."
+      exit 4
+    fi
+  fi
 }
 
 # Wait until $port is free, capped at $2 seconds.
@@ -124,6 +212,10 @@ if [ "$RESTART" -eq 1 ]; then
     tail -n 40 "$CANDIDATE_LOG" || true
     exit 3
   fi
+  # Polluted-run guard. Only meaningful right after a restart since we know
+  # which log file the migration just wrote to; for the no-flag path the log
+  # may be missing or stale.
+  check_migration_health "$CANDIDATE_LOG"
 elif ! health "$CANDIDATE_PORT"; then
   echo "ERROR: candidate (:$CANDIDATE_PORT) is not running and --restart was not passed."
   echo "       Either: re-run with --restart, or start manually with ./scripts/local-stands/candidate.sh"


### PR DESCRIPTION
## Summary

- Adds a polluted-run guard to `verify.sh` (`scripts/local-stands/verify.sh`): after the candidate is healthy, parse the candidate log for the auto-migrate summary marker (`Migration complete: total=…, migrated=…, failed=…, skipped=…`, with fallback to the older `Auto-migrate complete: …` format). If any component failed to import, print a `POLLUTED RUN` banner with the failed-component list and exit `4`. Code-only PRs that don't touch the auto-migrate path see no change.
- New flag `--allow-partial-migration` is the explicit escape hatch when an agent needs to validate a targeted smoke that knowingly excludes the failed components — gate still prints the warning, but proceeds. Flag has no effect without `--restart`/`--reset-db`; documented.
- Fallback parser anchors each capture against the full surrounding template. The obvious `.*([0-9]+) keyword.*` form is greedy-left and silently loses the last digit of multi-digit counts ending in 0 (`"30 failed"` → `"0"`) — would have suppressed exit `4` on the very kind of polluted run this PR is meant to catch.
- `AGENTS.md` gets an exit-code table, a polluted-run diff signature (`200→500` + `NULL_VS_EMPTY` on many distinct `componentId`), and the cluster-classification rule of thumb (if the failed components aren't in *your* cluster, file the upstream regression separately).
- `scripts/local-stands/README.md` short cross-reference section.

## Why this PR exists

First-attempt usage of PR #210 (the local-stand verify gate) revealed a real hole. The user ran `--reset-db` against `feat/schema-v2-sql @ b165ad0` (post #207 §6.3 component-groups merge). 22 of 948 components hit dup-key violations during import, candidate JVM still came up, gate didn't notice, compat ran, and the resulting 510 diffs were dominated by environment noise (NULL_VS_EMPTY on missing components / 200→500 on endpoints referencing them) rather than real backward-compat regressions of the branch. An AI agent reading `summary.md` cold cannot tell signal from noise from the numbers alone.

This PR closes that gap so the next plan-agent gets a hard fail instead of a confusing diff stream.

## Pre-merge validation

- Subagent review (Sonnet) flagged one correctness bug (the greedy-left sed) and three documentation gaps — all addressed in this same PR before push.
- Parser unit-tested across five log shapes (clean / polluted-inner-format / polluted-with-allow-partial / polluted-outer-format-only / no-marker-at-all) and a trailing-zero-count case for the greedy-fix; all behave correctly.
- `verify.sh --tests "*ServiceStatusV2CompatTest*"` on the running stands: clean run, exit 0.
- `grep -n -F -f forbidden-literals.txt scripts/local-stands/verify.sh AGENTS.md scripts/local-stands/README.md` returns empty.

## Test plan

- [ ] Reviewer cherry-picks an artificial log with a known `failed > 0` summary into `/tmp/crs-candidate-4568.log` and confirms `verify.sh` exits `4` with the expected banner.
- [ ] With `--allow-partial-migration`, the same log triggers the warning but proceeds.
- [ ] On a clean candidate, the guard logs the summary and proceeds (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)