### PR TITLE
feat(compat-test): TD-007 L3 — CANDIDATE_NOT_DB_MODE preflight + diagnostic ServiceStatus fields

### DIFF
--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffClassifier.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffClassifier.kt
@@ -5,8 +5,12 @@ package org.octopusden.octopus.components.registry.compat
  */
 enum class DiffClassifier {
     // Environment / precondition issues — surfaced once at the top of the report.
+    // Both categories are non-suppressible via known-deltas.json (see envCategories in build.gradle).
     SNAPSHOT_MISMATCH,         // baseline vs candidate /service/status .versionControlRevision differ
-    CANDIDATE_NOT_DB_MODE,     // reserved — currently unused (no DB value in ServiceMode enum on this branch)
+    CANDIDATE_NOT_DB_MODE,     // candidate /service/status .defaultSource != "db" or .dbComponentCount == 0 —
+                               // the candidate is serving the V1 in-memory resolver, schema-v2 DB code path
+                               // is dormant, and any diff measurements will reflect V1-vs-V1 drift, not real
+                               // schema-v2-vs-V1 regressions. SnapshotPreconditionTest records this.
 
     // Per-endpoint divergence categories.
     MISSING_COMPONENT,

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluator.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluator.kt
@@ -1,0 +1,134 @@
+package org.octopusden.octopus.components.registry.compat
+
+/**
+ * Pure inputs for [evaluateEnvironmentPreflight] — separates the impure HTTP/parse
+ * stage from the classifier logic so the latter can be unit-tested with synthetic
+ * fixtures (per the stricter compat-test-infra review protocol, every new diff-
+ * classification branch needs a RED-then-GREEN demo on a pair of fixtures).
+ */
+internal data class EnvironmentPreflightInputs(
+    val baselineStatus: Int,
+    val baselineSnapshot: ServiceStatusSnapshot?,
+    val candidateStatus: Int,
+    val candidateSnapshot: ServiceStatusSnapshot?,
+    /** Count of unique components in baseline's `/rest/api/3/components` listing.
+     *  `-1L` signals discovery failed (non-2xx, undecodable, or response was not a
+     *  JSON array — see ArrayNode guard at the caller); evaluator treats `-1L` as
+     *  "no useful threshold available, fall back to >0". */
+    val baselineComponentCount: Long,
+)
+
+/**
+ * Evaluate the environment preflight: produce zero or more [DiffRecord]s with env
+ * categories ([DiffClassifier.SNAPSHOT_MISMATCH], [DiffClassifier.CANDIDATE_NOT_DB_MODE]).
+ *
+ * Pure function — no HTTP, no time/date sources, no globals. The two impure inputs
+ * are passed through:
+ *
+ * @param ts      timestamp string to stamp on every produced [DiffRecord]; caller
+ *                  supplies `Instant.now().toString()` in production, fixed value in tests.
+ * @param endpoint endpoint string used as the [DiffRecord.endpoint] field; defaults to
+ *                  the `/service/status` GET path that the live test calls.
+ */
+internal fun evaluateEnvironmentPreflight(
+    inputs: EnvironmentPreflightInputs,
+    ts: String,
+    endpoint: String = "GET /rest/api/2/components-registry/service/status",
+): List<DiffRecord> {
+    val records = mutableListOf<DiffRecord>()
+
+    val baselineOk = inputs.baselineStatus in 200..299 && inputs.baselineSnapshot?.versionControlRevision != null
+    val candidateOk = inputs.candidateStatus in 200..299 && inputs.candidateSnapshot?.versionControlRevision != null
+
+    if (!baselineOk || !candidateOk) {
+        // Fail-causing precondition: if /service/status is unreachable, non-2xx, or
+        // undecodable, the run would otherwise proceed against bogus stands and the
+        // reporter would see a clean diff count purely because every endpoint
+        // returned the same non-contract response. Record once and short-circuit
+        // the remaining checks (without a valid snapshot they have no inputs).
+        records += DiffRecord(
+            ts = ts,
+            endpoint = endpoint,
+            pathParams = emptyMap(),
+            category = DiffClassifier.SNAPSHOT_MISMATCH,
+            layer = "raw",
+            baselineValue = if (baselineOk) inputs.baselineSnapshot?.versionControlRevision else "status=${inputs.baselineStatus}",
+            candidateValue = if (candidateOk) inputs.candidateSnapshot?.versionControlRevision else "status=${inputs.candidateStatus}",
+            message = "/service/status unreachable or undecodable on " + listOfNotNull(
+                "baseline".takeIf { !baselineOk },
+                "candidate".takeIf { !candidateOk },
+            ).joinToString(" and ") + " — precondition for any compat run cannot be evaluated",
+        )
+        return records
+    }
+
+    val b = inputs.baselineSnapshot!!
+    val c = inputs.candidateSnapshot!!
+
+    if (b.versionControlRevision != c.versionControlRevision) {
+        records += DiffRecord(
+            ts = ts,
+            endpoint = endpoint,
+            pathParams = emptyMap(),
+            category = DiffClassifier.SNAPSHOT_MISMATCH,
+            layer = "raw",
+            baselineValue = b.versionControlRevision,
+            candidateValue = c.versionControlRevision,
+            message = "baseline and candidate are pointed at different VCS revisions; data drift cannot be distinguished from migration regressions until they are re-synced",
+        )
+    }
+
+    // CANDIDATE_NOT_DB_MODE check: candidate must report defaultSource="db" AND
+    // dbComponentCount >= 90% of the baseline component count to confirm the
+    // schema-v2 DB resolver is actually serving requests for substantially all
+    // components. Either condition false → V1 path is dormant or only partially
+    // migrated, and the compat result is V1-vs-V1 drift.
+    //
+    // The 90% threshold (vs strict equality) is chosen because:
+    // - `requireMigrationSucceeded` on the candidate aborts startup if any
+    //   component failed to import, so legitimate partial-migrate states never
+    //   reach the gate.
+    // - The remaining 10% slack absorbs minor DSL drift between baseline and
+    //   candidate (a component just added on one side) without spurious env-
+    //   warnings — those would surface anyway as MISSING_COMPONENT diffs.
+    //
+    // Integer-arithmetic ceil for the threshold: `(n*9 + 9) / 10 == ceil(0.9*n)`
+    // for any non-negative integer n. Verified exhaustively for n ∈ {1, 5, 10,
+    // 11, 100, 948}.
+    //
+    // Backward compat: an old candidate (pre-this-PR) returns defaultSource /
+    // dbComponentCount as null; null is treated as "diagnostic surface not
+    // exposed" and the warning fires so the operator either upgrades or
+    // verifies out-of-band. Likewise if baseline discovery failed
+    // (baselineComponentCount == -1L) the threshold collapses to 1, which makes
+    // the check effectively "candidate must have >0 db-routed components" —
+    // weaker than the 90% target but a clear non-zero signal that DB-mode is
+    // on. The companion SNAPSHOT_MISMATCH check above surfaces the broken
+    // baseline so the operator sees the root cause.
+    val threshold: Long = if (inputs.baselineComponentCount > 0L) {
+        (inputs.baselineComponentCount * 9 + 9) / 10
+    } else {
+        1L
+    }
+    val candidateInDbMode =
+        c.defaultSource == "db" && (c.dbComponentCount ?: 0L) >= threshold
+    if (!candidateInDbMode) {
+        records += DiffRecord(
+            ts = ts,
+            endpoint = endpoint,
+            pathParams = emptyMap(),
+            category = DiffClassifier.CANDIDATE_NOT_DB_MODE,
+            layer = "raw",
+            baselineValue = "baselineComponentCount=${inputs.baselineComponentCount}, threshold=$threshold",
+            candidateValue = "defaultSource=${c.defaultSource ?: "<null — old candidate>"}, dbComponentCount=${c.dbComponentCount ?: "<null>"}",
+            message = "candidate's /service/status indicates the schema-v2 DB resolver is dormant " +
+                "or only partially active (needs defaultSource=\"db\" AND dbComponentCount >= " +
+                "0.9 × baselineComponentCount). Any diffs reported by this compat run are V1-vs-V1 " +
+                "drift, NOT real schema-v2-vs-V1 regressions. Fix the candidate config (set " +
+                "components-registry.default-source=db, ensure auto-migrate ran with failed=0) " +
+                "before treating the report as authoritative.",
+        )
+    }
+
+    return records
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluatorTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluatorTest.kt
@@ -1,0 +1,242 @@
+package org.octopusden.octopus.components.registry.compat
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * RED-then-GREEN unit coverage for [evaluateEnvironmentPreflight] — satisfies the
+ * compat-test-infra review protocol requirement that "every new diff-classification
+ * branch needs a RED-then-GREEN demo".
+ *
+ * Each test constructs a synthetic [EnvironmentPreflightInputs] and asserts the
+ * exact list of [DiffRecord]s the evaluator should produce. A change to the
+ * evaluator that silently swallows a classification (or fires one when it
+ * shouldn't) breaks the corresponding test by going RED — exactly the regression
+ * signal the protocol mandates.
+ */
+class EnvironmentPreflightEvaluatorTest {
+
+    private val ts = "2026-05-16T20:00:00Z"
+
+    private fun ok(rev: String, defaultSource: String? = "db", dbComponentCount: Long? = 948L) =
+        ServiceStatusSnapshot(
+            cacheUpdatedAt = "2026-05-16T19:59:00Z",
+            serviceMode = "VCS",
+            versionControlRevision = rev,
+            defaultSource = defaultSource,
+            dbComponentCount = dbComponentCount,
+        )
+
+    @Test
+    fun `happy path — both stands healthy, revs match, candidate in DB mode → no diffs`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A", defaultSource = null, dbComponentCount = null), // baseline = main code, fields not exposed
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = "db", dbComponentCount = 948L),
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).isEmpty()
+    }
+
+    @Test
+    fun `baseline unreachable — single SNAPSHOT_MISMATCH 'unreachable', subsequent checks skipped`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 503,
+                baselineSnapshot = null,
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-X", defaultSource = "db", dbComponentCount = 948L),
+                baselineComponentCount = -1L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(1)
+        val r = out.single()
+        assertThat(r.category).isEqualTo(DiffClassifier.SNAPSHOT_MISMATCH)
+        assertThat(r.message).contains("unreachable", "baseline")
+        // Crucially: the CANDIDATE_NOT_DB_MODE check does NOT fire on this path
+        // (no valid snapshot pair → comparison is not meaningful).
+    }
+
+    @Test
+    fun `candidate unreachable — single SNAPSHOT_MISMATCH, candidate side identified`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 502,
+                candidateSnapshot = null,
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(1)
+        assertThat(out.single().message).contains("unreachable", "candidate")
+    }
+
+    @Test
+    fun `revisions differ — SNAPSHOT_MISMATCH 'differ' fires, DB-mode check ALSO runs and passes`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A", defaultSource = null, dbComponentCount = null),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-B", defaultSource = "db", dbComponentCount = 948L),
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(1)
+        assertThat(out.single().category).isEqualTo(DiffClassifier.SNAPSHOT_MISMATCH)
+        assertThat(out.single().message).contains("different VCS revisions")
+    }
+
+    @Test
+    fun `candidate defaultSource is git — CANDIDATE_NOT_DB_MODE fires`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A", defaultSource = null, dbComponentCount = null),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = "git", dbComponentCount = 948L),
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(1)
+        assertThat(out.single().category).isEqualTo(DiffClassifier.CANDIDATE_NOT_DB_MODE)
+        assertThat(out.single().candidateValue).contains("defaultSource=git")
+    }
+
+    @Test
+    fun `candidate dbComponentCount below 0_9x threshold — CANDIDATE_NOT_DB_MODE fires`() {
+        // baseline=948 → threshold=ceil(0.9*948)=854; candidate=853 falls just below
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = "db", dbComponentCount = 853L),
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(1)
+        assertThat(out.single().category).isEqualTo(DiffClassifier.CANDIDATE_NOT_DB_MODE)
+        assertThat(out.single().baselineValue).contains("threshold=854")
+        assertThat(out.single().candidateValue).contains("dbComponentCount=853")
+    }
+
+    @Test
+    fun `candidate dbComponentCount exactly at threshold — passes (boundary)`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = "db", dbComponentCount = 854L),
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).isEmpty()
+    }
+
+    @Test
+    fun `candidate diagnostic fields null — CANDIDATE_NOT_DB_MODE fires with 'old candidate' hint`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = null, dbComponentCount = null),
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(1)
+        assertThat(out.single().category).isEqualTo(DiffClassifier.CANDIDATE_NOT_DB_MODE)
+        assertThat(out.single().candidateValue).contains("<null — old candidate>")
+    }
+
+    @Test
+    fun `baseline discovery failed (count -1) — threshold collapses to 1, candidate with count=0 still fails`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = "db", dbComponentCount = 0L),
+                baselineComponentCount = -1L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(1)
+        assertThat(out.single().category).isEqualTo(DiffClassifier.CANDIDATE_NOT_DB_MODE)
+    }
+
+    @Test
+    fun `baseline discovery failed but candidate has count=1 — passes weak fallback`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = "db", dbComponentCount = 1L),
+                baselineComponentCount = -1L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).isEmpty()
+    }
+
+    @Test
+    fun `revisions differ AND db-mode wrong — both records fire (independent)`() {
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-B", defaultSource = "git", dbComponentCount = 0L),
+                baselineComponentCount = 948L,
+            ),
+            ts = ts,
+        )
+        assertThat(out).hasSize(2)
+        assertThat(out.map { it.category })
+            .containsExactly(DiffClassifier.SNAPSHOT_MISMATCH, DiffClassifier.CANDIDATE_NOT_DB_MODE)
+    }
+
+    @Test
+    fun `integer ceil math is exact across boundary values`() {
+        // Verifies the (n*9 + 9) / 10 = ceil(0.9 * n) identity for documented test points.
+        // Build via the public API rather than reaching into private helpers: a candidate
+        // with dbComponentCount = threshold-1 must fire; dbComponentCount = threshold passes.
+        fun threshold(baselineCount: Long): Long {
+            val out = evaluateEnvironmentPreflight(
+                EnvironmentPreflightInputs(
+                    baselineStatus = 200,
+                    baselineSnapshot = ok("rev-A"),
+                    candidateStatus = 200,
+                    candidateSnapshot = ok("rev-A", defaultSource = "db", dbComponentCount = 0L),
+                    baselineComponentCount = baselineCount,
+                ),
+                ts = ts,
+            )
+            // The CANDIDATE_NOT_DB_MODE record echoes "threshold=N" in baselineValue.
+            val rec = out.single { it.category == DiffClassifier.CANDIDATE_NOT_DB_MODE }
+            val match = Regex("threshold=(\\d+)").find(rec.baselineValue ?: "")
+            return match!!.groupValues[1].toLong()
+        }
+        assertThat(threshold(1L)).isEqualTo(1L)
+        assertThat(threshold(5L)).isEqualTo(5L) // ceil(0.9*5) = ceil(4.5) = 5
+        assertThat(threshold(10L)).isEqualTo(9L) // ceil(0.9*10) = 9
+        assertThat(threshold(11L)).isEqualTo(10L) // ceil(0.9*11) = ceil(9.9) = 10
+        assertThat(threshold(100L)).isEqualTo(90L)
+        assertThat(threshold(948L)).isEqualTo(854L) // ceil(0.9*948) = ceil(853.2) = 854
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/SnapshotPreconditionTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/SnapshotPreconditionTest.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.compat
 
+import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -7,27 +8,35 @@ import java.time.Instant
 
 /**
  * Pre-flight environment check: read /service/status from both stands and record
- * the VCS-revision mismatch as an env-level diff so it appears at the top of
- * `summary.md` and explains downstream divergences.
+ * env-level diffs as [DiffRecord]s with category [DiffClassifier.SNAPSHOT_MISMATCH]
+ * or [DiffClassifier.CANDIDATE_NOT_DB_MODE] so they appear at the top of
+ * `summary.md` and explain downstream divergences.
  *
  * The test method itself ALWAYS passes — it only records [DiffRecord]s. The Gradle
- * `compatibilityReporter` task aggregates them; env categories (currently only
- * `SNAPSHOT_MISMATCH`) are surfaced separately and are NOT suppressible via
- * `known-deltas.json` (they signal that the comparison itself is unsound, not an
- * intentional v3 delta).
+ * `compatibilityReporter` task aggregates them; env categories are surfaced
+ * separately and are NOT suppressible via `known-deltas.json` (they signal that
+ * the comparison itself is unsound, not an intentional v3 delta).
  *
- * Why a recorded diff and not a fail-fast assertion: per operator decision, we
- * want the full compat surface to run even when stands disagree on snapshot, so
- * all real divergences are visible in one report. The environment warning is
- * just *one more record* in summary.md, surfaced at the top.
+ * Why recorded diffs and not fail-fast assertions: per operator decision, we want
+ * the full compat surface to run even when stands disagree on snapshot or when
+ * the candidate is misconfigured, so all real divergences are visible in one
+ * report. The environment warnings are just *more records* in summary.md,
+ * surfaced at the top.
  *
- * NOTE: a "candidate not in DB mode" precondition lived here historically. It was
- * removed because the public `ServiceStatusDTO.serviceMode` enum on this branch
- * is `{FS, VCS}` only — there is no `DB` value to compare against, so the check
- * unconditionally fired regardless of the candidate's actual read path. The
- * candidate's source mode (Git vs DB) is an internal selector via
- * `ComponentSourceRegistry` / profile settings and is not exposed via this DTO;
- * operators must verify it out-of-band.
+ * Two env signals are recorded:
+ * 1. [DiffClassifier.SNAPSHOT_MISMATCH] — baseline and candidate point at different
+ *    VCS revisions; data drift between snapshots cannot be distinguished from
+ *    migration regressions.
+ * 2. [DiffClassifier.CANDIDATE_NOT_DB_MODE] — candidate's `/service/status` reports
+ *    `defaultSource != "db"` OR `dbComponentCount == 0` (or both fields null —
+ *    candidate predates the diagnostic-field PR). The schema-v2 `DatabaseComponent-
+ *    RegistryResolver` is dormant and the candidate is serving V1 in-memory data;
+ *    any diff measurements are V1-vs-V1 drift, not real schema-v2-vs-V1 deltas.
+ *    Note that `ServiceStatusDTO.serviceMode {FS, VCS}` is NOT a sufficient signal
+ *    on its own (it tracks `vcs.enabled` only); the actual resolver routing is
+ *    governed by per-component `component_sources.source`, with `defaultSource`
+ *    as the fallback for unmigrated components. The two new diagnostic fields
+ *    were added in the same PR as this check.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SnapshotPreconditionTest : CompatibilityTestBase() {
@@ -42,45 +51,35 @@ class SnapshotPreconditionTest : CompatibilityTestBase() {
         val baseline = runCatching { mapper.readValue(baselineResp.bodyBytes, ServiceStatusSnapshot::class.java) }.getOrNull()
         val candidate = runCatching { mapper.readValue(candidateResp.bodyBytes, ServiceStatusSnapshot::class.java) }.getOrNull()
 
-        val ts = Instant.now().toString()
+        // Baseline component count: fetched once here and passed into the pure
+        // [evaluateEnvironmentPreflight] for the threshold computation. ArrayNode
+        // guard: a non-2xx response, an undecodable body, or a JSON ObjectNode
+        // (typical for error responses like `{"errorMessage": "..."}`) all map to
+        // -1L so the evaluator falls back to the "any non-zero count" threshold
+        // instead of letting an error-shaped response masquerade as a small
+        // component-count via JsonNode.size() on ObjectNode returning property count.
+        val baselineComponentCount: Long = runCatching {
+            val resp = baselineRaw.get("/rest/api/3/components")
+            if (resp.status in 200..299) {
+                val node = mapper.readTree(resp.bodyBytes)
+                if (node is ArrayNode) node.size().toLong() else -1L
+            } else {
+                -1L
+            }
+        }.getOrDefault(-1L)
 
-        // Fail-causing precondition: if /service/status itself is unreachable, returns
-        // non-2xx, or yields a body we can't decode (HTML error page, wrong base URL,
-        // auth failure), both snapshots come back null — without this record the run
-        // would proceed against bogus stands and the reporter would see a clean diff
-        // count purely because every endpoint returned the same non-contract response.
-        val baselineOk = baselineResp.status in 200..299 && baseline?.versionControlRevision != null
-        val candidateOk = candidateResp.status in 200..299 && candidate?.versionControlRevision != null
-        if (!baselineOk || !candidateOk) {
-            DiffCollector.record(
-                DiffRecord(
-                    ts = ts,
-                    endpoint = endpoint,
-                    pathParams = emptyMap(),
-                    category = DiffClassifier.SNAPSHOT_MISMATCH,
-                    layer = "raw",
-                    baselineValue = if (baselineOk) baseline?.versionControlRevision else "status=${baselineResp.status}",
-                    candidateValue = if (candidateOk) candidate?.versionControlRevision else "status=${candidateResp.status}",
-                    message = "/service/status unreachable or undecodable on " + listOfNotNull(
-                        "baseline".takeIf { !baselineOk },
-                        "candidate".takeIf { !candidateOk },
-                    ).joinToString(" and ") + " — precondition for any compat run cannot be evaluated",
-                ),
-            )
-        } else if (baseline!!.versionControlRevision != candidate!!.versionControlRevision) {
-            DiffCollector.record(
-                DiffRecord(
-                    ts = ts,
-                    endpoint = endpoint,
-                    pathParams = emptyMap(),
-                    category = DiffClassifier.SNAPSHOT_MISMATCH,
-                    layer = "raw",
-                    baselineValue = baseline.versionControlRevision,
-                    candidateValue = candidate.versionControlRevision,
-                    message = "baseline and candidate are pointed at different VCS revisions; data drift cannot be distinguished from migration regressions until they are re-synced",
-                ),
-            )
-        }
+        val records = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = baselineResp.status,
+                baselineSnapshot = baseline,
+                candidateStatus = candidateResp.status,
+                candidateSnapshot = candidate,
+                baselineComponentCount = baselineComponentCount,
+            ),
+            ts = Instant.now().toString(),
+            endpoint = endpoint,
+        )
+        records.forEach { DiffCollector.record(it) }
 
         ExecutionLogger.log(
             ExecutionEntry(
@@ -91,7 +90,7 @@ class SnapshotPreconditionTest : CompatibilityTestBase() {
                 baselineMs = baselineResp.durationMs,
                 candidateMs = candidateResp.durationMs,
                 layer = "precondition",
-                diffCount = 0,
+                diffCount = records.size,
             ),
         )
     }
@@ -105,4 +104,9 @@ internal data class ServiceStatusSnapshot(
     val cacheUpdatedAt: String? = null,
     val serviceMode: String? = null,
     val versionControlRevision: String? = null,
+    // Diagnostic fields added in the same PR as the CANDIDATE_NOT_DB_MODE check.
+    // Old candidates that predate the addition return null for both; treated as
+    // "diagnostic surface not exposed".
+    val defaultSource: String? = null,
+    val dbComponentCount: Long? = null,
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ServiceStatusDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ServiceStatusDTO.kt
@@ -5,9 +5,38 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
+/**
+ * Operational metadata for the Components-Registry service.
+ *
+ * **Diagnostic surface only.** This DTO is NOT part of the strict v1/v2/v3 backward-
+ * compatibility contract — additive fields are explicitly permitted. The compat-test
+ * framework excludes `/rest/api/2/components-registry/service/status` from the
+ * baseline `EndpointCoverageTest`; only environment-precondition probes read this
+ * response (see `SnapshotPreconditionTest` in `components-registry-compat-test`).
+ *
+ * @property cacheUpdatedAt              timestamp of the last `updateConfigCache()` call.
+ * @property serviceMode                 read-side mechanism: VCS (Git clone in-memory) or FS
+ *                                        (no clone, schema-v2 path). Derived from `vcs.enabled`,
+ *                                        NOT from `default-source` (see `ApplicationConfig`).
+ * @property versionControlRevision      VCS revision the cloned DSL is pinned to; null if VCS
+ *                                        not active or initial clone hasn't run.
+ * @property defaultSource               components-registry `default-source` property (`"git"`
+ *                                        or `"db"`) — the resolver fallback for components
+ *                                        without an explicit `component_sources` row.
+ *                                        **Nullable for backward compatibility**: old servers
+ *                                        that predate this field simply omit it, Jackson
+ *                                        deserialises as null.
+ * @property dbComponentCount            number of components currently routed through the DB
+ *                                        resolver (`component_sources.source = 'db'`). Used
+ *                                        by env-preconditions to detect partial-migration
+ *                                        states. **Nullable** for the same backward-compat
+ *                                        reason as `defaultSource`.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ServiceStatusDTO @JsonCreator constructor(
     @JsonProperty("cacheUpdatedAt") val cacheUpdatedAt: Date,
     @JsonProperty("serviceMode") val serviceMode: ServiceMode,
-    @JsonProperty("versionControlRevision") val versionControlRevision: String?
+    @JsonProperty("versionControlRevision") val versionControlRevision: String?,
+    @JsonProperty("defaultSource") val defaultSource: String? = null,
+    @JsonProperty("dbComponentCount") val dbComponentCount: Long? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentsRegistryServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentsRegistryServiceImpl.kt
@@ -4,6 +4,7 @@ import jakarta.annotation.PostConstruct
 import org.octopusden.octopus.components.registry.core.dto.ServiceStatusDTO
 import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
 import org.octopusden.octopus.components.registry.server.model.ServiceStatus
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
 import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
 import org.octopusden.octopus.components.registry.server.service.ComponentsRegistryService
 import org.octopusden.octopus.components.registry.server.service.ImportService
@@ -20,6 +21,7 @@ class ComponentsRegistryServiceImpl(
     private val serviceStatus: ServiceStatus,
     private val properties: ComponentsRegistryProperties,
     private val importService: ImportService,
+    private val componentSourceRepository: ComponentSourceRepository,
 ) : ComponentsRegistryService {
     override fun updateConfigCache(): Long {
         log.info("Start update of Component Registry")
@@ -35,9 +37,11 @@ class ComponentsRegistryServiceImpl(
 
     override fun getComponentsRegistryStatus(): ServiceStatusDTO =
         ServiceStatusDTO(
-            serviceStatus.cacheUpdatedAt,
-            serviceStatus.serviceMode,
-            serviceStatus.versionControlRevision,
+            cacheUpdatedAt = serviceStatus.cacheUpdatedAt,
+            serviceMode = serviceStatus.serviceMode,
+            versionControlRevision = serviceStatus.versionControlRevision,
+            defaultSource = properties.defaultSource,
+            dbComponentCount = componentSourceRepository.countBySource("db"),
         )
 
     @PostConstruct


### PR DESCRIPTION
## Summary

Closes the silent-failure mode exposed earlier today: both prod-vs-QA stands reported `serviceMode=VCS` while the candidate was actually in DB mode (resolver routing is per-component via `component_sources`, not surfaced via the `{FS, VCS}` enum). Compat would run against the wrong target without the gate noticing.

Two halves:

1. **Public DTO extension (diagnostic-tier, additive):** `ServiceStatusDTO` gains two nullable fields — `defaultSource: String?` and `dbComponentCount: Long?`. Old responses deserialise cleanly with both as null (`@JsonIgnoreProperties(ignoreUnknown = true)` + Kotlin defaults via jackson-module-kotlin). Populated in `ComponentsRegistryServiceImpl.getComponentsRegistryStatus()`.

2. **Activates `DiffClassifier.CANDIDATE_NOT_DB_MODE`** (already reserved and already in `envCategories` at `build.gradle:109` → non-suppressible). `SnapshotPreconditionTest` records the env-warning when candidate reports `defaultSource != "db"` OR `dbComponentCount < 0.9 × baselineComponentCount`.

## 90% threshold

- `requireMigrationSucceeded` aborts startup on any import failure → legitimate partial-migrate states never reach the gate.
- Slack absorbs minor DSL drift (component added on one side); those would surface as `MISSING_COMPONENT` diffs anyway.
- `(n*9 + 9) / 10 == ceil(0.9 * n)` — verified exhaustively for `{1, 5, 10, 11, 100, 948}`.
- Baseline count fetched from baseline's `/rest/api/3/components` with an `ArrayNode` guard (`ObjectNode.size()` returns property count and would silently collapse the threshold — guard maps non-array to `-1L`).

## TD-007 review-protocol compliance

Per the stricter compat-test-infra review protocol the same TD introduces (Stage-1 Sonnet code review + Stage-2 Opus adversarial — "could this test pass while production is silently wrong?"), this PR went through both stages before push:

- **Sonnet (Stage-1)** — minor: "the `> 0` check is too weak for partial-migration; the 0.9× threshold should land in this PR not as a follow-up". Resolved.
- **Opus (Stage-2 adversarial)** — blocking: "no unit tests for the new classifier branches; the protocol THIS PR introduces requires RED-then-GREEN demos". Resolved by extracting the classifier logic into the pure-function `evaluateEnvironmentPreflight(EnvironmentPreflightInputs)` and covering 12 cases including every classifier branch + boundary value + the integer-ceil identity in the new `EnvironmentPreflightEvaluatorTest`. `SnapshotPreconditionTest` retains the impure HTTP/parse stage and delegates to the evaluator.

## Pre-merge validation

- `gradlew :components-registry-compat-test:compileTestKotlin` — clean.
- `gradlew :components-registry-compat-test:test --tests "*EnvironmentPreflightEvaluator*"` — 12/12 PASSED:
  - happy path (no diffs)
  - baseline unreachable / candidate unreachable (single SNAPSHOT_MISMATCH each, subsequent checks short-circuit)
  - revisions differ (SNAPSHOT_MISMATCH; DB-mode check runs independently)
  - candidate `defaultSource=git`
  - candidate count below threshold (853 vs 854 for baseline=948)
  - candidate count exactly at threshold (854 — passes boundary)
  - candidate diagnostic fields null (old candidate)
  - baseline discovery failed (count -1) — threshold collapses to 1
  - baseline discovery failed but candidate count=1 passes weak fallback
  - revisions differ AND db-mode wrong (2 independent records)
  - integer ceil math identity across boundary values

## Test plan

- [ ] Reviewer runs `verify.sh --reset-db` against a candidate misconfigured with `--mode=vcs` (or with `dev-db-only` profile omitted) — confirms `summary.md` env-warnings section reports `CANDIDATE_NOT_DB_MODE` at the top, gate still produces the full per-endpoint report (env-warnings are non-suppressible but not gate-aborting).
- [ ] Reviewer runs the same against properly-configured `--mode=db` candidate — confirms zero env-warnings on the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)