### PR TITLE
test(import): IMP-003 regression guard — KTS-only build-block shape

### DIFF
--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/BuildToolBeansImportTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/BuildToolBeansImportTest.kt
@@ -137,4 +137,40 @@ class BuildToolBeansImportTest {
             "Expected PTKProductToolBean(03.49) in $buildTools"
         }
     }
+
+    // -------------------------------------------------------------------------
+    // IMP-003: cards_db-shape — KTS carries build.tools, Groovy has NO build block
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName(
+        "IMP-003: TEST_COMPONENT_BUILD_TOOLS_KTS_ONLY (KTS-only build block, Groovy without build) " +
+            "MUST persist its Oracle bean after auto-migrate — reproduces production cards_db shape",
+    )
+    @Transactional
+    fun imp003_ktsOnlyBuildBlock_persistsOracleBean() {
+        val component = componentRepository.findByComponentKey("TEST_COMPONENT_BUILD_TOOLS_KTS_ONLY")
+        assertNotNull(component, "TEST_COMPONENT_BUILD_TOOLS_KTS_ONLY must be migrated")
+
+        val baseRow = configurationRepository.findBaseByComponentId(component!!.id!!)
+        assertNotNull(baseRow, "BASE row must exist for TEST_COMPONENT_BUILD_TOOLS_KTS_ONLY")
+
+        val beans = buildToolBeanRepository
+            .findByComponentConfigurationId(baseRow!!.id!!)
+            .sortedBy { it.sortOrder }
+
+        assertEquals(
+            1,
+            beans.size,
+            "Expected 1 build-tool bean row (oracleDatabase 12.0); got ${beans.size}. " +
+                "The KTS-only-build-block shape (matching production cards_db) MUST flow " +
+                "through the merge so that ImportServiceImpl.attachBuildToolBeans sees " +
+                "the Oracle bean. If this test is red, the merge is short-circuiting " +
+                "for components whose Groovy side has no `build` block.",
+        )
+
+        val oracle = beans.firstOrNull { it.beanType == "oracleDatabase" }
+        assertNotNull(oracle, "oracleDatabase bean must be persisted")
+        assertEquals("12.0", oracle!!.versionPattern)
+    }
 }

--- a/test-common/src/test/resources/components-registry/common/Defaults.groovy
+++ b/test-common/src/test/resources/components-registry/common/Defaults.groovy
@@ -18,4 +18,10 @@ Defaults {
         explicit = false
         external = true
     }
+    // Mirror production Defaults.groovy shape: presence of a `build` block makes
+    // `Defaults.buildParameters` non-null so that components without their own
+    // `build` block (e.g. cards_db in production) inherit it as the clone-base
+    // and the KTS-side `tools { database { oracle { ... } } }` merge has a
+    // non-null `buildConfiguration` to clear+addAll into.
+    build { }
 }

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -981,6 +981,54 @@ TEST_COMPONENT4 {
     build { }
 }
 
+// Reproduces production-DSL shape: Groovy carries NO `build` block at the
+// component level — relies on `Defaults.groovy`. Build tools come from the
+// KTS counterpart via merge. Two version-range subcomponents matching
+// production cards_db / dwh_db shape, including a per-range `build` block
+// that triggers `parseBuildSection` (which hardcodes `buildTools = emptyList()`),
+// per-range overrides for buildSystem and escrow.generation, and a
+// component-level jira block — full cards_db shape minus the customer DSL.
+"TEST_COMPONENT_BUILD_TOOLS_KTS_ONLY" {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.build.tools"
+    artifactId = "test-build-tools-kts-only"
+
+    jira {
+        projectKey = "TBTKO"
+        technical = true
+        majorVersionFormat = '$major.$minor'
+        releaseVersionFormat = '$major.$minor.$service'
+        buildVersionFormat = '$major.$minor.$service-$build'
+        displayName = "Test build tools KTS-only"
+    }
+
+    "[2.0,)" {
+        groupId = "org.octopusden.octopus.test.kts-only.v2"
+        buildSystem = MAVEN
+        build {
+            requiredTools = "BuildEnv"
+        }
+        vcsSettings {
+            externalRegistry = "kts-only"
+        }
+    }
+    "(,2.0)" {
+        groupId = "org.octopusden.octopus.test.kts-only.v1"
+        buildSystem = ESCROW_NOT_SUPPORTED
+        escrow {
+            generation = EscrowGenerationMode.UNSUPPORTED
+        }
+        vcsSettings {
+            externalRegistry = "kts-only"
+        }
+    }
+
+    distribution {
+        explicit = false
+        external = false
+    }
+}
+
 "TEST_COMPONENT_VERSIONED_ARTIFACT" {
     componentOwner = "user9"
     buildSystem = MAVEN

--- a/test-common/src/test/resources/components-registry/common/TestComponents.kts
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.kts
@@ -34,3 +34,23 @@ component("TEST_COMPONENT_BUILD_TOOLS") {
         }
     }
 }
+
+// Reproduces the production-DSL shape of database-backed components where the
+// KTS file carries the full `build { tools { database { oracle {...} } } }`
+// block but the Groovy counterpart has NO `build` block (relies on
+// `Defaults.groovy` for build defaults). PR-D+E's `attachBuildToolBeans` must
+// still persist the Oracle bean for this shape — covered by IMP-003.
+// `productType` mirrors `cards_db`/`dwh_db` shape (presence of any productType,
+// not the specific value — the test environment registers PT_K-family keys only).
+component("TEST_COMPONENT_BUILD_TOOLS_KTS_ONLY") {
+    productType = "PT_K"
+    build {
+        tools {
+            database {
+                oracle {
+                    version = "12.0"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a regression guard test (`IMP-003`) covering the production-DSL shape where the KTS file carries the full `build { tools { database { oracle { ... } } } }` block and the Groovy counterpart has no component-level `build` block. This matches the cluster-D production components (the ones with Oracle/PTC/PTK build-tool beans).

**This is NOT a bug fix.** PR-D+E (#208) handles this shape correctly. The test exists to lock the contract in place: if `attachBuildToolBeans` ever stops firing for this shape after a refactor, IMP-003 turns red.

## How the false alarm started

Local compat-test against the merged `feat/schema-v2-sql` showed 510 active divergences. Root cause: the local candidate JVM was in a half-broken state — two JVMs (one stale, one fresh) had been racing on the same Postgres after a partial `--reset-db`. The race produced 22 `duplicate key value violates unique constraint "components_component_key_key"` errors during auto-migrate, which made `requireMigrationSucceeded` throw → context refresh failed → partial commits left the DB inconsistent. Cards_db's BASE row got committed but the Oracle bean attach was rolled back.

After a clean reset (kill all candidate JVMs, wipe + recreate Postgres volume, start a single fresh candidate), auto-migrate completed `total=948, migrated=948, failed=0`, and `component_build_tool_beans` correctly contained 8 rows — one for each cluster-D component:

| component_key | bean_type | version_pattern |
|---|---|---|
| cards_db | oracleDatabase | `[12,)` |
| DBK | kProduct | (null) |
| DM | dDbProduct | (null) |
| dwh_db | oracleDatabase | `[12,)` |
| kernel_db | oracleDatabase | `[12,)` |
| pm_java | cProduct | (null) |
| ufxcore | cProduct | (null) |
| w4manager | kProduct | (null) |

`curl /rest/api/2/components/cards_db/versions/.../build-tools?ignore-required=true` returns `[{"@type":"oracleDatabase","type":"ORACLE","settingsProperty":"db","version":"[12,)","edition":null}]` matching baseline.

## What's in this PR

- **`Defaults.groovy`** — adds an empty `build { }` block so test components without their own component-level `build` block inherit a non-null `buildConfiguration` clone-base (matching the production Defaults shape).
- **`TestComponents.kts`** — adds `TEST_COMPONENT_BUILD_TOOLS_KTS_ONLY` with the full KTS DSL: `productType = "PT_K"` (test-registered key), `build { tools { database { oracle { version = "12.0" } } } }`.
- **`TestComponents.groovy`** — adds the Groovy counterpart with NO component-level `build` block; two version ranges (`[2.0,)` and `(,2.0)`), per-range `build { requiredTools }`, vcsSettings, escrow.generation override — full cards_db shape.
- **`BuildToolBeansImportTest`** — IMP-003 asserts `component_build_tool_beans` has exactly 1 row (oracleDatabase 12.0) on the BASE row.

## Test plan

- [x] `./gradlew :components-registry-service-server:test --tests "*BuildToolBeansImportTest*"` — all 3 tests pass (imp001, imp002, imp003).
- [x] `--reset-db` on local candidate against current `feat/schema-v2-sql` HEAD: auto-migrate clean, all 8 cluster-D components persist their build-tool-bean rows, `/build-tools` endpoint matches baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)