### PR TITLE
feat(server): log POST/PUT request bodies at DEBUG

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/RequestBodyLoggingConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/RequestBodyLoggingConfig.kt
@@ -6,40 +6,44 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.filter.CommonsRequestLoggingFilter
 
 /**
- * Logs POST/PUT request bodies at DEBUG level for compatibility-test capture.
+ * Logs POST/PUT request bodies at DEBUG for compatibility-test capture.
  *
- * Off by default — the filter is registered but only emits when DEBUG is
- * enabled for this class. To turn on at runtime via service-config:
+ * **⚠️ Security/privacy**
+ * Request bodies and query strings can include credentials, tokens, PII,
+ * or other sensitive data. Enable this filter only with:
+ *  - a short log-retention window for the capture period,
+ *  - restricted RBAC on `oc logs` and the Graylog stream,
+ *  - data-handling owner approval before each prod-enable.
  *
- *     logging:
- *       level:
- *         org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
+ * **Off by default**
+ * The filter bean is always registered, but `shouldLog` gates emission on
+ * DEBUG for the concrete subclass [PostPutBodyLoggingFilter] — NOT on the
+ * parent `org.springframework.web.filter.CommonsRequestLoggingFilter`,
+ * because Spring's internal `logger` uses the runtime class name.
  *
- * Remove that line from service-config and redeploy to stop emitting bodies
- * (no code change required).
+ * Toggle on via service-config:
+ * ```yaml
+ * logging:
+ *   level:
+ *     org.octopusden.octopus.components.registry.server.config.PostPutBodyLoggingFilter: DEBUG
+ * ```
  *
- * Only POST and PUT are logged — GET/HEAD/DELETE have no body. The line is
- * emitted AFTER the controller has read the body (Spring's payload caching
- * requires the request to be consumed first).
+ * **Performance caveat**
+ * `setIncludePayload(true)` makes Spring wrap every incoming request in
+ * `ContentCachingRequestWrapper`, regardless of whether DEBUG is on. The
+ * cached buffer is capped at `maxPayloadLength` (4 KB), so the cost is
+ * bounded — but it is NOT zero when DEBUG is off.
  *
- * `maxPayloadLength = 4000` is a guard against pathological large bodies;
- * truncated bodies end with `... (truncated)` in the log.
+ * **Truncation**
+ * Bodies longer than 4 KB are silently cut off — Spring does NOT append
+ * a `... (truncated)` marker. To detect truncation, compare the logged
+ * body length against the request's `Content-Length` header.
  */
 @Configuration
 class RequestBodyLoggingConfig {
     @Bean
-    fun requestBodyLoggingFilter(): CommonsRequestLoggingFilter =
-        object : CommonsRequestLoggingFilter() {
-            override fun shouldLog(request: HttpServletRequest): Boolean =
-                (request.method == "POST" || request.method == "PUT") && logger.isDebugEnabled
-
-            // Suppress the "Before request" line — body is not yet available
-            // before the controller reads it, so the line carries no extra
-            // info beyond what the access log already has.
-            override fun beforeRequest(request: HttpServletRequest, message: String) {
-                // intentionally empty
-            }
-        }.apply {
+    fun requestBodyLoggingFilter(): PostPutBodyLoggingFilter =
+        PostPutBodyLoggingFilter().apply {
             setIncludeClientInfo(false)
             setIncludeQueryString(true)
             setIncludePayload(true)
@@ -47,4 +51,20 @@ class RequestBodyLoggingConfig {
             setAfterMessagePrefix("REQ-BODY: ")
             setAfterMessageSuffix("")
         }
+}
+
+/**
+ * Named subclass so Spring's `logger` (which uses the runtime class name)
+ * resolves to a stable, configurable category — see [RequestBodyLoggingConfig].
+ */
+class PostPutBodyLoggingFilter : CommonsRequestLoggingFilter() {
+    override fun shouldLog(request: HttpServletRequest): Boolean =
+        (request.method == "POST" || request.method == "PUT") && logger.isDebugEnabled
+
+    /** Suppress the "Before request" line — body is not yet available before
+     *  the controller reads it, so the line carries no extra info beyond
+     *  what the access log already has. */
+    override fun beforeRequest(request: HttpServletRequest, message: String) {
+        // intentionally empty
+    }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/RequestBodyLoggingConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/RequestBodyLoggingConfig.kt
@@ -1,0 +1,50 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.CommonsRequestLoggingFilter
+
+/**
+ * Logs POST/PUT request bodies at DEBUG level for compatibility-test capture.
+ *
+ * Off by default — the filter is registered but only emits when DEBUG is
+ * enabled for this class. To turn on at runtime via service-config:
+ *
+ *     logging:
+ *       level:
+ *         org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
+ *
+ * Remove that line from service-config and redeploy to stop emitting bodies
+ * (no code change required).
+ *
+ * Only POST and PUT are logged — GET/HEAD/DELETE have no body. The line is
+ * emitted AFTER the controller has read the body (Spring's payload caching
+ * requires the request to be consumed first).
+ *
+ * `maxPayloadLength = 4000` is a guard against pathological large bodies;
+ * truncated bodies end with `... (truncated)` in the log.
+ */
+@Configuration
+class RequestBodyLoggingConfig {
+    @Bean
+    fun requestBodyLoggingFilter(): CommonsRequestLoggingFilter =
+        object : CommonsRequestLoggingFilter() {
+            override fun shouldLog(request: HttpServletRequest): Boolean =
+                (request.method == "POST" || request.method == "PUT") && logger.isDebugEnabled
+
+            // Suppress the "Before request" line — body is not yet available
+            // before the controller reads it, so the line carries no extra
+            // info beyond what the access log already has.
+            override fun beforeRequest(request: HttpServletRequest, message: String) {
+                // intentionally empty
+            }
+        }.apply {
+            setIncludeClientInfo(false)
+            setIncludeQueryString(true)
+            setIncludePayload(true)
+            setMaxPayloadLength(4000)
+            setAfterMessagePrefix("REQ-BODY: ")
+            setAfterMessageSuffix("")
+        }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/RequestBodyLoggingConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/RequestBodyLoggingConfig.kt
@@ -1,56 +1,74 @@
 package org.octopusden.octopus.components.registry.server.config
 
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.filter.CommonsRequestLoggingFilter
 
 /**
- * Logs POST/PUT request bodies at DEBUG for compatibility-test capture.
+ * Logs POST/PUT request bodies for compatibility-test capture.
  *
- * **⚠️ Security/privacy**
- * Request bodies and query strings can include credentials, tokens, PII,
- * or other sensitive data. Enable this filter only with:
+ * **⚠️ Security / privacy**
+ * Request bodies can include credentials, tokens, PII, or other sensitive
+ * data. Enable only with:
  *  - a short log-retention window for the capture period,
  *  - restricted RBAC on `oc logs` and the Graylog stream,
  *  - data-handling owner approval before each prod-enable.
  *
- * **Off by default**
- * The filter bean is always registered, but `shouldLog` gates emission on
- * DEBUG for the concrete subclass [PostPutBodyLoggingFilter] — NOT on the
- * parent `org.springframework.web.filter.CommonsRequestLoggingFilter`,
- * because Spring's internal `logger` uses the runtime class name.
+ * **Two-step opt-in** — both must be set to start emitting bodies:
+ *  1. `crs.request-body-logging.enabled=true` — also controls bean
+ *     registration, so the `ContentCachingRequestWrapper` overhead is only
+ *     incurred when this is on.
+ *  2. DEBUG on [PostPutBodyLoggingFilter] — gates the actual log line.
  *
- * Toggle on via service-config:
+ * Requiring both prevents accidental activation via a broad package-level
+ * DEBUG override used for unrelated troubleshooting.
+ *
+ * Service-config toggle:
  * ```yaml
+ * crs:
+ *   request-body-logging:
+ *     enabled: true
  * logging:
  *   level:
  *     org.octopusden.octopus.components.registry.server.config.PostPutBodyLoggingFilter: DEBUG
  * ```
  *
- * **Performance caveat**
- * `setIncludePayload(true)` makes Spring wrap every incoming request in
- * `ContentCachingRequestWrapper`, regardless of whether DEBUG is on. The
- * cached buffer is capped at `maxPayloadLength` (4 KB), so the cost is
- * bounded — but it is NOT zero when DEBUG is off.
+ * **What we do NOT log**
+ *  - Query string — already in the Tomcat access log, may contain tokens.
+ *  - Headers (Authorization, Cookie, etc.).
  *
  * **Truncation**
- * Bodies longer than 4 KB are silently cut off — Spring does NOT append
- * a `... (truncated)` marker. To detect truncation, compare the logged
- * body length against the request's `Content-Length` header.
+ * Bodies past 4 KB are silently cut off — Spring does NOT append a
+ * `(truncated)` marker. To detect truncation, compare the logged body
+ * length against the request's `Content-Length` header.
+ *
+ * **Log-line safety**
+ * CR/LF characters in the body are escaped to `\r`, `\n` so a pretty-printed
+ * JSON body cannot split or forge subsequent log lines.
  */
 @Configuration
 class RequestBodyLoggingConfig {
     @Bean
+    @ConditionalOnProperty(
+        name = ["crs.request-body-logging.enabled"],
+        havingValue = "true",
+        matchIfMissing = false,
+    )
     fun requestBodyLoggingFilter(): PostPutBodyLoggingFilter =
         PostPutBodyLoggingFilter().apply {
             setIncludeClientInfo(false)
-            setIncludeQueryString(true)
+            setIncludeQueryString(false)
             setIncludePayload(true)
-            setMaxPayloadLength(4000)
+            setMaxPayloadLength(MAX_PAYLOAD_BYTES)
             setAfterMessagePrefix("REQ-BODY: ")
             setAfterMessageSuffix("")
         }
+
+    companion object {
+        const val MAX_PAYLOAD_BYTES = 4000
+    }
 }
 
 /**
@@ -61,10 +79,17 @@ class PostPutBodyLoggingFilter : CommonsRequestLoggingFilter() {
     override fun shouldLog(request: HttpServletRequest): Boolean =
         (request.method == "POST" || request.method == "PUT") && logger.isDebugEnabled
 
-    /** Suppress the "Before request" line — body is not yet available before
-     *  the controller reads it, so the line carries no extra info beyond
-     *  what the access log already has. */
+    /** Suppress the "Before request" line — body is not yet available
+     *  before the controller reads it, so the line carries no extra
+     *  info beyond what the access log already has. */
     override fun beforeRequest(request: HttpServletRequest, message: String) {
         // intentionally empty
     }
+
+    /** Escape CR/LF so a multi-line JSON body stays on a single log line
+     *  and cannot inject or forge log entries. */
+    override fun getMessagePayload(request: HttpServletRequest): String? =
+        super.getMessagePayload(request)
+            ?.replace("\r", "\\r")
+            ?.replace("\n", "\\n")
 }


### PR DESCRIPTION
## Summary
- Adds `RequestBodyLoggingConfig` — a `@ConditionalOnProperty`-gated Spring bean that registers a custom `CommonsRequestLoggingFilter` subclass (`PostPutBodyLoggingFilter`) to log POST/PUT request bodies for compatibility-test capture.
- **Two-step opt-in**: both `crs.request-body-logging.enabled=true` AND DEBUG on `PostPutBodyLoggingFilter` must be set to start emitting bodies. Bean is not registered at all when the property is off, so no per-request `ContentCachingRequestWrapper` overhead in the default state.
- One `REQ-BODY: ...` line per POST/PUT after the controller reads the body. `beforeRequest` is suppressed.
- Query string is NOT included (it's already in the Tomcat access log, and would not be capped by `maxPayloadLength`).
- 4 KB cap on payload — Spring truncates silently (no `(truncated)` marker; detect via `Content-Length` if needed).
- CR/LF in the body is escaped to `\r`, `\n` so a multi-line JSON body cannot split or forge log lines.

## Why
Capturing real request bodies (`find-by-artifact`, `findByArtifacts`, v2 `detailed-versions`, v3 `find-by-artifacts`/`find-by-docker-images`, ...) from prod is needed to replay the same payloads against new code paths in upcoming compat-tests. Access log (Tomcat `AccessLogValve`) only logs method/path/status/IP/UA/XFF — body lives below the servlet stack.

## ⚠️ Security / privacy
Request bodies can include credentials, tokens, PII, or other sensitive data. The two-step opt-in is a guard, but enabling it in prod still requires:
- a short log-retention window for the capture period,
- restricted RBAC on `oc logs` and the Graylog stream,
- data-handling owner approval before each prod-enable.

## How to use
1. Merge this PR → CRS pipeline auto-builds a release docker image and rolls it out (per existing CD flow; no `service-deployment` tag bump needed for the release flow).
2. At this point the filter is **not registered** — `crs.request-body-logging.enabled` defaults to false. Zero overhead.
3. To turn body-logging on for a capture window, add **both** entries to `service-config/components-registry-service-cloud-prod.yml`:
   ```yaml
   crs:
     request-body-logging:
       enabled: true
   logging:
     level:
       org.octopusden.octopus.components.registry.server.config.PostPutBodyLoggingFilter: DEBUG
   ```
   Restart the pod (or wait for config-server refresh).
4. To turn off: revert that block and redeploy.

## Test plan
- [x] Builds locally (`AUTH_SERVER_URL=… ./gradlew build -x dockerBuildImage … -x :components-registry-automation:test`) — BUILD SUCCESSFUL.
- [ ] Deploy to QA with both opt-ins on; verify `REQ-BODY: POST /rest/api/2/components/find-by-artifact ... body=[{...}]` lines appear in `oc logs`.
- [ ] Verify default (neither opt-in set) produces zero `REQ-BODY:` lines AND that the filter bean is absent from the application context (`/actuator/beans` if exposed, or thread dump).
- [ ] Verify that with property ON but DEBUG OFF, no body lines are emitted.
- [ ] Spot-check that body for large requests is truncated near 4 KB and that CR/LF in JSON is rendered as `\r`/`\n`.

## Follow-up (not in this PR)
- Automated MockMvc / log-capture test (Copilot review feedback) — tracked as separate work; manual QA above covers the capture window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
