### PR TITLE
fix(schema-v2): MIG-047 — per-range groupId/artifactId not preserved for DSL-only declarations

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/FieldOverrideRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/FieldOverrideRequest.kt
@@ -73,6 +73,17 @@ data class FieldOverrideResponse(
  *  - `distribution.packages` → `packages`
  *  - `build.requiredTools` → `requiredTools` (list of tool names)
  *  - `build.buildTools` → `buildToolBeans` (structured DB tool beans)
+ *
+ * Additionally, the V4 `GET /components/{id}/field-overrides` response (and
+ * only that endpoint) may surface a read-only import-managed marker:
+ *
+ *  - `group-artifact-pattern` → `mavenArtifacts` (MIG-047). The import path
+ *    emits this when a DSL component sets `groupId`/`artifactId` per range
+ *    without an explicit `distribution { gav = … }` block. The marker is
+ *    NOT acceptable in `POST` / `PATCH` payloads — `addFieldOverride` rejects
+ *    it at request validation, and `updateFieldOverride` / `deleteFieldOverride`
+ *    refuse import-managed markers. To change the underlying configuration,
+ *    edit the source DSL and re-import.
  */
 data class MarkerChildrenPayload(
     val vcsEntries: List<VcsEntryRequest>? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -51,6 +51,19 @@ internal object MarkerAttributes {
     const val BUILD_REQUIRED_TOOLS: String = "build.requiredTools"
     const val BUILD_TOOLS: String = "build.buildTools"
 
+    /**
+     * MIG-047: synthetic per-range `groupId`/`artifactId` marker.
+     *
+     * Used when the DSL sets `groupId`/`artifactId` per range WITHOUT an
+     * explicit `distribution { gav = … }` block.  Unlike [DISTRIBUTION_MAVEN]
+     * (which feeds into `config.distribution.GAV()` and therefore affects ALL
+     * callers of the `EscrowModuleConfig` distribution field including
+     * `getAllJiraComponentVersionRanges`), this marker is intentionally NOT
+     * registered in [ALL] and is NOT picked by [pickMarkerChildren] inside
+     * `buildEscrowModuleConfig`.  Only `getMavenArtifactParameters` reads it.
+     */
+    const val GROUP_ARTIFACT_PATTERN: String = "group-artifact-pattern"
+
     val ALL: Set<String> =
         setOf(
             VCS_SETTINGS,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -302,7 +302,14 @@ private fun ComponentConfigurationEntity.toMarkerChildrenPayload(): MarkerChildr
                     },
             )
 
-        MarkerAttributes.DISTRIBUTION_MAVEN ->
+        MarkerAttributes.DISTRIBUTION_MAVEN,
+        MarkerAttributes.GROUP_ARTIFACT_PATTERN,
+        ->
+            // GROUP_ARTIFACT_PATTERN (MIG-047) is import-internal and stays out of
+            // MarkerAttributes.ALL — so it cannot be created/edited via the V4 POST
+            // endpoint — but it shares the same `mavenArtifacts` child-collection
+            // shape as DISTRIBUTION_MAVEN. listFieldOverrides projects it identically
+            // so the V4 admin UI never throws on components that contain it.
             MarkerChildrenPayload(
                 mavenArtifacts =
                     mavenArtifacts.sortedBy { it.sortOrder }.map { e ->

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -521,6 +521,7 @@ class ComponentManagementServiceImpl(
         require(row.rowType != "BASE" && row.rowType != "RANGE_PRESENCE") {
             "Cannot update id $overrideId via field-override endpoint (row_type=${row.rowType})"
         }
+        requireNotImportManagedMarker(row, "update")
 
         request.versionRange?.let {
             validateRangeSyntax(it)
@@ -564,9 +565,32 @@ class ComponentManagementServiceImpl(
         require(row.rowType != "BASE" && row.rowType != "RANGE_PRESENCE") {
             "Cannot delete id $overrideId via field-override endpoint (row_type=${row.rowType})"
         }
+        requireNotImportManagedMarker(row, "delete")
         val owningComponent = row.component
         configurationRepository.delete(row)
         bumpParentVersion(owningComponent)
+    }
+
+    /**
+     * MIG-047: refuse V4 write paths for MARKER rows whose `overriddenAttribute`
+     * is NOT in [MarkerAttributes.ALL] — those are import-internal markers
+     * (currently only [MarkerAttributes.GROUP_ARTIFACT_PATTERN]) created by
+     * `ImportServiceImpl` and recovered on re-import. The V4 admin API surfaces
+     * them read-only via `listFieldOverrides` so users can see the configuration;
+     * editing or deleting them would diverge the DB from the DSL source of
+     * truth until the next import overwrote the change.
+     */
+    private fun requireNotImportManagedMarker(
+        row: ComponentConfigurationEntity,
+        operation: String,
+    ) {
+        if (row.rowType == "MARKER" && row.overriddenAttribute !in MarkerAttributes.ALL) {
+            throw IllegalArgumentException(
+                "Cannot $operation id ${row.id} via field-override endpoint: " +
+                    "marker '${row.overriddenAttribute}' is import-managed and read-only via V4. " +
+                    "Edit the source DSL and re-import to change this override.",
+            )
+        }
     }
 
     @Transactional(readOnly = true)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -10,6 +10,7 @@ import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.octopus.components.registry.server.mapper.toEscrowModule
@@ -300,24 +301,34 @@ class DatabaseComponentRegistryResolver(
                 )
             }
 
-        // Per-range MARKER `distribution.maven` rows: only these ranges have a real
-        // per-range override of the maven coordinate. For ranges without such a marker,
-        // the BASE row's per-config maven-artifacts are merely the inherited GAV used
-        // by other read paths (packaging resolution etc.); they MUST NOT be re-synthesized
-        // into the `/maven-artifacts` response, because the V1 contract returns the
-        // component-level `artifactIdPattern` verbatim (RES-C-prime).
-        val markerRanges: Set<String> =
+        // Per-range MARKER rows that carry an explicit per-range maven coordinate.
+        //
+        // Two marker types may carry per-range maven artifact rows:
+        //
+        //   DISTRIBUTION_MAVEN: the DSL component uses an explicit `distribution { gav = … }`
+        //     block per range.  The marker's `mavenArtifacts` collection is populated from
+        //     the GAV.  `getMavenArtifactParameters` reads it the same way as below.
+        //
+        //   GROUP_ARTIFACT_PATTERN (MIG-047): the DSL component sets `groupId`/`artifactId`
+        //     per range WITHOUT an explicit `distribution { gav = … }` block.  A synthetic
+        //     marker was emitted at import time with `mavenArtifacts` built from the per-range
+        //     groupId/artifactId.  This marker is intentionally NOT registered in
+        //     MarkerAttributes.ALL so `buildEscrowModuleConfig` ignores it and
+        //     `getAllJiraComponentVersionRanges` is not affected.
+        //
+        // For both types, we extract the artifact configuration directly from the marker
+        // entity's `mavenArtifacts` child collection (sorted by `sortOrder`), bypassing
+        // `config.distribution.GAV()` to avoid the side-effect described above.
+        val perRangeMarkerRows: Map<String, ComponentConfigurationEntity> =
             componentEntity.configurations
                 .asSequence()
                 .filter {
-                    it.rowType == ROW_TYPE_MARKER && it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN
+                    it.rowType == ROW_TYPE_MARKER &&
+                        (it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN ||
+                            it.overriddenAttribute == MarkerAttributes.GROUP_ARTIFACT_PATTERN)
                 }
-                .map { it.versionRange }
-                .toSet()
+                .associateBy { it.versionRange }
 
-        // Walk the per-range EscrowModule view so that DISTRIBUTION_MAVEN marker
-        // overrides are respected: each EscrowModuleConfig already has the correct
-        // per-range distribution.GAV() after pickMarkerChildren applied the markers.
         val module = componentEntity.toEscrowModule(versionRangeFactory, numericVersionFactory)
 
         if (module.moduleConfigurations.isEmpty()) {
@@ -329,26 +340,15 @@ class DatabaseComponentRegistryResolver(
             .associate { config ->
                 val rangeKey = config.versionRangeString ?: ALL_VERSIONS
                 val artifact =
-                    if (rangeKey in markerRanges) {
-                        // Real per-range override → GAV-extraction branch (RES-C bug fix from PR #209).
-                        val gavCsv = config.distribution?.GAV()
-                        if (!gavCsv.isNullOrBlank()) {
-                            val coords =
-                                splitCsv(gavCsv)
-                                    .filterNot {
-                                        it.startsWith("file://") ||
-                                            it.startsWith("http://") ||
-                                            it.startsWith("https://")
-                                    }
-                                    .mapNotNull { parseMavenGavEntry(it) }
-                            if (coords.isNotEmpty()) {
-                                ComponentArtifactConfiguration(
-                                    coords.first().groupId,
-                                    coords.joinToString(",") { it.artifactId },
-                                )
-                            } else {
-                                componentLevelFallback
-                            }
+                    if (rangeKey in perRangeMarkerRows) {
+                        // Per-range override: extract directly from the marker entity's child rows.
+                        val markerRow = perRangeMarkerRows[rangeKey]!!
+                        val coords = markerRow.mavenArtifacts.sortedBy { it.sortOrder }
+                        if (coords.isNotEmpty()) {
+                            ComponentArtifactConfiguration(
+                                coords.first().groupPattern,
+                                coords.joinToString(",") { it.artifactPattern },
+                            )
                         } else {
                             componentLevelFallback
                         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -319,6 +319,14 @@ class DatabaseComponentRegistryResolver(
         // For both types, we extract the artifact configuration directly from the marker
         // entity's `mavenArtifacts` child collection (sorted by `sortOrder`), bypassing
         // `config.distribution.GAV()` to avoid the side-effect described above.
+        // Same-range conflict resolution: a V4 user may add a DISTRIBUTION_MAVEN
+        // override on a range that already carries an import-managed
+        // GROUP_ARTIFACT_PATTERN row (V4 createFieldOverride only de-dupes by
+        // overriddenAttribute). `componentEntity.configurations` is a @OneToMany
+        // collection with no specified iteration order, so a naive `associateBy`
+        // makes selection non-deterministic. Resolve deterministically: the
+        // explicit DISTRIBUTION_MAVEN user override always wins; GROUP_ARTIFACT_PATTERN
+        // is the fallback (used only when no DISTRIBUTION_MAVEN exists on the range).
         val perRangeMarkerRows: Map<String, ComponentConfigurationEntity> =
             componentEntity.configurations
                 .asSequence()
@@ -327,7 +335,11 @@ class DatabaseComponentRegistryResolver(
                         (it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN ||
                             it.overriddenAttribute == MarkerAttributes.GROUP_ARTIFACT_PATTERN)
                 }
-                .associateBy { it.versionRange }
+                .groupBy { it.versionRange }
+                .mapValues { (_, rows) ->
+                    rows.firstOrNull { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN }
+                        ?: rows.first()
+                }
 
         val module = componentEntity.toEscrowModule(versionRangeFactory, numericVersionFactory)
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1424,9 +1424,9 @@ class ImportServiceImpl(
     }
 
     /**
-     * MIG-047: synthetic DISTRIBUTION_MAVEN entries built from DSL-level
-     * `groupId`/`artifactId` fields when neither range carries an explicit
-     * `distribution { gav = … }` block.
+     * MIG-047: populate a GROUP_ARTIFACT_PATTERN MARKER row with synthetic
+     * [DistributionMavenArtifactEntity] rows built from DSL-level `groupId`/`artifactId`
+     * fields when neither range carries an explicit `distribution { gav = … }` block.
      *
      * [artifactIdCsv] is treated as a comma-separated list (each token becomes
      * one [DistributionMavenArtifactEntity] row), matching the V1 behaviour in

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1281,6 +1281,17 @@ class ImportServiceImpl(
             saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.DISTRIBUTION_MAVEN) { row ->
                 attachMavenArtifacts(row, overDist)
             }?.let { saved += it }
+        } else if (groupArtifactPatternsDiffer(base, override)) {
+            // MIG-047: DSL sets groupId/artifactId per range without distribution.GAV().
+            // Both distribution.GAV() are null so mavenArtifactsDiffer returns false, but
+            // the effective groupIdPattern/artifactIdPattern differ across ranges.
+            // Emit a GROUP_ARTIFACT_PATTERN marker (NOT distribution.maven) so that
+            // getMavenArtifactParameters can read the per-range values while
+            // getAllJiraComponentVersionRanges / buildEscrowModuleConfig remain unaffected
+            // (they only look at DISTRIBUTION_MAVEN markers for the distribution field).
+            saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.GROUP_ARTIFACT_PATTERN) { row ->
+                attachMavenArtifactsFromGroupArtifact(row, override.groupIdPattern, override.artifactIdPattern)
+            }?.let { saved += it }
         }
         if (fileUrlArtifactsDiffer(baseDist, overDist)) {
             saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.DISTRIBUTION_FILE_URL) { row ->
@@ -1406,6 +1417,37 @@ class ImportServiceImpl(
                     artifactPattern = coords.artifactId,
                     extension = coords.extension,
                     classifier = coords.classifier,
+                    sortOrder = sortOrder++,
+                ),
+            )
+        }
+    }
+
+    /**
+     * MIG-047: synthetic DISTRIBUTION_MAVEN entries built from DSL-level
+     * `groupId`/`artifactId` fields when neither range carries an explicit
+     * `distribution { gav = … }` block.
+     *
+     * [artifactIdCsv] is treated as a comma-separated list (each token becomes
+     * one [DistributionMavenArtifactEntity] row), matching the V1 behaviour in
+     * `JiraParametersResolver.getMavenArtifactParameters` which uses
+     * `artifactIdPattern` directly.
+     */
+    private fun attachMavenArtifactsFromGroupArtifact(
+        row: ComponentConfigurationEntity,
+        groupId: String?,
+        artifactIdCsv: String?,
+    ) {
+        val group = groupId ?: return
+        var sortOrder = 0
+        for (artifactToken in splitCsv(artifactIdCsv ?: return)) {
+            row.mavenArtifacts.add(
+                DistributionMavenArtifactEntity(
+                    componentConfiguration = row,
+                    groupPattern = group,
+                    artifactPattern = artifactToken,
+                    extension = null,
+                    classifier = null,
                     sortOrder = sortOrder++,
                 ),
             )
@@ -1729,6 +1771,23 @@ class ImportServiceImpl(
         base: Distribution?,
         override: Distribution?,
     ): Boolean = extractMavenGavs(base?.GAV()) != extractMavenGavs(override?.GAV())
+
+    /**
+     * MIG-047: returns true when the override range's DSL-level `groupId`/`artifactId`
+     * differ from the base range — independently of `distribution.GAV()`.
+     *
+     * This supplements [mavenArtifactsDiffer] for the common DSL pattern where
+     * component ranges declare `groupId`/`artifactId` directly (not via a
+     * `distribution { gav = … }` block).  In that pattern both
+     * `distribution.GAV()` values are null so [mavenArtifactsDiffer] returns
+     * false, yet the effective maven co-ordinates differ per range.
+     */
+    private fun groupArtifactPatternsDiffer(
+        base: EscrowModuleConfig,
+        override: EscrowModuleConfig,
+    ): Boolean =
+        base.groupIdPattern != override.groupIdPattern ||
+            splitCsv(base.artifactIdPattern ?: "") != splitCsv(override.artifactIdPattern ?: "")
 
     private fun fileUrlArtifactsDiffer(
         base: Distribution?,

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -149,6 +149,10 @@ CREATE TABLE component_configurations (
     --   - The SCALAR_OVERRIDE branch likewise pins non-NULL before evaluating
     --     `NOT IN (...)`, and forbids reusing a marker name as a scalar
     --     attribute path.
+    -- MIG-047 added `group-artifact-pattern` as a synthetic import-internal MARKER
+    -- name (NOT in MarkerAttributes.ALL — see EntityMappers.kt:65 kdoc). The
+    -- allowlist below is the union of MarkerAttributes.ALL and that synthetic
+    -- name; the SCALAR_OVERRIDE NOT-IN list is its symmetric exclusion.
     CHECK (
         (row_type IN ('BASE', 'RANGE_PRESENCE') AND overridden_attribute IS NULL)
         OR (row_type = 'MARKER'
@@ -156,14 +160,14 @@ CREATE TABLE component_configurations (
             AND overridden_attribute IN (
                 'vcs.settings', 'distribution.maven', 'distribution.fileUrl',
                 'distribution.docker', 'distribution.packages', 'build.requiredTools',
-                'build.buildTools'
+                'build.buildTools', 'group-artifact-pattern'
             ))
         OR (row_type = 'SCALAR_OVERRIDE'
             AND overridden_attribute IS NOT NULL
             AND overridden_attribute NOT IN (
                 'vcs.settings', 'distribution.maven', 'distribution.fileUrl',
                 'distribution.docker', 'distribution.packages', 'build.requiredTools',
-                'build.buildTools'
+                'build.buildTools', 'group-artifact-pattern'
             ))
     ),
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/MIG047V4FieldOverrideMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/MIG047V4FieldOverrideMapperTest.kt
@@ -1,0 +1,103 @@
+package org.octopusden.octopus.components.registry.server.mapper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.octopus.components.registry.server.dto.v4.ConfigurationRowType
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * MIG-047 P1-B: V4 field-override projection must handle the synthetic
+ * `group-artifact-pattern` MARKER name.
+ *
+ * Background:
+ *   `ComponentManagementServiceImpl.listFieldOverrides` projects every
+ *   SCALAR_OVERRIDE / MARKER row through `ComponentConfigurationEntity.toFieldOverrideResponse()`.
+ *   The marker branch dispatches via `toMarkerChildrenPayload()`, whose
+ *   `when (overriddenAttribute)` recognises only `MarkerAttributes.ALL` values
+ *   and falls through to `error("Marker row has unknown overriddenAttribute …")`
+ *   for anything else.
+ *
+ *   Once the MIG-047 import path persists a `GROUP_ARTIFACT_PATTERN` marker,
+ *   `GET /rest/api/4/components/{id}/field-overrides` for that component throws
+ *   `IllegalStateException`, breaking the V4 admin UI for the entire component.
+ *
+ * Pre-fix behaviour (RED):
+ *   `toFieldOverrideResponse()` throws `IllegalStateException` on a synthetic
+ *   in-memory entity whose `overriddenAttribute = "group-artifact-pattern"`.
+ *
+ * Post-fix behaviour (GREEN):
+ *   The mapper recognises the marker and projects it the same way as
+ *   `DISTRIBUTION_MAVEN` (the underlying child collection — `mavenArtifacts` —
+ *   is shared between the two markers; see `ImportServiceImpl.attachMavenArtifactsFromGroupArtifact`).
+ *
+ * Pure in-memory test — no Spring context, no DB. Synthetic ID + collections.
+ */
+@Timeout(10, unit = TimeUnit.SECONDS)
+class MIG047V4FieldOverrideMapperTest {
+
+    @Test
+    @DisplayName(
+        "MIG-047 P1-B: toFieldOverrideResponse must not throw on GROUP_ARTIFACT_PATTERN marker; " +
+            "must project the synthetic mavenArtifacts children",
+    )
+    fun mig047_p1b_groupArtifactPatternMarkerProjectsAsMavenArtifacts() {
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "alpha-fixture")
+        val markerRow =
+            ComponentConfigurationEntity(
+                id = UUID.randomUUID(),
+                component = component,
+                versionRange = "[1.1,)",
+                overriddenAttribute = MarkerAttributes.GROUP_ARTIFACT_PATTERN,
+                rowType = "MARKER",
+            )
+        markerRow.mavenArtifacts.addAll(
+            listOf(
+                DistributionMavenArtifactEntity(
+                    id = UUID.randomUUID(),
+                    componentConfiguration = markerRow,
+                    groupPattern = "com.example.ic",
+                    artifactPattern = "core-a",
+                    extension = null,
+                    classifier = null,
+                    sortOrder = 0,
+                ),
+                DistributionMavenArtifactEntity(
+                    id = UUID.randomUUID(),
+                    componentConfiguration = markerRow,
+                    groupPattern = "com.example.ic",
+                    artifactPattern = "core-b",
+                    extension = null,
+                    classifier = null,
+                    sortOrder = 1,
+                ),
+            ),
+        )
+
+        // Pre-fix this call throws IllegalStateException from the `else` branch
+        // of toMarkerChildrenPayload(). Post-fix it returns a populated response.
+        val response = markerRow.toFieldOverrideResponse()
+
+        assertNotNull(response, "Mapper must produce a FieldOverrideResponse, not throw")
+        assertEquals(ConfigurationRowType.MARKER, response.rowType)
+        assertEquals(MarkerAttributes.GROUP_ARTIFACT_PATTERN, response.overriddenAttribute)
+        assertEquals("[1.1,)", response.versionRange)
+        assertNull(response.value, "Marker rows must not carry a scalar value")
+
+        val payload = response.markerChildren
+        assertNotNull(payload, "Marker payload must be present")
+        val artifacts = payload!!.mavenArtifacts
+        assertNotNull(artifacts, "GROUP_ARTIFACT_PATTERN payload must surface mavenArtifacts (same shape as DISTRIBUTION_MAVEN)")
+        assertEquals(2, artifacts!!.size, "Both synthetic maven artifact rows must round-trip")
+        assertEquals("core-a", artifacts[0].artifactPattern)
+        assertEquals("com.example.ic", artifacts[0].groupPattern)
+        assertEquals("core-b", artifacts[1].artifactPattern)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MIG047SchemaConstraintIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MIG047SchemaConstraintIntegrationTest.kt
@@ -1,0 +1,157 @@
+package org.octopusden.octopus.components.registry.server.migration
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionMavenArtifactRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Paths
+
+/**
+ * MIG-047 P1-A: schema CHECK constraint must accept the `group-artifact-pattern`
+ * marker name introduced by the MIG-047 import path.
+ *
+ * Background:
+ *   `ImportServiceImpl.emitMarkerOverrides` (post-MIG-047 fix) persists a
+ *   `ComponentConfigurationEntity` with `rowType = "MARKER"` and
+ *   `overriddenAttribute = "group-artifact-pattern"` whenever the DSL sets
+ *   `groupId`/`artifactId` per range without an explicit `distribution { gav = … }`
+ *   block. The unit tests for that path use a mocked repository, so they never
+ *   hit the actual DB CHECK constraint defined in `V1__schema.sql` on the
+ *   `component_configurations.overridden_attribute` column.
+ *
+ * Pre-fix behaviour (RED):
+ *   The CHECK constraint's MARKER allowlist enumerates only the seven names in
+ *   `MarkerAttributes.ALL` (`vcs.settings`, `distribution.*`, `build.*`).
+ *   Inserting `overridden_attribute = 'group-artifact-pattern'` violates the
+ *   constraint and the transaction rolls back with `SQLState 23514`
+ *   (`check_violation`).
+ *
+ * Post-fix behaviour (GREEN):
+ *   The CHECK allowlist accepts `'group-artifact-pattern'` for MARKER rows and
+ *   the symmetric NOT-IN list excludes it from SCALAR_OVERRIDE rows. The save
+ *   succeeds and the row reloads with the expected child rows.
+ *
+ * Test environment uses a PostgreSQL 16 testcontainer with `ddl-auto=validate`
+ * + Flyway applying the production V1__schema.sql, mirroring the
+ * `FlywayValidatePostgresStartupTest` SYS-026 pattern.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "test-db-validate")
+@Timeout(120)
+class MIG047SchemaConstraintIntegrationTest {
+
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+
+    @Autowired
+    private lateinit var mavenArtifactRepository: DistributionMavenArtifactRepository
+
+    init {
+        val testResourcesPath =
+            Paths.get(
+                MIG047SchemaConstraintIntegrationTest::class.java.getResource("/expected-data")!!.toURI(),
+            ).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-047 P1-A: MARKER row with overridden_attribute='group-artifact-pattern' " +
+            "persists against the production Flyway schema",
+    )
+    @Transactional
+    fun mig047_p1a_groupArtifactPatternMarkerPersists() {
+        val component =
+            componentRepository.save(
+                ComponentEntity(
+                    componentKey = "MIG047-P1A-FIXTURE",
+                    archived = false,
+                ),
+            )
+
+        // A BASE row is required because the override range's MARKER row references
+        // the same (component, version_range) tuple where typed scalars live.
+        configurationRepository.save(
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = "(,0),[0,)",
+                rowType = "BASE",
+            ),
+        )
+
+        val markerRow =
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = "[2.0,)",
+                overriddenAttribute = MarkerAttributes.GROUP_ARTIFACT_PATTERN,
+                rowType = "MARKER",
+            )
+        val savedMarker = configurationRepository.save(markerRow)
+
+        mavenArtifactRepository.save(
+            DistributionMavenArtifactEntity(
+                componentConfiguration = savedMarker,
+                groupPattern = "com.example.fixture",
+                artifactPattern = "alpha-fixture",
+                extension = null,
+                classifier = null,
+                sortOrder = 0,
+            ),
+        )
+
+        val reloaded = configurationRepository.findById(savedMarker.id!!).orElse(null)
+        assertNotNull(reloaded, "MARKER row with GROUP_ARTIFACT_PATTERN must persist")
+        assertEquals("MARKER", reloaded!!.rowType)
+        assertEquals(
+            MarkerAttributes.GROUP_ARTIFACT_PATTERN,
+            reloaded.overriddenAttribute,
+            "overridden_attribute must round-trip exactly as 'group-artifact-pattern'",
+        )
+
+        val children = mavenArtifactRepository.findByComponentConfigurationId(savedMarker.id!!)
+        assertEquals(1, children.size, "Child maven-artifact row must persist alongside the marker")
+        assertEquals("com.example.fixture", children[0].groupPattern)
+        assertEquals("alpha-fixture", children[0].artifactPattern)
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -14,6 +14,7 @@ import org.octopusden.octopus.components.registry.server.entity.ComponentArtifac
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
 import org.octopusden.releng.versions.NumericVersionFactory
@@ -453,6 +454,96 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
             "real-artifact-id",
             rangeWithMarker.artifactPattern,
             "[1.0,) artifactPattern must come from the marker's GAV (override is active)",
+        )
+    }
+
+    // ========================================================================
+    // MIG-047 read-path coverage (PR #240 P2 follow-up)
+    // ========================================================================
+    //
+    // Symmetric coverage for the GROUP_ARTIFACT_PATTERN marker emitted by
+    // `ImportServiceImpl.attachMavenArtifactsFromGroupArtifact` (RES-C tests
+    // above cover the same read-path for DISTRIBUTION_MAVEN). The resolver
+    // accepts either marker name when looking up per-range maven coordinates;
+    // these tests guard that branch so it cannot regress independently of the
+    // import-side unit tests.
+
+    @Test
+    @DisplayName(
+        "MIG-047-RES-001: per-range GROUP_ARTIFACT_PATTERN marker overrides groupPattern " +
+            "even when neither side carries an explicit distribution.GAV",
+    )
+    fun `MIG-047-RES-001 getMavenArtifactParameters returns per-range groupPattern from GROUP_ARTIFACT_PATTERN marker`() {
+        // MIG-047 import-path shape:
+        //   BASE at [1.0,1.1) with maven artifact (com.example, alpha-fixture)
+        //   GROUP_ARTIFACT_PATTERN MARKER at [1.1,) with maven artifact (com.example.ic, alpha-fixture)
+        // Neither config had an explicit distribution { gav = … } block — the maven-artifact
+        // rows were synthesized from per-range groupId/artifactId by the import path.
+        val comp = makeComponent("alpha-fixture-mig047-resolver")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example", "alpha-fixture")
+
+        val base = makeBase(comp, "[1.0,1.1)")
+        addMavenArtifact(base, "com.example", "alpha-fixture")
+
+        val marker = makeMarkerRow(comp, "[1.1,)", MarkerAttributes.GROUP_ARTIFACT_PATTERN)
+        addMavenArtifact(marker, "com.example.ic", "alpha-fixture")
+
+        comp.configurations.addAll(listOf(base, marker))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("alpha-fixture-mig047-resolver")
+
+        assertEquals(2, result.size, "Expected two range entries (base + GROUP_ARTIFACT_PATTERN override)")
+
+        val rangeBase = result["[1.0,1.1)"]
+        assertNotNull(rangeBase, "[1.0,1.1) entry must be present")
+        assertEquals("com.example", rangeBase!!.groupPattern)
+        assertEquals("alpha-fixture", rangeBase.artifactPattern)
+
+        val rangeOverride = result["[1.1,)"]
+        assertNotNull(rangeOverride, "[1.1,) entry must be present")
+        assertEquals(
+            "com.example.ic",
+            rangeOverride!!.groupPattern,
+            "[1.1,) groupPattern must come from GROUP_ARTIFACT_PATTERN marker",
+        )
+        assertEquals("alpha-fixture", rangeOverride.artifactPattern)
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-047-RES-002: per-range GROUP_ARTIFACT_PATTERN marker with multi-artifact CSV " +
+            "(artifactId list grows across ranges, same groupId)",
+    )
+    fun `MIG-047-RES-002 getMavenArtifactParameters handles GROUP_ARTIFACT_PATTERN with multi-artifact CSV`() {
+        val comp = makeComponent("beta-fixture-mig047-csv")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example.mcloud", "core-a")
+
+        val base = makeBase(comp, "[1.0,)")
+        addMavenArtifact(base, "com.example.mcloud", "core-a")
+
+        val marker = makeMarkerRow(comp, "[2.0,)", MarkerAttributes.GROUP_ARTIFACT_PATTERN)
+        addMavenArtifact(marker, "com.example.mcloud", "core-a", sortOrder = 0)
+        addMavenArtifact(marker, "com.example.mcloud", "core-b", sortOrder = 1)
+        addMavenArtifact(marker, "com.example.mcloud", "core-c", sortOrder = 2)
+
+        comp.configurations.addAll(listOf(base, marker))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("beta-fixture-mig047-csv")
+
+        assertEquals(2, result.size, "Expected two range entries")
+        val rangeOverride = result["[2.0,)"]
+        assertNotNull(rangeOverride, "[2.0,) entry must be present")
+        assertEquals("com.example.mcloud", rangeOverride!!.groupPattern)
+        assertEquals(
+            "core-a,core-b,core-c",
+            rangeOverride.artifactPattern,
+            "[2.0,) artifactPattern must be CSV of all three GROUP_ARTIFACT_PATTERN children in sort order",
         )
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -547,6 +547,54 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         )
     }
 
+    @Test
+    @DisplayName(
+        "MIG-047-RES-003: when both DISTRIBUTION_MAVEN and GROUP_ARTIFACT_PATTERN markers " +
+            "exist on the same versionRange, DISTRIBUTION_MAVEN wins deterministically",
+    )
+    fun `MIG-047-RES-003 same-range conflict — DISTRIBUTION_MAVEN takes precedence over GROUP_ARTIFACT_PATTERN`() {
+        // Conflict shape: a V4 user added a distribution.maven override on a range that
+        // already had an import-managed GROUP_ARTIFACT_PATTERN row (V4 createFieldOverride
+        // only de-dupes by `overriddenAttribute`, so this pair is reachable). With the
+        // pre-fix `associateBy { it.versionRange }`, whichever row sits last in
+        // `componentEntity.configurations` wins — non-deterministic because @OneToMany
+        // does not specify iteration order. Post-fix, the explicit DISTRIBUTION_MAVEN
+        // override wins regardless of row-order (mirrors the V4 user's stated intent;
+        // GROUP_ARTIFACT_PATTERN is import-internal and supplanted).
+        val comp = makeComponent("gamma-fixture-mig047-conflict")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example", "gamma-fixture")
+
+        val base = makeBase(comp, "[1.0,1.1)")
+        addMavenArtifact(base, "com.example", "gamma-fixture")
+
+        // Build a deliberately adversarial ordering: GROUP_ARTIFACT_PATTERN appears AFTER
+        // DISTRIBUTION_MAVEN in the configurations list. The pre-fix `associateBy` keeps
+        // the LAST entry with the same key — so GROUP_ARTIFACT_PATTERN wins under the bug.
+        val distributionMaven = makeMarkerRow(comp, "[1.1,)", MarkerAttributes.DISTRIBUTION_MAVEN)
+        addMavenArtifact(distributionMaven, "com.example.user-explicit", "gamma-fixture")
+
+        val groupArtifactPattern = makeMarkerRow(comp, "[1.1,)", MarkerAttributes.GROUP_ARTIFACT_PATTERN)
+        addMavenArtifact(groupArtifactPattern, "com.example.import-internal", "gamma-fixture")
+
+        comp.configurations.addAll(listOf(base, distributionMaven, groupArtifactPattern))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("gamma-fixture-mig047-conflict")
+
+        assertEquals(2, result.size, "Expected two range entries")
+
+        val rangeOverride = result["[1.1,)"]
+        assertNotNull(rangeOverride, "[1.1,) entry must be present")
+        assertEquals(
+            "com.example.user-explicit",
+            rangeOverride!!.groupPattern,
+            "DISTRIBUTION_MAVEN must take precedence over GROUP_ARTIFACT_PATTERN on the same range",
+        )
+        assertEquals("gamma-fixture", rangeOverride.artifactPattern)
+    }
+
     // ========================================================================
     // Coverage gaps (out of scope for this PR, tracked for follow-up)
     // ========================================================================

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
@@ -1,0 +1,176 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.Optional
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpdateRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.MarkerChildrenPayload
+import org.octopusden.octopus.components.registry.server.dto.v4.MavenArtifactRequest
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSystemRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * MIG-047 post-P1-B hardening: V4 write paths must refuse import-internal markers.
+ *
+ * After `listFieldOverrides` started surfacing GROUP_ARTIFACT_PATTERN rows
+ * (commit e847607, the P1-B GREEN), a V4 client can read the row's UUID. The
+ * write paths — `updateFieldOverride` / `deleteFieldOverride` — currently only
+ * check `row.overriddenAttribute in MarkerAttributes.ALL` to dispatch between
+ * marker and scalar update logic. GROUP_ARTIFACT_PATTERN is NOT in `ALL`, so
+ * `updateFieldOverride` falls through to the scalar branch, eventually hitting
+ * `applyScalarValue` which throws a misleading "Unknown scalar attribute path"
+ * error. `deleteFieldOverride` has no guard at all and removes the row outright,
+ * silently dropping an import-managed override (recovered only on re-import).
+ *
+ * These tests pin the desired contract: V4 write paths return a clear,
+ * stable error for import-managed marker rows, leaving the row intact.
+ *
+ * Tests use mocked repositories — no Spring context, no DB. The guards live in
+ * service-layer code (`ComponentManagementServiceImpl.updateFieldOverride` /
+ * `.deleteFieldOverride`) so the unit test is sufficient.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG047FieldOverrideWriteGuardTest {
+
+    private lateinit var componentRepository: ComponentRepository
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+    private lateinit var service: ComponentManagementServiceImpl
+
+    private val componentId = UUID.randomUUID()
+    private val overrideId = UUID.randomUUID()
+    private lateinit var component: ComponentEntity
+    private lateinit var markerRow: ComponentConfigurationEntity
+
+    @BeforeEach
+    fun setUp() {
+        componentRepository = mock(ComponentRepository::class.java)
+        configurationRepository = mock(ComponentConfigurationRepository::class.java)
+
+        val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+
+        service =
+            ComponentManagementServiceImpl(
+                componentRepository = componentRepository,
+                configurationRepository = configurationRepository,
+                componentGroupRepository = mock(ComponentGroupRepository::class.java),
+                componentLabelRepository = mock(ComponentLabelRepository::class.java),
+                componentSystemRepository = mock(ComponentSystemRepository::class.java),
+                componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+                componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+                labelRepository = mock(LabelRepository::class.java),
+                systemRepository = mock(SystemRepository::class.java),
+                toolRepository = mock(ToolRepository::class.java),
+                sourceRegistry = mock(ComponentSourceRegistry::class.java),
+                applicationEventPublisher = mock(ApplicationEventPublisher::class.java),
+                currentUserResolver = mock(CurrentUserResolver::class.java),
+                fieldConfigService = mock(FieldConfigService::class.java),
+                teamcityProperties = mock(TeamcityProperties::class.java),
+                versionRangeFactory = VersionRangeFactory(versionNames),
+            )
+
+        component = ComponentEntity(id = componentId, componentKey = "alpha-fixture")
+        markerRow =
+            ComponentConfigurationEntity(
+                id = overrideId,
+                component = component,
+                versionRange = "[1.1,)",
+                overriddenAttribute = MarkerAttributes.GROUP_ARTIFACT_PATTERN,
+                rowType = "MARKER",
+            )
+
+        doReturn(Optional.of(markerRow)).`when`(configurationRepository).findById(overrideId)
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-047 P1-B-W-001: updateFieldOverride rejects GROUP_ARTIFACT_PATTERN row with a clear " +
+            "import-managed error and does NOT mutate the row",
+    )
+    fun mig047_updateFieldOverrideRejectsImportManagedMarker() {
+        val request =
+            FieldOverrideUpdateRequest(
+                versionRange = null,
+                value = null,
+                markerChildren =
+                    MarkerChildrenPayload(
+                        mavenArtifacts =
+                            listOf(
+                                MavenArtifactRequest(
+                                    groupPattern = "com.example.malicious",
+                                    artifactPattern = "tampered",
+                                    extension = null,
+                                    classifier = null,
+                                ),
+                            ),
+                    ),
+            )
+
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                service.updateFieldOverride(componentId, overrideId, request)
+            }
+        assertTrue(
+            ex.message!!.contains("import-managed", ignoreCase = true),
+            "Error message must identify the row as import-managed; got: '${ex.message}'",
+        )
+        assertTrue(
+            ex.message!!.contains(MarkerAttributes.GROUP_ARTIFACT_PATTERN),
+            "Error message must include the marker name for diagnosability; got: '${ex.message}'",
+        )
+
+        // No mutation, no save attempt.
+        verify(configurationRepository, never()).save(markerRow)
+        assertEquals(
+            "[1.1,)",
+            markerRow.versionRange,
+            "Row's versionRange must not have been mutated by the rejected update",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-047 P1-B-W-002: deleteFieldOverride rejects GROUP_ARTIFACT_PATTERN row " +
+            "and does NOT call repository.delete()",
+    )
+    fun mig047_deleteFieldOverrideRejectsImportManagedMarker() {
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                service.deleteFieldOverride(componentId, overrideId)
+            }
+        assertTrue(
+            ex.message!!.contains("import-managed", ignoreCase = true),
+            "Error message must identify the row as import-managed; got: '${ex.message}'",
+        )
+
+        verify(configurationRepository, never()).delete(markerRow)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047PerRangeGroupIdImportTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047PerRangeGroupIdImportTest.kt
@@ -1,0 +1,288 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.lang.reflect.Method
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSystemRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.DefaultConfigParameters
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+
+/**
+ * MIG-047 RED test: `emitMarkerOverrides` must create a DISTRIBUTION_MAVEN MARKER
+ * row when the override config has a different `groupIdPattern` than the base — even
+ * when neither base nor override carries an explicit `distribution.GAV()`.
+ *
+ * Bug shape (prod-vs-schema-v2 compat regression):
+ *   Component DSL has two version ranges:
+ *     - base   `[1.0,1.1)` : groupId = "com.example",    artifactId = "alpha-fixture"
+ *     - override `[1.1,)` : groupId = "com.example.ic", artifactId = "alpha-fixture"
+ *   Neither range declares an explicit `distribution { gav = … }` block.
+ *
+ * Pre-fix behaviour:
+ *   `emitMarkerOverrides(base=[1.0,1.1), override=[1.1,))` compares
+ *   `distribution.GAV()` on both sides.  Both are null → `mavenArtifactsDiffer`
+ *   returns false → no DISTRIBUTION_MAVEN MARKER is emitted for `[1.1,)`.
+ *   Consequence: `getMavenArtifactParameters` falls back to `componentLevelFallback`
+ *   (from base config) for ALL ranges, so `[1.1,)` wrongly returns
+ *   `com.example` instead of `com.example.ic`.
+ *
+ * Post-fix behaviour:
+ *   `emitMarkerOverrides` additionally detects `groupIdPattern` / `artifactIdPattern`
+ *   divergence and emits a DISTRIBUTION_MAVEN MARKER whose `mavenArtifacts` rows
+ *   are synthetic entries built from `override.groupIdPattern` / `override.artifactIdPattern`.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG047PerRangeGroupIdImportTest {
+
+    private lateinit var service: ImportServiceImpl
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+    private lateinit var emitMarkerOverridesMethod: Method
+
+    @BeforeEach
+    fun setUp() {
+        configurationRepository = mock(ComponentConfigurationRepository::class.java)
+
+        // saveMarkerRowWithChildren uses two repository methods:
+        //   1. findByComponentIdAndVersionRangeAndOverriddenAttribute → returns ComponentConfigurationEntity?
+        //      Default mock behavior returns null (no existing row) — no stub needed.
+        //   2. save(row) — return value is NOT used by saveMarkerRowWithChildren (returns `row` directly).
+        //      Default mock behavior returns null for reference-return methods — safe to leave unstubbed.
+
+        // emitMarkerOverrides accesses commonDefaultsToolsCache which calls
+        // configurationLoader.loadCommonDefaults(emptyMap()). The mock default returns
+        // null which causes NPE. Stub it to return an empty DefaultConfigParameters
+        // (buildParameters=null → tools chain returns null → emptyList() fallback).
+        val configurationLoader = mock(EscrowConfigurationLoader::class.java)
+        val emptyDefaults = mock(DefaultConfigParameters::class.java)
+        doReturn(emptyDefaults).`when`(configurationLoader).loadCommonDefaults(emptyMap())
+
+        service = ImportServiceImpl(
+            gitResolver = mock(ComponentRegistryResolverImpl::class.java),
+            dbResolver = mock(DatabaseComponentRegistryResolver::class.java),
+            componentSourceRepository = mock(ComponentSourceRepository::class.java),
+            sourceRegistry = mock(ComponentSourceRegistry::class.java),
+            configurationLoader = configurationLoader,
+            registryConfigRepository = mock(RegistryConfigRepository::class.java),
+            componentRepository = mock(ComponentRepository::class.java),
+            configurationRepository = configurationRepository,
+            componentGroupRepository = mock(ComponentGroupRepository::class.java),
+            systemRepository = mock(SystemRepository::class.java),
+            toolRepository = mock(ToolRepository::class.java),
+            labelRepository = mock(LabelRepository::class.java),
+            componentLabelRepository = mock(ComponentLabelRepository::class.java),
+            componentSystemRepository = mock(ComponentSystemRepository::class.java),
+            componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+            componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+        )
+
+        emitMarkerOverridesMethod = ImportServiceImpl::class.java.getDeclaredMethod(
+            "emitMarkerOverrides",
+            ComponentEntity::class.java,
+            ComponentConfigurationEntity::class.java,
+            EscrowModuleConfig::class.java,
+            EscrowModuleConfig::class.java,
+        )
+        emitMarkerOverridesMethod.isAccessible = true
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun makeConfig(
+        groupId: String,
+        artifactId: String,
+        versionRange: String? = null,
+    ): EscrowModuleConfig {
+        val cfg = EscrowModuleConfig()
+        setGroovyField(cfg, "groupIdPattern", groupId)
+        setGroovyField(cfg, "artifactIdPattern", artifactId)
+        if (versionRange != null) setGroovyField(cfg, "versionRange", versionRange)
+        // distribution deliberately left null — no explicit distribution.gav in DSL
+        return cfg
+    }
+
+    private fun setGroovyField(target: Any, fieldName: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun callEmitMarkerOverrides(
+        component: ComponentEntity,
+        savedBase: ComponentConfigurationEntity,
+        base: EscrowModuleConfig,
+        override: EscrowModuleConfig,
+    ): List<ComponentConfigurationEntity> =
+        emitMarkerOverridesMethod.invoke(service, component, savedBase, base, override)
+            as List<ComponentConfigurationEntity>
+
+    // =========================================================================
+    // MIG-047-001 RED: groupIdPattern change per range, no distribution.GAV
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "MIG-047-001: emitMarkerOverrides creates DISTRIBUTION_MAVEN MARKER " +
+            "when groupIdPattern differs across ranges (no distribution.GAV on either side)",
+    )
+    fun `MIG-047-001 DISTRIBUTION_MAVEN MARKER created when groupId differs per range without distribution gav`() {
+        // synthetic component entity with a stable UUID so saveMarkerRowWithChildren
+        // can invoke component.id!!
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "alpha-fixture")
+
+        val savedBase = ComponentConfigurationEntity(
+            id = UUID.randomUUID(),
+            component = component,
+            versionRange = "[1.0,1.1)",
+            overriddenAttribute = null,
+            rowType = "BASE",
+        )
+
+        // base config: range [1.0,1.1), group=com.example, artifact=alpha-fixture, distribution=null
+        val baseConfig = makeConfig("com.example", "alpha-fixture", "[1.0,1.1)")
+
+        // override config: range [1.1,), group=com.example.ic (different!), artifact=alpha-fixture, distribution=null
+        val overrideConfig = makeConfig("com.example.ic", "alpha-fixture", "[1.1,)")
+
+        val result = callEmitMarkerOverrides(component, savedBase, baseConfig, overrideConfig)
+
+        // MIG-047 assertion: a DISTRIBUTION_MAVEN MARKER must be emitted for [1.1,)
+        // even though distribution.GAV() is null on both sides.
+        //
+        // Pre-fix: result is empty (mavenArtifactsDiffer(null, null) = false → no MARKER).
+        // Post-fix: result contains the DISTRIBUTION_MAVEN MARKER with com.example.ic.
+        assertEquals(1, result.size, "Expected exactly one MARKER row for the [1.1,) override range")
+
+        val marker = result[0]
+        assertEquals("MARKER", marker.rowType, "Row type must be MARKER")
+        assertEquals(
+            MarkerAttributes.GROUP_ARTIFACT_PATTERN,
+            marker.overriddenAttribute,
+            "MIG-047 path must emit a GROUP_ARTIFACT_PATTERN marker (not distribution.maven)",
+        )
+        assertEquals("[1.1,)", marker.versionRange, "Marker must be on the [1.1,) range")
+
+        // The marker must carry a synthetic maven artifact row for the override's group/artifact
+        assertEquals(
+            1,
+            marker.mavenArtifacts.size,
+            "MARKER must have one synthetic maven artifact row for the override groupId/artifactId",
+        )
+        val mavenRow = marker.mavenArtifacts[0]
+        assertEquals(
+            "com.example.ic",
+            mavenRow.groupPattern,
+            "Maven artifact row groupPattern must be override groupIdPattern",
+        )
+        assertEquals(
+            "alpha-fixture",
+            mavenRow.artifactPattern,
+            "Maven artifact row artifactPattern must be override artifactIdPattern",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-047-002: emitMarkerOverrides creates DISTRIBUTION_MAVEN MARKER " +
+            "when artifactIdPattern differs across ranges (no distribution.GAV on either side)",
+    )
+    fun `MIG-047-002 DISTRIBUTION_MAVEN MARKER created when artifactId CSV differs per range without distribution gav`() {
+        // bug-shape: artifactId adds a new token in newer range (same group)
+        // base [1.0,): group=com.example.mcloud, artifact=core-a,core-b,core-c
+        // override [2.0,): group=com.example.mcloud, artifact=core-a,core-b,core-c,core-tcp-client
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "beta-fixture")
+        val savedBase = ComponentConfigurationEntity(
+            id = UUID.randomUUID(),
+            component = component,
+            versionRange = "[1.0,)",
+            overriddenAttribute = null,
+            rowType = "BASE",
+        )
+
+        val baseConfig = makeConfig("com.example.mcloud", "core-a,core-b,core-c", "[1.0,)")
+        val overrideConfig = makeConfig("com.example.mcloud", "core-a,core-b,core-c,core-tcp-client", "[2.0,)")
+
+        val result = callEmitMarkerOverrides(component, savedBase, baseConfig, overrideConfig)
+
+        assertEquals(1, result.size, "Expected one DISTRIBUTION_MAVEN MARKER for [2.0,)")
+        val marker = result[0]
+        assertEquals(MarkerAttributes.GROUP_ARTIFACT_PATTERN, marker.overriddenAttribute)
+        assertEquals("[2.0,)", marker.versionRange)
+
+        // The marker must carry 4 maven artifact rows (one per CSV token) in sort order
+        assertEquals(4, marker.mavenArtifacts.size, "Marker must have one row per artifactId token")
+        val patterns = marker.mavenArtifacts.sortedBy { it.sortOrder }.map { it.artifactPattern }
+        assertEquals(listOf("core-a", "core-b", "core-c", "core-tcp-client"), patterns)
+        marker.mavenArtifacts.forEach { row ->
+            assertEquals("com.example.mcloud", row.groupPattern, "All rows must have the same groupPattern")
+        }
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-047-003 (anti-regression): emitMarkerOverrides does NOT double-create DISTRIBUTION_MAVEN MARKER " +
+            "when distribution.GAV already differs (existing RES-C path must not be duplicated)",
+    )
+    fun `MIG-047-003 anti-regression no duplicate MARKER when distribution GAV already differs`() {
+        // If distribution.GAV() already differs, the existing mavenArtifactsDiffer path fires.
+        // The new groupIdPattern-check must NOT fire a second time for the same range.
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "gamma-fixture")
+        val savedBase = ComponentConfigurationEntity(
+            id = UUID.randomUUID(),
+            component = component,
+            versionRange = "[1.0,)",
+            overriddenAttribute = null,
+            rowType = "BASE",
+        )
+
+        // Build a Distribution with an explicit GAV so that mavenArtifactsDiffer returns true
+        val baseDist = org.octopusden.octopus.escrow.model.Distribution(
+            true, false,
+            "com.example:gamma-lib:jar",
+            null, null, null, null,
+        )
+        val overrideDist = org.octopusden.octopus.escrow.model.Distribution(
+            true, false,
+            "com.example.new:gamma-lib-v2:jar",
+            null, null, null, null,
+        )
+
+        val baseConfig = makeConfig("com.example", "gamma-lib", "[1.0,)")
+        setGroovyField(baseConfig, "distribution", baseDist)
+
+        val overrideConfig = makeConfig("com.example.new", "gamma-lib-v2", "[2.0,)")
+        setGroovyField(overrideConfig, "distribution", overrideDist)
+
+        val result = callEmitMarkerOverrides(component, savedBase, baseConfig, overrideConfig)
+
+        // Must be exactly one DISTRIBUTION_MAVEN MARKER (from the existing GAV path),
+        // NOT two (one for GAV path + one for new groupIdPattern path).
+        assertEquals(1, result.size, "Must emit exactly one DISTRIBUTION_MAVEN MARKER, not two")
+        assertEquals(MarkerAttributes.DISTRIBUTION_MAVEN, result[0].overriddenAttribute)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047PerRangeGroupIdImportTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047PerRangeGroupIdImportTest.kt
@@ -31,9 +31,9 @@ import org.octopusden.octopus.escrow.configuration.model.DefaultConfigParameters
 import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
 
 /**
- * MIG-047 RED test: `emitMarkerOverrides` must create a DISTRIBUTION_MAVEN MARKER
- * row when the override config has a different `groupIdPattern` than the base — even
- * when neither base nor override carries an explicit `distribution.GAV()`.
+ * MIG-047 RED test: `emitMarkerOverrides` must create a GROUP_ARTIFACT_PATTERN MARKER
+ * row when the override config has a different `groupIdPattern` or `artifactIdPattern`
+ * than the base — even when neither base nor override carries an explicit `distribution.GAV()`.
  *
  * Bug shape (prod-vs-schema-v2 compat regression):
  *   Component DSL has two version ranges:
@@ -44,15 +44,17 @@ import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
  * Pre-fix behaviour:
  *   `emitMarkerOverrides(base=[1.0,1.1), override=[1.1,))` compares
  *   `distribution.GAV()` on both sides.  Both are null → `mavenArtifactsDiffer`
- *   returns false → no DISTRIBUTION_MAVEN MARKER is emitted for `[1.1,)`.
+ *   returns false → no MARKER is emitted for `[1.1,)`.
  *   Consequence: `getMavenArtifactParameters` falls back to `componentLevelFallback`
  *   (from base config) for ALL ranges, so `[1.1,)` wrongly returns
  *   `com.example` instead of `com.example.ic`.
  *
  * Post-fix behaviour:
  *   `emitMarkerOverrides` additionally detects `groupIdPattern` / `artifactIdPattern`
- *   divergence and emits a DISTRIBUTION_MAVEN MARKER whose `mavenArtifacts` rows
+ *   divergence and emits a GROUP_ARTIFACT_PATTERN MARKER whose `mavenArtifacts` rows
  *   are synthetic entries built from `override.groupIdPattern` / `override.artifactIdPattern`.
+ *   Unlike DISTRIBUTION_MAVEN, GROUP_ARTIFACT_PATTERN is excluded from MarkerAttributes.ALL
+ *   so it does not affect `getAllJiraComponentVersionRanges`.
  */
 @Timeout(30, unit = TimeUnit.SECONDS)
 class MIG047PerRangeGroupIdImportTest {
@@ -147,10 +149,10 @@ class MIG047PerRangeGroupIdImportTest {
 
     @Test
     @DisplayName(
-        "MIG-047-001: emitMarkerOverrides creates DISTRIBUTION_MAVEN MARKER " +
+        "MIG-047-001: emitMarkerOverrides creates GROUP_ARTIFACT_PATTERN MARKER " +
             "when groupIdPattern differs across ranges (no distribution.GAV on either side)",
     )
-    fun `MIG-047-001 DISTRIBUTION_MAVEN MARKER created when groupId differs per range without distribution gav`() {
+    fun `MIG-047-001 GROUP_ARTIFACT_PATTERN MARKER created when groupId differs per range without distribution gav`() {
         // synthetic component entity with a stable UUID so saveMarkerRowWithChildren
         // can invoke component.id!!
         val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "alpha-fixture")
@@ -171,11 +173,11 @@ class MIG047PerRangeGroupIdImportTest {
 
         val result = callEmitMarkerOverrides(component, savedBase, baseConfig, overrideConfig)
 
-        // MIG-047 assertion: a DISTRIBUTION_MAVEN MARKER must be emitted for [1.1,)
+        // MIG-047 assertion: a GROUP_ARTIFACT_PATTERN MARKER must be emitted for [1.1,)
         // even though distribution.GAV() is null on both sides.
         //
         // Pre-fix: result is empty (mavenArtifactsDiffer(null, null) = false → no MARKER).
-        // Post-fix: result contains the DISTRIBUTION_MAVEN MARKER with com.example.ic.
+        // Post-fix: result contains one GROUP_ARTIFACT_PATTERN MARKER with com.example.ic.
         assertEquals(1, result.size, "Expected exactly one MARKER row for the [1.1,) override range")
 
         val marker = result[0]
@@ -208,10 +210,10 @@ class MIG047PerRangeGroupIdImportTest {
 
     @Test
     @DisplayName(
-        "MIG-047-002: emitMarkerOverrides creates DISTRIBUTION_MAVEN MARKER " +
+        "MIG-047-002: emitMarkerOverrides creates GROUP_ARTIFACT_PATTERN MARKER " +
             "when artifactIdPattern differs across ranges (no distribution.GAV on either side)",
     )
-    fun `MIG-047-002 DISTRIBUTION_MAVEN MARKER created when artifactId CSV differs per range without distribution gav`() {
+    fun `MIG-047-002 GROUP_ARTIFACT_PATTERN MARKER created when artifactId CSV differs per range without distribution gav`() {
         // bug-shape: artifactId adds a new token in newer range (same group)
         // base [1.0,): group=com.example.mcloud, artifact=core-a,core-b,core-c
         // override [2.0,): group=com.example.mcloud, artifact=core-a,core-b,core-c,core-tcp-client
@@ -229,7 +231,7 @@ class MIG047PerRangeGroupIdImportTest {
 
         val result = callEmitMarkerOverrides(component, savedBase, baseConfig, overrideConfig)
 
-        assertEquals(1, result.size, "Expected one DISTRIBUTION_MAVEN MARKER for [2.0,)")
+        assertEquals(1, result.size, "Expected one GROUP_ARTIFACT_PATTERN MARKER for [2.0,)")
         val marker = result[0]
         assertEquals(MarkerAttributes.GROUP_ARTIFACT_PATTERN, marker.overriddenAttribute)
         assertEquals("[2.0,)", marker.versionRange)


### PR DESCRIPTION
## Summary

- **Root cause**: `emitMarkerOverrides` only compared `distribution.GAV()` (via `mavenArtifactsDiffer`). For components that set `groupId`/`artifactId` per version range at DSL level—without an explicit `distribution { gav = ... }` block—both sides return `null` → `mavenArtifactsDiffer = false` → no per-range MARKER is emitted → `getMavenArtifactParameters` falls back to the component-level (base range) group/artifact for all ranges.
- **Fix (import path)**: Added `groupArtifactPatternsDiffer()` check in `emitMarkerOverrides`. When `groupIdPattern`/`artifactIdPattern` differ between base and override and `distribution.GAV()` does not already differ, emit a new `GROUP_ARTIFACT_PATTERN` MARKER with synthetic `DistributionMavenArtifactEntity` rows built from the override's group/artifact patterns.
- **Fix (read path)**: `getMavenArtifactParameters` now checks both `DISTRIBUTION_MAVEN` and `GROUP_ARTIFACT_PATTERN` markers, reading coordinates directly from `markerRow.mavenArtifacts` (sorted by `sortOrder`) rather than via `config.distribution.GAV()`.
- **No schema change**: `GROUP_ARTIFACT_PATTERN` is a new string constant stored in the existing `overridden_attribute` column (same pattern as `DISTRIBUTION_MAVEN`). No DDL delta.
- **Regression guard**: `GROUP_ARTIFACT_PATTERN` is intentionally excluded from `MarkerAttributes.ALL`, so `buildEscrowModuleConfig`/`pickMarkerChildren` never picks it up → `getAllJiraComponentVersionRanges` and `buildDistribution` are unaffected (RES-001 preserved).

## Changed files

| File | Role |
|---|---|
| `EntityMappers.kt` | Adds `GROUP_ARTIFACT_PATTERN` constant to `MarkerAttributes` (not in `ALL`) |
| `ImportServiceImpl.kt` | Adds `groupArtifactPatternsDiffer`, `attachMavenArtifactsFromGroupArtifact`, and the new `else if` branch in `emitMarkerOverrides` |
| `DatabaseComponentRegistryResolver.kt` | Extends `perRangeMarkerRows` filter to include `GROUP_ARTIFACT_PATTERN`; reads artifact coords from `markerRow.mavenArtifacts` |
| `MIG047PerRangeGroupIdImportTest.kt` | Three unit tests (RED commit): MIG-047-001 (groupId differs), MIG-047-002 (artifactId CSV differs), MIG-047-003 (anti-regression: no duplicate when GAV already differs) |

## Test plan

- [x] MIG-047-001: `emitMarkerOverrides` emits `GROUP_ARTIFACT_PATTERN` MARKER when `groupIdPattern` differs across ranges (no `distribution.GAV()`)
- [x] MIG-047-002: same for `artifactIdPattern` CSV differences; marker carries 4 artifact rows in sort order
- [x] MIG-047-003 (anti-regression): when `distribution.GAV()` already differs, only one `DISTRIBUTION_MAVEN` MARKER is created (not duplicated by new path)
- [x] RES-001: `getAllJiraComponentVersionRanges` output unchanged (Jira version-range context unaffected)
- [x] RES-C-001..RES-C-006: `getMavenArtifactParameters` / `distribution.GAV()` path unchanged for components using explicit `distribution { gav = ... }` blocks
- [x] Full build: `BUILD SUCCESSFUL`, 625 tests pass

## TDD commit structure

| Commit | Files | State |
|---|---|---|
| `a543d28` `test:` RED | `MIG047PerRangeGroupIdImportTest.kt` only | Tests fail before fix |
| `41140fb` `fix:` GREEN | `EntityMappers.kt`, `ImportServiceImpl.kt`, `DatabaseComponentRegistryResolver.kt` | All tests pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)