### PR TITLE
fix(quality): SUPPORTED_ATTRIBUTES — final + immutable (1/2 SpotBugs cleanup)

### DIFF
--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidator.groovy
@@ -44,12 +44,12 @@ class GroovySlurperConfigValidator {
     private static final String DOCKER_ENTRY_PATTERN_V2 = "$DOCKER_IMAGE_PATH_PATTERN(:$DOCKER_IMAGE_TAG_SUFFIX_PATTERN_V2)?"
     public static final Pattern DOCKER_PATTERN_V2 = Pattern.compile("^($DOCKER_ENTRY_PATTERN_V2)(,($DOCKER_ENTRY_PATTERN_V2))*\$")
 
-    public static SUPPORTED_ATTRIBUTES = ['buildSystem', VCS_URL, REPOSITORY_TYPE, 'groupId', 'artifactId',
+    public static final List<String> SUPPORTED_ATTRIBUTES = ['buildSystem', VCS_URL, REPOSITORY_TYPE, 'groupId', 'artifactId',
                                           TAG, 'versionRange', 'version', 'module',
                                           'teamcityReleaseConfigId', 'jiraProjectKey', 'jiraMajorVersionFormat', 'jiraReleaseVersionFormat',
                                           'buildFilePath', 'deprecated', BRANCH, HOTFIX_BRANCH,
                                           'componentDisplayName', 'componentOwner', 'releaseManager', 'securityChampion', 'system',
-                                          'clientCode', 'releasesInDefaultBranch', 'solution', 'parentComponent', 'octopusVersion', 'archived', 'copyright']
+                                          'clientCode', 'releasesInDefaultBranch', 'solution', 'parentComponent', 'octopusVersion', 'archived', 'copyright'].asImmutable()
 
     static SUPPORTED_JIRA_ATTRIBUTES = ['projectKey', 'lineVersionFormat', 'majorVersionFormat', 'releaseVersionFormat', 'buildVersionFormat', 'hotfixVersionFormat', "displayName", 'technical']
 

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/configuration/validation/GroovySlurperConfigValidatorTest.groovy
@@ -1,11 +1,13 @@
 package org.octopusden.octopus.escrow.configuration.validation
 
+import java.lang.reflect.Modifier
 import org.octopusden.releng.versions.VersionNames
 
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DEB_PATTERN
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.DOCKER_PATTERN_V2
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.GAV_PATTERN
 import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.RPM_PATTERN
+import static org.octopusden.octopus.escrow.configuration.validation.GroovySlurperConfigValidator.SUPPORTED_ATTRIBUTES
 
 class GroovySlurperConfigValidatorTest extends GroovyTestCase {
 
@@ -85,6 +87,28 @@ class GroovySlurperConfigValidatorTest extends GroovyTestCase {
             }
         }
         assert errorCount == incorrectDockerStrings.size()
+    }
+
+    void testSupportedAttributesIsStaticFinal() {
+        def field = GroovySlurperConfigValidator.class.getDeclaredField('SUPPORTED_ATTRIBUTES')
+        assert Modifier.isStatic(field.modifiers)
+        assert Modifier.isFinal(field.modifiers)
+        assert Modifier.isPublic(field.modifiers)
+    }
+
+    void testSupportedAttributesIsUnmodifiable() {
+        shouldFail(UnsupportedOperationException) {
+            SUPPORTED_ATTRIBUTES.add('extraAttribute')
+        }
+        shouldFail(UnsupportedOperationException) {
+            SUPPORTED_ATTRIBUTES.clear()
+        }
+    }
+
+    void testSupportedAttributesContainsExpectedEntries() {
+        assert SUPPORTED_ATTRIBUTES.contains('buildSystem')
+        assert SUPPORTED_ATTRIBUTES.contains('groupId')
+        assert SUPPORTED_ATTRIBUTES.contains('artifactId')
     }
 
 }


### PR DESCRIPTION
## Summary

- Closes the single real-bug SpotBugs HIGH-priority finding in production code: `MS_SHOULD_BE_FINAL` on `GroovySlurperConfigValidator.SUPPORTED_ATTRIBUTES`.
- Adds `final` + wraps in `.asImmutable()` so accidental mutation throws `UnsupportedOperationException` instead of silently corrupting shared validator state.
- Visibility stays `public` — `EscrowConfigurationLoader.groovy:60` imports the field statically.

## Why both `final` AND `.asImmutable()`

Just `final` alone would have swapped one HIGH-priority pattern for another: `MS_SHOULD_BE_FINAL` → `MS_MUTABLE_COLLECTION`. Same priority, same class of bug. Already observed on `TestConfigUtils.SUPPORTED_GROUP_IDS/SUPPORTED_SYSTEMS` in build 2.0.84-3436.

## Scope note

This is **1 of 2 PRs** for SpotBugs cleanup. The follow-up PR will disable SpotBugs in `build.gradle` + remove the TeamCity FINDBUGS xmlReport feature — after analysis (build 3436) showed 1 real bug out of 21 HIGH-priority findings, with the rest being Kotlin lateinit / DSL getter / test-code false positives.

8 sibling static fields in the same class (`SUPPORTED_JIRA_ATTRIBUTES`, `SUPPORTED_BUILD_ATTRIBUTES`, etc.) have the same mutable-static shape but were not flagged HIGH — intentionally left for the SpotBugs-removal PR rather than touched here.

## Test plan

- [x] `./gradlew :component-resolver-core:test --tests "*GroovySlurperConfigValidatorTest*"` — 8 tests pass (3 new for invariants).
- [x] `./gradlew :component-resolver-core:spotbugsMain` — `SUPPORTED_ATTRIBUTES` no longer in spotbugs report; total drops 424 → 423 for the module.
- [x] Full `./gradlew build` with CRS-local exclusions (AUTH_SERVER + `-x` docker/oc/automation:test) — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)