### PR TITLE
perf(jpa): enable Hibernate jdbc.batch_size=50 for migration inserts

### DIFF
--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -52,6 +52,24 @@ spring:
       # single IN(...) per collection per page → 5 SELECTs total. Page size
       # in the v4 controller is capped at 100, so 50 is comfortable.
       hibernate.default_batch_fetch_size: 50
+      # Write-side batching for the migration pipeline. `importModule`
+      # persists ~10–20 rows per component (ComponentEntity + base config +
+      # system/label/tool junctions + per-range overrides). Without batching,
+      # each row is its own INSERT round-trip; on a CPU-throttled OKD pod
+      # against a remote DB this dominates Pass 1 (measured 250 s for 948
+      # components in QA). With batch_size=50 Hibernate batches sequential
+      # INSERTs of the same entity type into a single JDBC statement. Most
+      # PKs are `@GeneratedValue(strategy = UUID)` so batching applies;
+      # AuditLogEntity uses IDENTITY (not batched) but is not written during
+      # migration.
+      #
+      # `hibernate.order_inserts` is intentionally NOT enabled: it groups
+      # inserts across the entire transaction by entity type, which can
+      # reorder a `component_systems` junction insert ahead of its
+      # `components` parent insert and trip the FK constraint. Sequential
+      # batching alone gives us the bulk of the speed-up without that
+      # ordering risk.
+      hibernate.jdbc.batch_size: 50
   flyway:
     enabled: false
 


### PR DESCRIPTION
## Summary

Adds `spring.jpa.properties.hibernate.jdbc.batch_size: 50` to `application.yml`. `importModule` persists ~10–20 rows per component (ComponentEntity + base config + system/label/tool junctions + per-range overrides). Without batching each row is its own INSERT round-trip; on a CPU-throttled OKD pod against a remote DB this dominates Pass 1 (measured **250 s for 948 components in QA**, vs **19 s locally on Testcontainer** — 13× ratio that this PR aims to close).

With `batch_size=50` Hibernate groups sequential INSERTs of the same entity type into a single JDBC statement. Most PKs are `@GeneratedValue(strategy = UUID)`, so batching applies; AuditLogEntity uses IDENTITY (not batched) but is not written during migration.

## What was tried and rolled back

`order_inserts: true` and `order_updates: true` were tried first. They reorder INSERTs across the entire transaction by entity type, which moves a `component_systems` junction INSERT ahead of its parent `components` INSERT and reliably trips the FK constraint `fkqkkb183iweebomwbs1p8cuu8q` (reproduced in `MigrateEndpointTest` — `Batch entry 1 ... was aborted: insert or update on table "component_systems" violates foreign key constraint`). Sequential batching alone gives us most of the speed-up without that ordering risk.

## Test plan

- [x] `AUTH_SERVER_URL=http://localhost:9999 AUTH_SERVER_REALM=octopus ./gradlew build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test` exits 0
- [ ] CI green
- [ ] Deploy to QA, re-measure migration timing — expected Pass 1 250 s → ~80–120 s; total 319 s → ~170–200 s.