### PR TITLE
chore(quality): disable SpotBugs (2/2 SpotBugs cleanup)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ All existing v1/v2/v3 endpoints (34 endpoints, 28 Feign client methods) must rem
 - Java checks (Checkstyle, PMD) are **blocking**.
 - Kotlin checks (detekt, ktlint) are **blocking** with module-level baselines.
 - Groovy CodeNarc is **report-only** — do not make blocking without explicit decision.
-- **SpotBugs intentionally disabled** in `build.gradle` (see `afterEvaluate { tasks.matching { spotbugs } }`). Bytecode-flow analysis gave high false-positive rate on Kotlin lateinit / DSL getter / test code; the per-language tools above already cover the same ground. Do not re-enable without an explicit policy decision.
+- **SpotBugs intentionally disabled** in `build.gradle` via `tasks.matching { it.name.startsWith('spotbugs') }.configureEach { enabled = false }` (the plugin itself stays applied because it's owned by the `octopus-quality` convention plugin). Bytecode-flow analysis gave high false-positive rate on Kotlin lateinit / DSL getter / test code; the per-language tools above already cover the same ground. Do not re-enable without an explicit policy decision.
 - JaCoCo coverage: per-module minimum 10%, overall weighted minimum 70%.
 
 ## CI Workflows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ All existing v1/v2/v3 endpoints (34 endpoints, 28 Feign client methods) must rem
 - Java checks (Checkstyle, PMD) are **blocking**.
 - Kotlin checks (detekt, ktlint) are **blocking** with module-level baselines.
 - Groovy CodeNarc is **report-only** — do not make blocking without explicit decision.
+- **SpotBugs intentionally disabled** in `build.gradle` (see `afterEvaluate { tasks.matching { spotbugs } }`). Bytecode-flow analysis gave high false-positive rate on Kotlin lateinit / DSL getter / test code; the per-language tools above already cover the same ground. Do not re-enable without an explicit policy decision.
 - JaCoCo coverage: per-module minimum 10%, overall weighted minimum 70%.
 
 ## CI Workflows

--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,9 @@ configure(subprojects) {
         // detekt + ktlint (Kotlin, blocking), CodeNarc (Groovy, report-only) — already covers
         // each language with native rule sets. Keeping SpotBugs would require ongoing exclude-filter
         // maintenance for marginal signal. See AGENTS.md Quality Gates section.
+        //
+        // We disable the *tasks* rather than apply-false the plugin: the SpotBugs plugin is owned
+        // by octopus-quality (shared convention), so opting out happens at the consumer side here.
         if (pluginManager.hasPlugin('com.github.spotbugs')) {
             tasks.matching { it.name.startsWith('spotbugs') }.configureEach { enabled = false }
         }
@@ -271,8 +274,7 @@ def writeQualityReportsIndex = {
                     [pattern: '**/build/reports/pmd/*.html', artifactPrefix: 'pmd'],
                     [pattern: '**/build/reports/codenarc/*.html', artifactPrefix: 'codenarc'],
                     [pattern: '**/build/reports/detekt/*.html', artifactPrefix: 'detekt'],
-                    [pattern: '**/build/reports/ktlint/*.html', artifactPrefix: 'ktlint'],
-                    [pattern: '**/build/reports/spotbugs/*.html', artifactPrefix: 'spotbugs']
+                    [pattern: '**/build/reports/ktlint/*.html', artifactPrefix: 'ktlint']
             ],
             'Coverage': [
                     [pattern: '**/build/reports/jacoco/*/html/index.html', artifactPrefix: 'jacoco'],

--- a/build.gradle
+++ b/build.gradle
@@ -176,12 +176,15 @@ configure(subprojects) {
     }
 
     afterEvaluate {
-        // SpotBugs is newly introduced by the convention plugin; suppress gate failures
-        // until violations in this repo are reviewed and addressed.
+        // SpotBugs disabled for this project. The octopus-quality convention plugin enables it,
+        // but bytecode-flow analysis produced a 95% false-positive rate on Kotlin lateinit / DSL
+        // getter / test code in build 2.0.84-3436 (1 real bug out of 21 HIGH-priority findings,
+        // resolved in PR #218). The remaining toolchain — Checkstyle + PMD (Java, blocking),
+        // detekt + ktlint (Kotlin, blocking), CodeNarc (Groovy, report-only) — already covers
+        // each language with native rule sets. Keeping SpotBugs would require ongoing exclude-filter
+        // maintenance for marginal signal. See AGENTS.md Quality Gates section.
         if (pluginManager.hasPlugin('com.github.spotbugs')) {
-            spotbugs {
-                ignoreFailures = true
-            }
+            tasks.matching { it.name.startsWith('spotbugs') }.configureEach { enabled = false }
         }
     }
 


### PR DESCRIPTION
## Summary

- Disables every `spotbugs*` Gradle task via `tasks.matching { it.name.startsWith('spotbugs') }.configureEach { enabled = false }` in `build.gradle`'s subprojects block.
- Drops the spotbugs glob from `qualityReportsIndex` so the unified HTML stops linking stale reports.
- Documents the policy in `AGENTS.md` Quality Gates with explicit "do not re-enable" guidance.

## Why

Analysis of build 2.0.84-3436 (1761 BugInstance / 21 HIGH-priority) showed only **1 real production bug** worth fixing (`MS_SHOULD_BE_FINAL` — closed in #218). The remaining 20 HIGH-priority were either Kotlin lateinit / DSL getter false positives, test/integration-test code (Kotlin synthetic null checks, `DM_DEFAULT_ENCODING` on `InputStreamReader`), or annotation ambiguities.

The existing toolchain already covers each language with native rules: Checkstyle+PMD (Java, blocking), detekt+ktlint (Kotlin, blocking with baselines), CodeNarc (Groovy, report-only). Keeping SpotBugs would have required ongoing exclude-filter maintenance plus `spotbugs-annotations` dependencies in 4 source-set scopes (main/test/integrationTest/testFixtures) for marginal additional signal.

## Plugin stays applied

The `com.github.spotbugs` plugin is applied by the `octopus-quality` convention plugin, which we don't own. We opt out at the consumer (this project) by disabling tasks. This adds a small dependency-resolution cost at configure time but leaves the shared convention untouched.

## Coordination

PR #218 (commit `0033035` was authored on the same base) lands the only real fix SpotBugs found. Either PR can merge first; the order doesn't matter because:
- #218 is a pure code-quality improvement (mutable static → immutable) that stands on its own.
- This PR doesn't touch any production logic.

## TeamCity (manual, outside this PR)

After merge, the user removes two build features from TeamCity build config `[1.0] Compile & UT [AUTO]`:
- `BUILD_EXT_1793` — `FINDBUGS` xmlReport from `**/findbugsXml.xml` (legacy, matched nothing)
- `BUILD_EXT_1814` — `FINDBUGS` xmlReport from `+:**/build/reports/spotbugs/*.xml` (main one)

Once removed, the **Code Inspection** tab stops surfacing 1670/21.

## Test plan

- [x] `./gradlew :component-resolver-core:spotbugsMain` — task SKIPPED.
- [x] Full `./gradlew build` with CRS-local exclusions — BUILD SUCCESSFUL; all `spotbugs*` tasks SKIPPED across all modules and source sets (main, test, integrationTest, testFixtures).
- [x] `./gradlew help` after fixup commit — build script syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)