### PR TITLE
fix(routing): MIG-049 — project endpoints return 200 instead of 404 for unknown projects

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -144,18 +144,30 @@ class ComponentRoutingResolver(
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override fun getJiraComponentVersionRangesByProject(projectKey: String): Set<JiraComponentVersionRange> {
+        var gitNotFound = false
+        var dbNotFound = false
         val gitResults =
             try {
                 gitResolver.getJiraComponentVersionRangesByProject(projectKey)
+            } catch (e: NotFoundException) {
+                gitNotFound = true
+                emptySet()
             } catch (e: Exception) {
                 emptySet()
             }
         val dbResults =
             try {
                 dbResolver.getJiraComponentVersionRangesByProject(projectKey)
+            } catch (e: NotFoundException) {
+                dbNotFound = true
+                emptySet()
             } catch (e: Exception) {
                 emptySet()
             }
+        // MIG-049: see getJiraComponentsByProject for the same pattern.
+        if (gitNotFound && dbNotFound) {
+            throw NotFoundException("Project '$projectKey' is not found")
+        }
         val dbNames = sourceRegistry.getDbComponentNames()
         val filteredGit = gitResults.filter { !dbNames.contains(it.componentName) }
         return filteredGit.toSet() + dbResults

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -175,18 +175,30 @@ class ComponentRoutingResolver(
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override fun getComponentsDistributionByJiraProject(projectKey: String): Map<String, Distribution> {
+        var gitNotFound = false
+        var dbNotFound = false
         val gitResults =
             try {
                 gitResolver.getComponentsDistributionByJiraProject(projectKey)
+            } catch (e: NotFoundException) {
+                gitNotFound = true
+                emptyMap()
             } catch (e: Exception) {
                 emptyMap()
             }
         val dbResults =
             try {
                 dbResolver.getComponentsDistributionByJiraProject(projectKey)
+            } catch (e: NotFoundException) {
+                dbNotFound = true
+                emptyMap()
             } catch (e: Exception) {
                 emptyMap()
             }
+        // MIG-049: see getJiraComponentsByProject for the same pattern.
+        if (gitNotFound && dbNotFound) {
+            throw NotFoundException("Project '$projectKey' is not found")
+        }
         val dbNames = sourceRegistry.getDbComponentNames()
         val filteredGit = gitResults.filter { !dbNames.contains(it.key) }
         return filteredGit + dbResults

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -7,6 +7,7 @@ import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
@@ -110,18 +111,34 @@ class ComponentRoutingResolver(
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override fun getJiraComponentsByProject(projectKey: String): Set<String> {
+        var gitNotFound = false
+        var dbNotFound = false
         val gitResults =
             try {
                 gitResolver.getJiraComponentsByProject(projectKey)
+            } catch (e: NotFoundException) {
+                gitNotFound = true
+                emptySet()
             } catch (e: Exception) {
                 emptySet()
             }
         val dbResults =
             try {
                 dbResolver.getJiraComponentsByProject(projectKey)
+            } catch (e: NotFoundException) {
+                dbNotFound = true
+                emptySet()
             } catch (e: Exception) {
                 emptySet()
             }
+        // MIG-049: when BOTH resolvers say the project is unknown, propagate
+        // NotFoundException so the controller exception handler renders 404.
+        // Other exception types from either resolver (e.g. transient DB
+        // failure) are still swallowed so a partial outage doesn't degrade
+        // the union-merge response.
+        if (gitNotFound && dbNotFound) {
+            throw NotFoundException("Project '$projectKey' is not found")
+        }
         return gitResults + dbResults
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverProjectNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverProjectNotFoundTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mockito.mock
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
+import org.octopusden.octopus.escrow.model.Distribution
 
 /**
  * MIG-049: V2 project endpoints return 200 instead of 404 for unknown projects.
@@ -175,5 +176,63 @@ class ComponentRoutingResolverProjectNotFoundTest {
 
         val result = routing.getJiraComponentVersionRangesByProject(projectKey)
         assertEquals(setOf(gitRange), result)
+    }
+
+    // =========================================================================
+    // MIG-049-003: getComponentsDistributionByJiraProject
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "MIG-049-003: getComponentsDistributionByJiraProject re-throws NotFoundException " +
+            "when both resolvers raise it (project genuinely unknown)",
+    )
+    fun mig049_003_componentsDistributionByJiraProject_bothNotFound_reThrows() {
+        val projectKey = "theta-project"
+        doThrow(NotFoundException("Project '$projectKey' is not found"))
+            .`when`(gitResolver).getComponentsDistributionByJiraProject(projectKey)
+        doThrow(NotFoundException("Project '$projectKey' is not found"))
+            .`when`(dbResolver).getComponentsDistributionByJiraProject(projectKey)
+
+        val ex =
+            assertThrows(NotFoundException::class.java) {
+                routing.getComponentsDistributionByJiraProject(projectKey)
+            }
+        assertEquals(
+            "Project '$projectKey' is not found",
+            ex.message,
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-049-003 anti-regression: gitResolver throws, dbResolver returns map → routing returns the V2 map",
+    )
+    fun mig049_003_componentsDistributionByJiraProject_gitNotFound_dbHasMap_returnsDb() {
+        val projectKey = "iota-project"
+        val dbDistribution = mock(Distribution::class.java)
+        doThrow(NotFoundException("not in git"))
+            .`when`(gitResolver).getComponentsDistributionByJiraProject(projectKey)
+        doReturn(mapOf("db-routed-comp" to dbDistribution))
+            .`when`(dbResolver).getComponentsDistributionByJiraProject(projectKey)
+
+        val result = routing.getComponentsDistributionByJiraProject(projectKey)
+        assertEquals(mapOf("db-routed-comp" to dbDistribution), result)
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-049-003 anti-regression: gitResolver returns map, dbResolver throws → routing returns the V1 map",
+    )
+    fun mig049_003_componentsDistributionByJiraProject_gitHasMap_dbNotFound_returnsGit() {
+        val projectKey = "kappa-project"
+        val gitDistribution = mock(Distribution::class.java)
+        doReturn(mapOf("legacy-comp" to gitDistribution))
+            .`when`(gitResolver).getComponentsDistributionByJiraProject(projectKey)
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getComponentsDistributionByJiraProject(projectKey)
+
+        val result = routing.getComponentsDistributionByJiraProject(projectKey)
+        assertEquals(mapOf("legacy-comp" to gitDistribution), result)
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverProjectNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverProjectNotFoundTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.mock
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
 
 /**
  * MIG-049: V2 project endpoints return 200 instead of 404 for unknown projects.
@@ -115,5 +116,64 @@ class ComponentRoutingResolverProjectNotFoundTest {
 
         val result = routing.getJiraComponentsByProject(projectKey)
         assertEquals(setOf("git-only-a", "shared-b", "db-only-c"), result)
+    }
+
+    // =========================================================================
+    // MIG-049-002: getJiraComponentVersionRangesByProject
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "MIG-049-002: getJiraComponentVersionRangesByProject re-throws NotFoundException " +
+            "when both resolvers raise it (project genuinely unknown)",
+    )
+    fun mig049_002_jiraVersionRangesByProject_bothNotFound_reThrows() {
+        val projectKey = "epsilon-project"
+        doThrow(NotFoundException("Project '$projectKey' is not found"))
+            .`when`(gitResolver).getJiraComponentVersionRangesByProject(projectKey)
+        doThrow(NotFoundException("Project '$projectKey' is not found"))
+            .`when`(dbResolver).getJiraComponentVersionRangesByProject(projectKey)
+
+        val ex =
+            assertThrows(NotFoundException::class.java) {
+                routing.getJiraComponentVersionRangesByProject(projectKey)
+            }
+        assertEquals(
+            "Project '$projectKey' is not found",
+            ex.message,
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-049-002 anti-regression: gitResolver throws, dbResolver returns rows → routing returns the V2 rows " +
+            "(de-duped via sourceRegistry — git rows for db-routed components are dropped)",
+    )
+    fun mig049_002_jiraVersionRangesByProject_gitNotFound_dbHasRows_returnsDb() {
+        val projectKey = "zeta-project"
+        val dbRange = mock(JiraComponentVersionRange::class.java)
+        doReturn("db-routed-comp").`when`(dbRange).componentName
+        doThrow(NotFoundException("not in git"))
+            .`when`(gitResolver).getJiraComponentVersionRangesByProject(projectKey)
+        doReturn(setOf(dbRange)).`when`(dbResolver).getJiraComponentVersionRangesByProject(projectKey)
+
+        val result = routing.getJiraComponentVersionRangesByProject(projectKey)
+        assertEquals(setOf(dbRange), result)
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-049-002 anti-regression: gitResolver returns rows, dbResolver throws → routing returns the V1 rows",
+    )
+    fun mig049_002_jiraVersionRangesByProject_gitHasRows_dbNotFound_returnsGit() {
+        val projectKey = "eta-project"
+        val gitRange = mock(JiraComponentVersionRange::class.java)
+        doReturn("legacy-comp").`when`(gitRange).componentName
+        doReturn(setOf(gitRange)).`when`(gitResolver).getJiraComponentVersionRangesByProject(projectKey)
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentVersionRangesByProject(projectKey)
+
+        val result = routing.getJiraComponentVersionRangesByProject(projectKey)
+        assertEquals(setOf(gitRange), result)
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverProjectNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverProjectNotFoundTest.kt
@@ -1,0 +1,119 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+
+/**
+ * MIG-049: V2 project endpoints return 200 instead of 404 for unknown projects.
+ *
+ * `ComponentRoutingResolver`'s three union-merge methods (jira-components,
+ * jira-component-version-ranges, components-distribution) wrap each resolver
+ * call in `try { … } catch (e: Exception) { empty }`. When BOTH gitResolver
+ * (V1) and dbResolver (V2) raise `NotFoundException` because the project key
+ * is genuinely unknown, the routing layer silently substitutes an empty
+ * collection. The controller returns 200 + `[]`/`{}` instead of the 404
+ * `ControllerExceptionHandler` maps from `NotFoundException`.
+ *
+ * Trace-replay against the 2026-05-17 deploy of `feat/schema-v2-sql` surfaces
+ * this as 27 STATUS_CODE_DIFF on `/jira-components` + 4 on
+ * `/component-distributions` records.
+ *
+ * Pure in-memory tests: mocked resolvers, no Spring context, no global
+ * fixtures (per `feedback_regression_guards_avoid_global_fixtures`).
+ * Synthetic project keys only (`feedback_redacted_identifiers`).
+ */
+@Timeout(10, unit = TimeUnit.SECONDS)
+class ComponentRoutingResolverProjectNotFoundTest {
+
+    private lateinit var gitResolver: ComponentRegistryResolverImpl
+    private lateinit var dbResolver: DatabaseComponentRegistryResolver
+    private lateinit var sourceRegistry: ComponentSourceRegistry
+    private lateinit var routing: ComponentRoutingResolver
+
+    @BeforeEach
+    fun setUp() {
+        gitResolver = mock(ComponentRegistryResolverImpl::class.java)
+        dbResolver = mock(DatabaseComponentRegistryResolver::class.java)
+        sourceRegistry = mock(ComponentSourceRegistry::class.java)
+        // Default: no DB-routed components — exercised methods read this from
+        // sourceRegistry to deduplicate union-merge results.
+        doReturn(emptySet<String>()).`when`(sourceRegistry).getDbComponentNames()
+        routing = ComponentRoutingResolver(gitResolver, dbResolver, sourceRegistry)
+    }
+
+    // =========================================================================
+    // MIG-049-001: getJiraComponentsByProject
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "MIG-049-001: getJiraComponentsByProject re-throws NotFoundException " +
+            "when both resolvers raise it (project genuinely unknown)",
+    )
+    fun mig049_001_jiraComponentsByProject_bothNotFound_reThrows() {
+        val projectKey = "alpha-project"
+        doThrow(NotFoundException("Project '$projectKey' is not found"))
+            .`when`(gitResolver).getJiraComponentsByProject(projectKey)
+        doThrow(NotFoundException("Project '$projectKey' is not found"))
+            .`when`(dbResolver).getJiraComponentsByProject(projectKey)
+
+        val ex =
+            assertThrows(NotFoundException::class.java) {
+                routing.getJiraComponentsByProject(projectKey)
+            }
+        assertEquals(
+            "Project '$projectKey' is not found",
+            ex.message,
+            "Re-thrown NotFoundException must carry the project-key context",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-049-001 anti-regression: gitResolver throws, dbResolver returns rows → routing returns the V2 rows (no throw)",
+    )
+    fun mig049_001_jiraComponentsByProject_gitNotFound_dbHasRows_returnsDb() {
+        val projectKey = "beta-project"
+        doThrow(NotFoundException("not in git")).`when`(gitResolver).getJiraComponentsByProject(projectKey)
+        doReturn(setOf("widget-core", "widget-cli")).`when`(dbResolver).getJiraComponentsByProject(projectKey)
+
+        val result = routing.getJiraComponentsByProject(projectKey)
+        assertEquals(setOf("widget-core", "widget-cli"), result)
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-049-001 anti-regression: gitResolver returns rows, dbResolver throws → routing returns the V1 rows (no throw)",
+    )
+    fun mig049_001_jiraComponentsByProject_gitHasRows_dbNotFound_returnsGit() {
+        val projectKey = "gamma-project"
+        doReturn(setOf("legacy-core")).`when`(gitResolver).getJiraComponentsByProject(projectKey)
+        doThrow(NotFoundException("not in db")).`when`(dbResolver).getJiraComponentsByProject(projectKey)
+
+        val result = routing.getJiraComponentsByProject(projectKey)
+        assertEquals(setOf("legacy-core"), result)
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-049-001 anti-regression: both resolvers return non-empty → routing returns the union (existing semantics preserved)",
+    )
+    fun mig049_001_jiraComponentsByProject_bothHaveRows_returnsUnion() {
+        val projectKey = "delta-project"
+        doReturn(setOf("git-only-a", "shared-b")).`when`(gitResolver).getJiraComponentsByProject(projectKey)
+        doReturn(setOf("shared-b", "db-only-c")).`when`(dbResolver).getJiraComponentsByProject(projectKey)
+
+        val result = routing.getJiraComponentsByProject(projectKey)
+        assertEquals(setOf("git-only-a", "shared-b", "db-only-c"), result)
+    }
+}

--- a/docs/db-migration/tech-debt/006-compat-test-coverage.md
+++ b/docs/db-migration/tech-debt/006-compat-test-coverage.md
@@ -101,7 +101,8 @@ If the PSI approach proves fragile, fall back to runtime introspection via
 ### Traffic-classified reporting (1a / 1b)
 
 Optional preflight reads an env-provided trace file (default
-`COMPAT_TRAFFIC_TRACE=/tmp/crs-top1000-augmented.txt`). For each baseline
+`COMPAT_TRACE_FILE=/tmp/crs-top1000-augmented.txt`, same env var as TD-008
+and TD-009 — they all consume the same trace source). For each baseline
 endpoint, classify:
 
 - **1a** — appears in the trace window. High operational priority.

--- a/docs/db-migration/tech-debt/006-compat-test-coverage.md
+++ b/docs/db-migration/tech-debt/006-compat-test-coverage.md
@@ -54,23 +54,33 @@ Diagnostic endpoints (`/service/status`, `/service/ping`, `/service/updateCache`
 `diagnostic-endpoints.json` (or are filtered by path-prefix in the coverage
 test).
 
-### `EndpointCoverageTest` — the gate
+### Coverage gate — two test classes
 
-A new `@Tag("unit")` test class with three assertions:
+Per the TD-007 L4 split (`:unitTest` is URL-config-free; `:test` is
+HTTP-gated), the coverage gate is implemented as **two** classes — the
+static-analysis assertions and the live-HTTP probe must not share a JUnit
+tag, otherwise either PR CI starts requiring a deployed candidate stand or
+the liveness gate gets silently skipped on URL-less runs.
 
-1. **Baseline coverage** — for each `endpoints-baseline.json` entry, at least
-   one method in any `*CompatTest` class is annotated
-   `@CompatEndpoint("METHOD path")` matching that entry. Today the annotation
-   is informational; this test elevates it to a contract.
-2. **Candidate liveness (preservation probe)** — at `@BeforeAll`, HTTP-probe
+**`EndpointCoverageTest` (`@Tag("unit")`, pure static — runs in `:unitTest`):**
+
+1. **Baseline coverage** — for each `endpoints-baseline.json` entry, at
+   least one method in any `*CompatTest` class is annotated
+   `@CompatEndpoint("METHOD path")` matching that entry. Today the
+   annotation is informational; this test elevates it to a contract.
+2. **Candidate additions (warn-only)** — statically scan the v3-branch
+   controller AST, diff against the baseline, surface any *new* endpoints
+   in the summary as `candidate adds: METHOD path`. Not blocking — new
+   endpoints are allowed; this just makes them visible for review.
+
+**`EndpointLivenessProbeTest` (`@Tag("http")`, URL-gated — runs in `:test`):**
+
+3. **Candidate liveness (preservation probe)** — at `@BeforeAll`, HTTP-probe
    each baseline entry against the candidate stand. Expected
    `actualStatus == probe.expectedStatus` and, if `expectedBodyShape` is
-   declared, the actual body must contain those keys. Probe failure means the
-   candidate has dropped an endpoint or changed its terminal-status behavior.
-3. **Candidate additions (warn-only)** — statically scan the v3-branch
-   controller AST, diff against the baseline, surface any *new* endpoints in
-   the summary as `candidate adds: METHOD path`. Not blocking — new endpoints
-   are allowed; this just makes them visible for review.
+   declared, the actual body must contain those keys. Probe failure means
+   the candidate has dropped an endpoint or changed its terminal-status
+   behavior.
 
 ### Generation
 

--- a/docs/db-migration/tech-debt/008-compat-test-trace-replay.md
+++ b/docs/db-migration/tech-debt/008-compat-test-trace-replay.md
@@ -48,9 +48,12 @@ Example:
   already concrete, not templated).
 
 Source: `COMPAT_TRACE_FILE` env var. Default path documented in `README.md`
-of `components-registry-compat-test/`; no default in code (so a misconfigured
-TC job fails-fast at `@BeforeAll` rather than silently replaying an empty
-trace).
+of `components-registry-compat-test/`; no default in code. When the var is
+unset, `TraceReplayCompatTest` calls `Assumptions.assumeTrue(...)` at
+`@BeforeAll` with a clear message — so an unconfigured CI lane is reported
+as a skip (visible in the test log, not a silent empty replay) and the rest
+of the compat run still passes (not a hard abort that would mask unrelated
+results). See the Acceptance section below for the symmetric statement.
 
 The trace file itself is **not** committed to the repo — it contains
 production component identifiers and request bodies. Operators supply it via


### PR DESCRIPTION
## Summary

- **MIG-049**: `ComponentRoutingResolver`'s three union-merge methods swallow `NotFoundException` from both resolvers, causing `GET /rest/api/2/projects/{projectKey}/{jira-components,component-distributions,jira-component-version-ranges}` to return `200 + [] / {}` where V1 contract is `404`. Trace-replay against the 2026-05-17 deploy surfaced this as **27 + 4 STATUS_CODE_DIFF records**. Fix: distinguish `NotFoundException` from generic `Exception`; re-throw `NotFoundException` only when BOTH resolvers raised it. Other exception types (transient DB errors etc.) still get swallowed so a partial outage doesn't degrade the union-merge.
- **TD-006/008 doc reconciliation** (bundled per design discussion): three internal inconsistencies in the spec docs merged via PR #231 — `EndpointCoverageTest` tag/probe conflict, `COMPAT_TRACE_FILE` fail-fast↔skip contradiction, env-var name drift `COMPAT_TRAFFIC_TRACE`↔`COMPAT_TRACE_FILE`. All three closed; pre/post grep confirms `COMPAT_TRAFFIC_TRACE` is gone from `docs/db-migration/`.

Pre-existing latent bug from commit `dc9ac3d` (the v3 routing-resolver scaffolding) — not a schema-v2 regression. Schema-v2 only surfaced it by activating the V2 path that legitimately throws on empty results.

## TDD discipline (pre-squash branch history)

Three RED→GREEN pairs for the code, three `docs:` commits for the spec reconciliation:

```
3f1a995 docs(td-006): rename COMPAT_TRAFFIC_TRACE → COMPAT_TRACE_FILE (align with TD-008/009)
5127a34 docs(td-008): reconcile trace-file fail-fast → skip contract
708ca88 docs(td-006): split EndpointCoverageTest assertions across @Tag("unit") + @Tag("http")
1af4244 fix(routing): MIG-049-003 GREEN — same fix for getComponentsDistributionByJiraProject
01d372c test(routing): MIG-049-003 RED — getComponentsDistributionByJiraProject same shape
fc4b370 fix(routing): MIG-049-002 GREEN — same fix for getJiraComponentVersionRangesByProject
22c0112 test(routing): MIG-049-002 RED — getJiraComponentVersionRangesByProject same shape
56775f0 fix(routing): MIG-049-001 GREEN — propagate NotFound when both resolvers raise it
9a9eec0 test(routing): MIG-049-001 RED — getJiraComponentsByProject swallows NotFound from both resolvers
```

Each RED fails on the prior commit; each GREEN turns it green without changing the three anti-regression cases (V1-throws/V2-rows, V1-rows/V2-throws, both-rows → union).

## Behavior matrix (after fix)

| V1 (git) | V2 (db) | Returned | HTTP status |
|---|---|---|---|
| throws NotFound | throws NotFound | re-throw NotFound | 404 ✓ |
| throws NotFound | returns rows | rows from V2 | 200 ✓ |
| returns rows | throws NotFound | rows from V1 | 200 ✓ |
| returns rows | returns rows | union | 200 ✓ |
| throws transient | throws NotFound | empty (or partial) | 200 (preserves fault tolerance) |

## Test plan

- [x] `:components-registry-service-server:test --tests "*ComponentRoutingResolverProjectNotFoundTest*"` — 9/9 green (3 main + 3×3 anti-regression).
- [x] Full `./gradlew build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test` — green (5m 47s).
- [x] `git grep -nE '[3][D][Ss]ecure|[Oo]pen[Ww]ay|[Mm]cloud|[Dd]emobank|[Mm]piStandalone'` on the diff — empty.
- [x] `git grep -n 'COMPAT_TRAFFIC_TRACE' docs/db-migration/` — empty (rename complete).
- [x] Independent Sonnet review — no blocking findings.
- [ ] After merge + QA-stand redeploy: trace-replay confirms 27 + 4 STATUS_CODE_DIFF records collapse to 0 on the affected endpoints.

## Out of scope (follow-up PRs)

- Refactor: the three near-duplicate `try/catch` blocks → shared helper function (e.g. `unionMergeOrPropagateNotFound`).
- TD-006/008/009 implementation itself — only spec reconciliation here.
- QA-stand redeploy / `default-source=db` flip — environmental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)