### PR TITLE
fix(schema-v2): preserve V1 wildcard artifactPattern when DSL omits artifactId (RES-C-prime)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -271,11 +271,18 @@ class DatabaseComponentRegistryResolver(
                 ?: throw NotFoundException("Component '$component' is not found")
 
         // Component-level fallback: the top-level groupId/artifactId rows imported from DSL.
-        // For components whose DSL omits an explicit `artifactId` line, ImportServiceImpl
-        // writes the inherited `Defaults.artifactId = ANY_ARTIFACT (/[\w-\.]+/)` verbatim
-        // (see ImportServiceImpl.kt:893-902). The V1 in-memory resolver returns that
-        // wildcard literal as-is; we must do the same to preserve API parity (RES-C-prime).
-        val artifactIdRows = componentEntity.artifactIds.toList()
+        // For components whose DSL omits an explicit `artifactId` line, the import path
+        // writes the inherited `Defaults.artifactId = ANY_ARTIFACT (/[\w-\.]+/)` verbatim;
+        // the V1 in-memory resolver returns that wildcard literal as-is (RES-C-prime).
+        //
+        // `componentEntity.artifactIds` is a JPA `@OneToMany` without `@OrderBy`, so the
+        // DB load order is not contractual. Sort by `id` (UUID) for a deterministic
+        // CSV across reloads of the same DB state. Note: the import writes one row per
+        // CSV-split entry with a SHARED `groupPattern` (the per-component groupId
+        // from `EscrowModuleConfig.groupIdPattern`), so `first().groupPattern` is stable
+        // by construction — any row picks the same group. Multi-artifact DSL order
+        // preservation is a known follow-up; see TD-008 once filed.
+        val artifactIdRows = componentEntity.artifactIds.sortedBy { it.id?.toString().orEmpty() }
         val componentLevelFallback =
             if (artifactIdRows.isEmpty()) {
                 null
@@ -660,8 +667,8 @@ class DatabaseComponentRegistryResolver(
 
         /**
          * SoT literal for `ComponentConfigurationEntity.rowType`. Matches the
-         * String constants used inside `EntityMappers.kt` (lines 91/148/170/198 etc.).
-         * The entity field is a `String` — there is no shared enum to reference.
+         * String constants used throughout `EntityMappers`. The entity field is
+         * a `String` — there is no shared enum to reference.
          */
         private const val ROW_TYPE_MARKER = "MARKER"
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -11,6 +11,7 @@ import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.octopus.components.registry.server.mapper.toEscrowModule
 import org.octopusden.octopus.components.registry.server.mapper.toResolvedEscrowModuleConfig
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
@@ -270,6 +271,10 @@ class DatabaseComponentRegistryResolver(
                 ?: throw NotFoundException("Component '$component' is not found")
 
         // Component-level fallback: the top-level groupId/artifactId rows imported from DSL.
+        // For components whose DSL omits an explicit `artifactId` line, ImportServiceImpl
+        // writes the inherited `Defaults.artifactId = ANY_ARTIFACT (/[\w-\.]+/)` verbatim
+        // (see ImportServiceImpl.kt:893-902). The V1 in-memory resolver returns that
+        // wildcard literal as-is; we must do the same to preserve API parity (RES-C-prime).
         val artifactIdRows = componentEntity.artifactIds.toList()
         val componentLevelFallback =
             if (artifactIdRows.isEmpty()) {
@@ -280,6 +285,23 @@ class DatabaseComponentRegistryResolver(
                     artifactIdRows.joinToString(",") { it.artifactPattern },
                 )
             }
+
+        // Per-range MARKER `distribution.maven` rows: only these ranges have a real
+        // per-range override of the maven coordinate. For ranges without such a marker,
+        // the BASE row's per-config maven-artifacts are merely the inherited GAV used
+        // by other read paths (packaging resolution etc.); they MUST NOT be re-synthesized
+        // into the `/maven-artifacts` response, because the V1 contract returns the
+        // component-level `artifactIdPattern` verbatim (RES-C-prime).
+        // `rowType` is a String on the entity; the literal matches the SoT used inside
+        // EntityMappers.kt (lines 148/170/198 — "MARKER").
+        val markerRanges: Set<String> =
+            componentEntity.configurations
+                .asSequence()
+                .filter {
+                    it.rowType == "MARKER" && it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN
+                }
+                .map { it.versionRange }
+                .toSet()
 
         // Walk the per-range EscrowModule view so that DISTRIBUTION_MAVEN marker
         // overrides are respected: each EscrowModuleConfig already has the correct
@@ -294,27 +316,33 @@ class DatabaseComponentRegistryResolver(
         return module.moduleConfigurations
             .associate { config ->
                 val rangeKey = config.versionRangeString ?: ALL_VERSIONS
-                val gavCsv = config.distribution?.GAV()
                 val artifact =
-                    if (!gavCsv.isNullOrBlank()) {
-                        // Per-range GAV present: parse maven entries (skip URL entries).
-                        val coords =
-                            splitCsv(gavCsv)
-                                .filterNot {
-                                    it.startsWith("file://") ||
-                                        it.startsWith("http://") ||
-                                        it.startsWith("https://")
-                                }
-                                .mapNotNull { parseMavenGavEntry(it) }
-                        if (coords.isNotEmpty()) {
-                            ComponentArtifactConfiguration(
-                                coords.first().groupId,
-                                coords.joinToString(",") { it.artifactId },
-                            )
+                    if (rangeKey in markerRanges) {
+                        // Real per-range override → GAV-extraction branch (RES-C bug fix from PR #209).
+                        val gavCsv = config.distribution?.GAV()
+                        if (!gavCsv.isNullOrBlank()) {
+                            val coords =
+                                splitCsv(gavCsv)
+                                    .filterNot {
+                                        it.startsWith("file://") ||
+                                            it.startsWith("http://") ||
+                                            it.startsWith("https://")
+                                    }
+                                    .mapNotNull { parseMavenGavEntry(it) }
+                            if (coords.isNotEmpty()) {
+                                ComponentArtifactConfiguration(
+                                    coords.first().groupId,
+                                    coords.joinToString(",") { it.artifactId },
+                                )
+                            } else {
+                                componentLevelFallback
+                            }
                         } else {
                             componentLevelFallback
                         }
                     } else {
+                        // No per-range marker: V1 parity — return component-level fallback
+                        // verbatim (wildcard literal when DSL omitted `artifactId`).
                         componentLevelFallback
                     }
                 rangeKey to (artifact ?: ComponentArtifactConfiguration("", ""))

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -292,13 +292,11 @@ class DatabaseComponentRegistryResolver(
         // by other read paths (packaging resolution etc.); they MUST NOT be re-synthesized
         // into the `/maven-artifacts` response, because the V1 contract returns the
         // component-level `artifactIdPattern` verbatim (RES-C-prime).
-        // `rowType` is a String on the entity; the literal matches the SoT used inside
-        // EntityMappers.kt (lines 148/170/198 — "MARKER").
         val markerRanges: Set<String> =
             componentEntity.configurations
                 .asSequence()
                 .filter {
-                    it.rowType == "MARKER" && it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN
+                    it.rowType == ROW_TYPE_MARKER && it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN
                 }
                 .map { it.versionRange }
                 .toSet()
@@ -345,6 +343,10 @@ class DatabaseComponentRegistryResolver(
                         // verbatim (wildcard literal when DSL omitted `artifactId`).
                         componentLevelFallback
                     }
+                // Empty pair is the "no data" sentinel when both the marker-gated GAV
+                // branch and the component-level fallback returned nothing. The
+                // `filterValues` below drops these so the empty ranges aren't reported
+                // — matches the legacy contract for components with no maven artifacts.
                 rangeKey to (artifact ?: ComponentArtifactConfiguration("", ""))
             }
             .filterValues { it.groupPattern.isNotEmpty() || it.artifactPattern.isNotEmpty() }
@@ -655,5 +657,12 @@ class DatabaseComponentRegistryResolver(
         /** Must match EscrowConfigurationLoader.ALL_VERSIONS = "(,0),[0,)" */
         @Suppress("VariableNaming")
         private const val ALL_VERSIONS = "(,0),[0,)"
+
+        /**
+         * SoT literal for `ComponentConfigurationEntity.rowType`. Matches the
+         * String constants used inside `EntityMappers.kt` (lines 91/148/170/198 etc.).
+         * The entity field is a `String` — there is no shared enum to reference.
+         */
+        private const val ROW_TYPE_MARKER = "MARKER"
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -416,6 +416,19 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
     }
 
     // ========================================================================
+    // Coverage gaps (out of scope for this PR, tracked for follow-up)
+    // ========================================================================
+    //
+    // RES-C-006 (TODO): synthetic-base + DISTRIBUTION_MAVEN MARKER. Per
+    // EntityMappers.kt:106, `toEscrowModule` suppresses the synthetic-base range
+    // `(,)` when overrides are present. A MARKER row whose `versionRange` is the
+    // synthetic placeholder ends up in `markerRanges` here but is never emitted
+    // by `toEscrowModule`, so the resolver short-circuits to fallback for any
+    // real range — which is the correct outcome. No reproducer in production
+    // today, but the path is untested and worth a dedicated fixture if the
+    // schema ever evolves.
+
+    // ========================================================================
     // Companion
     // ========================================================================
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
@@ -102,6 +103,38 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
             ),
         )
     }
+
+    /**
+     * Append a row to `componentEntity.artifactIds` — the component-level fallback table
+     * populated by `ImportServiceImpl` from `EscrowModuleConfig.artifactIdPattern`. For
+     * components whose DSL omits an explicit `artifactId` line, the inherited
+     * `Defaults.artifactId = ANY_ARTIFACT (/[\w-\.]+/)` is written verbatim as the
+     * `artifactPattern`. See `ImportServiceImpl.kt:893-902`.
+     */
+    private fun addComponentLevelArtifact(
+        component: ComponentEntity,
+        groupPattern: String,
+        artifactPattern: String,
+    ) {
+        component.artifactIds.add(
+            ComponentArtifactIdEntity(
+                component = component,
+                groupPattern = groupPattern,
+                artifactPattern = artifactPattern,
+            ),
+        )
+    }
+
+    private fun makeRangePresenceRow(
+        component: ComponentEntity,
+        versionRange: String,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = null,
+            rowType = "RANGE_PRESENCE",
+        )
 
     private fun stubComponent(component: ComponentEntity) {
         `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
@@ -230,11 +263,156 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
     }
 
     // ========================================================================
+    // RES-C-prime tests (Contract B): V1 wildcard preservation
+    // ========================================================================
+    //
+    // Plan ref: `~/.claude/plans/image-6-playful-gizmo.md` TASK-1.
+    //
+    // The V1 in-memory resolver returns `EscrowModuleConfig.artifactIdPattern`
+    // verbatim. When the DSL has no explicit `artifactId` line, the inherited
+    // default is `Defaults.artifactId = ANY_ARTIFACT (/[\w-\.]+/)`, so prod
+    // emits the wildcard literal for every range. PR-C's V2 implementation
+    // unconditionally extracted artifactIds from `config.distribution?.GAV()`,
+    // which silently changed the public-API semantic for any DB-routed
+    // component without an explicit `artifactId` declaration. The fix gates
+    // GAV-extraction on a per-range `DISTRIBUTION_MAVEN` MARKER row being
+    // present for the range; otherwise we return `componentLevelFallback`
+    // which on V1-import path is the wildcard literal.
+
+    @Test
+    @DisplayName(
+        "RES-C-004: BASE has per-config GAV but no per-range DISTRIBUTION_MAVEN marker " +
+            "→ component-level wildcard wins; do not synthesize artifactIds from GAV",
+    )
+    fun `RES-C-004 BASE GAV without marker returns component-level wildcard`() {
+        // Production shape: a database-backed component with no explicit `artifactId` line
+        // in its DSL. Defaults inject the wildcard, ImportServiceImpl writes a single
+        // component-level row with `artifactPattern = "[\w-\.]+"`. The per-config
+        // distribution carries the concrete GAV CSV (`groupId:artifactId:packaging,...`)
+        // for downstream packaging-resolution use, but the `/maven-artifacts` endpoint
+        // must return the wildcard, matching V1.
+        val comp = makeComponent("res-c-prime-fixture-single-range")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example.test", V1_WILDCARD)
+
+        val base = makeBase(comp, ALL_VERSIONS)
+        // Per-config maven-artifact rows simulate the inherited GAV that PR-C
+        // would have extracted into a CSV. Two entries to make the regression
+        // visible (a CSV like "art-a,art-b" would land here pre-fix).
+        addMavenArtifact(base, "com.example.test", "art-a", sortOrder = 0)
+        addMavenArtifact(base, "com.example.test", "art-b", sortOrder = 1)
+
+        comp.configurations.add(base)
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("res-c-prime-fixture-single-range")
+
+        assertEquals(1, result.size, "Expected exactly one range entry (no markers)")
+        val entry = result[ALL_VERSIONS]
+        assertNotNull(entry, "ALL_VERSIONS entry must be present")
+        assertEquals("com.example.test", entry!!.groupPattern, "groupPattern must come from component-level fallback")
+        assertEquals(
+            V1_WILDCARD,
+            entry.artifactPattern,
+            "artifactPattern must be the V1 wildcard literal — NOT the GAV-synthesized CSV",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "RES-C-004b: two ranges (BASE + RANGE_PRESENCE) with per-config GAV but no markers " +
+            "→ both ranges return the V1 wildcard via component-level fallback",
+    )
+    fun `RES-C-004b two ranges without markers both return wildcard`() {
+        val comp = makeComponent("res-c-prime-fixture-two-ranges")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example.test", V1_WILDCARD)
+
+        val base = makeBase(comp, "(,1.0.107)")
+        addMavenArtifact(base, "com.example.test", "art-a", sortOrder = 0)
+        // RANGE_PRESENCE row brings the second range into the toEscrowModule enumeration
+        // without introducing a DISTRIBUTION_MAVEN marker — exactly the prod shape where
+        // a component has multiple ranges but no per-range maven override.
+        val presence = makeRangePresenceRow(comp, "[1.0.107,)")
+
+        comp.configurations.addAll(listOf(base, presence))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("res-c-prime-fixture-two-ranges")
+
+        assertEquals(2, result.size, "Expected two range entries")
+        for (range in listOf("(,1.0.107)", "[1.0.107,)")) {
+            val entry = result[range]
+            assertNotNull(entry, "$range entry must be present")
+            assertEquals("com.example.test", entry!!.groupPattern, "$range groupPattern must be from fallback")
+            assertEquals(V1_WILDCARD, entry.artifactPattern, "$range artifactPattern must be the V1 wildcard")
+        }
+    }
+
+    @Test
+    @DisplayName(
+        "RES-C-005: mixed — BASE+GAV, MARKER for range B only → range B uses GAV, range A uses fallback",
+    )
+    fun `RES-C-005 marker-gated GAV extraction only for marked ranges`() {
+        // Demonstrates that the per-range MARKER gate is the discriminator:
+        //   - range A (BASE, no marker)            → wildcard from component-level fallback
+        //   - range B (DISTRIBUTION_MAVEN marker)  → GAV-derived CSV
+        val comp = makeComponent("res-c-prime-fixture-mixed")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example.test", V1_WILDCARD)
+
+        val base = makeBase(comp, "(,1.0)")
+        addMavenArtifact(base, "com.example.test", "art-x", sortOrder = 0)
+
+        val markerNew = makeMarkerRow(comp, "[1.0,)", "distribution.maven")
+        addMavenArtifact(markerNew, "com.example.new", "real-artifact-id", sortOrder = 0)
+
+        comp.configurations.addAll(listOf(base, markerNew))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("res-c-prime-fixture-mixed")
+
+        assertEquals(2, result.size, "Expected two range entries")
+
+        val rangeNoMarker = result["(,1.0)"]
+        assertNotNull(rangeNoMarker, "(,1.0) entry must be present")
+        assertEquals(
+            "com.example.test",
+            rangeNoMarker!!.groupPattern,
+            "(,1.0) groupPattern must be component-level fallback (no marker for this range)",
+        )
+        assertEquals(
+            V1_WILDCARD,
+            rangeNoMarker.artifactPattern,
+            "(,1.0) artifactPattern must be wildcard — marker is on a different range",
+        )
+
+        val rangeWithMarker = result["[1.0,)"]
+        assertNotNull(rangeWithMarker, "[1.0,) entry must be present")
+        assertEquals(
+            "com.example.new",
+            rangeWithMarker!!.groupPattern,
+            "[1.0,) groupPattern must come from the marker's GAV (override is active)",
+        )
+        assertEquals(
+            "real-artifact-id",
+            rangeWithMarker.artifactPattern,
+            "[1.0,) artifactPattern must come from the marker's GAV (override is active)",
+        )
+    }
+
+    // ========================================================================
     // Companion
     // ========================================================================
 
     companion object {
         /** Must match EscrowConfigurationLoader.ALL_VERSIONS */
         private const val ALL_VERSIONS = "(,0),[0,)"
+
+        /** V1 wildcard placeholder emitted by `Defaults.artifactId = ANY_ARTIFACT`. */
+        private const val V1_WILDCARD = "[\\w-\\.]+"
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -277,7 +277,7 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
     // RES-C-prime tests (Contract B): V1 wildcard preservation
     // ========================================================================
     //
-    // Plan ref: `~/.claude/plans/image-6-playful-gizmo.md` TASK-1.
+    // RES-C-prime: V1 wildcard preservation for `/maven-artifacts`.
     //
     // The V1 in-memory resolver returns `EscrowModuleConfig.artifactIdPattern`
     // verbatim. When the DSL has no explicit `artifactId` line, the inherited

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -157,6 +157,10 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         val comp = makeComponent("bug-C-component-A-like")
         comp.distributionExplicit = true
 
+        // Component-level fallback: ImportServiceImpl writes this from the BASE
+        // EscrowModuleConfig.artifactIdPattern — non-marker ranges return it verbatim.
+        addComponentLevelArtifact(comp, "com.example.ic", "bug-C-component-A")
+
         val base = makeBase(comp, "[1.1,)")
         addMavenArtifact(base, "com.example.ic", "bug-C-component-A")
 
@@ -197,6 +201,9 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         //     (com.example.cardsmodel2, bug-C-fixture-v2) and (com.example.cardsmodel, bug-C-fixture-legacy)
         val comp = makeComponent("bug-C-fixture-B-shape")
         comp.distributionExplicit = true
+
+        // Component-level fallback (production import writes this from BASE artifactIdPattern).
+        addComponentLevelArtifact(comp, "com.example.cardsmodel2.dummy", "bug-C-component-B")
 
         val base = makeBase(comp, "[03.51.29.15,)")
         addMavenArtifact(base, "com.example.cardsmodel2.dummy", "bug-C-component-B", sortOrder = 0)
@@ -244,8 +251,12 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
     )
     fun `RES-C-003 getMavenArtifactParameters falls back to component-level artifactIds when no GAV override`() {
         // No per-range overrides: only a BASE row with maven artifact at ALL_VERSIONS
+        // and a component-level row (production-shape: import writes both from a single
+        // BASE EscrowModuleConfig).
         val comp = makeComponent("simple-component")
         comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example", "simple-lib")
 
         val base = makeBase(comp, ALL_VERSIONS)
         addMavenArtifact(base, "com.example", "simple-lib")


### PR DESCRIPTION
## Summary
PR #209 (per-range maven-artifacts override leak fix) inadvertently changed the public-API semantic of `/maven-artifacts` for any DB-routed component whose DSL omits an explicit `artifactId` line: it unconditionally synthesized artifactIds from per-config `distribution.GAV()`. V1 in-memory resolver returns `EscrowModuleConfig.artifactIdPattern` verbatim — for components without an explicit declaration, that's the wildcard literal `[\w-\.]+` inherited from `Defaults.artifactId = ANY_ARTIFACT`. 109 components in today's compat run show the divergence.

Implements **Contract B** from `~/.claude/plans/image-6-playful-gizmo.md` TASK-1:
- Gate the GAV-extraction branch on the presence of a per-range `DISTRIBUTION_MAVEN` MARKER row for that range.
- Non-marker ranges return `componentLevelFallback` from `componentEntity.artifactIds` — the row(s) `ImportServiceImpl.kt:893-902` populates from `EscrowModuleConfig.artifactIdPattern`.

## Behaviour
| Range shape | Before (PR-C) | After (PR-C-prime) |
|---|---|---|
| Range has `DISTRIBUTION_MAVEN` MARKER row | GAV-extracted `(group, CSV)` from marker | GAV-extracted `(group, CSV)` from marker — unchanged, RES-C bug stays fixed |
| Range has no marker, component has explicit `artifactId` in DSL | GAV-extracted CSV (wrong if DSL artifactId differs from GAV) | Component-level fallback (`(group, artifactId)`) — V1 parity |
| Range has no marker, no explicit `artifactId` | GAV-extracted CSV (wrong: 109 components in prod) | Component-level fallback (`(group, "[\w-\.]+")`) — V1 parity |
| No component-level fallback AND no marker | Component-level fallback null → filtered out | (unchanged) |

## Test plan
- [x] **RES-C-001/002/003** stay GREEN (fixture updated to include `componentEntity.artifactIds` to mirror production import shape).
- [x] **RES-C-004** new: single range, BASE has per-config GAV, no marker → V1 wildcard wins.
- [x] **RES-C-004b** new: two ranges via `RANGE_PRESENCE`, no markers → both ranges return wildcard.
- [x] **RES-C-005** new: mixed — BASE+GAV, MARKER on range B only → A=fallback, B=GAV.
- [x] Full `./gradlew build` passes.

## Review-feedback log
- `c76a863` `test:` introduce 3 RED tests + helpers (`addComponentLevelArtifact`, `makeRangePresenceRow`).
- `78adb80` `fix:` Contract B implementation + RES-C-001/002/003 fixture updates to production shape.
- `c840e89` `docs:` Sonnet review fixes — `ROW_TYPE_MARKER` constant, sentinel-comment on `filterValues`, RES-C-006 TODO note.

Plan ref: `~/.claude/plans/image-6-playful-gizmo.md` TASK-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)