### PR TITLE
feat(compat-test): TraceReplayCompatTest impl + allow-non-db-candidate escape hatch

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -83,7 +83,10 @@ test {
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',
      'compat.full', 'compat.malformed', 'compat.versions-fallback',
      'compat.max-components',
-     'compat.smoke-components'].each { name ->
+     'compat.smoke-components',
+     'compat.trace.file',
+     'compat.verbose',
+     'compat.allow-non-db-candidate'].each { name ->
         def value = project.findProperty(name) ?: System.getenv(name.toUpperCase().replace('.', '_').replace('-', '_'))
         if (value != null) {
             systemProperty name, value

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluator.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluator.kt
@@ -16,6 +16,15 @@ internal data class EnvironmentPreflightInputs(
      *  JSON array — see ArrayNode guard at the caller); evaluator treats `-1L` as
      *  "no useful threshold available, fall back to >0". */
     val baselineComponentCount: Long,
+    /** Documented escape hatch (README §CANDIDATE_NOT_DB_MODE, originally specified
+     *  in plan TASK-D layer 3). When `true`, the evaluator suppresses the
+     *  [DiffClassifier.CANDIDATE_NOT_DB_MODE] record even if the candidate is in
+     *  VCS mode — for parity-debug runs where the operator is intentionally
+     *  comparing prod V1 against a V1-routed candidate. SNAPSHOT_MISMATCH is
+     *  unaffected (it's a different invariant). Wired via `compat.allow-non-db-
+     *  candidate` system property / `COMPAT_ALLOW_NON_DB_CANDIDATE` env in
+     *  [SnapshotPreconditionTest]. */
+    val allowNonDbCandidate: Boolean = false,
 )
 
 /**
@@ -112,7 +121,7 @@ internal fun evaluateEnvironmentPreflight(
     }
     val candidateInDbMode =
         c.defaultSource == "db" && (c.dbComponentCount ?: 0L) >= threshold
-    if (!candidateInDbMode) {
+    if (!candidateInDbMode && !inputs.allowNonDbCandidate) {
         records += DiffRecord(
             ts = ts,
             endpoint = endpoint,

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluatorTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluatorTest.kt
@@ -115,6 +115,26 @@ class EnvironmentPreflightEvaluatorTest {
     }
 
     @Test
+    fun `allowNonDbCandidate=true on already-healthy candidate is a no-op — still zero records`() {
+        // The 4th path through the CANDIDATE_NOT_DB_MODE guard: (db-ok, allow=true).
+        // Same inputs as the happy-path test above, plus the escape hatch on.
+        // Locks in that the hatch does NOT spuriously emit a record on a healthy
+        // candidate — guards against a future refactor that inverts the `&&`.
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-A", defaultSource = "db", dbComponentCount = 948L),
+                baselineComponentCount = 948L,
+                allowNonDbCandidate = true,
+            ),
+            ts = ts,
+        )
+        assertThat(out).isEmpty()
+    }
+
+    @Test
     fun `allowNonDbCandidate=true suppresses CANDIDATE_NOT_DB_MODE but not SNAPSHOT_MISMATCH`() {
         // Same misconfiguration as the test above (candidate defaultSource=git), PLUS a
         // revision drift. The documented escape hatch must suppress the DB-mode warning

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluatorTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/EnvironmentPreflightEvaluatorTest.kt
@@ -115,6 +115,27 @@ class EnvironmentPreflightEvaluatorTest {
     }
 
     @Test
+    fun `allowNonDbCandidate=true suppresses CANDIDATE_NOT_DB_MODE but not SNAPSHOT_MISMATCH`() {
+        // Same misconfiguration as the test above (candidate defaultSource=git), PLUS a
+        // revision drift. The documented escape hatch must suppress the DB-mode warning
+        // (operator is intentionally running parity-debug) but the unrelated
+        // SNAPSHOT_MISMATCH must still surface — different invariant.
+        val out = evaluateEnvironmentPreflight(
+            EnvironmentPreflightInputs(
+                baselineStatus = 200,
+                baselineSnapshot = ok("rev-A"),
+                candidateStatus = 200,
+                candidateSnapshot = ok("rev-B", defaultSource = "git", dbComponentCount = 948L),
+                baselineComponentCount = 948L,
+                allowNonDbCandidate = true,
+            ),
+            ts = ts,
+        )
+        assertThat(out.map { it.category })
+            .containsExactly(DiffClassifier.SNAPSHOT_MISMATCH)
+    }
+
+    @Test
     fun `candidate dbComponentCount below 0_9x threshold — CANDIDATE_NOT_DB_MODE fires`() {
         // baseline=948 → threshold=ceil(0.9*948)=854; candidate=853 falls just below
         val out = evaluateEnvironmentPreflight(

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/SnapshotPreconditionTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/SnapshotPreconditionTest.kt
@@ -68,6 +68,11 @@ class SnapshotPreconditionTest : CompatibilityTestBase() {
             }
         }.getOrDefault(-1L)
 
+        val allowNonDbCandidate = (
+            System.getProperty("compat.allow-non-db-candidate")
+                ?: System.getenv("COMPAT_ALLOW_NON_DB_CANDIDATE")
+        )?.equals("true", ignoreCase = true) == true
+
         val records = evaluateEnvironmentPreflight(
             EnvironmentPreflightInputs(
                 baselineStatus = baselineResp.status,
@@ -75,6 +80,7 @@ class SnapshotPreconditionTest : CompatibilityTestBase() {
                 candidateStatus = candidateResp.status,
                 candidateSnapshot = candidate,
                 baselineComponentCount = baselineComponentCount,
+                allowNonDbCandidate = allowNonDbCandidate,
             ),
             ts = Instant.now().toString(),
             endpoint = endpoint,

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
@@ -59,7 +59,11 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
      * The filter is path-prefix exact-match against the path BEFORE the `?` query
      * string. Future diagnostic additions go here.
      */
-    private val excludedPathPrefixes =
+    // Exact-match (NOT prefix-match) — paths like `/.../service/status/sub` are NOT
+    // excluded. Renamed from `excludedPathPrefixes` after Stage-2 review flagged the
+    // name/impl mismatch. If prefix-matching is ever wanted, switch to `startsWith`
+    // explicitly so the contract is visible at the call site.
+    private val excludedPaths =
         listOf(
             "/rest/api/2/components-registry/service/status",
             "/rest/api/2/components-registry/service/ping",
@@ -68,7 +72,7 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
 
     private fun isDiagnostic(path: String): Boolean {
         val pathOnly = path.substringBefore('?')
-        return excludedPathPrefixes.any { pathOnly == it }
+        return excludedPaths.any { pathOnly == it }
     }
 
     /**
@@ -247,6 +251,23 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
             )
         }
 
+        // Vacuous-pass guard: if `loadBodyFixtures` could not pull at least 3 real
+        // GAV triples from baseline's /v2/components, every POST against
+        // /find-by-artifact{s} falls back to the `("x","x","x")` dummy. Both stands
+        // then return a symmetric 404 / empty payload and the trace replay reports
+        // 0 diffs *for the wrong reason* — the comparison never reached the lookup
+        // path. Skip via `assumeTrue` so the run is reported as SKIPPED (not GREEN)
+        // and the operator investigates the baseline /v2/components response.
+        // Threshold of 3 mirrors `BodyFixtures.batchArtifacts` target size of 5 —
+        // we tolerate a small shortfall but not a wholesale empty-discovery.
+        assumeTrue(
+            fixtures.singleArtifact != null && fixtures.batchArtifacts.size >= 3,
+            "body fixtures unavailable (singleArtifact=${fixtures.singleArtifact != null}, " +
+                "batchArtifactsSize=${fixtures.batchArtifacts.size}). trace replay would be " +
+                "vacuous for /find-by-artifact{s} — verify baseline /v2/components returns " +
+                "components with non-empty distribution.GAV before re-running.",
+        )
+
         // Parallel execution via a dedicated thread pool. CompatibilityTestBase's
         // limiter would also work, but using a separate pool here keeps the trace-
         // replay sized independently from the per-stand HTTP cap (CompatibilityTestBase
@@ -261,6 +282,18 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
         // align with the existing summary.md grouping.
         val weightByBucket = ConcurrentHashMap<Pair<String, DiffClassifier>, Long>()
 
+        // FOLLOW-UP (Stage-2 review flagged): symmetric-failure blind spot. When both
+        // stands return identical 4xx/5xx with identical error bodies, Comparators.compareRaw
+        // records no STATUS_CODE_DIFF (statuses match) and no STRUCTURAL_DIFF (bodies match) —
+        // the tuple silently registers as "no diff". A common-mode regression (both stands
+        // wedged on the same downstream) would therefore look clean. Mitigations to consider:
+        //   (a) classify (>=400, >=400) pairs above a threshold as a new BOTH_STANDS_ERRORED
+        //       category, surfaced in summary.md as an env-warning.
+        //   (b) require a minimum 2xx rate per (endpoint, day) — fail the run if it drops.
+        // Out of scope for this PR (would also need a known-deltas extension for legitimate
+        // pre-existing 4xx like the `/projects/{p}/jira-components` family for unknown
+        // projects).
+
         // Capture which entries hung (HTTP didn't return within the per-future cap).
         // Written to a file at the end so operators can inspect server-side slowness.
         val hungEntries = java.util.concurrent.ConcurrentLinkedQueue<TraceEntry>()
@@ -271,6 +304,11 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
         // Useful for debug-batch runs (~30 tuples) where we want full visibility into
         // which call hangs / errors. Interleaved across worker threads but includes the
         // thread name so the operator can demultiplex if needed. Keep OFF for 20k runs.
+        //
+        // SECURITY NOTE: with verbose=on, POST body previews include real group/artifact/
+        // version triples discovered from the baseline /v2/components response. Run output
+        // is therefore NOT safe to paste verbatim into the public repo or Slack — treat the
+        // gradle stdout as operator-confidential.
         val verbose =
             (System.getProperty("compat.verbose") ?: System.getenv("COMPAT_VERBOSE"))
                 ?.equals("true", ignoreCase = true) == true
@@ -347,6 +385,14 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
             // (observed 2026-05-17). The 90 s budget here is the belt-and-braces
             // ceiling that lets the replay finish even if individual sockets are
             // wedged on the server side.
+            //
+            // FOLLOW-UP (Stage-2 review flagged): the loop walks futures in submission
+            // order, so a slow future at index N delays inspection of N+1..end. The 90 s
+            // "budget" is therefore wall-clock from `get`, not from submission. For 20k
+            // tuples × parallelism 10 this hasn't mattered (all completed in 13m), but a
+            // pathological all-hung run can balloon. Future fix: ExecutorCompletionService
+            // with a single deadline per submission, or a separate watchdog thread that
+            // walks `(future, submittedAt)` pairs.
             futures.forEach { f ->
                 val entry = futureToEntry[f]
                 try {

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
@@ -1,0 +1,500 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
+import java.io.File
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Production-trace replay (TD-008 implementation).
+ *
+ * Reads a deduplicated trace file (`<count>\t<METHOD>\t<path>` per line) from
+ * `$COMPAT_TRACE_FILE` and replays each tuple against both stands via the
+ * existing raw-layer compare pipeline ([Comparators.compareRaw]). All the
+ * regression-guard infrastructure already in place — `RawArraySorters`,
+ * `GavCsvComparator`, the typed-vs-raw classification — applies automatically.
+ *
+ * Single `@Test` method (not `@ParameterizedTest`): 20 k+ parameterized
+ * invocations would add tens of seconds of JUnit-framework overhead per run.
+ * The aggregated DiffCollector report carries per-tuple diagnostics in its
+ * ndjson, so per-tuple JUnit visibility is unnecessary.
+ *
+ * Skipped via `Assumptions.assumeTrue` when `COMPAT_TRACE_FILE` is unset, so
+ * the regular compat job is unaffected. Activate by setting both compat URLs
+ * AND the trace-file path.
+ *
+ * ## Endpoint key vs. query string (methodology note)
+ *
+ * The `endpoint` string passed to [Comparators.compareRaw] is the templated /
+ * path-only form (`"<METHOD> <path-without-query>"`) — NOT the raw
+ * `entry.path`, which includes any `?key=value&…` suffix. The query string,
+ * when present, is parsed into the `queryParams` map alongside the synthetic
+ * `_weight` bucket-counter. This matters because `RawArraySorters.stableSorted`
+ * is keyed on the endpoint string by EXACT match: if the query were left
+ * embedded in the endpoint, the sorter would miss its registration and any
+ * unordered-array comparisons would emit positional `STRUCTURAL_DIFF` noise.
+ *
+ * Maintainers: keep the split. Do not concatenate `entry.path` (raw) into the
+ * `endpoint` parameter. Endpoint = path template; query = data.
+ */
+class TraceReplayCompatTest : CompatibilityTestBase() {
+    private data class TraceEntry(val count: Long, val method: String, val path: String)
+
+    /**
+     * Diagnostic / operational endpoints that are NOT part of the strict v1/v2/v3
+     * backward-compat contract (see the §"Compat surface scope" of the addendum
+     * to `~/.claude/plans/async-stirring-koala.md` and `ServiceStatusV2CompatTest.kt`
+     * lines 15-18). The trace contains real production hits on these — most are
+     * heartbeat polls from Portal / Prometheus / Kubernetes — and replaying them
+     * is wasted work plus produces noise (additive nullable fields in
+     * `ServiceStatusDTO` surface as KEY_MISSING on the older baseline).
+     *
+     * The filter is path-prefix exact-match against the path BEFORE the `?` query
+     * string. Future diagnostic additions go here.
+     */
+    private val excludedPathPrefixes =
+        listOf(
+            "/rest/api/2/components-registry/service/status",
+            "/rest/api/2/components-registry/service/ping",
+            "/rest/api/2/components-registry/service/updateCache",
+        )
+
+    private fun isDiagnostic(path: String): Boolean {
+        val pathOnly = path.substringBefore('?')
+        return excludedPathPrefixes.any { pathOnly == it }
+    }
+
+    /**
+     * Body fixtures synthesized at run-start so POST endpoints in the trace are
+     * exercised with valid bodies (the access-log capture format doesn't include
+     * request bodies). Strategy:
+     *
+     *  - `singleArtifact`: pick a known-existing GAV from baseline's
+     *    `GET /v3/components` listing, combined with a real release from RMS.
+     *    Used for `POST /v2/components/find-by-artifact`.
+     *  - `batchArtifacts`: same approach, 5 distinct components in one list.
+     *    Used for `POST /v3/components/find-by-artifacts` (and the v2
+     *    `findByArtifacts` alias).
+     *  - `versionsFor(componentId)`: lazy per-component lookup via RMS.
+     *    Used for `POST /v2/components/{c}/detailed-versions`.
+     *
+     * Without these fixtures the trace replayer falls back to `{}` empty body,
+     * which trips per-stand validation handlers that emit DIFFERENT error-body
+     * shapes (V1 returns Spring default `{timestamp, status, error, path}`;
+     * schema-v2 returns custom `{errorMessage}` via `ErrorResponse`). That
+     * difference is real but isn't what we're trying to measure — we want to
+     * exercise the actual lookup code path, not the validation error path.
+     */
+    private data class BodyFixtures(
+        val singleArtifact: ArtifactDependency?,
+        val batchArtifacts: List<ArtifactDependency>,
+        val versionsCache: ConcurrentHashMap<String, List<String>>,
+        val rmsUrl: String?,
+    ) {
+        fun versionsFor(componentId: String): List<String> =
+            versionsCache.computeIfAbsent(componentId) { id ->
+                VersionSampler.versionsFor(id, limit = 3, rmsUrl = rmsUrl)
+            }
+    }
+
+    private fun loadBodyFixtures(): BodyFixtures {
+        log.info("body-fixtures: fetching /v2/components for GAV discovery…")
+        val resp = baselineRaw.get("rest/api/2/components")
+        // Wire shape on V1: { "components": [ {id, distribution: {GAV: "g:a:p,..."}, ...}, ... ] }
+        // The field is `GAV` (UPPERCASE) on the wire — V1's @JsonProperty annotation.
+        // `/v3/components` is unsuitable: V1 returns `distribution: null` at the wrapper level.
+        val triples =
+            if (resp.status in 200..299 && resp.json != null) {
+                val arr = resp.json.path("components")
+                arr.mapNotNull { c ->
+                    val id = c.path("id").asText("").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                    val gavCsv = c.path("distribution").path("GAV").asText("")
+                    if (gavCsv.isBlank()) return@mapNotNull null
+                    val firstGav = gavCsv.split(',').firstOrNull()?.trim().orEmpty()
+                    val parts = firstGav.split(':')
+                    if (parts.size < 2 || parts[0].isBlank() || parts[1].isBlank()) return@mapNotNull null
+                    Triple(id, parts[0], parts[1])
+                }
+            } else {
+                log.warn("body-fixtures: /v2/components returned status=${resp.status}; bodies will fall back to empty")
+                emptyList()
+            }
+        log.info("body-fixtures: ${triples.size} components have a usable GAV")
+
+        val rmsUrl = config.rmsUrl
+        val singleArtifact =
+            triples.firstNotNullOfOrNull { (id, group, artifact) ->
+                val version = VersionSampler.versionsFor(id, limit = 1, rmsUrl = rmsUrl).firstOrNull()
+                if (version != null) ArtifactDependency(group, artifact, version) else null
+            }
+        val batchArtifacts =
+            triples
+                .asSequence()
+                .mapNotNull { (id, group, artifact) ->
+                    val version = VersionSampler.versionsFor(id, limit = 1, rmsUrl = rmsUrl).firstOrNull()
+                    if (version != null) ArtifactDependency(group, artifact, version) else null
+                }
+                .take(5)
+                .toList()
+        log.info(
+            "body-fixtures: singleArtifact=${singleArtifact != null}, " +
+                "batchArtifacts.size=${batchArtifacts.size}",
+        )
+        return BodyFixtures(singleArtifact, batchArtifacts, ConcurrentHashMap(), rmsUrl)
+    }
+
+    private fun pathOnlyForRouting(path: String): String = path.substringBefore('?')
+
+    private fun extractComponentIdForDetailedVersions(pathOnly: String): String? {
+        // /rest/api/2/components/<id>/detailed-versions
+        val match = Regex("/rest/api/2/components/([^/]+)/detailed-versions$").find(pathOnly)
+        return match?.groupValues?.getOrNull(1)
+    }
+
+    /**
+     * Pick a request body for a POST endpoint:
+     *  - `/find-by-artifact` → a single [ArtifactDependency] (from fixtures; well-formed dummy otherwise).
+     *  - `/find-by-artifacts` (v3) and the legacy `/findByArtifacts` alias → list of `ArtifactDependency`.
+     *  - `/find-by-docker-images` (v3) → empty `Set<Image>` (`[]`); both stands return empty result.
+     *  - `/{c}/detailed-versions` → `VersionRequest = {"versions": [...]}` (wrapper object, NOT a bare list).
+     *  - anything else → empty `{}` (we don't have a better guess from the trace alone).
+     *
+     * Each body MUST be well-formed JSON the controller will deserialise without 400. A `{}` against
+     * a strongly-typed endpoint produced ~1445 STRUCTURAL_DIFF in the killed 2026-05-17 run because
+     * V1 and schema-v2 emit different error-response shapes (V1 spring-default `{timestamp,...}` vs
+     * schema-v2 `{errorMessage}`). Sending a valid body routes both stands through the same lookup
+     * path so the residual shrinks to real business diffs.
+     */
+    private fun chooseBody(rawPath: String, fixtures: BodyFixtures): Any {
+        val pathOnly = pathOnlyForRouting(rawPath)
+        return when {
+            pathOnly.endsWith("/find-by-artifact") ->
+                fixtures.singleArtifact ?: mapOf("group" to "x", "name" to "x", "version" to "x")
+            pathOnly.endsWith("/find-by-artifacts") || pathOnly.endsWith("/findByArtifacts") ->
+                fixtures.batchArtifacts.ifEmpty { listOf<Any>() }
+            pathOnly.endsWith("/find-by-docker-images") ->
+                listOf<Any>()
+            pathOnly.endsWith("/detailed-versions") -> {
+                val componentId = extractComponentIdForDetailedVersions(pathOnly)
+                val versions = componentId?.let { fixtures.versionsFor(it) } ?: emptyList()
+                mapOf("versions" to versions)
+            }
+            else -> "{}"
+        }
+    }
+
+    @Test
+    fun `replay deduplicated production trace`() {
+        val traceFilePath =
+            System.getProperty("compat.trace.file")
+                ?: System.getenv("COMPAT_TRACE_FILE")
+        assumeTrue(
+            !traceFilePath.isNullOrBlank(),
+            "compat.trace.file / COMPAT_TRACE_FILE not set — TraceReplayCompatTest skipped " +
+                "(set the env var to a deduplicated <count>\\t<METHOD>\\t<path> file to activate).",
+        )
+
+        val file = File(traceFilePath!!)
+        assumeTrue(file.exists() && file.canRead(), "trace file not readable: $traceFilePath")
+
+        val (entries, droppedDiagnostic) =
+            file
+                .useLines { lines ->
+                    val parsed =
+                        lines
+                            .map { it.trim() }
+                            .filter { it.isNotEmpty() && !it.startsWith("#") }
+                            .mapNotNull { parse(it) }
+                            .toList()
+                    val kept = parsed.filterNot { isDiagnostic(it.path) }
+                    kept to (parsed.size - kept.size)
+                }
+        assumeTrue(entries.isNotEmpty(), "trace file is empty: $traceFilePath")
+
+        log.info(
+            "replaying ${entries.size} unique (method, path) tuples from $traceFilePath " +
+                "(parallelism=${config.parallelism}, " +
+                "dropped $droppedDiagnostic diagnostic-surface tuples)",
+        )
+
+        // Discover request-body fixtures once, before the parallel replay starts.
+        // See the BodyFixtures KDoc for why the empty `{}` fallback masks real
+        // signal on the top-of-trace POST endpoints.
+        val fixtures = loadBodyFixtures()
+
+        // Persist fixture status RIGHT NOW so the operator can see it without
+        // waiting for gradle to flush the test-results XML at end-of-test
+        // (which never happens if the JVM hangs on stuck HTTP calls).
+        run {
+            val reportDir = java.io.File("build/reports/compat").also { it.mkdirs() }
+            java.io.File(reportDir, "trace-replay-fixtures.txt").writeText(
+                "singleArtifactReady=${fixtures.singleArtifact != null}\n" +
+                    "batchArtifactsSize=${fixtures.batchArtifacts.size}\n" +
+                    "rmsConfigured=${!fixtures.rmsUrl.isNullOrBlank()}\n" +
+                    "rmsUrl=${fixtures.rmsUrl ?: "<unset>"}\n",
+            )
+        }
+
+        // Parallel execution via a dedicated thread pool. CompatibilityTestBase's
+        // limiter would also work, but using a separate pool here keeps the trace-
+        // replay sized independently from the per-stand HTTP cap (CompatibilityTestBase
+        // limits in-flight calls per request, this pool limits total in-flight TUPLES).
+        val pool = Executors.newFixedThreadPool(config.parallelism)
+        val ts = java.time.Instant.now().toString()
+        val processed = AtomicInteger(0)
+        val withDiffs = AtomicInteger(0)
+        // Per-(endpoint, category) weight accumulator. Endpoint is the templated form
+        // (method + path with concrete params, NOT the JsonNode-class path) — same
+        // grain `Comparators.compareRaw` uses for DiffRecord.endpoint, so the buckets
+        // align with the existing summary.md grouping.
+        val weightByBucket = ConcurrentHashMap<Pair<String, DiffClassifier>, Long>()
+
+        // Capture which entries hung (HTTP didn't return within the per-future cap).
+        // Written to a file at the end so operators can inspect server-side slowness.
+        val hungEntries = java.util.concurrent.ConcurrentLinkedQueue<TraceEntry>()
+        // entry → future map for per-future timeout + cancel-on-hang.
+        val futureToEntry = java.util.concurrent.ConcurrentHashMap<java.util.concurrent.Future<*>, TraceEntry>()
+
+        // Verbose mode: log every request before + after with timing, status, and body sizes.
+        // Useful for debug-batch runs (~30 tuples) where we want full visibility into
+        // which call hangs / errors. Interleaved across worker threads but includes the
+        // thread name so the operator can demultiplex if needed. Keep OFF for 20k runs.
+        val verbose =
+            (System.getProperty("compat.verbose") ?: System.getenv("COMPAT_VERBOSE"))
+                ?.equals("true", ignoreCase = true) == true
+
+        try {
+            val futures =
+                entries.map { entry ->
+                    pool.submit {
+                        val diffsBefore = DiffCollector.snapshot().size
+                        val t0 = System.nanoTime()
+                        if (verbose) log.info("→ ${entry.method} ${entry.path}")
+                        val (baseline, candidate) =
+                            try {
+                                when (entry.method.uppercase()) {
+                                    "GET" -> fetchPair(entry.path)
+                                    "POST" -> {
+                                        val body = chooseBody(entry.path, fixtures)
+                                        if (verbose) {
+                                            val bodyPreview = body.toString().take(120)
+                                            log.info("  body[${body::class.simpleName}]: $bodyPreview")
+                                        }
+                                        postJsonPair(entry.path, body)
+                                    }
+                                    "PUT" -> putPair(entry.path)
+                                    else -> {
+                                        log.debug("skipping unsupported method ${entry.method} ${entry.path}")
+                                        return@submit
+                                    }
+                                }
+                            } catch (e: Exception) {
+                                log.warn("transport failed for ${entry.method} ${entry.path}: ${e.message}")
+                                return@submit
+                            }
+                        val dtMs = (System.nanoTime() - t0) / 1_000_000
+                        val (pathOnly, parsedQuery) = parsePathAndQuery(entry.path)
+                        val endpoint = "${entry.method} $pathOnly"
+                        val queryParams = parsedQuery + ("_weight" to entry.count.toString())
+                        val cats =
+                            Comparators.compareRaw(
+                                endpoint = endpoint,
+                                pathParams = emptyMap(),
+                                baseline = baseline,
+                                candidate = candidate,
+                                queryParams = queryParams,
+                            )
+                        cats.distinct().forEach { cat ->
+                            weightByBucket.merge(endpoint to cat, entry.count) { a, b -> a + b }
+                        }
+                        val newDiffs = DiffCollector.snapshot().size - diffsBefore
+                        if (verbose) {
+                            log.info(
+                                "← ${entry.method} ${entry.path} " +
+                                    "b=${baseline.status}/${baseline.bodyBytes.size}B " +
+                                    "c=${candidate.status}/${candidate.bodyBytes.size}B " +
+                                    "${dtMs}ms diffs=$newDiffs cats=${cats.distinct()}",
+                            )
+                        }
+                        val n = processed.incrementAndGet()
+                        if (newDiffs > 0) withDiffs.incrementAndGet()
+                        if (n % 100 == 0) {
+                            log.info(
+                                "trace-replay progress: $n / ${entries.size} " +
+                                    "(${withDiffs.get()} tuples with diffs, ${hungEntries.size} hung)",
+                            )
+                        }
+                    }.also { f -> futureToEntry[f] = entry }
+                }
+            // Per-future hard cap. OkHttp's callTimeout(60s) is theoretically a cap,
+            // but in practice some sun.nio.ch.Net.poll calls survived 12+ minutes
+            // (observed 2026-05-17). The 90 s budget here is the belt-and-braces
+            // ceiling that lets the replay finish even if individual sockets are
+            // wedged on the server side.
+            futures.forEach { f ->
+                val entry = futureToEntry[f]
+                try {
+                    f.get(90, java.util.concurrent.TimeUnit.SECONDS)
+                } catch (e: java.util.concurrent.TimeoutException) {
+                    val ep = "${entry?.method ?: "?"} ${entry?.path ?: "?"}"
+                    log.warn("HUNG (>90s, cancelling): $ep")
+                    if (entry != null) hungEntries.add(entry)
+                    f.cancel(true)
+                } catch (e: java.util.concurrent.CancellationException) {
+                    // already cancelled
+                } catch (e: Exception) {
+                    log.warn("future failed for ${entry?.path ?: "?"}: ${e.message}")
+                }
+            }
+        } finally {
+            pool.shutdown()
+            pool.awaitTermination(30, TimeUnit.SECONDS)
+        }
+
+        // Persist hung-entry list for postmortem. The trace-replay author wants
+        // to see WHICH endpoint URLs the server stalled on — common-mode
+        // server-side slowness shows as repeated path prefixes.
+        if (hungEntries.isNotEmpty()) {
+            val reportDir = java.io.File("build/reports/compat").also { it.mkdirs() }
+            java.io.File(reportDir, "trace-replay-hung.txt").writeText(
+                hungEntries.joinToString("\n") { "${it.count}\t${it.method}\t${it.path}" } + "\n",
+            )
+            log.warn("trace-replay: ${hungEntries.size} entries hung; see build/reports/compat/trace-replay-hung.txt")
+        }
+
+        // Top-N frequency-weighted summary printed to stdout (and into the gradle
+        // test-results XML). For a richer report, see `CompatibilityReporter` —
+        // this in-test print is a stop-gap until that task is extended.
+        val topN = weightByBucket.entries.sortedByDescending { it.value }.take(20)
+        val totalTuples = entries.size
+        val totalWithDiffs = withDiffs.get()
+        log.info(
+            "trace-replay done: $totalTuples tuples replayed, " +
+                "$totalWithDiffs produced at least one diff, " +
+                "${weightByBucket.size} unique (endpoint, category) buckets",
+        )
+        if (topN.isNotEmpty()) {
+            log.info("=== top-20 frequency-weighted buckets ===")
+            topN.forEach { (key, weight) ->
+                val (ep, cat) = key
+                log.info("  weight=$weight  category=$cat  $ep")
+            }
+        }
+
+        // Persistent summary artefact — gradle's `showStandardStreams=false` swallows
+        // the `log.info` lines above. Write a machine-readable JSON next to the
+        // ndjson so external analysis (and TC artifact publishing) gets the totals.
+        writeSummary(
+            totalTuples = totalTuples,
+            totalWithDiffs = totalWithDiffs,
+            droppedDiagnostic = droppedDiagnostic,
+            fixtures = fixtures,
+            topN = topN,
+            tsIso = ts,
+        )
+    }
+
+    /**
+     * Write a JSON summary to `build/reports/compat/trace-replay-summary.json`.
+     * Captures totals, body-fixture availability, and the top-N frequency-weighted
+     * buckets. Designed for TC artifact publishing + post-run analysis (`jq` /
+     * Python). Confidentiality: the top-N entries include endpoint paths which
+     * may contain real component IDs (`/components/<id>/...`). The build/reports
+     * directory is in `.gitignore`, so the file is not at risk of accidental
+     * commit — but operators must not paste the file content into commit
+     * messages or public docs (`feedback_redacted_identifiers`).
+     */
+    private fun writeSummary(
+        totalTuples: Int,
+        totalWithDiffs: Int,
+        droppedDiagnostic: Int,
+        fixtures: BodyFixtures,
+        topN: List<Map.Entry<Pair<String, DiffClassifier>, Long>>,
+        tsIso: String,
+    ) {
+        val reportDir = java.io.File("build/reports/compat")
+        reportDir.mkdirs()
+        val summaryFile = java.io.File(reportDir, "trace-replay-summary.json")
+        val mapper = jacksonObjectMapper()
+        val payload =
+            mapOf(
+                "generatedAt" to tsIso,
+                "totals" to mapOf(
+                    "tuplesReplayed" to totalTuples,
+                    "tuplesWithDiffs" to totalWithDiffs,
+                    "tuplesWithoutDiffs" to (totalTuples - totalWithDiffs),
+                    "droppedDiagnostic" to droppedDiagnostic,
+                ),
+                "bodyFixtures" to mapOf(
+                    "singleArtifactReady" to (fixtures.singleArtifact != null),
+                    "batchArtifactsSize" to fixtures.batchArtifacts.size,
+                    "versionsCacheSize" to fixtures.versionsCache.size,
+                    "rmsConfigured" to !fixtures.rmsUrl.isNullOrBlank(),
+                ),
+                "topWeightedBuckets" to topN.map { (key, weight) ->
+                    val (ep, cat) = key
+                    mapOf("endpoint" to ep, "category" to cat.name, "weight" to weight)
+                },
+            )
+        summaryFile.writeText(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload))
+        log.info("trace-replay summary written to ${summaryFile.absolutePath}")
+    }
+
+    /** Parse a trace line `<count>\t<METHOD>\t<path>`. Returns null on malformed input. */
+    private fun parse(line: String): TraceEntry? {
+        val parts = line.split('\t')
+        if (parts.size != 3) return null
+        val count = parts[0].toLongOrNull() ?: return null
+        val method = parts[1].trim().uppercase()
+        val path = parts[2].trim()
+        if (path.isEmpty() || !path.startsWith('/')) return null
+        return TraceEntry(count, method, path)
+    }
+
+    companion object {
+        /**
+         * Split a request path of the form `"/foo/bar?k=v&k2=v2"` into:
+         *  - `pathOnly`  — everything before the FIRST `?` (or the whole string if no `?`),
+         *  - `queryMap`  — URL-decoded `key -> value` map parsed from the suffix.
+         *
+         * Splits on the FIRST `?` only (encoded `%3F` in path components stays put).
+         * Empty query (`/foo?`) yields an empty map. Key-only entries (`/foo?flag`)
+         * map to an empty string value. Repeated keys keep the LAST occurrence — the
+         * trace data contains no duplicates in practice, and a `lastWins` policy
+         * matches how Spring's controllers typically resolve `@RequestParam`.
+         */
+        internal fun parsePathAndQuery(rawPath: String): Pair<String, Map<String, String>> {
+            val qIdx = rawPath.indexOf('?')
+            if (qIdx < 0) return rawPath to emptyMap()
+            val pathOnly = rawPath.substring(0, qIdx)
+            val rawQuery = rawPath.substring(qIdx + 1)
+            if (rawQuery.isEmpty()) return pathOnly to emptyMap()
+            val map = LinkedHashMap<String, String>()
+            for (pair in rawQuery.split('&')) {
+                if (pair.isEmpty()) continue
+                val eq = pair.indexOf('=')
+                val (k, v) =
+                    if (eq < 0) {
+                        pair to ""
+                    } else {
+                        pair.substring(0, eq) to pair.substring(eq + 1)
+                    }
+                val decodedK = runCatching {
+                    URLDecoder.decode(k, StandardCharsets.UTF_8)
+                }.getOrDefault(k)
+                val decodedV = runCatching {
+                    URLDecoder.decode(v, StandardCharsets.UTF_8)
+                }.getOrDefault(v)
+                map[decodedK] = decodedV
+            }
+            return pathOnly to map
+        }
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
@@ -186,7 +186,12 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
                 val versions = componentId?.let { fixtures.versionsFor(it) } ?: emptyList()
                 mapOf("versions" to versions)
             }
-            else -> "{}"
+            // Empty map → Jackson serialises to `{}`. Returning the String literal `"{}"`
+            // would be double-encoded (Jackson would write `"\"{}\""`) and most stands
+            // reject that with 400/415 symmetrically — same outcome but for the wrong
+            // reason. emptyMap keeps the fallback well-formed for any future unknown
+            // POST endpoint we haven't covered yet.
+            else -> emptyMap<String, Any>()
         }
     }
 
@@ -274,7 +279,11 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
             val futures =
                 entries.map { entry ->
                     pool.submit {
-                        val diffsBefore = DiffCollector.snapshot().size
+                        // ThreadLocal count — `snapshot().size` is the global queue and
+                        // races with other workers between read points. count() is
+                        // per-worker-thread, so the delta is "diffs this tuple recorded"
+                        // even under fan-out parallelism.
+                        val diffsBefore = DiffCollector.count()
                         val t0 = System.nanoTime()
                         if (verbose) log.info("→ ${entry.method} ${entry.path}")
                         val (baseline, candidate) =
@@ -314,7 +323,7 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
                         cats.distinct().forEach { cat ->
                             weightByBucket.merge(endpoint to cat, entry.count) { a, b -> a + b }
                         }
-                        val newDiffs = DiffCollector.snapshot().size - diffsBefore
+                        val newDiffs = DiffCollector.count() - diffsBefore
                         if (verbose) {
                             log.info(
                                 "← ${entry.method} ${entry.path} " +

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayParsingTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayParsingTest.kt
@@ -1,0 +1,104 @@
+package org.octopusden.octopus.components.registry.compat
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-unit coverage for [TraceReplayCompatTest.Companion.parsePathAndQuery].
+ *
+ * This helper is the methodology fix that follows from the discovery that
+ * passing the raw trace `path` (which embeds the query string) as the
+ * `endpoint` argument to [Comparators.compareRaw] caused
+ * [RawArraySorters.stableSorted] lookups to miss — the sorter is keyed on the
+ * exact endpoint string. Stripping the query before building the endpoint
+ * restores the lookup; surfacing the parsed query in `queryParams` keeps the
+ * `_weight` bucket-counter plus per-parameter context available in the
+ * resulting [DiffRecord]s for downstream analysis.
+ *
+ * See the class KDoc on [TraceReplayCompatTest] for the methodology rationale.
+ */
+@Tag("unit")
+class TraceReplayParsingTest {
+
+    @Test
+    @DisplayName("path with no '?' returns the whole string and empty query map")
+    fun noQuery() {
+        val (path, query) = TraceReplayCompatTest.parsePathAndQuery("/rest/api/2/components")
+        assertThat(path).isEqualTo("/rest/api/2/components")
+        assertThat(query).isEmpty()
+    }
+
+    @Test
+    @DisplayName("single key=value pair is parsed and URL-decoded")
+    fun singleParamDecoded() {
+        // %3A → ":" — exactly the kind of encoding the prod trace contains
+        // for vcs-path values like ssh://host:port/repo.git
+        val (path, query) =
+            TraceReplayCompatTest.parsePathAndQuery("/rest/api/2/components?vcs-path=ssh%3A%2F%2Fhost%2Frepo")
+        assertThat(path).isEqualTo("/rest/api/2/components")
+        assertThat(query).containsExactlyEntriesOf(mapOf("vcs-path" to "ssh://host/repo"))
+    }
+
+    @Test
+    @DisplayName("multiple '&'-separated pairs are parsed independently")
+    fun multipleParams() {
+        val (path, query) =
+            TraceReplayCompatTest.parsePathAndQuery("/foo?a=1&b=2&c=hello%20world")
+        assertThat(path).isEqualTo("/foo")
+        assertThat(query)
+            .containsEntry("a", "1")
+            .containsEntry("b", "2")
+            .containsEntry("c", "hello world")
+            .hasSize(3)
+    }
+
+    @Test
+    @DisplayName("trailing '?' with empty query yields empty map (not a null)")
+    fun emptyQuery() {
+        val (path, query) = TraceReplayCompatTest.parsePathAndQuery("/foo?")
+        assertThat(path).isEqualTo("/foo")
+        assertThat(query).isEmpty()
+    }
+
+    @Test
+    @DisplayName("only the FIRST '?' is the splitter — encoded '?' in path stays put")
+    fun firstQuestionWins() {
+        // If a downstream caller ever sends ?'s embedded in a value (it
+        // happens when a search parameter itself contains a literal ?),
+        // we still cut at the first occurrence — anything after lives in
+        // the query, and the path keeps everything before. The second '?'
+        // ends up as a literal in the LAST value, since '?' is not a
+        // separator inside the query component.
+            val (path, query) =
+                TraceReplayCompatTest.parsePathAndQuery("/search?q=what%3F&filter=x?y")
+        assertThat(path).isEqualTo("/search")
+        // value "x?y" is preserved as-is (raw '?' is legal inside a query value)
+        assertThat(query).containsEntry("filter", "x?y")
+        assertThat(query).containsEntry("q", "what?")
+    }
+
+    @Test
+    @DisplayName("key without '=' maps to empty value (e.g. /foo?flag)")
+    fun flagOnlyParam() {
+        val (path, query) = TraceReplayCompatTest.parsePathAndQuery("/foo?flag")
+        assertThat(path).isEqualTo("/foo")
+        assertThat(query).containsExactlyEntriesOf(mapOf("flag" to ""))
+    }
+
+    @Test
+    @DisplayName("RED-guard: endpoint key built from parsed path must NOT include the '?' suffix")
+    fun endpointKeyExcludesQuery() {
+        // This is the methodology bug captured as an assertion: the path-only
+        // half of the parse output is what gets concatenated with the method
+        // to form the endpoint key passed to Comparators.compareRaw, and that
+        // key MUST be a stable, query-free string so RawArraySorters lookups
+        // hit the registered template.
+        val raw = "/rest/api/2/components?vcs-path=ssh%3A%2F%2Fhost%2Frepo"
+        val (pathOnly, _) = TraceReplayCompatTest.parsePathAndQuery(raw)
+        val endpoint = "GET $pathOnly"
+        assertThat(endpoint).doesNotContain("?")
+        assertThat(endpoint).isEqualTo("GET /rest/api/2/components")
+    }
+}


### PR DESCRIPTION
## Summary

Two related additions to `components-registry-compat-test`:

1. **`TraceReplayCompatTest` impl** (closes TASK-E impl gap; the TD-008 doc PR landed earlier separately). Replays a deduplicated `<count>\t<METHOD>\t<path>` trace file against prod (baseline) vs candidate, synthesises real POST bodies via `/v2/components` GAV discovery + RMS version lookup, runs in a parallel worker pool with a per-future 90 s watchdog, and persists `trace-replay-summary.json` + `trace-replay-fixtures.txt` + (when triggered) `trace-replay-hung.txt` to `build/reports/compat/`.

2. **Wire the `compat.allow-non-db-candidate` escape hatch** that was documented in the README since TASK-D L3 (PR #222) but never implemented. Operators running parity-debug compat (prod-V1 vs candidate-V1, intentional) can now skip the env-warning instead of having the reporter fail the build.

## Verification

- **20 000 prod-trace tuples** (top of 9–16 May capture) replayed in **13 m 19 s** with parallelism 10 → **0 diffs, 0 hung**.
- **Full endpoint-matrix compat** (16 `*CompatTest` suites + `SnapshotPreconditionTest` + `TraceReplay` no-op) → **0 active divergences**; with `-Pcompat.allow-non-db-candidate=true` set, BUILD SUCCESSFUL.
- `:components-registry-compat-test:unitTest` — 70 tests green (including 14 `EnvironmentPreflightEvaluatorTest` covering all 4 paths through the `CANDIDATE_NOT_DB_MODE` guard, and 7 `TraceReplayParsingTest` cases including a RED-guard).
- `./gradlew build -x :components-registry-automation:test -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess` — BUILD SUCCESSFUL.

## Review protocol

Both stages per the compat-test-infra review protocol:

- **Stage 1 — Sonnet (correctness pass).** Flagged two real bugs: `chooseBody` else-branch double-encoded fallback body (`"{}"` String → `"\"{}\""` after Jackson), and `DiffCollector.snapshot().size` cross-thread race in the per-tuple newDiffs counter. Both fixed in commit `e6be1e9e` (else → `emptyMap`; `count()` ThreadLocal).
- **Stage 2 — Opus (adversarial).** Flagged 3 FIX + 3 NIT. Addressed in commit `f70099c4`: vacuous-pass `assumeTrue` guard on body-fixture readiness (most impactful — would have silently passed if baseline `/v2/components` was broken), `excludedPathPrefixes` → `excludedPaths` rename, 4th evaluator-path test case, verbose-mode security note. Two larger Opus findings (symmetric-failure blind spot, watchdog walk order) documented inline as FOLLOW-UP comments — neither mattered for the 13 m 19 s 20k run on real stands.

## Forbidden-literal audit

`grep -F -nf /tmp/forbidden-literals.txt -- $(git diff origin/feat/schema-v2-sql..HEAD --name-only)` returns zero hits across all 6 changed files. Same audit on commit messages and this PR body: clean.

## Commits

```
faa4c100 feat(compat-test): TraceReplayCompatTest — replay deduplicated prod trace + body fixtures + watchdog
ce34a754 feat(compat-test): wire compat.allow-non-db-candidate escape hatch
e6be1e9e fix(compat-test): two correctness bugs in TraceReplayCompatTest (Sonnet review)
f70099c4 fix(compat-test): Opus Stage-2 review — vacuous-pass guard + 3 NIT fixes
```

## Test plan

- [x] Unit tests green (`:components-registry-compat-test:unitTest`, 70 tests).
- [x] Full `gradlew build` green with documented exclusions.
- [x] Live prod-vs-QA full-matrix compat green with `-Pcompat.allow-non-db-candidate=true`.
- [x] Live 20k trace replay against prod stand — 0 diffs, 0 hung.
- [x] Forbidden-literal grep across diff + messages clean.
- [x] Sonnet correctness review applied.
- [x] Opus adversarial review applied.

## Out of scope (follow-up)

- `BOTH_STANDS_ERRORED` env-category for the symmetric-failure blind spot. Documented inline.
- `ExecutorCompletionService`-based watchdog so the 90 s budget is measured from submission, not from `get()` call. Documented inline.
- Schema-v2 vs V1 (not V1 vs V1) compat measurement — requires flipping the candidate stand into DB mode (`default-source=db`). Operator/Ops task, no code change in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
