### PR TITLE
test(compat): TD-007 L1 — ComparatorLogicTest + Comparators extraction

### DIFF
--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComparatorLogicTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComparatorLogicTest.kt
@@ -1,0 +1,311 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-unit coverage for [Comparators.compareRaw] — the raw-layer compare
+ * entrypoint exercised by every live-stand suite via the delegator in
+ * [CompatibilityTestBase].
+ *
+ * Pins the comparator semantics the addendum plan (TD-007 L1) calls out as
+ * "could this test pass when production is silently wrong":
+ *
+ *  - status divergence short-circuits the shape walk (no spurious
+ *    STRUCTURAL_DIFFs piled on top of a real STATUS_CODE_DIFF).
+ *  - status=0 (transport failure) is itself a STATUS_CODE_DIFF — even when
+ *    BOTH sides degrade to 0, the bare `baseline.status != candidate.status`
+ *    equality would otherwise mask the failure.
+ *  - the header allow-list compares the configured headers and ignores
+ *    everything else, case-insensitively.
+ *  - JSON-object key order is structurally insignificant (key permutation
+ *    on baseline vs candidate is NOT a diff).
+ *  - additive fields surface as KEY_MISSING_BASELINE / KEY_MISSING_CANDIDATE,
+ *    via the [JsonShape] layer, with the path encoded into the message.
+ *
+ * `DiffCollector` is a process-singleton. Each test clears it first and then
+ * inspects [DiffCollector.snapshot] after the call. The collector also writes
+ * to `build/reports/compat/diff-worker-*.ndjson` as a side effect; that file
+ * is recreated on each `:unitTest` run and is harmless test output.
+ */
+@Tag("unit")
+class ComparatorLogicTest {
+
+    private val mapper = jacksonObjectMapper()
+    private fun node(json: String): JsonNode = mapper.readTree(json)
+
+    private fun response(
+        status: Int = 200,
+        body: String? = null,
+        headers: Map<String, String> = mapOf("Content-Type" to "application/json"),
+    ): RawResponse =
+        RawResponse(
+            status = status,
+            headers = headers,
+            bodyBytes = (body ?: "").toByteArray(Charsets.UTF_8),
+            json = body?.let { node(it) },
+            durationMs = 0L,
+        )
+
+    @BeforeEach
+    fun clearCollector() {
+        DiffCollector.clear()
+    }
+
+    // ----- Status divergence short-circuits the shape walk -----
+
+    @Test
+    @DisplayName(
+        "status divergence (200 vs 404) records STATUS_CODE_DIFF and does NOT pile on STRUCTURAL_DIFFs",
+    )
+    fun statusCodeDiffShortCircuitsShape() {
+        val baseline = response(status = 200, body = """{"x":1}""")
+        val candidate = response(status = 404, body = """{"errorMessage":"not found"}""")
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components/{c}",
+            pathParams = mapOf("c" to "nonexistent"),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).containsExactly(DiffClassifier.STATUS_CODE_DIFF)
+        val recorded = DiffCollector.snapshot()
+        assertThat(recorded).hasSize(1)
+        assertThat(recorded.single().category).isEqualTo(DiffClassifier.STATUS_CODE_DIFF)
+        assertThat(recorded.single().baselineValue).isEqualTo("200")
+        assertThat(recorded.single().candidateValue).isEqualTo("404")
+    }
+
+    @Test
+    @DisplayName(
+        "transport failure on candidate (status=0) → STATUS_CODE_DIFF with 'transport failure on candidate' message",
+    )
+    fun transportFailureCandidate() {
+        val baseline = response(status = 200, body = """{"x":1}""")
+        val candidate = response(status = 0, body = null)
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).containsExactly(DiffClassifier.STATUS_CODE_DIFF)
+        val recorded = DiffCollector.snapshot().single()
+        assertThat(recorded.message).contains("transport failure", "candidate")
+        assertThat(recorded.message).doesNotContain("baseline and")
+    }
+
+    @Test
+    @DisplayName(
+        "transport failure on BOTH sides (status=0/0) still records STATUS_CODE_DIFF — bare equality check would otherwise mask this",
+    )
+    fun transportFailureBothSides() {
+        val baseline = response(status = 0, body = null)
+        val candidate = response(status = 0, body = null)
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        // The naive `baseline.status != candidate.status` check would pass
+        // here (0 == 0). The OR-branch on either side being 0 catches it.
+        assertThat(categories).containsExactly(DiffClassifier.STATUS_CODE_DIFF)
+        val recorded = DiffCollector.snapshot().single()
+        assertThat(recorded.message).contains("transport failure", "baseline and candidate")
+    }
+
+    // ----- Shape semantics -----
+
+    @Test
+    @DisplayName("clean run: identical body + identical Content-Type → zero diffs recorded")
+    fun cleanRunRecordsNothing() {
+        val body = """{"a":1,"b":"two"}"""
+        val baseline = response(body = body)
+        val candidate = response(body = body)
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components/{c}",
+            pathParams = mapOf("c" to "foo"),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).isEmpty()
+        assertThat(DiffCollector.snapshot()).isEmpty()
+    }
+
+    @Test
+    @DisplayName("same body with permuted object key order — zero diffs")
+    fun keyOrderIsNotADiff() {
+        val baseline = response(body = """{"a":1,"b":"two","c":[1,2,3]}""")
+        val candidate = response(body = """{"c":[1,2,3],"b":"two","a":1}""")
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components/{c}",
+            pathParams = mapOf("c" to "foo"),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).isEmpty()
+        assertThat(DiffCollector.snapshot()).isEmpty()
+    }
+
+    @Test
+    @DisplayName("additive field on candidate → STRUCTURAL_DIFF with KEY_MISSING_BASELINE in message")
+    fun additiveFieldOnCandidateIsAStructuralDiff() {
+        val baseline = response(body = """{"x":1}""")
+        val candidate = response(body = """{"x":1,"newField":"hello"}""")
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).containsExactly(DiffClassifier.STRUCTURAL_DIFF)
+        val recorded = DiffCollector.snapshot().single()
+        assertThat(recorded.category).isEqualTo(DiffClassifier.STRUCTURAL_DIFF)
+        assertThat(recorded.message).contains("KEY_MISSING_BASELINE", "newField")
+    }
+
+    @Test
+    @DisplayName("removed field on candidate → STRUCTURAL_DIFF with KEY_MISSING_CANDIDATE in message")
+    fun removedFieldOnCandidateIsAStructuralDiff() {
+        val baseline = response(body = """{"x":1,"oldField":"hello"}""")
+        val candidate = response(body = """{"x":1}""")
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).containsExactly(DiffClassifier.STRUCTURAL_DIFF)
+        val recorded = DiffCollector.snapshot().single()
+        assertThat(recorded.message).contains("KEY_MISSING_CANDIDATE", "oldField")
+    }
+
+    // ----- Header allow-list semantics -----
+
+    @Test
+    @DisplayName("Content-Type difference → HEADER_DIFF (with the header key in the message)")
+    fun contentTypeMismatchIsAHeaderDiff() {
+        val baseline = response(
+            body = """{"x":1}""",
+            headers = mapOf("Content-Type" to "application/json"),
+        )
+        val candidate = response(
+            body = """{"x":1}""",
+            headers = mapOf("Content-Type" to "text/plain"),
+        )
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).contains(DiffClassifier.HEADER_DIFF)
+        val headerRec = DiffCollector.snapshot().single { it.category == DiffClassifier.HEADER_DIFF }
+        // `stableHeaders` normalizes to lowercase keys, so the message echoes
+        // `header=content-type` regardless of how the wire spelled it.
+        assertThat(headerRec.message).contains("content-type")
+        assertThat(headerRec.baselineValue).isEqualTo("application/json")
+        assertThat(headerRec.candidateValue).isEqualTo("text/plain")
+    }
+
+    @Test
+    @DisplayName("Date / ETag / Server differ but are not in the allow-list → no HEADER_DIFF")
+    fun outOfAllowListHeadersAreIgnored() {
+        val baseline = response(
+            body = """{"x":1}""",
+            headers = mapOf(
+                "Content-Type" to "application/json",
+                "Date" to "Mon, 16 May 2026 10:00:00 GMT",
+                "ETag" to "abc123",
+                "Server" to "nginx/1.21",
+            ),
+        )
+        val candidate = response(
+            body = """{"x":1}""",
+            headers = mapOf(
+                "Content-Type" to "application/json",
+                "Date" to "Mon, 16 May 2026 10:00:42 GMT",
+                "ETag" to "def456",
+                "Server" to "tomcat/10.0",
+            ),
+        )
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).isEmpty()
+        assertThat(DiffCollector.snapshot()).isEmpty()
+    }
+
+    @Test
+    @DisplayName("Header allow-list is case-insensitive: baseline 'Content-Type' vs candidate 'content-type' → no HEADER_DIFF when values match")
+    fun headerAllowListIsCaseInsensitive() {
+        val baseline = response(
+            body = """{"x":1}""",
+            headers = mapOf("Content-Type" to "application/json"),
+        )
+        val candidate = response(
+            body = """{"x":1}""",
+            // Same value, but the key has different casing — the comparator
+            // must normalize before comparing or it produces a spurious diff.
+            headers = mapOf("content-type" to "application/json"),
+        )
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).isEmpty()
+        assertThat(DiffCollector.snapshot()).isEmpty()
+    }
+
+    // ----- Plumbing: pathParams + queryParams thread through to the record -----
+
+    @Test
+    @DisplayName("recorded DiffRecord carries the endpoint + path + queryParams the caller passed")
+    fun diffRecordCarriesContext() {
+        val baseline = response(status = 200, body = """{"x":1}""")
+        val candidate = response(status = 500, body = """{"errorMessage":"boom"}""")
+
+        Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components/{c}/build-tools",
+            pathParams = mapOf("c" to "alpha"),
+            baseline = baseline,
+            candidate = candidate,
+            queryParams = mapOf("ignore-required" to "true"),
+        )
+
+        val r = DiffCollector.snapshot().single()
+        assertThat(r.endpoint).isEqualTo("GET /rest/api/2/components/{c}/build-tools")
+        assertThat(r.pathParams).containsEntry("c", "alpha")
+        assertThat(r.queryParams).containsEntry("ignore-required", "true")
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComparatorLogicTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComparatorLogicTest.kt
@@ -32,6 +32,14 @@ import org.junit.jupiter.api.Test
  * inspects [DiffCollector.snapshot] after the call. The collector also writes
  * to `build/reports/compat/diff-worker-*.ndjson` as a side effect; that file
  * is recreated on each `:unitTest` run and is harmless test output.
+ *
+ * **Parallel-execution caveat:** the `clear()` + `snapshot()` pair is process-
+ * wide. The `:unitTest` task (build.gradle) does NOT set
+ * `junit.jupiter.execution.parallel.enabled`, so cases here run sequentially
+ * within one JVM and there is no risk of cross-class pollution. If parallel
+ * unit execution is ever enabled and another unit test class also writes to
+ * `DiffCollector`, this assumption breaks — switch to a thread-local snapshot
+ * helper at that point.
  */
 @Tag("unit")
 class ComparatorLogicTest {
@@ -101,6 +109,32 @@ class ComparatorLogicTest {
         val recorded = DiffCollector.snapshot().single()
         assertThat(recorded.message).contains("transport failure", "candidate")
         assertThat(recorded.message).doesNotContain("baseline and")
+    }
+
+    @Test
+    @DisplayName(
+        "transport failure on BASELINE (status=0 on baseline, 200 on candidate) → STATUS_CODE_DIFF identifies baseline",
+    )
+    fun transportFailureBaseline() {
+        // Symmetric counterpart to the candidate-only case. Without this assertion,
+        // a regression that swapped the two `takeIf` predicates in the message
+        // builder would pass every other test in this suite. The 'baseline'
+        // branch must be exercised explicitly.
+        val baseline = response(status = 0, body = null)
+        val candidate = response(status = 200, body = """{"x":1}""")
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).containsExactly(DiffClassifier.STATUS_CODE_DIFF)
+        val recorded = DiffCollector.snapshot().single()
+        assertThat(recorded.message).contains("transport failure", "baseline")
+        // The "and candidate" suffix must NOT appear — only baseline failed here.
+        assertThat(recorded.message).doesNotContain("and candidate")
     }
 
     @Test
@@ -179,6 +213,31 @@ class ComparatorLogicTest {
         val recorded = DiffCollector.snapshot().single()
         assertThat(recorded.category).isEqualTo(DiffClassifier.STRUCTURAL_DIFF)
         assertThat(recorded.message).contains("KEY_MISSING_BASELINE", "newField")
+    }
+
+    @Test
+    @DisplayName("array of different sizes at same status → STRUCTURAL_DIFF with ARRAY_SIZE_MISMATCH in message")
+    fun arraySizeMismatchSurfacesViaStructuralDiff() {
+        // Exercises the JsonShape array-walk branch — not covered by the other
+        // shape cases, which all use object roots. Pinning this case is the
+        // regression guard against accidentally short-circuiting array diffs
+        // (e.g. by mis-passing the body through RawArraySorters which would
+        // align same-sized arrays but should NOT mask different-sized arrays).
+        val baseline = response(body = """{"items":[1,2,3]}""")
+        val candidate = response(body = """{"items":[1,2]}""")
+
+        val categories = Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/components",
+            pathParams = emptyMap(),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        assertThat(categories).containsExactly(DiffClassifier.STRUCTURAL_DIFF)
+        val recorded = DiffCollector.snapshot().single()
+        assertThat(recorded.message).contains("ARRAY_SIZE_MISMATCH")
+        assertThat(recorded.baselineValue).isEqualTo("3")
+        assertThat(recorded.candidateValue).isEqualTo("2")
     }
 
     @Test

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/Comparators.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/Comparators.kt
@@ -1,0 +1,134 @@
+package org.octopusden.octopus.components.registry.compat
+
+import java.time.Instant
+
+/**
+ * Pure-function compare layer for raw HTTP responses. Extracted out of
+ * [CompatibilityTestBase] so its semantics can be unit-tested without the
+ * HTTP/Spring scaffolding the base class needs at runtime.
+ *
+ * [CompatibilityTestBase.compareRaw] delegates here; every live-stand suite
+ * hits the same code path.
+ *
+ * Effects: emits [DiffRecord]s into the process-wide [DiffCollector]. Callers
+ * that need a side-effect-free comparison should not use this — instead, pass
+ * the constructed inputs through the building blocks directly
+ * ([JsonShape.diff], [RawResponse.stableHeaders]). The tests in
+ * `ComparatorLogicTest` exercise the collector by snapshotting / clearing it
+ * around each case.
+ */
+object Comparators {
+    /**
+     * Status -> header allow-list -> JSON-shape compare. Records every
+     * divergence to [DiffCollector] and returns the categories observed.
+     *
+     * See [CompatibilityTestBase.compareRaw] for parameter semantics —
+     * this object is the implementation, the method on the base class is
+     * a thin delegate so existing call sites need no churn.
+     */
+    fun compareRaw(
+        endpoint: String,
+        pathParams: Map<String, String>,
+        baseline: RawResponse,
+        candidate: RawResponse,
+        headerAllowList: Set<String> = setOf("Content-Type"),
+        queryParams: Map<String, String> = emptyMap(),
+    ): List<DiffClassifier> {
+        val categories = mutableListOf<DiffClassifier>()
+        val ts = Instant.now().toString()
+
+        // status=0 is reserved by [RawHttpClient] for transport failures (timeout,
+        // connection-refused, DNS, etc.). If both sides degrade to 0 the bare
+        // `baseline.status != candidate.status` check passes silently and the run
+        // looks clean — record a fail-causing diff whenever EITHER side is 0, even
+        // if both are.
+        val baselineTransportFailed = baseline.status == 0
+        val candidateTransportFailed = candidate.status == 0
+        if (baselineTransportFailed || candidateTransportFailed) {
+            categories += DiffClassifier.STATUS_CODE_DIFF
+            DiffCollector.record(
+                DiffRecord(
+                    ts = ts,
+                    endpoint = endpoint,
+                    pathParams = pathParams,
+                    queryParams = queryParams,
+                    category = DiffClassifier.STATUS_CODE_DIFF,
+                    layer = "raw",
+                    baselineValue = baseline.status.toString(),
+                    candidateValue = candidate.status.toString(),
+                    message = "transport failure on " + listOfNotNull(
+                        "baseline".takeIf { baselineTransportFailed },
+                        "candidate".takeIf { candidateTransportFailed },
+                    ).joinToString(" and "),
+                ),
+            )
+        } else if (baseline.status != candidate.status) {
+            categories += DiffClassifier.STATUS_CODE_DIFF
+            DiffCollector.record(
+                DiffRecord(
+                    ts = ts,
+                    endpoint = endpoint,
+                    pathParams = pathParams,
+                    queryParams = queryParams,
+                    category = DiffClassifier.STATUS_CODE_DIFF,
+                    layer = "raw",
+                    baselineValue = baseline.status.toString(),
+                    candidateValue = candidate.status.toString(),
+                ),
+            )
+        }
+
+        val baselineHeaders = baseline.stableHeaders(headerAllowList)
+        val candidateHeaders = candidate.stableHeaders(headerAllowList)
+        for (key in (baselineHeaders.keys + candidateHeaders.keys).distinctBy { it.lowercase() }) {
+            val bv = baselineHeaders[key]
+            val cv = candidateHeaders[key]
+            if (bv != cv) {
+                categories += DiffClassifier.HEADER_DIFF
+                DiffCollector.record(
+                    DiffRecord(
+                        ts = ts,
+                        endpoint = endpoint,
+                        pathParams = pathParams,
+                        queryParams = queryParams,
+                        category = DiffClassifier.HEADER_DIFF,
+                        layer = "raw",
+                        baselineValue = bv,
+                        candidateValue = cv,
+                        message = "header=$key",
+                    ),
+                )
+            }
+        }
+
+        // Skip shape diffing if status codes already diverged or no JSON.
+        if (baseline.status == candidate.status && baseline.json != null && candidate.json != null) {
+            // For Set-shape endpoints (`/jira-component-version-ranges`, `/v3/components`)
+            // the wire-order of elements is non-deterministic across stands. Pre-sort
+            // both sides by a stable per-endpoint key so JsonShape.diff doesn't report
+            // positional false-positives. Pass-through for unregistered endpoints
+            // (see RawArraySorters and its unit test for the registered list + contract).
+            val baselineForShape = RawArraySorters.stableSorted(endpoint, baseline.json)
+            val candidateForShape = RawArraySorters.stableSorted(endpoint, candidate.json)
+            val shapeDiffs = JsonShape.diff(baselineForShape, candidateForShape)
+            for (sd in shapeDiffs) {
+                categories += DiffClassifier.STRUCTURAL_DIFF
+                DiffCollector.record(
+                    DiffRecord(
+                        ts = ts,
+                        endpoint = endpoint,
+                        pathParams = pathParams,
+                        queryParams = queryParams,
+                        category = DiffClassifier.STRUCTURAL_DIFF,
+                        layer = "raw",
+                        baselineValue = sd.baseline,
+                        candidateValue = sd.candidate,
+                        message = "${sd.kind} at ${sd.path}",
+                    ),
+                )
+            }
+        }
+
+        return categories
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatibilityTestBase.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatibilityTestBase.kt
@@ -93,6 +93,10 @@ abstract class CompatibilityTestBase {
      * [queryParams] threads through to every emitted [DiffRecord] so that cases
      * differing only in query parameters (e.g. `?ignore-required=true` vs `false`)
      * produce distinguishable records in `summary.md` and in known-delta matching.
+     *
+     * Implementation lives in [Comparators.compareRaw] so the semantics are
+     * unit-testable without the HTTP/Spring scaffolding this base class needs
+     * at runtime — see `ComparatorLogicTest`.
      */
     protected fun compareRaw(
         endpoint: String,
@@ -101,104 +105,14 @@ abstract class CompatibilityTestBase {
         candidate: RawResponse,
         headerAllowList: Set<String> = setOf("Content-Type"),
         queryParams: Map<String, String> = emptyMap(),
-    ): List<DiffClassifier> {
-        val categories = mutableListOf<DiffClassifier>()
-        val ts = Instant.now().toString()
-
-        // status=0 is reserved by [RawHttpClient] for transport failures (timeout,
-        // connection-refused, DNS, etc.). If both sides degrade to 0 the bare
-        // `baseline.status != candidate.status` check passes silently and the run
-        // looks clean — record a fail-causing diff whenever EITHER side is 0, even
-        // if both are.
-        val baselineTransportFailed = baseline.status == 0
-        val candidateTransportFailed = candidate.status == 0
-        if (baselineTransportFailed || candidateTransportFailed) {
-            categories += DiffClassifier.STATUS_CODE_DIFF
-            DiffCollector.record(
-                DiffRecord(
-                    ts = ts,
-                    endpoint = endpoint,
-                    pathParams = pathParams,
-                    queryParams = queryParams,
-                    category = DiffClassifier.STATUS_CODE_DIFF,
-                    layer = "raw",
-                    baselineValue = baseline.status.toString(),
-                    candidateValue = candidate.status.toString(),
-                    message = "transport failure on " + listOfNotNull(
-                        "baseline".takeIf { baselineTransportFailed },
-                        "candidate".takeIf { candidateTransportFailed },
-                    ).joinToString(" and "),
-                ),
-            )
-        } else if (baseline.status != candidate.status) {
-            categories += DiffClassifier.STATUS_CODE_DIFF
-            DiffCollector.record(
-                DiffRecord(
-                    ts = ts,
-                    endpoint = endpoint,
-                    pathParams = pathParams,
-                    queryParams = queryParams,
-                    category = DiffClassifier.STATUS_CODE_DIFF,
-                    layer = "raw",
-                    baselineValue = baseline.status.toString(),
-                    candidateValue = candidate.status.toString(),
-                ),
-            )
-        }
-
-        val baselineHeaders = baseline.stableHeaders(headerAllowList)
-        val candidateHeaders = candidate.stableHeaders(headerAllowList)
-        for (key in (baselineHeaders.keys + candidateHeaders.keys).distinctBy { it.lowercase() }) {
-            val bv = baselineHeaders[key]
-            val cv = candidateHeaders[key]
-            if (bv != cv) {
-                categories += DiffClassifier.HEADER_DIFF
-                DiffCollector.record(
-                    DiffRecord(
-                        ts = ts,
-                        endpoint = endpoint,
-                        pathParams = pathParams,
-                        queryParams = queryParams,
-                        category = DiffClassifier.HEADER_DIFF,
-                        layer = "raw",
-                        baselineValue = bv,
-                        candidateValue = cv,
-                        message = "header=$key",
-                    ),
-                )
-            }
-        }
-
-        // Skip shape diffing if status codes already diverged or no JSON
-        if (baseline.status == candidate.status && baseline.json != null && candidate.json != null) {
-            // For Set-shape endpoints (`/jira-component-version-ranges`, `/v3/components`)
-            // the wire-order of elements is non-deterministic across stands. Pre-sort
-            // both sides by a stable per-endpoint key so JsonShape.diff doesn't report
-            // positional false-positives. Pass-through for unregistered endpoints
-            // (see RawArraySorters and its unit test for the registered list + contract).
-            val baselineForShape = RawArraySorters.stableSorted(endpoint, baseline.json)
-            val candidateForShape = RawArraySorters.stableSorted(endpoint, candidate.json)
-            val shapeDiffs = JsonShape.diff(baselineForShape, candidateForShape)
-            for (sd in shapeDiffs) {
-                categories += DiffClassifier.STRUCTURAL_DIFF
-                DiffCollector.record(
-                    DiffRecord(
-                        ts = ts,
-                        endpoint = endpoint,
-                        pathParams = pathParams,
-                        queryParams = queryParams,
-                        category = DiffClassifier.STRUCTURAL_DIFF,
-                        layer = "raw",
-                        baselineValue = sd.baseline,
-                        candidateValue = sd.candidate,
-                        message = "${sd.kind} at ${sd.path}",
-                    ),
-                )
-            }
-        }
-
-        return categories
-    }
+    ): List<DiffClassifier> = Comparators.compareRaw(
+        endpoint = endpoint,
+        pathParams = pathParams,
+        baseline = baseline,
+        candidate = candidate,
+        headerAllowList = headerAllowList,
+        queryParams = queryParams,
+    )
 
     /**
      * Run [block] under the parallel-request limiter.


### PR DESCRIPTION
## Summary
- Extracts the body of `compareRaw` from `CompatibilityTestBase` into a top-level `object Comparators`. The base method becomes a thin delegate (one call) and existing live-stand suites keep working unchanged.
- Adds `ComparatorLogicTest` (13 cases, `@Tag("unit")`, runs via `:unitTest`) pinning every semantic the addendum plan (TD-007 L1) calls out for the raw-layer comparator.
- This is the L1 layer of TD-007. L4 (PR #228, merged) and L3 (PR #223, merged) landed earlier; L2 (PR #229) is in CI in parallel.

## Why extract before testing
`compareRaw` lived as a `protected` method on `CompatibilityTestBase`, which extends an HTTP-bound base with an `@BeforeAll` that requires compat URLs to be set. Inheriting from it for unit tests would either pollute the test with @Tag("http") (inherited from the base, so the test would mis-route through `:test`) or force fragile URL-stubbing. Lifting the body into a pure top-level object lets the unit test target the real production code path without any of that.

## Coverage matrix (13 cases)

| Branch | Case |
|---|---|
| status divergence | 200 vs 404 → STATUS_CODE_DIFF, no STRUCTURAL pile-on |
| transport failure | candidate (status=0) → message identifies candidate |
| transport failure | baseline (status=0) → message identifies baseline (regression guard for the `takeIf` predicate-swap) |
| transport failure | BOTH sides (0/0) → STATUS_CODE_DIFF (regression guard against the naive `if (a.status != b.status)` form) |
| shape | identical body → zero diffs |
| shape | key permutation → zero diffs |
| shape | additive field → STRUCTURAL_DIFF + KEY_MISSING_BASELINE |
| shape | removed field → STRUCTURAL_DIFF + KEY_MISSING_CANDIDATE |
| shape | array size mismatch → STRUCTURAL_DIFF + ARRAY_SIZE_MISMATCH (regression guard for the array-walk branch) |
| headers | Content-Type difference → HEADER_DIFF |
| headers | Date/ETag/Server outside allow-list → no HEADER_DIFF |
| headers | case-insensitive keys → no diff when values match |
| plumbing | recorded DiffRecord carries endpoint/pathParams/queryParams |

## Test plan
- [x] `./gradlew :components-registry-compat-test:unitTest` → 42 tests pass in ~8s (29 prior + 13 new).
- [x] `./gradlew :components-registry-compat-test:compileTestKotlin` — passes; all 16 `CompatibilityTestBase` subclasses still compile against the delegated method.
- [x] Stage-1 Sonnet review — extraction byte-identical (one cosmetic comment-period drift), assertions tight, KDoc accurate. One nit: parallel-execution caveat documented in class KDoc.
- [x] Stage-2 Opus adversarial review — 1 BLOCKING (baseline-only transport branch uncovered) + 1 NIT (no array-walk coverage) found in the first commit. Both addressed in the second commit (`a5d77c5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)