### PR TITLE
feat(local-stands): TeamCity end-to-end compat wrapper + operator spec

### DIFF
--- a/scripts/local-stands/README.md
+++ b/scripts/local-stands/README.md
@@ -99,6 +99,13 @@ Subagent workflow: a PR agent in a sibling worktree exports
 from that worktree's code on restart. Port-scoped kill leaves parallel
 worktrees on other ports untouched.
 
+## TeamCity (end-to-end on the agent)
+
+For a single-step TC job that boots **both** sides from pre-built JARs (released
+baseline + current-chain candidate) and runs the compat-test against them,
+see [`TEAMCITY.md`](TEAMCITY.md). The wrapper [`teamcity-run.sh`](teamcity-run.sh)
+chains postgres → baseline JAR → candidate JAR → compat → teardown.
+
 ## Tear-down
 
 ```bash

--- a/scripts/local-stands/TEAMCITY.md
+++ b/scripts/local-stands/TEAMCITY.md
@@ -1,0 +1,240 @@
+# TeamCity local-stand compat job — operator spec
+
+This document describes the manual TC build configuration that runs the local-
+stand compat test (boot baseline + candidate side-by-side on the agent, then
+run the compat-test module against both). The actual configuration is set up
+by hand in the TC UI — there is no in-repo Kotlin DSL. The wrapper script
+[`teamcity-run.sh`](teamcity-run.sh) does the orchestration so the TC build
+has a single command-line step.
+
+## Build identity
+
+- **Build name**: `Components Registry — Local-Stand Compat`
+- **Build type**: regular (not deployment).
+- **Project**: place under the same TC project as the other CRS builds.
+
+## Agent requirements
+
+- Linux (preferred) or macOS — both supported by the helper scripts.
+- **Java 21** on PATH.
+- **Docker daemon** running (used by `postgres-up.sh` via `docker compose`).
+- `lsof`, `curl`, `git`, `bash`.
+- ≥ **8 GB RAM** free at job start — two CRS JVMs (~1.5 GB each) + postgres
+  + gradle worker + headroom.
+- ≥ 8 GB free disk under the agent's work-dir (gradle caches + DSL clone +
+  service-config clone + postgres volume).
+
+## VCS roots
+
+Set up three TC VCS roots; the build attaches all three with checkout rules
+that place each repo in a predictable sub-directory of the build's work-dir:
+
+| VCS root | Repo | Checkout rule | Branch spec |
+|---|---|---|---|
+| `components-registry-service` | the CRS repo itself | `. => crs/` | `+:refs/heads/feat/schema-v2-sql` (override per run) |
+| `registry-dsl` | the DSL git repo | `. => dsl/` | `+:refs/heads/master` (or the branch your QA stand consumes) |
+| `service-config` | the service-config repo | `. => service-config/` | `+:refs/heads/master` (see drift note below) |
+
+> **Service-config drift note.** Branch spec `master` means today's service-config
+> overlays the baseline JAR (which may have been built against an older
+> service-config snapshot). Spring tolerates unknown keys, so this is usually
+> safe — but if a key's *value* changed (e.g. a deprecation flip), the baseline
+> reports today's behaviour, not its-actual-release behaviour. For bit-exact
+> baseline reproduction, override this branch spec to the service-config tag
+> matching `%COMPONENTS_REGISTRY_SERVICE_VERSION%` (if your service-config repo
+> tags releases). For ordinary "is the contract preserved" sweeps, master is
+> fine.
+
+After checkout the agent's work-dir looks like:
+
+```
+<work-dir>/
+├── crs/                     ← compat-test source + scripts/local-stands/
+├── dsl/                     ← Groovy/Kotlin DSL files (LOCAL_VCS_ROOT)
+├── service-config/          ← application.yml + components-registry-service.yml
+└── artifacts/               ← (populated by artifact deps below)
+```
+
+## Artifact dependencies
+
+The build resolves two artifact dependencies — one per side. Both stage their
+JAR into `<work-dir>/artifacts/` under predictable file names; the wrapper
+script reads from those paths via `BASELINE_JAR` / `CANDIDATE_JAR` parameters.
+
+### Baseline (released old version)
+
+Wire an artifact dependency on whatever TC build produces the **released**
+fat JAR of the CRS server.
+
+- Build: `Components Registry — Build` (the same job that publishes to
+  Artifactory).
+- Build number selector: `%COMPONENTS_REGISTRY_SERVICE_VERSION%`
+  (the parameter value at run time — see parameters section below).
+- Artifact rule:
+  `components-registry-service-server-%COMPONENTS_REGISTRY_SERVICE_VERSION%.jar => artifacts/baseline.jar`
+
+### Candidate (current build chain output)
+
+Wire an artifact dependency on the upstream `Build` step in the same chain.
+
+- Build: the upstream `Build CRS` job (same chain).
+- Build number selector: `lastFinished` (or chain-specific).
+- Artifact rule:
+  `components-registry-service-server-*.jar => artifacts/candidate.jar`
+
+## Parameters
+
+All set via TC's "Parameters" tab. **Marked `(secret)` are confidential and
+must use TC's password / secure parameter type** — never inline into the
+configuration XML or commit messages (`feedback_redacted_identifiers`).
+
+### System parameters / configuration parameters
+
+| Name | Value / Default | Notes |
+|---|---|---|
+| `COMPONENTS_REGISTRY_SERVICE_VERSION` | _required, set at run_ | Version of the released baseline (e.g. `2.0.86`). |
+| `BUILD_VERSION` | from chain | Version of the candidate; usually `%dep.<upstream-build-id>.build.number%`. |
+| `env.BASELINE_JAR` | `%teamcity.build.checkoutDir%/artifacts/baseline.jar` | Picked up by the wrapper. |
+| `env.CANDIDATE_JAR` | `%teamcity.build.checkoutDir%/artifacts/candidate.jar` | Picked up by the wrapper. |
+| `env.LOCAL_VCS_ROOT` | `%teamcity.build.checkoutDir%/dsl` | DSL clone path. |
+| `env.SERVICE_CONFIG_DIR` | `%teamcity.build.checkoutDir%/service-config` | service-config clone path. |
+| `env.COMPONENTS_REGISTRY_SERVICE_VERSION` | `%COMPONENTS_REGISTRY_SERVICE_VERSION%` | For the wrapper's log header. |
+| `env.BUILD_VERSION` | `%BUILD_VERSION%` | Same. |
+| `env.COMPAT_FULL` | `false` | `true` for full sweep (~10-30 min); default smoke (~1-3 min). |
+| `env.COMPAT_PARALLELISM` | `8` | Concurrent in-flight requests per stand. |
+| `env.COMPAT_RMS_URL` | (optional, secret) | RMS URL for real version sampling. |
+| `env.COMPAT_SMOKE_COMPONENTS` | (secret) | CSV of real component names. |
+| `env.RESET_DB` | `1` | `1` = `docker compose down -v` before postgres-up (wipes the postgres volume). Required on persistent agents so a previous run's stale rows don't leak. Set `0` only when intentionally iterating on the same DB locally. |
+| `env.BASELINE_HEALTH_TIMEOUT_ITERS` | `75` (= 5 min) | Health-poll iterations × 4 s for the baseline. Bump on cold-cache agents. |
+| `env.CANDIDATE_HEALTH_TIMEOUT_ITERS` | `120` (= 8 min) | Same for the candidate (includes auto-migrate). |
+
+### Triggers
+
+- **None by default**. Job is manual-run only — it's expensive and
+  reproducibility hinges on which `COMPONENTS_REGISTRY_SERVICE_VERSION` the
+  operator picks. Add a VCS trigger on `feat/schema-v2-sql` only after the
+  job is proven stable.
+
+## Build steps
+
+Single step — invoke the wrapper:
+
+| Step name | Runner type | Command |
+|---|---|---|
+| Run compat | Command Line | `bash crs/scripts/local-stands/teamcity-run.sh` |
+
+The wrapper:
+
+1. Validates all required env vars and resolved paths.
+2. Brings up postgres via `docker compose`.
+3. Boots the baseline JAR on port `4567` with V1 profile suite.
+4. Waits for baseline `/actuator/health` (up to 5 min).
+5. Boots the candidate JAR on port `4568` with schema-v2 DB-mode profile suite
+   (`dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local`).
+6. Waits for candidate `/actuator/health` (up to 8 min — includes auto-migrate).
+7. Parses the candidate log for the migration summary and exits with code `4`
+   if any component failed to import (`POLLUTED RUN`).
+8. Runs `compat.sh`, which invokes
+   `:components-registry-compat-test:test` against both stands.
+9. Tears down (kills both JVMs, `docker compose down`) on any exit, success
+   or failure.
+
+## Artifact rules (build artifacts)
+
+Publish from the wrapper's gradle reports dir:
+
+```
+crs/components-registry-compat-test/build/reports/compat/summary.md          => compat/summary.md
+crs/components-registry-compat-test/build/reports/compat/execution-log.md    => compat/execution-log.md
+crs/components-registry-compat-test/build/reports/compat/execution-log.ndjson => compat/execution-log.ndjson
+crs/components-registry-compat-test/build/reports/compat/diff-worker-*.ndjson => compat/
+crs/components-registry-compat-test/build/test-results/test/**/*.xml         => junit-xml/
+```
+
+Optional (useful for postmortem when something goes wrong):
+
+```
+/tmp/crs-baseline-tc.log   => logs/baseline.log
+/tmp/crs-candidate-tc.log  => logs/candidate.log
+```
+
+## Reports tab
+
+Add a Markdown / HTML report tab:
+
+- **Tab title**: `Compat summary`
+- **Artifact path**: `compat/summary.md`
+
+Operators get the diff classification on the build overview page without
+unzipping the artifacts.
+
+## JUnit report
+
+Wire the standard JUnit XML report path: `junit-xml/**/*.xml`. The compat-test
+methods are JUnit 5; per-endpoint failures appear as individual rows on the
+"Tests" tab.
+
+## Failure-mode mapping (wrapper exit code → TC status)
+
+The wrapper preserves explicit exit codes; configure TC's failure conditions
+to surface them clearly:
+
+| Exit | Meaning | TC presentation |
+|---|---|---|
+| 0   | Compat clean (0 active diffs). | Green. |
+| 2   | Env validation failed — missing parameter, file not found. | Red — fix configuration. |
+| 3   | Baseline or candidate failed to come up within the health timeout. | Red — check the `logs/baseline.log` / `logs/candidate.log` artifacts. |
+| 4   | Polluted run — auto-migrate reported failures. | Red — `compat/summary.md` is unreliable; resolve the import regression upstream. |
+| 1   | Gradle exit (active diffs > 0). | Red — review `compat/summary.md`. |
+| _other_ | Gradle hang / crash. | Red — check stdout. |
+
+## Reproducibility checklist
+
+Before treating a compat-run report as authoritative:
+
+1. Confirm `COMPONENTS_REGISTRY_SERVICE_VERSION` matches the baseline you
+   want to compare against (the build header in the wrapper stdout echoes
+   the parameter).
+2. Confirm the candidate `BUILD_VERSION` is the chain's expected upstream.
+3. In `compat/summary.md`, check the "Environment / precondition" section:
+   - No `CANDIDATE_NOT_DB_MODE` warning — candidate is in DB mode. (The wrapper
+     pre-asserts `/service/status.defaultSource == "db"` and exits 2 if it
+     isn't, so this should never appear in TC runs.)
+   - No `SNAPSHOT_MISMATCH` warning — both stands read the same DSL revision.
+4. Active divergence count is finite (not "5000+"). If it explodes, suspect
+   sort-fix regression and inspect for STRUCTURAL_DIFF patterns.
+5. **`componentsTested > 0` in `execution-log.md` header.** A zero count means
+   every name in `COMPAT_SMOKE_COMPONENTS` mismatched the stand and the
+   per-component tests were skipped via `assumeTrue` — gradle exits 0 and the
+   report looks clean for the wrong reason. Cross-check the smoke-list against
+   the latest `GET /rest/api/3/components` listing if this happens.
+
+## One-time TC setup tasks
+
+1. Create the build config under the CRS project, name as above.
+2. Add the three VCS roots with checkout rules.
+3. Add both artifact dependencies (point at correct upstream builds).
+4. Add the parameters table.
+5. Add the single build step (`bash crs/scripts/local-stands/teamcity-run.sh`).
+6. Add the artifact rules + report tab + JUnit wiring.
+7. **First run** with the smoke set (`COMPAT_FULL=false`) — should complete
+   in ~5-10 min. Verify report tab loads, JUnit XML is parsed.
+8. Subsequent runs may flip `COMPAT_FULL=true` for the full sweep.
+
+## Notes / gotchas
+
+- The wrapper kills any JVM listening on the configured ports on teardown
+  via `stop-all.sh`. If multiple compat builds run concurrently on the same
+  agent, configure them with different `BASELINE_PORT` / `CANDIDATE_PORT`
+  values (TC parameters), otherwise they will TERM each other.
+- The agent's `/tmp` is used for work dirs (`/tmp/crs-baseline-tc-work`,
+  `/tmp/crs-candidate-tc-work`) and logs. Subsequent runs reuse them —
+  fresh runs require the wrapper to clean them, OR for the agent to be
+  ephemeral. The wrapper relies on Spring's idempotent `work-dir` semantics
+  + the postgres `docker compose down` for state cleanup.
+- The `bootJar` for either side is NOT built by this job; both JARs come
+  from upstream builds via artifact-dependency. This is intentional — keeps
+  the compat job fast and decoupled from build-side breakage.
+- Real component names live ONLY in the `COMPAT_SMOKE_COMPONENTS` TC
+  parameter (secret). They never appear in the repo or in any commit
+  message. The wrapper echoes only the count, not the values.

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# End-to-end TeamCity wrapper for the local-stand compat run.
+#
+# Boots TWO pre-built fat JARs side-by-side on the agent: baseline (released
+# old version) and candidate (current build chain output), runs the compat-test
+# module from the current source checkout against both. Single TC build step
+# replaces what would otherwise be five sequential script invocations.
+#
+# Required env (TC parameters / artifact-dependencies):
+#   BASELINE_JAR              absolute path to the baseline (old) fat JAR. Wire
+#                             via TC artifact-dependency on the released artifact
+#                             of version `$COMPONENTS_REGISTRY_SERVICE_VERSION`.
+#   CANDIDATE_JAR             absolute path to the candidate (new) fat JAR. Wire
+#                             via TC artifact-dependency on the upstream build
+#                             chain's output for `$BUILD_VERSION`.
+#   LOCAL_VCS_ROOT            absolute path to the DSL git clone (TC VCS root
+#                             checkout).
+#   SERVICE_CONFIG_DIR        absolute path to the service-config clone (TC VCS
+#                             root checkout). Must contain `application.yml` and
+#                             `components-registry-service.yml`.
+#   COMPAT_SMOKE_COMPONENTS   comma-separated real component names (TC secret
+#                             parameter — never echo into committed files).
+#
+# Optional:
+#   COMPAT_RMS_URL            release-management URL for real version sampling
+#                             (TC secret parameter; absent ⇒ versioned endpoints
+#                             fall back to OOR probes only).
+#   COMPAT_FULL               `true` for full sweep (default `false`).
+#   COMPAT_PARALLELISM        concurrent in-flight requests per stand (default 8).
+#   BASELINE_PORT             default 4567.
+#   CANDIDATE_PORT            default 4568.
+#   BASELINE_LOG              default /tmp/crs-baseline-tc.log.
+#   CANDIDATE_LOG             default /tmp/crs-candidate-tc.log.
+#   BASELINE_HEALTH_TIMEOUT_ITERS  health-poll iterations × 4s for baseline.
+#                             Default 75 (= 5 min). Increase on cold-cache agents.
+#   CANDIDATE_HEALTH_TIMEOUT_ITERS  health-poll iterations × 4s for candidate.
+#                             Default 120 (= 8 min). Includes auto-migrate.
+#   RESET_DB                  `1` (default) ⇒ `docker compose down -v` BEFORE
+#                             `postgres-up.sh` so the agent starts with a clean
+#                             volume. Set to `0` to keep an existing DB (e.g.
+#                             when iterating locally).
+#   COMPONENTS_REGISTRY_SERVICE_VERSION  echoed in the header for traceability.
+#   BUILD_VERSION             echoed in the header for traceability.
+#
+# Extra args are forwarded to `compat.sh` / gradle verbatim
+# (e.g. `--tests "*ComponentDetailV2*"`).
+#
+# Exit codes:
+#   0  — compat clean: 0 active divergences.
+#   2  — env validation failed (missing var, file not found, ...).
+#   3  — baseline or candidate failed to come up within the health timeout.
+#   4  — POLLUTED RUN: auto-migrate on candidate reported failures
+#        (count > 0); compat result is unreliable.
+#   *  — gradle exit code from compat.sh otherwise.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANDIDATE_WORKTREE="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ---------- env validation ----------
+: "${BASELINE_JAR:?BASELINE_JAR must be set (path to baseline fat JAR — wire via TC artifact-dependency on COMPONENTS_REGISTRY_SERVICE_VERSION)}"
+: "${CANDIDATE_JAR:?CANDIDATE_JAR must be set (path to candidate fat JAR — wire via TC artifact-dependency on BUILD_VERSION)}"
+: "${LOCAL_VCS_ROOT:?LOCAL_VCS_ROOT must be set (path to DSL git clone — TC VCS root)}"
+: "${SERVICE_CONFIG_DIR:?SERVICE_CONFIG_DIR must be set (path to service-config clone — TC VCS root)}"
+: "${COMPAT_SMOKE_COMPONENTS:?COMPAT_SMOKE_COMPONENTS must be set (CSV of real component names — TC secret parameter)}"
+
+[ -f "$BASELINE_JAR" ]  || { echo "ERROR: BASELINE_JAR=$BASELINE_JAR is not a file";   exit 2; }
+[ -f "$CANDIDATE_JAR" ] || { echo "ERROR: CANDIDATE_JAR=$CANDIDATE_JAR is not a file"; exit 2; }
+[ -d "$LOCAL_VCS_ROOT" ] || { echo "ERROR: LOCAL_VCS_ROOT=$LOCAL_VCS_ROOT is not a directory"; exit 2; }
+[ -d "$SERVICE_CONFIG_DIR" ] || { echo "ERROR: SERVICE_CONFIG_DIR=$SERVICE_CONFIG_DIR is not a directory"; exit 2; }
+[ -f "$SERVICE_CONFIG_DIR/application.yml" ] || {
+  echo "ERROR: $SERVICE_CONFIG_DIR/application.yml not found (does not look like a service-config dir)"
+  exit 2
+}
+[ -f "$SERVICE_CONFIG_DIR/components-registry-service.yml" ] || {
+  echo "ERROR: $SERVICE_CONFIG_DIR/components-registry-service.yml not found"
+  exit 2
+}
+
+BASELINE_PORT="${BASELINE_PORT:-4567}"
+CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
+BASELINE_LOG="${BASELINE_LOG:-/tmp/crs-baseline-tc.log}"
+CANDIDATE_LOG="${CANDIDATE_LOG:-/tmp/crs-candidate-tc.log}"
+
+cleanup() {
+  echo ">>> teardown"
+  "$SCRIPT_DIR/stop-all.sh" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "============================================================"
+echo "TeamCity compat run"
+echo "  baseline version:  ${COMPONENTS_REGISTRY_SERVICE_VERSION:-<unset>}"
+echo "  baseline JAR:      $BASELINE_JAR"
+echo "  candidate version: ${BUILD_VERSION:-<unset>}"
+echo "  candidate JAR:     $CANDIDATE_JAR"
+echo "  DSL root:          $LOCAL_VCS_ROOT"
+echo "  service-config:    $SERVICE_CONFIG_DIR"
+echo "  ports:             baseline=$BASELINE_PORT  candidate=$CANDIDATE_PORT"
+echo "  compat.full:       ${COMPAT_FULL:-false}    parallelism=${COMPAT_PARALLELISM:-8}"
+echo "============================================================"
+
+# ---------- Stage 1/4: postgres ----------
+echo ">>> Stage 1/4: postgres"
+RESET_DB="${RESET_DB:-1}"
+if [ "$RESET_DB" = "1" ]; then
+  # State contamination guard (Stage-2 review BLOCKING): postgres-up.sh runs
+  # `docker compose up -d` against a NAMED VOLUME, and stop-all.sh tears down
+  # WITHOUT `-v`. On a persistent agent the DB survives between TC runs;
+  # idempotent migrate then skips already-imported components and leaves
+  # ghost rows from runs whose DSL had components since removed. Wipe first.
+  COMPOSE_FILE="$CANDIDATE_WORKTREE/docker-compose.local-postgres.yml"
+  if [ -f "$COMPOSE_FILE" ]; then
+    if docker compose version >/dev/null 2>&1; then
+      docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+    elif command -v docker-compose >/dev/null 2>&1; then
+      docker-compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+    fi
+  fi
+fi
+"$SCRIPT_DIR/postgres-up.sh"
+
+# ---------- Stage 2/4: baseline JAR ----------
+echo ">>> Stage 2/4: baseline JAR (V1 mode)"
+BASELINE_WORK_DIR="${BASELINE_WORK_DIR:-/tmp/crs-baseline-tc-work}"
+# Spring `additional-location` is searched left-to-right; later wins for
+# overlapping keys. Order mirrors baseline.sh: dev/ profile yamls first,
+# then service-config defaults. The JAR's bundled application.yml is the
+# lowest-priority fallback.
+BASELINE_ADDITIONAL="file:$CANDIDATE_WORKTREE/components-registry-service-server/dev/"
+BASELINE_ADDITIONAL="$BASELINE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/application.yml"
+BASELINE_ADDITIONAL="$BASELINE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
+
+nohup java -jar "$BASELINE_JAR" \
+  --server.port="$BASELINE_PORT" \
+  --spring.cloud.config.enabled=false \
+  --spring.cloud.bootstrap.enabled=false \
+  --spring.config.additional-location="$BASELINE_ADDITIONAL" \
+  --spring.profiles.active=dev,dev-vcs-local,local \
+  --components-registry.vcs.root="file://$LOCAL_VCS_ROOT" \
+  --components-registry.work-dir="$BASELINE_WORK_DIR" \
+  --components-registry.groovy-path="$BASELINE_WORK_DIR/src/main/resources" \
+  --auth-server.disabled=true \
+  >"$BASELINE_LOG" 2>&1 &
+BASELINE_PID=$!
+echo "    baseline started (PID=$BASELINE_PID, log=$BASELINE_LOG)"
+
+BASELINE_HEALTH_TIMEOUT_ITERS="${BASELINE_HEALTH_TIMEOUT_ITERS:-75}"
+echo -n "    waiting for baseline health on :$BASELINE_PORT (up to $((BASELINE_HEALTH_TIMEOUT_ITERS * 4 / 60)) min)"
+for i in $(seq 1 "$BASELINE_HEALTH_TIMEOUT_ITERS"); do
+  if curl -fsS --max-time 2 "http://localhost:$BASELINE_PORT/actuator/health" >/dev/null 2>&1; then
+    echo
+    echo "    baseline up after $((i * 4))s"
+    break
+  fi
+  if [ $((i % 15)) -eq 0 ]; then echo -n " ${i}/$BASELINE_HEALTH_TIMEOUT_ITERS "; else echo -n "."; fi
+  sleep 4
+done
+echo
+if ! curl -fsS --max-time 2 "http://localhost:$BASELINE_PORT/actuator/health" >/dev/null 2>&1; then
+  echo "ERROR: baseline failed to come up — tail of $BASELINE_LOG:"
+  tail -n 40 "$BASELINE_LOG" || true
+  exit 3
+fi
+
+# ---------- Stage 3/4: candidate JAR ----------
+echo ">>> Stage 3/4: candidate JAR (schema-v2 DB-mode + auto-migrate)"
+CANDIDATE_WORK_DIR="${CANDIDATE_WORK_DIR:-/tmp/crs-candidate-tc-work}"
+# Candidate's profile suite mirrors candidate.sh --mode=db:
+#   dev                  — base dev overlay
+#   dev-vcs-local        — file:// VCS access (no remote bitbucket pull)
+#   dev-db-automigrate   — run DSL→DB migration at startup
+#   dev-db-only          — components-registry.default-source=db (schema-v2 code
+#                          path active for unmigrated-component fallback)
+#   local                — local stand identity marker
+CANDIDATE_ADDITIONAL="file:$CANDIDATE_WORKTREE/components-registry-service-server/dev/"
+CANDIDATE_ADDITIONAL="$CANDIDATE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
+CANDIDATE_PROFILES="dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local"
+
+nohup java -jar "$CANDIDATE_JAR" \
+  --server.port="$CANDIDATE_PORT" \
+  --spring.profiles.active="$CANDIDATE_PROFILES" \
+  --spring.config.additional-location="$CANDIDATE_ADDITIONAL" \
+  --components-registry.vcs.root="file://$LOCAL_VCS_ROOT" \
+  --components-registry.work-dir="$CANDIDATE_WORK_DIR" \
+  --components-registry.groovy-path="$CANDIDATE_WORK_DIR/src/main/resources" \
+  --auth-server.disabled=true \
+  >"$CANDIDATE_LOG" 2>&1 &
+CANDIDATE_PID=$!
+echo "    candidate started (PID=$CANDIDATE_PID, log=$CANDIDATE_LOG)"
+
+CANDIDATE_HEALTH_TIMEOUT_ITERS="${CANDIDATE_HEALTH_TIMEOUT_ITERS:-120}"
+# Auto-migrate import takes ~30-60s, plus startup ~20s, plus headroom for slow agents.
+echo -n "    waiting for candidate health on :$CANDIDATE_PORT (up to $((CANDIDATE_HEALTH_TIMEOUT_ITERS * 4 / 60)) min — includes auto-migrate)"
+for i in $(seq 1 "$CANDIDATE_HEALTH_TIMEOUT_ITERS"); do
+  if curl -fsS --max-time 2 "http://localhost:$CANDIDATE_PORT/actuator/health" >/dev/null 2>&1; then
+    echo
+    echo "    candidate up after $((i * 4))s"
+    break
+  fi
+  if [ $((i % 15)) -eq 0 ]; then echo -n " ${i}/$CANDIDATE_HEALTH_TIMEOUT_ITERS "; else echo -n "."; fi
+  sleep 4
+done
+echo
+if ! curl -fsS --max-time 2 "http://localhost:$CANDIDATE_PORT/actuator/health" >/dev/null 2>&1; then
+  echo "ERROR: candidate failed to come up — tail of $CANDIDATE_LOG:"
+  tail -n 60 "$CANDIDATE_LOG" || true
+  exit 3
+fi
+
+# Polluted-migration guard: reuse verify.sh's parser. verify.sh's source-guard
+# (added by TD-007 L2 / PR #229) returns 0 before its orchestration block when
+# sourced, exposing the helpers without side effects.
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/verify.sh"
+# `check_migration_health` exits 4 on its own (failed > 0 and ALLOW_PARTIAL=0).
+ALLOW_PARTIAL="${ALLOW_PARTIAL:-0}"
+check_migration_health "$CANDIDATE_LOG"
+
+# Hard assert candidate routing mode (Stage-2 review NIT): if `dev-db-only.yml`
+# is ever dropped and the JVM silently falls back to `default-source=git`,
+# the compat run would tolerate it via the env-warning record but exit 0
+# anyway when no other diffs surface. Fail-fast here so a misconfiguration
+# is impossible to miss.
+CANDIDATE_STATUS_URL="http://localhost:$CANDIDATE_PORT/rest/api/2/components-registry/service/status"
+CANDIDATE_DEFAULT_SOURCE=$(curl -fsS --max-time 5 "$CANDIDATE_STATUS_URL" | sed -nE 's/.*"defaultSource":"([^"]*)".*/\1/p' || true)
+if [ -z "$CANDIDATE_DEFAULT_SOURCE" ]; then
+  echo "WARN: could not read candidate /service/status.defaultSource (older candidate JVM that does not expose the field?)"
+  echo "      Proceeding — compat-test's L3 preflight (SnapshotPreconditionTest) will catch a mismatch."
+elif [ "$CANDIDATE_DEFAULT_SOURCE" != "db" ]; then
+  echo "ERROR: candidate reports defaultSource=$CANDIDATE_DEFAULT_SOURCE — expected 'db'."
+  echo "       The schema-v2 DB resolver is dormant; compat would measure V1-vs-V1, not schema-v2-vs-V1."
+  echo "       Check that the 'dev-db-only' profile is active and that application-dev-db-only.yml is on the classpath."
+  exit 2
+else
+  echo "    candidate routing: defaultSource=db ✓"
+fi
+
+# ---------- Stage 4/4: compat ----------
+echo ">>> Stage 4/4: compat-test"
+# compat.sh exports COMPAT_BASELINE_URL=http://localhost:$BASELINE_PORT and
+# COMPAT_CANDIDATE_URL=http://localhost:$CANDIDATE_PORT, then invokes the
+# :components-registry-compat-test:test gradle task. It already accepts
+# COMPAT_RMS_URL / COMPAT_FULL / COMPAT_PARALLELISM / COMPAT_SMOKE_COMPONENTS
+# from the parent shell.
+#
+# Run as a foreground child (NOT `exec`) so the EXIT trap fires when compat
+# finishes — Stage-2 review found that `exec` was replacing the shell process
+# and silently discarding the trap, leaking the baseline/candidate JVMs and
+# the postgres container between TC runs on a persistent agent.
+"$SCRIPT_DIR/compat.sh" "$@"
+COMPAT_EXIT=$?
+exit $COMPAT_EXIT


### PR DESCRIPTION
## Summary
Adds a single-step TeamCity build configuration for the local-stand compat job. Boots both the released-baseline JAR (by `COMPONENTS_REGISTRY_SERVICE_VERSION`) and the current-chain candidate JAR (by `BUILD_VERSION`) side-by-side on the agent, runs the compat-test module against both, tears down on exit.

- **`scripts/local-stands/teamcity-run.sh`** — end-to-end wrapper. Chains: postgres-up (with `RESET_DB=1` volume wipe by default) → baseline JAR boot (V1 profile suite, port 4567) → health-wait → candidate JAR boot (schema-v2 DB-mode profile suite, port 4568) → health-wait → `defaultSource=db` hard-assert → polluted-migration guard (via verify.sh's `check_migration_health`) → `compat.sh` → cleanup via `trap`.
- **`scripts/local-stands/TEAMCITY.md`** — operator-facing TC spec. VCS roots (crs + dsl + service-config), artifact dependencies wiring, full parameter table, build step, artifact rules, failure-mode mapping, reproducibility checklist.
- **`scripts/local-stands/README.md`** — small cross-link.

## Constraints incorporated from clarification
- Baseline: pulled by `COMPONENTS_REGISTRY_SERVICE_VERSION` (TC parameter) via artifact-dependency.
- Candidate: from current build chain via `BUILD_VERSION` artifact-dependency.
- VCS roots: TC checks out DSL + service-config per run (no persistent mount assumption).

## Stage-1 (Sonnet) + Stage-2 (Opus adversarial) reviews — all findings addressed
| Severity | Finding | Fix |
|---|---|---|
| **BLOCKING** (Stage-2) | `exec compat.sh` was destroying the EXIT trap — JVMs + postgres leaked between TC runs on a persistent agent | Replaced `exec` with foreground call + explicit exit-code propagation; trap fires naturally |
| **BLOCKING** (Stage-2) | Postgres volume contamination on persistent agents — idempotent migrate would skip ghost rows from prior runs | `RESET_DB=1` default forces `docker compose down -v` before postgres-up |
| **NIT** (Stage-1+2) | Health-poll timeouts hardcoded | `BASELINE_HEALTH_TIMEOUT_ITERS` / `CANDIDATE_HEALTH_TIMEOUT_ITERS` env params |
| **NIT** (Stage-2) | `defaultSource=db` not actively asserted — could be silently masked by env-warning | Pre-compat HTTP probe with exit 2 on mismatch |
| **NIT** (Stage-2) | Smoke-list zero-count silent-skip risk | Documented in the reproducibility checklist |
| **NIT** (Stage-2) | Service-config branch-spec drift | Documented the tradeoff + override path for bit-exact baseline |

## Test plan
- [x] `bash -n teamcity-run.sh` — syntax clean.
- [x] Forbidden-literal scan on both files — clean (no company names, internal hosts, real component IDs, etc.).
- [x] JVM arg parity with `baseline.sh` / `candidate.sh --mode=db` verified by side-by-side diff (Sonnet review walked it).
- [x] Source-guard reuse pattern matches what verify.sh exposes (BASH_SOURCE != $0 → return 0 before orchestration block).
- [ ] **End-to-end smoke** — defer to TC setup time; needs a real agent with both JARs staged.

## Out of scope (next steps for the operator)
- The actual TC build configuration (VCS roots, parameters, artifact deps, build step, artifact rules) needs to be created in the TC UI. The spec in `TEAMCITY.md` is the authoritative reference for that one-time setup.
- After the first manual run, decide whether to add a VCS trigger on `feat/schema-v2-sql` or keep it manual-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)