### PR TITLE
fix(local-stands): verify gate three regressions surfaced by first-attempt use

### DIFF
--- a/scripts/local-stands/stop-all.sh
+++ b/scripts/local-stands/stop-all.sh
@@ -13,12 +13,12 @@ CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
 kill_port() {
   command -v lsof >/dev/null 2>&1 || { echo "WARN: lsof missing; skipping port-$1 kill"; return 0; }
   local pids
-  pids=$(lsof -ti -sTCP:LISTEN tcp:"$1" 2>/dev/null || true)
+  pids=$(lsof -t -i tcp:"$1" -sTCP:LISTEN 2>/dev/null || true)
   [ -z "$pids" ] && return 0
   echo "    :$1 — TERM $pids"
   kill $pids 2>/dev/null || true
   for i in $(seq 1 10); do
-    pids=$(lsof -ti -sTCP:LISTEN tcp:"$1" 2>/dev/null || true)
+    pids=$(lsof -t -i tcp:"$1" -sTCP:LISTEN 2>/dev/null || true)
     [ -z "$pids" ] && return 0
     sleep 1
   done

--- a/scripts/local-stands/verify.sh
+++ b/scripts/local-stands/verify.sh
@@ -64,12 +64,12 @@ kill_port() {
   local port="$1"
   command -v lsof >/dev/null 2>&1 || { echo "WARN: lsof not available; skipping port-$port kill"; return 0; }
   local pids
-  pids=$(lsof -ti -sTCP:LISTEN tcp:"$port" 2>/dev/null || true)
+  pids=$(lsof -t -i tcp:"$port" -sTCP:LISTEN 2>/dev/null || true)
   [ -z "$pids" ] && return 0
   echo "    sending TERM to PID(s) on :$port — $pids"
   kill $pids 2>/dev/null || true
   for i in $(seq 1 10); do
-    pids=$(lsof -ti -sTCP:LISTEN tcp:"$port" 2>/dev/null || true)
+    pids=$(lsof -t -i tcp:"$port" -sTCP:LISTEN 2>/dev/null || true)
     [ -z "$pids" ] && return 0
     sleep 1
   done
@@ -151,7 +151,7 @@ wait_port_free() {
     if ! health "$port"; then
       # If lsof is missing, fall back to health-only as the readiness signal.
       [ "$have_lsof" -eq 0 ] && return 0
-      lsof -i -sTCP:LISTEN tcp:"$port" >/dev/null 2>&1 || return 0
+      lsof -i tcp:"$port" -sTCP:LISTEN >/dev/null 2>&1 || return 0
     fi
     sleep 1
   done
@@ -191,7 +191,13 @@ fi
 if [ "$RESTART" -eq 1 ]; then
   echo ">>> --restart: stopping candidate JVM on :$CANDIDATE_PORT"
   kill_port "$CANDIDATE_PORT"
-  wait_port_free "$CANDIDATE_PORT" 10 || echo "WARN: :$CANDIDATE_PORT still bound; continuing anyway"
+  if ! wait_port_free "$CANDIDATE_PORT" 15; then
+    echo "ERROR: :$CANDIDATE_PORT still bound after kill — refusing to spawn a new candidate"
+    echo "       that would race with the surviving JVM (PR #216 shows this race leaves the"
+    echo "       DB in a half-migrated state and produces garbage compat diffs)."
+    echo "       Manually inspect with: lsof -i tcp:$CANDIDATE_PORT -sTCP:LISTEN"
+    exit 3
+  fi
   CANDIDATE_LOG="/tmp/crs-candidate-${CANDIDATE_PORT}.log"
   echo ">>> starting candidate.sh in background (logs: $CANDIDATE_LOG)"
   nohup bash "$SCRIPT_DIR/candidate.sh" >"$CANDIDATE_LOG" 2>&1 &
@@ -223,4 +229,8 @@ elif ! health "$CANDIDATE_PORT"; then
 fi
 
 echo ">>> running compat"
-exec "$SCRIPT_DIR/compat.sh" "${PASS_ARGS[@]}"
+# `set -u` rejects bare "${PASS_ARGS[@]}" when the array is empty; use the
+# `${var+...}` empty-safe expansion so the array forwards verbatim when
+# present and expands to nothing when absent. (Regression-introduced by the
+# polluted-run guard merge — restored.)
+exec "$SCRIPT_DIR/compat.sh" ${PASS_ARGS[@]+"${PASS_ARGS[@]}"}


### PR DESCRIPTION
## Summary

First end-to-end use of the verify gate (after PR #215 merged) exposed three bugs that together made the gate silently test stale code:

- **`kill_port` lsof syntax wrong on macOS.** `lsof -ti -sTCP:LISTEN tcp:$port` — macOS lsof treats `tcp:$port` as a filename positional arg and errors out with "status error on tcp:<port>: No such file or directory", returning an empty PID list. `kill $empty` no-ops; the JVM survives. Corrected to `lsof -t -i tcp:$port -sTCP:LISTEN`. Applied to both `verify.sh` helpers and `stop-all.sh`.
- **`wait_port_free` warn-and-continue on timeout.** `verify.sh` then proceeded to spawn a new candidate while the old one still held the port; new bootRun JVM couldn't bind, old JVM kept responding to `/actuator/health`, `compat.sh` tested the surviving stale candidate. PR #216's closing comment documents the same race ("two JVMs racing on the same Postgres") from a different vector. Now hard-fails with `exit 3` + manual-inspection pointer.
- **`PASS_ARGS[@]: unbound variable` under `set -u`** when no extra args passed to `verify.sh`. The empty-safe form `${PASS_ARGS[@]+"${PASS_ARGS[@]}"}` was in PR #210/#215 but got dropped during the polluted-run guard merge. Restored.

## Pre-merge validation

End-to-end re-verify with all three fixes in place: clean `verify.sh --reset-db` on the post-#208/#209/#211/#212 candidate produced `Migration complete: total=948, migrated=948, failed=0, skipped=0` and `BUILD FAILED in 1m 40s` with 1899 active diffs matching the prod-vs-QA distribution (118 VALUE_DIFF + 1781 STRUCTURAL_DIFF Cluster I noise + 1 suppressed `updateCache` 410).

## Test plan

- [ ] `lsof -t -i tcp:4568 -sTCP:LISTEN` returns the candidate JVM PID (not 23 unrelated listeners as the broken syntax did).
- [ ] `verify.sh --restart` with a candidate already holding `:4568` cleanly kills it; if kill fails, exit 3 with a clear diagnostic.
- [ ] `verify.sh --restart` with no `--tests` arg passes through without `PASS_ARGS unbound` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)