### PR TITLE
fix(compat): kill Set-positional false-positives at raw layer (cluster I)

### DIFF
--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatibilityTestBase.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatibilityTestBase.kt
@@ -162,7 +162,14 @@ abstract class CompatibilityTestBase {
 
         // Skip shape diffing if status codes already diverged or no JSON
         if (baseline.status == candidate.status && baseline.json != null && candidate.json != null) {
-            val shapeDiffs = JsonShape.diff(baseline.json, candidate.json)
+            // For Set-shape endpoints (`/jira-component-version-ranges`, `/v3/components`)
+            // the wire-order of elements is non-deterministic across stands. Pre-sort
+            // both sides by a stable per-endpoint key so JsonShape.diff doesn't report
+            // positional false-positives. Pass-through for unregistered endpoints
+            // (see RawArraySorters and its unit test for the registered list + contract).
+            val baselineForShape = RawArraySorters.stableSorted(endpoint, baseline.json)
+            val candidateForShape = RawArraySorters.stableSorted(endpoint, candidate.json)
+            val shapeDiffs = JsonShape.diff(baselineForShape, candidateForShape)
             for (sd in shapeDiffs) {
                 categories += DiffClassifier.STRUCTURAL_DIFF
                 DiffCollector.record(

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
@@ -35,26 +35,39 @@ object RawArraySorters {
      * list minimal: only endpoints we have confirmed are Set-shape on the wire
      * and have been observed producing positional false-positives.
      */
+    /**
+     * Composite-key extractor for `Set<JiraComponentVersionRangeDTO>` — shared
+     * between the global and per-project endpoints so the registry stays DRY
+     * if the shape changes.
+     */
+    private val jiraComponentVersionRangeKey: (JsonNode) -> String = { node ->
+        // Wire shape (per JiraComponentVersionRangeDTO):
+        //   { "componentName": "...", "versionRange": "...", "component": { ... }, ... }
+        // `componentName` lives at the TOP LEVEL, NOT under `component` (which is a
+        // JiraComponentDTO with projectKey / displayName / componentInfo — no `id`).
+        val componentName = node.path("componentName").asText("")
+        val versionRange = node.path("versionRange").asText("")
+        componentName + KEY_SEP + versionRange
+    }
+
     private val sorters: Map<String, (JsonNode) -> String> =
         mapOf(
-            // `/jira-component-version-ranges` returns Set<JiraComponentVersionRangeDTO>.
+            // `/jira-component-version-ranges` (global) — Set<JiraComponentVersionRangeDTO>.
             // Stable key = componentName + NUL + versionRange — covers both kinds of
             // duplication (same component, different ranges; same range, different components).
-            // Wire shape (per JiraComponentVersionRangeDTO):
-            //   { "componentName": "...", "versionRange": "...", "component": { ... }, ... }
-            // `componentName` lives at the TOP LEVEL, NOT under `component` (which is a
-            // JiraComponentDTO with projectKey / displayName / componentInfo — no `id`).
-            "GET /rest/api/2/common/jira-component-version-ranges" to { node ->
-                val componentName = node.path("componentName").asText("")
-                val versionRange = node.path("versionRange").asText("")
-                componentName + KEY_SEP + versionRange
-            },
+            "GET /rest/api/2/common/jira-component-version-ranges" to jiraComponentVersionRangeKey,
+            // `/projects/{projectKey}/jira-component-version-ranges` — same DTO type,
+            // same Set semantics, just filtered by projectKey on the server. Used by
+            // ProjectControllerV2CompatTest; without registration the per-project run
+            // would re-introduce the same positional false-positives.
+            "GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges" to jiraComponentVersionRangeKey,
             // `/v3/components` returns a list of `{component, variants}` records — the server
-            // contract is one entry per `component.id`. Sort by that id. If duplicate ids ever
-            // appear, `sortedBy` (stable) preserves their input order, so equal-key elements
-            // stay in the same relative order on both stands provided the underlying Set
-            // iterator order is deterministic given identical Set contents — which the
-            // server-side `Set` guarantee already implies.
+            // contract is one entry per `component.id`. Sort by that id. `Set` guarantees
+            // uniqueness but NOT a deterministic iteration order for equal sort keys; if
+            // duplicate component ids ever reach this sorter, stable sorting would preserve
+            // each stand's potentially-different input order, leaving residual positional
+            // drift. Acceptable today because the server-side contract makes duplicates
+            // a contract violation, not because of any Set-iteration guarantee.
             "GET /rest/api/3/components" to { node ->
                 node.path("component").path("id").asText("")
             },

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
@@ -20,6 +20,16 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory
  */
 object RawArraySorters {
     /**
+     * U+0000 (NUL) as composite-key field separator. NUL cannot legally appear in
+     * a component id or in a Maven version-range expression, so the resulting
+     * key is unambiguous regardless of how those grammars evolve. Printable
+     * separators each have at least one corner case (e.g. `[1.0, 1.1)` contains
+     * a space; commas appear in artifact-list strings elsewhere) — NUL sidesteps
+     * the question entirely.
+     */
+    private const val KEY_SEP = "\u0000"
+
+    /**
      * Sort-key extractor per registered endpoint key. The endpoint string is the
      * same value the compat tests pass to `compareRaw(endpoint, …)`. Keep this
      * list minimal: only endpoints we have confirmed are Set-shape on the wire
@@ -28,15 +38,19 @@ object RawArraySorters {
     private val sorters: Map<String, (JsonNode) -> String> =
         mapOf(
             // `/jira-component-version-ranges` returns Set<JiraComponentVersionRangeDTO>.
-            // Stable key = component id + version range — covers both kinds of
+            // Stable key = component id + NUL + version range — covers both kinds of
             // duplication (same component, different ranges; same range, different components).
             "GET /rest/api/2/common/jira-component-version-ranges" to { node ->
                 val componentId = node.path("component").path("id").asText("")
                 val versionRange = node.path("versionRange").asText("")
-                "$componentId|$versionRange"
+                componentId + KEY_SEP + versionRange
             },
-            // `/v3/components` returns a list of `{component, variants}` records with one
-            // entry per component. Sort by component id.
+            // `/v3/components` returns a list of `{component, variants}` records — the server
+            // contract is one entry per `component.id`. Sort by that id. If duplicate ids ever
+            // appear, `sortedBy` (stable) preserves their input order, so equal-key elements
+            // stay in the same relative order on both stands provided the underlying Set
+            // iterator order is deterministic given identical Set contents — which the
+            // server-side `Set` guarantee already implies.
             "GET /rest/api/3/components" to { node ->
                 node.path("component").path("id").asText("")
             },
@@ -46,17 +60,25 @@ object RawArraySorters {
      * Return a stable-sorted copy of [root] when [endpoint] is registered AND
      * [root] is an `ArrayNode`. Otherwise return [root] unchanged (identity).
      *
-     * The identity-return guarantee is load-bearing: callers can wrap every
-     * raw-layer compare with this, and unregistered endpoints get exact pass-through
-     * with no allocation. The unit test `unregisteredEndpoint_passthrough` pins
-     * the contract.
+     * **Caller contract:** the returned node must be treated as read-only.
+     * On the identity-pass-through path (unregistered endpoint or non-array
+     * root) the return value aliases the input — mutating it would change the
+     * caller's input as a side effect. On the sorted-copy path the return value
+     * is a fresh `ArrayNode` whose element references are shared with the input,
+     * so mutating elements is similarly visible from outside. `compareRaw` only
+     * reads, so the alias is safe for the current call site; future callers
+     * adding mutation must take a defensive copy themselves.
+     *
+     * The unit test `unregisteredEndpoint_passthrough` pins the identity contract.
      */
     fun stableSorted(endpoint: String, root: JsonNode?): JsonNode? {
         if (root !is ArrayNode) return root
         val keyOf = sorters[endpoint] ?: return root
         val sorted = root.toList().sortedBy(keyOf)
-        // Preserve the original sort order ("stable") within equal keys by using sortedBy,
-        // which delegates to a stable sort on the JDK side.
+        // Preserve the original sort order ("stable") within equal keys: Kotlin's
+        // `sortedBy` delegates to a stable JDK sort. `arrayNode(int)` is an
+        // ArrayList capacity hint, not a fixed-size initialisation — we still
+        // populate via `add`.
         val out = JsonNodeFactory.instance.arrayNode(sorted.size)
         sorted.forEach { out.add(it) }
         return out

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
@@ -1,0 +1,64 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+
+/**
+ * Stable pre-sort for raw-layer JSON arrays whose underlying server type is `Set<T>`.
+ *
+ * Why this exists: `JsonShape.diff` walks two JSON arrays positionally
+ * (`baseline[i]` vs `candidate[i]`). For endpoints whose server-side type is a
+ * `Set` (no contractual wire-order), the same logical payload can arrive in
+ * different element orders on the two stands, producing thousands of spurious
+ * STRUCTURAL_DIFF / ARRAY_SIZE_MISMATCH / TYPE_MISMATCH records that drown the
+ * real signal. The typed layer already side-steps this by sorting DTOs before
+ * recursive comparison (see e.g. `CommonControllerV2CompatTest sliceCollection`
+ * and `ComponentsListCompatTest sorted-by-id`). This object brings the raw
+ * layer in line — narrowly, opt-in per known offender, no implicit
+ * auto-detection.
+ */
+object RawArraySorters {
+    /**
+     * Sort-key extractor per registered endpoint key. The endpoint string is the
+     * same value the compat tests pass to `compareRaw(endpoint, …)`. Keep this
+     * list minimal: only endpoints we have confirmed are Set-shape on the wire
+     * and have been observed producing positional false-positives.
+     */
+    private val sorters: Map<String, (JsonNode) -> String> =
+        mapOf(
+            // `/jira-component-version-ranges` returns Set<JiraComponentVersionRangeDTO>.
+            // Stable key = component id + version range — covers both kinds of
+            // duplication (same component, different ranges; same range, different components).
+            "GET /rest/api/2/common/jira-component-version-ranges" to { node ->
+                val componentId = node.path("component").path("id").asText("")
+                val versionRange = node.path("versionRange").asText("")
+                "$componentId|$versionRange"
+            },
+            // `/v3/components` returns a list of `{component, variants}` records with one
+            // entry per component. Sort by component id.
+            "GET /rest/api/3/components" to { node ->
+                node.path("component").path("id").asText("")
+            },
+        )
+
+    /**
+     * Return a stable-sorted copy of [root] when [endpoint] is registered AND
+     * [root] is an `ArrayNode`. Otherwise return [root] unchanged (identity).
+     *
+     * The identity-return guarantee is load-bearing: callers can wrap every
+     * raw-layer compare with this, and unregistered endpoints get exact pass-through
+     * with no allocation. The unit test `unregisteredEndpoint_passthrough` pins
+     * the contract.
+     */
+    fun stableSorted(endpoint: String, root: JsonNode?): JsonNode? {
+        if (root !is ArrayNode) return root
+        val keyOf = sorters[endpoint] ?: return root
+        val sorted = root.toList().sortedBy(keyOf)
+        // Preserve the original sort order ("stable") within equal keys by using sortedBy,
+        // which delegates to a stable sort on the JDK side.
+        val out = JsonNodeFactory.instance.arrayNode(sorted.size)
+        sorted.forEach { out.add(it) }
+        return out
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
@@ -38,12 +38,16 @@ object RawArraySorters {
     private val sorters: Map<String, (JsonNode) -> String> =
         mapOf(
             // `/jira-component-version-ranges` returns Set<JiraComponentVersionRangeDTO>.
-            // Stable key = component id + NUL + version range — covers both kinds of
+            // Stable key = componentName + NUL + versionRange — covers both kinds of
             // duplication (same component, different ranges; same range, different components).
+            // Wire shape (per JiraComponentVersionRangeDTO):
+            //   { "componentName": "...", "versionRange": "...", "component": { ... }, ... }
+            // `componentName` lives at the TOP LEVEL, NOT under `component` (which is a
+            // JiraComponentDTO with projectKey / displayName / componentInfo — no `id`).
             "GET /rest/api/2/common/jira-component-version-ranges" to { node ->
-                val componentId = node.path("component").path("id").asText("")
+                val componentName = node.path("componentName").asText("")
                 val versionRange = node.path("versionRange").asText("")
-                componentId + KEY_SEP + versionRange
+                componentName + KEY_SEP + versionRange
             },
             // `/v3/components` returns a list of `{component, variants}` records — the server
             // contract is one entry per `component.id`. Sort by that id. If duplicate ids ever

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
@@ -1,0 +1,175 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit coverage for [RawArraySorters] — pre-sort logic that kills the
+ * position-based STRUCTURAL_DIFF false-positives on Set-shape endpoints
+ * (legacy "cluster I").
+ *
+ * No HTTP, no live stand — pure JsonNode round-trip. Uses JUnit assertions
+ * directly to sidestep AssertJ overload-resolution ambiguity on
+ * `List<ShapeDiff>`.
+ */
+class RawArraySortersTest {
+    private val factory = JsonNodeFactory.instance
+
+    private fun rangeEntry(componentId: String, versionRange: String, displayName: String? = null): JsonNode {
+        val obj = factory.objectNode()
+        val component = factory.objectNode()
+        component.put("id", componentId)
+        if (displayName != null) component.put("displayName", displayName)
+        obj.set<JsonNode>("component", component)
+        obj.put("versionRange", versionRange)
+        return obj
+    }
+
+    private fun v3Entry(componentId: String): JsonNode {
+        val obj = factory.objectNode()
+        val component = factory.objectNode()
+        component.put("id", componentId)
+        obj.set<JsonNode>("component", component)
+        obj.set<JsonNode>("variants", factory.objectNode())
+        return obj
+    }
+
+    @Test
+    @DisplayName(
+        "registered Set-endpoint with same elements in different wire-order produces zero structural diffs after sort",
+    )
+    fun jiraComponentVersionRanges_sameElementsDifferentOrder_zeroShapeDiffs() {
+        val endpoint = "GET /rest/api/2/common/jira-component-version-ranges"
+
+        val baseline = factory.arrayNode().apply {
+            add(rangeEntry("alpha-fixture", "[1.0,)"))
+            add(rangeEntry("beta-fixture", "[2.0,)"))
+            add(rangeEntry("gamma-fixture", "(,3.0)"))
+        }
+        val candidate = factory.arrayNode().apply {
+            // Same three elements, deliberately reversed wire-order.
+            add(rangeEntry("gamma-fixture", "(,3.0)"))
+            add(rangeEntry("beta-fixture", "[2.0,)"))
+            add(rangeEntry("alpha-fixture", "[1.0,)"))
+        }
+
+        val baselineSorted = RawArraySorters.stableSorted(endpoint, baseline)
+        val candidateSorted = RawArraySorters.stableSorted(endpoint, candidate)
+
+        val diffs = JsonShape.diff(baselineSorted, candidateSorted)
+        assertTrue(
+            diffs.isEmpty(),
+            "after stable sort, JsonShape.diff must see zero structural divergence for Set-equivalent payloads, got: $diffs",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "registered v3 components endpoint with reordered entries produces zero structural diffs after sort",
+    )
+    fun v3Components_sameElementsDifferentOrder_zeroShapeDiffs() {
+        val endpoint = "GET /rest/api/3/components"
+
+        val baseline = factory.arrayNode().apply {
+            add(v3Entry("alpha-fixture"))
+            add(v3Entry("beta-fixture"))
+        }
+        val candidate = factory.arrayNode().apply {
+            add(v3Entry("beta-fixture"))
+            add(v3Entry("alpha-fixture"))
+        }
+
+        val baselineSorted = RawArraySorters.stableSorted(endpoint, baseline)
+        val candidateSorted = RawArraySorters.stableSorted(endpoint, candidate)
+
+        val diffs = JsonShape.diff(baselineSorted, candidateSorted)
+        assertTrue(diffs.isEmpty(), "expected zero diffs, got: $diffs")
+    }
+
+    @Test
+    @DisplayName(
+        "unregistered endpoint returns the input unchanged (no implicit auto-detection)",
+    )
+    fun unregisteredEndpoint_passthrough() {
+        val endpoint = "GET /rest/api/2/components/unregistered/maven-artifacts"
+
+        val baseline = factory.arrayNode().apply {
+            add(rangeEntry("alpha-fixture", "[1.0,)"))
+            add(rangeEntry("beta-fixture", "[2.0,)"))
+        }
+
+        val sorted = RawArraySorters.stableSorted(endpoint, baseline)
+        // Identity guarantee: when an endpoint is not registered we return the
+        // input node verbatim, preserving wire-order. This keeps the surface
+        // narrow — only the two known Set-shape offenders are normalized.
+        assertSame(baseline, sorted)
+    }
+
+    @Test
+    @DisplayName(
+        "non-array root (e.g. ObjectNode) is returned unchanged even for registered endpoint",
+    )
+    fun nonArrayRoot_passthrough() {
+        val endpoint = "GET /rest/api/2/common/jira-component-version-ranges"
+
+        val baseline: JsonNode = factory.objectNode().put("foo", "bar")
+        val sorted = RawArraySorters.stableSorted(endpoint, baseline)
+        assertSame(baseline, sorted)
+    }
+
+    @Test
+    @DisplayName(
+        "anti-regression: arrays with truly different sizes still produce ARRAY_SIZE_MISMATCH after sort",
+    )
+    fun antiRegression_arraySizeMismatchStillReported() {
+        val endpoint = "GET /rest/api/2/common/jira-component-version-ranges"
+
+        val baseline = factory.arrayNode().apply {
+            add(rangeEntry("alpha-fixture", "[1.0,)"))
+            add(rangeEntry("beta-fixture", "[2.0,)"))
+        }
+        val candidate = factory.arrayNode().apply {
+            add(rangeEntry("alpha-fixture", "[1.0,)"))
+        }
+
+        val baselineSorted = RawArraySorters.stableSorted(endpoint, baseline)
+        val candidateSorted = RawArraySorters.stableSorted(endpoint, candidate)
+
+        val diffs = JsonShape.diff(baselineSorted, candidateSorted)
+        assertEquals(1, diffs.size, "expected exactly one size-mismatch diff, got: $diffs")
+        assertEquals(JsonShape.ShapeDiff.Kind.ARRAY_SIZE_MISMATCH, diffs.single().kind)
+    }
+
+    @Test
+    @DisplayName(
+        "anti-regression: same-size arrays with a true per-element shape diff still surface it after sort",
+    )
+    fun antiRegression_perElementShapeDiffStillReported() {
+        val endpoint = "GET /rest/api/2/common/jira-component-version-ranges"
+
+        val baseline = factory.arrayNode().apply {
+            add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha"))
+            add(rangeEntry("beta-fixture", "[2.0,)", displayName = "Beta"))
+        }
+        // Same keys, but the candidate omits displayName on beta — a real shape divergence
+        // (KEY_MISSING_CANDIDATE) that survives any reordering.
+        val candidate = factory.arrayNode().apply {
+            add(rangeEntry("beta-fixture", "[2.0,)"))
+            add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha"))
+        }
+
+        val baselineSorted = RawArraySorters.stableSorted(endpoint, baseline)
+        val candidateSorted = RawArraySorters.stableSorted(endpoint, candidate)
+
+        val diffs = JsonShape.diff(baselineSorted, candidateSorted)
+        assertTrue(
+            diffs.any { it.kind == JsonShape.ShapeDiff.Kind.KEY_MISSING_CANDIDATE },
+            "expected at least one KEY_MISSING_CANDIDATE diff after sort, got: $diffs",
+        )
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
@@ -38,10 +38,17 @@ class RawArraySortersTest {
         return obj
     }
 
-    private fun v3Entry(componentId: String): JsonNode {
+    /**
+     * Mirrors the wire shape of `ComponentV3`:
+     *   { "component": { "id", "name", ... }, "variants": { ... } }
+     * `name` is optional in the wire response — use it as the structural-shape
+     * variable so tests can demonstrate that alignment actually happened.
+     */
+    private fun v3Entry(componentId: String, name: String? = null): JsonNode {
         val obj = factory.objectNode()
         val component = factory.objectNode()
         component.put("id", componentId)
+        if (name != null) component.put("name", name)
         obj.set<JsonNode>("component", component)
         obj.set<JsonNode>("variants", factory.objectNode())
         return obj
@@ -78,24 +85,28 @@ class RawArraySortersTest {
 
     @Test
     @DisplayName(
-        "regression guard: entries sharing versionRange but distinct componentName MUST sort deterministically " +
-            "(would FAIL if the key reached for a non-existent `component.id` field)",
+        "regression guard: heterogeneous-shape entries (one with displayName, one without) " +
+            "produce zero diffs ONLY after key-correct sort — no-op or wrong-key sorter would surface KEY_MISSING",
     )
-    fun jiraComponentVersionRanges_distinctComponentNameSameRange_zeroShapeDiffs() {
+    fun jiraComponentVersionRanges_heterogeneousShape_zeroDiffsOnlyAfterAlignment() {
         val endpoint = "GET /rest/api/2/common/jira-component-version-ranges"
 
-        // Both entries share the same versionRange. The composite key must use `componentName`
-        // (the TOP-LEVEL field on JiraComponentVersionRangeDTO) to differentiate them.
-        // An earlier draft of this PR keyed on `component.id`, which does not exist on the
-        // DTO — the key collapsed to "" + sep + versionRange and identical-range entries
-        // stayed in input order. That would re-introduce positional drift between stands.
-        // This test would FAIL under that buggy key shape; it must stay GREEN.
+        // alpha-fixture carries `component.displayName`; beta-fixture does NOT.
+        // The two stands ship the same set in OPPOSITE wire-order. JsonShape.diff
+        // is positional, so without alignment:
+        //   baseline[0] (alpha, with displayName) vs candidate[0] (beta, no displayName)
+        //   → KEY_MISSING_CANDIDATE on $[0].component.displayName
+        //   → KEY_MISSING_BASELINE  on $[1].component.displayName
+        // After alignment by `componentName`, both arrays land [alpha, beta] and
+        // every position matches. This test would FAIL under a no-op sorter or
+        // under the earlier-buggy `component.id` key (which collapses to "" so
+        // stable sort preserves input order).
         val baseline = factory.arrayNode().apply {
             add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha A"))
-            add(rangeEntry("beta-fixture", "[1.0,)", displayName = "Beta A"))
+            add(rangeEntry("beta-fixture", "[1.0,)"))
         }
         val candidate = factory.arrayNode().apply {
-            add(rangeEntry("beta-fixture", "[1.0,)", displayName = "Beta A"))
+            add(rangeEntry("beta-fixture", "[1.0,)"))
             add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha A"))
         }
 
@@ -105,31 +116,63 @@ class RawArraySortersTest {
         val diffs = JsonShape.diff(baselineSorted, candidateSorted)
         assertTrue(
             diffs.isEmpty(),
-            "componentName must differentiate entries sharing the same versionRange; got diffs: $diffs",
+            "expected zero diffs after alignment by componentName; got: $diffs",
         )
     }
 
     @Test
     @DisplayName(
-        "registered v3 components endpoint with reordered entries produces zero structural diffs after sort",
+        "per-project jira-component-version-ranges is normalized through the same composite-key sorter",
     )
-    fun v3Components_sameElementsDifferentOrder_zeroShapeDiffs() {
-        val endpoint = "GET /rest/api/3/components"
+    fun jiraComponentVersionRanges_perProject_heterogeneousShape_zeroDiffsAfterAlignment() {
+        val endpoint = "GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges"
 
         val baseline = factory.arrayNode().apply {
-            add(v3Entry("alpha-fixture"))
-            add(v3Entry("beta-fixture"))
+            add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha A"))
+            add(rangeEntry("beta-fixture", "[1.0,)"))
         }
         val candidate = factory.arrayNode().apply {
-            add(v3Entry("beta-fixture"))
-            add(v3Entry("alpha-fixture"))
+            add(rangeEntry("beta-fixture", "[1.0,)"))
+            add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha A"))
         }
 
         val baselineSorted = RawArraySorters.stableSorted(endpoint, baseline)
         val candidateSorted = RawArraySorters.stableSorted(endpoint, candidate)
 
         val diffs = JsonShape.diff(baselineSorted, candidateSorted)
-        assertTrue(diffs.isEmpty(), "expected zero diffs, got: $diffs")
+        assertTrue(
+            diffs.isEmpty(),
+            "per-project endpoint must share the global sort; got: $diffs",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "registered v3 components endpoint: heterogeneous-shape entries produce zero diffs ONLY after alignment by component.id",
+    )
+    fun v3Components_heterogeneousShape_zeroDiffsOnlyAfterAlignment() {
+        val endpoint = "GET /rest/api/3/components"
+
+        // alpha-fixture carries `component.name`; beta-fixture does NOT.
+        // Without alignment, positional `JsonShape.diff` surfaces
+        // KEY_MISSING_CANDIDATE on $[0].component.name (and the mirror on $[1]).
+        val baseline = factory.arrayNode().apply {
+            add(v3Entry("alpha-fixture", name = "Alpha"))
+            add(v3Entry("beta-fixture"))
+        }
+        val candidate = factory.arrayNode().apply {
+            add(v3Entry("beta-fixture"))
+            add(v3Entry("alpha-fixture", name = "Alpha"))
+        }
+
+        val baselineSorted = RawArraySorters.stableSorted(endpoint, baseline)
+        val candidateSorted = RawArraySorters.stableSorted(endpoint, candidate)
+
+        val diffs = JsonShape.diff(baselineSorted, candidateSorted)
+        assertTrue(
+            diffs.isEmpty(),
+            "expected zero diffs after alignment by component.id; got: $diffs",
+        )
     }
 
     @Test

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
@@ -20,13 +20,21 @@ import org.junit.jupiter.api.Test
 class RawArraySortersTest {
     private val factory = JsonNodeFactory.instance
 
-    private fun rangeEntry(componentId: String, versionRange: String, displayName: String? = null): JsonNode {
+    /**
+     * Mirrors the wire shape of `JiraComponentVersionRangeDTO`:
+     *   { componentName: <top-level>, versionRange, component: { displayName, ... }, ... }
+     * `componentName` lives at the TOP level. The nested `component` object is a
+     * `JiraComponentDTO` and does NOT carry an `id` field. `displayName` is the
+     * field used in the prod responses (and the one the compat report shows
+     * STRUCTURAL_DIFFs against).
+     */
+    private fun rangeEntry(componentName: String, versionRange: String, displayName: String? = null): JsonNode {
         val obj = factory.objectNode()
+        obj.put("componentName", componentName)
+        obj.put("versionRange", versionRange)
         val component = factory.objectNode()
-        component.put("id", componentId)
         if (displayName != null) component.put("displayName", displayName)
         obj.set<JsonNode>("component", component)
-        obj.put("versionRange", versionRange)
         return obj
     }
 
@@ -65,6 +73,39 @@ class RawArraySortersTest {
         assertTrue(
             diffs.isEmpty(),
             "after stable sort, JsonShape.diff must see zero structural divergence for Set-equivalent payloads, got: $diffs",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "regression guard: entries sharing versionRange but distinct componentName MUST sort deterministically " +
+            "(would FAIL if the key reached for a non-existent `component.id` field)",
+    )
+    fun jiraComponentVersionRanges_distinctComponentNameSameRange_zeroShapeDiffs() {
+        val endpoint = "GET /rest/api/2/common/jira-component-version-ranges"
+
+        // Both entries share the same versionRange. The composite key must use `componentName`
+        // (the TOP-LEVEL field on JiraComponentVersionRangeDTO) to differentiate them.
+        // An earlier draft of this PR keyed on `component.id`, which does not exist on the
+        // DTO — the key collapsed to "" + sep + versionRange and identical-range entries
+        // stayed in input order. That would re-introduce positional drift between stands.
+        // This test would FAIL under that buggy key shape; it must stay GREEN.
+        val baseline = factory.arrayNode().apply {
+            add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha A"))
+            add(rangeEntry("beta-fixture", "[1.0,)", displayName = "Beta A"))
+        }
+        val candidate = factory.arrayNode().apply {
+            add(rangeEntry("beta-fixture", "[1.0,)", displayName = "Beta A"))
+            add(rangeEntry("alpha-fixture", "[1.0,)", displayName = "Alpha A"))
+        }
+
+        val baselineSorted = RawArraySorters.stableSorted(endpoint, baseline)
+        val candidateSorted = RawArraySorters.stableSorted(endpoint, candidate)
+
+        val diffs = JsonShape.diff(baselineSorted, candidateSorted)
+        assertTrue(
+            diffs.isEmpty(),
+            "componentName must differentiate entries sharing the same versionRange; got diffs: $diffs",
         )
     }
 


### PR DESCRIPTION
## Summary
- Today's compat run reports ~1781 STRUCTURAL_DIFFs on Set-shape endpoints. The diffs are infra false-positives: `JsonShape.diff` walks arrays positionally while `Set` element wire-order is non-deterministic across stands.
- Introduce `RawArraySorters` with a narrow per-endpoint registry of stable sort-key extractors, and pre-sort both sides in `CompatibilityTestBase.compareRaw` before structural diff.
- Pass-through identity for unregistered endpoints — opt-in surface, no implicit auto-detection.

## Registered endpoints (deliberately narrow)

| Endpoint | Sort key | Notes |
|---|---|---|
| `GET /rest/api/2/common/jira-component-version-ranges` | `componentName` + NUL + `versionRange` | `componentName` is the TOP-LEVEL field on `JiraComponentVersionRangeDTO`; the nested `component` is a `JiraComponentDTO` with no `id`. |
| `GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges` | (same) | Same DTO, filtered by `projectKey` server-side. Shares the key extractor with the global endpoint. |
| `GET /rest/api/3/components` | `component.id` | `ComponentV3.component` is `ComponentV2` with `id` field. |

## Behaviour
| Case | Before | After |
|---|---|---|
| Registered Set endpoint, same elements / different wire-order | ARRAY_SIZE / TYPE_MISMATCH / KEY_MISSING flood | 0 shape diffs |
| Registered endpoint, true size mismatch | ARRAY_SIZE_MISMATCH | ARRAY_SIZE_MISMATCH (unchanged) |
| Registered endpoint, per-element shape diff | KEY_MISSING_* | KEY_MISSING_* (unchanged) |
| Unregistered endpoint | shape diff if any | identity pass-through (unchanged) |
| Non-array root | unchanged | unchanged (identity) |

## Test plan
- [x] New `RawArraySortersTest` with 8 unit tests:
  - **Heterogeneous-shape regression tests** (jira global + jira per-project + v3): one element carries an optional field (`displayName` / `name`), the other does not. Positional diff would surface `KEY_MISSING_*`; zero-diff is reached ONLY after key-correct alignment. These would FAIL under a no-op sorter or under the previous buggy `component.id` key (which collapsed to `""`).
  - Identity pass-through (unregistered endpoint, non-array root) using `assertSame`.
  - Anti-regression: true size mismatch and per-element shape divergence still surface.
- [x] Full `./gradlew build` (with standard exclusions) passes.
- [ ] Next compat run shows zero raw `STRUCTURAL_DIFF` records on the three registered endpoints.

## Review-feedback log
- `1b8b5f0` `test:` introduce helper + tests.
- `ac143af` `fix:` wire into `compareRaw`.
- `08b6e1d` `docs:` Sonnet review fixes — NUL separator via `KEY_SEP`, read-only contract, `arrayNode(int)` clarification.
- `36f4ec0` `fix:` Copilot P0 — correct `componentName` (top-level) instead of non-existent `component.id`; rewrite test fixture to mirror wire shape; add regression-guard test.
- `ab86dc3` `fix:` external reviewer P2 — register `projects/{projectKey}/jira-component-version-ranges`; rewrite tests with heterogeneous-shape elements so a no-op sorter would fail; soften the `Set`-iteration comment to match the actual contract.

Plan reference: `~/.claude/plans/image-6-playful-gizmo.md` TASK-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)