### PR TITLE
fix(routing): post-#192 review Group 1 — stale-git guards on 4 ComponentRoutingResolver methods

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -303,8 +303,12 @@ class ComponentRoutingResolver(
     }
 
     override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> {
-        val gitResults = gitResolver.findComponentsByDockerImages(images)
         val dbResults = dbResolver.findComponentsByDockerImages(images)
-        return gitResults + dbResults
+        val gitResults = gitResolver.findComponentsByDockerImages(images)
+        val dbNames = sourceRegistry.getDbComponentNames()
+        // Drop git results whose component is DB-sourced: for migrated components the DB
+        // is authoritative, and a git stale match would mask a true absence with legacy data.
+        val gitFiltered = gitResults.filterNot { dbNames.contains(it.component) }.toSet()
+        return gitFiltered + dbResults
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -108,9 +108,14 @@ class ComponentRoutingResolver(
         } catch (e: NotFoundException) {
             // db has no match — try git, but reject stale data for DB-sourced components
             val gitResult = gitResolver.getJiraComponentByProjectAndVersion(projectKey, version)
-            if (sourceRegistry.getDbComponentNames().contains(gitResult.componentVersion.componentName)) {
+            // Null-safe stale-guard: JiraComponentVersion's @JsonCreator ctor does not
+            // require non-null componentVersion, so a malformed/cached JCV can carry a null
+            // inner. Skip the guard in that case (gracefully degrades to pre-fix behaviour
+            // for this edge) rather than NPE.
+            val componentName = gitResult.componentVersion?.componentName
+            if (componentName != null && sourceRegistry.getDbComponentNames().contains(componentName)) {
                 throw NotFoundException(
-                    "Component '${gitResult.componentVersion.componentName}' is db-sourced; " +
+                    "Component '$componentName' is db-sourced; " +
                         "version '$version' for project '$projectKey' is not in DB",
                 )
             }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -243,7 +243,18 @@ class ComponentRoutingResolver(
     override fun findComponentByArtifact(artifact: ArtifactDependency): VersionedComponent =
         try {
             dbResolver.findComponentByArtifact(artifact)
+        } catch (e: NotFoundException) {
+            // db has no match — try git, but reject stale data for DB-sourced components
+            val gitResult = gitResolver.findComponentByArtifact(artifact)
+            if (sourceRegistry.getDbComponentNames().contains(gitResult.id)) {
+                throw NotFoundException(
+                    "Component '${gitResult.id}' is db-sourced; artifact " +
+                        "'${artifact.group}:${artifact.name}:${artifact.version}' is not in DB",
+                )
+            }
+            gitResult
         } catch (e: Exception) {
+            // transient — fall back to git (fault tolerance preserved)
             gitResolver.findComponentByArtifact(artifact)
         }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -105,7 +105,18 @@ class ComponentRoutingResolver(
     ): JiraComponentVersion =
         try {
             dbResolver.getJiraComponentByProjectAndVersion(projectKey, version)
+        } catch (e: NotFoundException) {
+            // db has no match — try git, but reject stale data for DB-sourced components
+            val gitResult = gitResolver.getJiraComponentByProjectAndVersion(projectKey, version)
+            if (sourceRegistry.getDbComponentNames().contains(gitResult.componentVersion.componentName)) {
+                throw NotFoundException(
+                    "Component '${gitResult.componentVersion.componentName}' is db-sourced; " +
+                        "version '$version' for project '$projectKey' is not in DB",
+                )
+            }
+            gitResult
         } catch (e: Exception) {
+            // transient — fall back to git (fault tolerance preserved)
             gitResolver.getJiraComponentByProjectAndVersion(projectKey, version)
         }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -267,12 +267,15 @@ class ComponentRoutingResolver(
             val dbResult = dbResults[artifact]
             val gitResult = gitResults[artifact]
             when {
-                // 1. DB found and component is DB-sourced → authoritative
-                dbResult != null && dbNames.contains(dbResult.id) -> dbResult
-                // 2. DB has no match, git stale match for DB-sourced component → reject
+                // 1. DB has a match → authoritative (regardless of whether the component is yet
+                //    registered in dbNames — partial migrations / pre-source-row inserts must not
+                //    drop a legitimate DB hit because git stale-matched a DIFFERENT db-sourced
+                //    component for the same artifact)
+                dbResult != null -> dbResult
+                // 2. DB has no match, git stale-matches a db-sourced component → reject
                 gitResult != null && dbNames.contains(gitResult.id) -> null
-                // 3. Fallback for non-DB-sourced components
-                else -> gitResult ?: dbResult
+                // 3. Legitimate git-only fallback
+                else -> gitResult
             }
         }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -266,10 +266,13 @@ class ComponentRoutingResolver(
         return artifacts.associateWith { artifact ->
             val dbResult = dbResults[artifact]
             val gitResult = gitResults[artifact]
-            if (dbResult != null && dbNames.contains(dbResult.id)) {
-                dbResult
-            } else {
-                gitResult ?: dbResult
+            when {
+                // 1. DB found and component is DB-sourced → authoritative
+                dbResult != null && dbNames.contains(dbResult.id) -> dbResult
+                // 2. DB has no match, git stale match for DB-sourced component → reject
+                gitResult != null && dbNames.contains(gitResult.id) -> null
+                // 3. Fallback for non-DB-sourced components
+                else -> gitResult ?: dbResult
             }
         }
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -128,6 +128,26 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
 
     @Test
     @DisplayName(
+        "1.1 fault tolerance: db transient + git stale (db-sourced) → still returns gitResult " +
+            "(fault tolerance preserved on non-NotFound db failures)",
+    )
+    fun pr192_1_1_jiraComponentByProjectAndVersion_dbTransient_gitStaleDbSourced_stillReturnsGit() {
+        val projectKey = "lambda-proj"
+        val version = "1.0.0"
+        val migratedComponent = "migrated-widget"
+        val gitResult = mockJiraComponentVersion(migratedComponent)
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doThrow(RuntimeException("transient db error"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(gitResult)
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+
+        val result = routing.getJiraComponentByProjectAndVersion(projectKey, version)
+        assertEquals(gitResult, result, "transient db failure falls back to git without stale-guard")
+    }
+
+    @Test
+    @DisplayName(
         "1.1 P1-B guard (Opus): gitResult.componentVersion is null → no NPE in stale-guard; " +
             "guard cannot evaluate → fall through and return gitResult as-is",
     )
@@ -191,6 +211,40 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
         assertThrows(NotFoundException::class.java) {
             routing.findComponentByArtifact(artifact)
         }
+    }
+
+    @Test
+    @DisplayName(
+        "1.4 anti-regression: db NotFound + git also NotFound → NotFoundException propagates",
+    )
+    fun pr192_1_4_findComponentByArtifact_bothNotFound_throws() {
+        val artifact = ArtifactDependency("org.test", "missing", "1.0.0")
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).findComponentByArtifact(artifact)
+        doThrow(NotFoundException("not in git"))
+            .`when`(gitResolver).findComponentByArtifact(artifact)
+
+        assertThrows(NotFoundException::class.java) {
+            routing.findComponentByArtifact(artifact)
+        }
+    }
+
+    @Test
+    @DisplayName(
+        "1.4 fault tolerance: db transient + git stale (db-sourced) → still returns gitResult " +
+            "(fault tolerance preserved on non-NotFound db failures)",
+    )
+    fun pr192_1_4_findComponentByArtifact_dbTransient_gitStaleDbSourced_stillReturnsGit() {
+        val artifact = ArtifactDependency("org.test", "widget", "1.0.0")
+        val migratedComponent = "migrated-widget"
+        val gitResult = mockVersionedComponent(migratedComponent)
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doThrow(RuntimeException("transient db error"))
+            .`when`(dbResolver).findComponentByArtifact(artifact)
+        doReturn(gitResult).`when`(gitResolver).findComponentByArtifact(artifact)
+
+        val result = routing.findComponentByArtifact(artifact)
+        assertEquals(gitResult, result, "transient db failure falls back to git without stale-guard")
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -128,6 +128,27 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
 
     @Test
     @DisplayName(
+        "1.1 P1-B guard (Opus): gitResult.componentVersion is null → no NPE in stale-guard; " +
+            "guard cannot evaluate → fall through and return gitResult as-is",
+    )
+    fun pr192_1_1_jiraComponentByProjectAndVersion_gitNullComponentVersion_noNpe() {
+        val projectKey = "epsilon-proj"
+        val version = "1.0.0"
+        val gitResult = mock(JiraComponentVersion::class.java)
+        doReturn(null).`when`(gitResult).componentVersion
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(gitResult)
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+
+        // Should not throw NPE — stale-guard cannot evaluate without componentName,
+        // so fall through and return gitResult as-is (pre-fix behaviour for this edge).
+        val result = routing.getJiraComponentByProjectAndVersion(projectKey, version)
+        assertEquals(gitResult, result)
+    }
+
+    @Test
+    @DisplayName(
         "1.1 anti-regression: db NotFound + git also NotFound → NotFoundException propagates",
     )
     fun pr192_1_1_jiraComponentByProjectAndVersion_bothNotFound_throws() {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -14,7 +14,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
-import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
@@ -22,7 +21,6 @@ import org.octopusden.octopus.components.registry.core.exceptions.NotFoundExcept
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.releng.dto.ComponentVersion
 import org.octopusden.octopus.releng.dto.JiraComponentVersion
-import java.util.EnumMap
 
 /**
  * Post-#192 review fixups (Group 1): stale-git-fallback guards + double-count
@@ -254,41 +252,14 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
     }
 
     // =========================================================================
-    // 1.5 getComponentsCountByBuildSystem — recompute from filtered list
+    // 1.5 getComponentsCountByBuildSystem — DEMOTED to Group 6-I follow-up.
+    // Fix requires refactoring private EscrowModule.getBuildSystem() /
+    // isArchived() extensions (currently class-private in
+    // ComponentRegistryResolverImpl and DatabaseComponentRegistryResolver) to
+    // a shared util. That refactor expands blast radius beyond planned Group
+    // 1 scope. Double-count affects monitoring metrics only, not user-facing
+    // API contract.
     // =========================================================================
-
-    @Test
-    @DisplayName(
-        "1.5: getComponentsCountByBuildSystem — git has migrated component, db tracks updated buildSystem " +
-            "→ count reflects db, not gitCount + dbCount (no double-count)",
-    )
-    fun pr192_1_5_getComponentsCountByBuildSystem_migratedNotDoubled() {
-        val migratedComponent = "migrated-widget"
-        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
-        // Both resolvers report this component in their getComponents() output.
-        // The current code adds gitCounts[BS] + dbCounts[BS], double-counting.
-        // After fix: only the db copy should count.
-        val gitCounts = EnumMap<BuildSystem, Int>(BuildSystem::class.java).apply {
-            put(BuildSystem.MAVEN, 1) // includes migrated-widget (stale)
-        }
-        val dbCounts = EnumMap<BuildSystem, Int>(BuildSystem::class.java).apply {
-            put(BuildSystem.GRADLE, 1) // migrated-widget post-migration switched to GRADLE
-        }
-        doReturn(gitCounts).`when`(gitResolver).getComponentsCountByBuildSystem()
-        doReturn(dbCounts).`when`(dbResolver).getComponentsCountByBuildSystem()
-        // Plus we need to mock getComponents() since the fix recomputes from the union:
-        val gitModule = mock(org.octopusden.octopus.escrow.configuration.model.EscrowModule::class.java)
-        doReturn(migratedComponent).`when`(gitModule).moduleName
-        val dbModule = mock(org.octopusden.octopus.escrow.configuration.model.EscrowModule::class.java)
-        doReturn(migratedComponent).`when`(dbModule).moduleName
-        doReturn(mutableListOf(gitModule)).`when`(gitResolver).getComponents()
-        doReturn(mutableListOf(dbModule)).`when`(dbResolver).getComponents()
-        // We won't mock per-module buildSystem here since the fix likely keeps using the
-        // count-map but filters git by dbNames. Easier acceptance: total count = 1.
-        val result = routing.getComponentsCountByBuildSystem()
-        val total = result.values.sum()
-        assertEquals(1, total, "migrated component must be counted exactly once across both resolvers")
-    }
 
     // =========================================================================
     // 1.6 findComponentsByDockerImages — source precedence

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -1,0 +1,331 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
+import org.octopusden.octopus.components.registry.core.dto.BuildSystem
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
+import org.octopusden.octopus.components.registry.core.dto.Image
+import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.releng.dto.ComponentVersion
+import org.octopusden.octopus.releng.dto.JiraComponentVersion
+import java.util.EnumMap
+
+/**
+ * Post-#192 review fixups (Group 1): stale-git-fallback guards + double-count
+ * elimination on `ComponentRoutingResolver` methods that are NOT covered by the
+ * MIG-049 union-merge fix in [ComponentRoutingResolverProjectNotFoundTest].
+ *
+ * The shared bug shape: db-first method's `catch (e: Exception)` falls back to
+ * gitResolver. For a component routed to `db` in [ComponentSourceRegistry],
+ * gitResolver may still return a stale legacy DSL match. Returning that match
+ * causes silent data corruption visible to v1/v2 callers as "200 with stale
+ * payload" instead of "404 / empty".
+ *
+ * Items covered here: 1.1, 1.4, 1.4b, 1.5, 1.6 (see
+ * ~/.claude/plans/pr-192-review-fixup-plan.md). Items 1.2/1.3 are demoted to
+ * Group 6-H since their return types do not expose `componentName` for a
+ * stale-guard check.
+ *
+ * Pure in-memory tests: mocked resolvers, no Spring context, no global
+ * fixtures (per `feedback_regression_guards_avoid_global_fixtures`).
+ */
+@Timeout(10, unit = TimeUnit.SECONDS)
+class ComponentRoutingResolverStaleAndNotFoundTest {
+
+    private lateinit var gitResolver: ComponentRegistryResolverImpl
+    private lateinit var dbResolver: DatabaseComponentRegistryResolver
+    private lateinit var sourceRegistry: ComponentSourceRegistry
+    private lateinit var routing: ComponentRoutingResolver
+
+    @BeforeEach
+    fun setUp() {
+        gitResolver = mock(ComponentRegistryResolverImpl::class.java)
+        dbResolver = mock(DatabaseComponentRegistryResolver::class.java)
+        sourceRegistry = mock(ComponentSourceRegistry::class.java)
+        doReturn(emptySet<String>()).`when`(sourceRegistry).getDbComponentNames()
+        routing = ComponentRoutingResolver(gitResolver, dbResolver, sourceRegistry)
+    }
+
+    // =========================================================================
+    // 1.1 getJiraComponentByProjectAndVersion stale-guard + NotFound
+    // =========================================================================
+
+    private fun mockJiraComponentVersion(componentName: String): JiraComponentVersion {
+        val jcv = mock(JiraComponentVersion::class.java)
+        val cv = mock(ComponentVersion::class.java)
+        doReturn(componentName).`when`(cv).componentName
+        doReturn(cv).`when`(jcv).componentVersion
+        return jcv
+    }
+
+    @Test
+    @DisplayName(
+        "1.1: getJiraComponentByProjectAndVersion — db NotFound + git returns DB-sourced match " +
+            "→ throws NotFound (stale-git guard) instead of returning stale gitResult",
+    )
+    fun pr192_1_1_jiraComponentByProjectAndVersion_dbNotFound_gitStaleDbSourced_throwsNotFound() {
+        val projectKey = "alpha-proj"
+        val version = "1.0.0"
+        val migratedComponent = "migrated-widget"
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(mockJiraComponentVersion(migratedComponent))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+
+        assertThrows(NotFoundException::class.java) {
+            routing.getJiraComponentByProjectAndVersion(projectKey, version)
+        }
+    }
+
+    @Test
+    @DisplayName(
+        "1.1 anti-regression: db NotFound + git returns NON-db-sourced match " +
+            "→ returns gitResult (legitimate git-only project)",
+    )
+    fun pr192_1_1_jiraComponentByProjectAndVersion_dbNotFound_gitFreshNonDbSourced_returnsGit() {
+        val projectKey = "beta-proj"
+        val version = "1.0.0"
+        val gitOnlyComponent = "legacy-widget"
+        // sourceRegistry.getDbComponentNames() returns empty by default in setUp()
+        val gitResult = mockJiraComponentVersion(gitOnlyComponent)
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(gitResult)
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+
+        val result = routing.getJiraComponentByProjectAndVersion(projectKey, version)
+        assertEquals(gitResult, result)
+    }
+
+    @Test
+    @DisplayName(
+        "1.1 anti-regression: db succeeds → returns dbResult, gitResolver not called",
+    )
+    fun pr192_1_1_jiraComponentByProjectAndVersion_dbSucceeds_returnsDb() {
+        val projectKey = "gamma-proj"
+        val version = "2.0.0"
+        val dbResult = mockJiraComponentVersion("db-widget")
+        doReturn(dbResult)
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+
+        val result = routing.getJiraComponentByProjectAndVersion(projectKey, version)
+        assertEquals(dbResult, result)
+        verify(gitResolver, never()).getJiraComponentByProjectAndVersion(projectKey, version)
+    }
+
+    @Test
+    @DisplayName(
+        "1.1 anti-regression: db NotFound + git also NotFound → NotFoundException propagates",
+    )
+    fun pr192_1_1_jiraComponentByProjectAndVersion_bothNotFound_throws() {
+        val projectKey = "delta-proj"
+        val version = "1.0.0"
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doThrow(NotFoundException("not in git"))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+
+        assertThrows(NotFoundException::class.java) {
+            routing.getJiraComponentByProjectAndVersion(projectKey, version)
+        }
+    }
+
+    // =========================================================================
+    // 1.4 findComponentByArtifact (single) stale-guard
+    // =========================================================================
+
+    private fun mockVersionedComponent(id: String): VersionedComponent {
+        val vc = mock(VersionedComponent::class.java)
+        doReturn(id).`when`(vc).id
+        return vc
+    }
+
+    @Test
+    @DisplayName(
+        "1.4: findComponentByArtifact — db NotFound + git returns DB-sourced match " +
+            "→ throws NotFound (stale-git guard)",
+    )
+    fun pr192_1_4_findComponentByArtifact_dbNotFound_gitStaleDbSourced_throwsNotFound() {
+        val artifact = ArtifactDependency("org.test", "widget", "1.0.0")
+        val migratedComponent = "migrated-widget"
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).findComponentByArtifact(artifact)
+        doReturn(mockVersionedComponent(migratedComponent))
+            .`when`(gitResolver).findComponentByArtifact(artifact)
+
+        assertThrows(NotFoundException::class.java) {
+            routing.findComponentByArtifact(artifact)
+        }
+    }
+
+    @Test
+    @DisplayName(
+        "1.4 anti-regression: db NotFound + git returns NON-db-sourced match → returns gitResult",
+    )
+    fun pr192_1_4_findComponentByArtifact_dbNotFound_gitFreshNonDbSourced_returnsGit() {
+        val artifact = ArtifactDependency("org.test", "widget", "1.0.0")
+        val gitOnlyComponent = "legacy-widget"
+        val gitResult = mockVersionedComponent(gitOnlyComponent)
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).findComponentByArtifact(artifact)
+        doReturn(gitResult).`when`(gitResolver).findComponentByArtifact(artifact)
+
+        val result = routing.findComponentByArtifact(artifact)
+        assertEquals(gitResult, result)
+    }
+
+    // =========================================================================
+    // 1.4b findComponentsByArtifact (batch) — db-authoritative, stale-git guard
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "1.4b: findComponentsByArtifact — both resolvers return same id, component is DB-sourced " +
+            "→ returns dbResult (authoritative), NOT null",
+    )
+    fun pr192_1_4b_findComponentsByArtifact_bothMatch_dbSourced_returnsDb() {
+        val artifact = ArtifactDependency("org.test", "widget", "1.0.0")
+        val artifacts = setOf(artifact)
+        val migratedComponent = "migrated-widget"
+        val dbResult = mockVersionedComponent(migratedComponent)
+        val gitStaleResult = mockVersionedComponent(migratedComponent)
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doReturn(mapOf(artifact to gitStaleResult))
+            .`when`(gitResolver).findComponentsByArtifact(artifacts)
+        doReturn(mapOf(artifact to dbResult))
+            .`when`(dbResolver).findComponentsByArtifact(artifacts)
+
+        val result = routing.findComponentsByArtifact(artifacts)
+        assertEquals(dbResult, result[artifact])
+    }
+
+    @Test
+    @DisplayName(
+        "1.4b: findComponentsByArtifact — db has no match, git stale match for DB-sourced component " +
+            "→ returns null (stale guard), NOT gitResult",
+    )
+    fun pr192_1_4b_findComponentsByArtifact_dbMiss_gitStaleDbSourced_returnsNull() {
+        val artifact = ArtifactDependency("org.test", "widget", "1.0.0")
+        val artifacts = setOf(artifact)
+        val migratedComponent = "migrated-widget"
+        val gitStaleResult = mockVersionedComponent(migratedComponent)
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doReturn(mapOf(artifact to gitStaleResult))
+            .`when`(gitResolver).findComponentsByArtifact(artifacts)
+        doReturn(emptyMap<ArtifactDependency, VersionedComponent>())
+            .`when`(dbResolver).findComponentsByArtifact(artifacts)
+
+        val result = routing.findComponentsByArtifact(artifacts)
+        assertNull(result[artifact])
+    }
+
+    @Test
+    @DisplayName(
+        "1.4b anti-regression: git-sourced component only matched in git → returns gitResult",
+    )
+    fun pr192_1_4b_findComponentsByArtifact_gitOnly_returnsGit() {
+        val artifact = ArtifactDependency("org.test", "legacy", "1.0.0")
+        val artifacts = setOf(artifact)
+        val gitOnlyComponent = "legacy-widget"
+        val gitResult = mockVersionedComponent(gitOnlyComponent)
+        doReturn(mapOf(artifact to gitResult))
+            .`when`(gitResolver).findComponentsByArtifact(artifacts)
+        doReturn(emptyMap<ArtifactDependency, VersionedComponent>())
+            .`when`(dbResolver).findComponentsByArtifact(artifacts)
+
+        val result = routing.findComponentsByArtifact(artifacts)
+        assertEquals(gitResult, result[artifact])
+    }
+
+    // =========================================================================
+    // 1.5 getComponentsCountByBuildSystem — recompute from filtered list
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "1.5: getComponentsCountByBuildSystem — git has migrated component, db tracks updated buildSystem " +
+            "→ count reflects db, not gitCount + dbCount (no double-count)",
+    )
+    fun pr192_1_5_getComponentsCountByBuildSystem_migratedNotDoubled() {
+        val migratedComponent = "migrated-widget"
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        // Both resolvers report this component in their getComponents() output.
+        // The current code adds gitCounts[BS] + dbCounts[BS], double-counting.
+        // After fix: only the db copy should count.
+        val gitCounts = EnumMap<BuildSystem, Int>(BuildSystem::class.java).apply {
+            put(BuildSystem.MAVEN, 1) // includes migrated-widget (stale)
+        }
+        val dbCounts = EnumMap<BuildSystem, Int>(BuildSystem::class.java).apply {
+            put(BuildSystem.GRADLE, 1) // migrated-widget post-migration switched to GRADLE
+        }
+        doReturn(gitCounts).`when`(gitResolver).getComponentsCountByBuildSystem()
+        doReturn(dbCounts).`when`(dbResolver).getComponentsCountByBuildSystem()
+        // Plus we need to mock getComponents() since the fix recomputes from the union:
+        val gitModule = mock(org.octopusden.octopus.escrow.configuration.model.EscrowModule::class.java)
+        doReturn(migratedComponent).`when`(gitModule).moduleName
+        val dbModule = mock(org.octopusden.octopus.escrow.configuration.model.EscrowModule::class.java)
+        doReturn(migratedComponent).`when`(dbModule).moduleName
+        doReturn(mutableListOf(gitModule)).`when`(gitResolver).getComponents()
+        doReturn(mutableListOf(dbModule)).`when`(dbResolver).getComponents()
+        // We won't mock per-module buildSystem here since the fix likely keeps using the
+        // count-map but filters git by dbNames. Easier acceptance: total count = 1.
+        val result = routing.getComponentsCountByBuildSystem()
+        val total = result.values.sum()
+        assertEquals(1, total, "migrated component must be counted exactly once across both resolvers")
+    }
+
+    // =========================================================================
+    // 1.6 findComponentsByDockerImages — source precedence
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "1.6: findComponentsByDockerImages — component DB-sourced, DB no image match, " +
+            "git stale match → empty (NOT git fallback)",
+    )
+    fun pr192_1_6_findComponentsByDockerImages_dbSourced_gitStale_returnsEmpty() {
+        val image = Image("registry.test/migrated-widget", "1.0.0")
+        val images = setOf(image)
+        val migratedComponent = "migrated-widget"
+        val gitStaleMatch = ComponentImage(component = migratedComponent, version = "1.0.0", image = image)
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doReturn(setOf(gitStaleMatch)).`when`(gitResolver).findComponentsByDockerImages(images)
+        doReturn(emptySet<ComponentImage>()).`when`(dbResolver).findComponentsByDockerImages(images)
+
+        val result = routing.findComponentsByDockerImages(images)
+        // DB-sourced component with no DB match → stale git result must be filtered out.
+        assertEquals(emptySet<ComponentImage>(), result)
+    }
+
+    @Test
+    @DisplayName(
+        "1.6 anti-regression: git-only component matched in git → returned",
+    )
+    fun pr192_1_6_findComponentsByDockerImages_gitOnly_returnsGit() {
+        val image = Image("registry.test/legacy-widget", "1.0.0")
+        val images = setOf(image)
+        val gitOnlyComponent = "legacy-widget"
+        val gitMatch = ComponentImage(component = gitOnlyComponent, version = "1.0.0", image = image)
+        doReturn(setOf(gitMatch)).`when`(gitResolver).findComponentsByDockerImages(images)
+        doReturn(emptySet<ComponentImage>()).`when`(dbResolver).findComponentsByDockerImages(images)
+
+        val result = routing.findComponentsByDockerImages(images)
+        assertEquals(setOf(gitMatch), result)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -235,6 +235,32 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
 
     @Test
     @DisplayName(
+        "1.4b P1-A guard (Opus): dbResult present for a component NOT in dbNames " +
+            "(partial-migration: component_source row missing) + git stale matches a DIFFERENT " +
+            "db-sourced component → routing must return dbResult, not null (no false-drop)",
+    )
+    fun pr192_1_4b_findComponentsByArtifact_dbHit_componentNotInDbNames_gitStaleOtherDb_returnsDb() {
+        val artifact = ArtifactDependency("org.test", "widget", "1.0.0")
+        val artifacts = setOf(artifact)
+        // partially-migrated: dbResult component is in `component` table but not in
+        // `component_source` table yet (failed migration / race)
+        val dbComponent = "partial-widget"
+        // a DIFFERENT db-sourced component that git stale-matches the same artifact
+        val otherDbComponent = "other-db-widget"
+        val dbResult = mockVersionedComponent(dbComponent)
+        val gitStaleOther = mockVersionedComponent(otherDbComponent)
+        doReturn(setOf(otherDbComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doReturn(mapOf(artifact to gitStaleOther))
+            .`when`(gitResolver).findComponentsByArtifact(artifacts)
+        doReturn(mapOf(artifact to dbResult))
+            .`when`(dbResolver).findComponentsByArtifact(artifacts)
+
+        val result = routing.findComponentsByArtifact(artifacts)
+        assertEquals(dbResult, result[artifact], "dbResult must win even when its id is not in dbNames")
+    }
+
+    @Test
+    @DisplayName(
         "1.4b anti-regression: git-sourced component only matched in git → returns gitResult",
     )
     fun pr192_1_4b_findComponentsByArtifact_gitOnly_returnsGit() {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -23,9 +23,9 @@ import org.octopusden.octopus.releng.dto.ComponentVersion
 import org.octopusden.octopus.releng.dto.JiraComponentVersion
 
 /**
- * Post-#192 review fixups (Group 1): stale-git-fallback guards + double-count
- * elimination on `ComponentRoutingResolver` methods that are NOT covered by the
- * MIG-049 union-merge fix in [ComponentRoutingResolverProjectNotFoundTest].
+ * Post-#192 review fixups (Group 1): stale-git-fallback guards on
+ * `ComponentRoutingResolver` methods that are NOT covered by the MIG-049
+ * union-merge fix in [ComponentRoutingResolverProjectNotFoundTest].
  *
  * The shared bug shape: db-first method's `catch (e: Exception)` falls back to
  * gitResolver. For a component routed to `db` in [ComponentSourceRegistry],
@@ -33,10 +33,14 @@ import org.octopusden.octopus.releng.dto.JiraComponentVersion
  * causes silent data corruption visible to v1/v2 callers as "200 with stale
  * payload" instead of "404 / empty".
  *
- * Items covered here: 1.1, 1.4, 1.4b, 1.5, 1.6 (see
- * ~/.claude/plans/pr-192-review-fixup-plan.md). Items 1.2/1.3 are demoted to
- * Group 6-H since their return types do not expose `componentName` for a
- * stale-guard check.
+ * Items covered here: 1.1, 1.4, 1.4b, 1.6 (see
+ * ~/.claude/plans/pr-192-review-fixup-plan.md). Items deferred:
+ *   - 1.2/1.3 (Group 6-H): return types lack a `componentName` accessor for
+ *     stale-guard, needs source-precedence-by-project-key design.
+ *   - 1.5 (Group 6-I): `getComponentsCountByBuildSystem` double-count of
+ *     migrated components — fix requires refactoring private
+ *     `EscrowModule.getBuildSystem()` / `isArchived()` extensions to a shared
+ *     util; affects monitoring metrics only, not user-facing API contract.
  *
  * Pure in-memory tests: mocked resolvers, no Spring context, no global
  * fixtures (per `feedback_regression_guards_avoid_global_fixtures`).


### PR DESCRIPTION
## Summary

First fixup wave addressing the multi-agent review of PR #192. Targets the routing-layer correctness gaps that surface as silent 200-with-stale-data or 500s on v1/v2 endpoints when `ComponentRoutingResolver` falls through to `gitResolver` for migrated (db-sourced) components.

Source: 8-agent review of PR #192 (Sonnet × 7 + Opus adversarial × 1) plus user-added findings and a Sonnet correctness-review pass over this branch itself. Full plan at `~/.claude/plans/pr-192-review-fixup-plan.md` (Group 1).

### What lands here

Four routing fixes on `ComponentRoutingResolver`, each with TDD-paired test commits:

| # | Method | Fix |
|---|--------|-----|
| 1.1 | `getJiraComponentByProjectAndVersion` | Distinguish `NotFoundException` from transient `Exception`; on `NotFoundException` path, reject git result whose `componentVersion.componentName` ∈ `getDbComponentNames()` (stale-guard). Null-safe access for malformed `JiraComponentVersion`. |
| 1.4 | `findComponentByArtifact` (single) | Same shape: stale-guard via `gitResult.id`. |
| 1.4b | `findComponentsByArtifact` (batch) | 3-tier `when`: (1) `dbResult != null → dbResult` (DB wins unconditionally), (2) `gitResult != null && id ∈ dbNames → null` (stale-guard), (3) `else → gitResult`. |
| 1.6 | `findComponentsByDockerImages` | Filter git results by `getDbComponentNames()` on `ComponentImage.component`; db-sourced components no longer fall through to git. |

### Test class

New `ComponentRoutingResolverStaleAndNotFoundTest` — 16 tests, pure Mockito, no Spring context, no global fixtures (per `feedback_regression_guards_avoid_global_fixtures`), synthetic identifiers only (per `feedback_redacted_identifiers`).

### TDD discipline (per `feedback_tdd_mandatory`)

- Batched initial RED commit (`9762d90d`) for the first 5 sub-items; per-bug RED→GREEN pairs for the 2 P1s found during sub-agent review of the branch.
- Each fix commit message shows the GREEN gradle output for the newly-passing tests.
- 3 additional regression-guard tests (`c9a60086`) close Sonnet's P2 review findings (both-NotFound for 1.4, transient fault-tolerance for 1.1 + 1.4).

### Deferred (not in this PR — explicit decisions in the plan)

- **1.2 / 1.3** `getVCSSettingForProject` / `getDistributionForProject` — return types (`VCSSettings`, `Distribution`) lack `componentName`, so the same stale-guard pattern cannot apply directly. Tracked as **Group 6-H** (source-precedence-by-project-key design needed).
- **1.5** `getComponentsCountByBuildSystem` — requires refactoring `EscrowModule.getBuildSystem()` / `isArchived()` extensions out of class-private into a shared util. Affects monitoring metrics only, not user-facing API. Tracked as **Group 6-I**.
- **1.7** `PUT /service/updateCache` 410 GONE — Sonnet plan-review confirmed it's intentional (deprecated OpenAPI, explicit `ErrorResponse`). No code change needed; will land as `known-deltas.json` entry in **Group 6-G** so compat-test stops flagging it.
- **Opus adversarial P2s** (perf, cold-start, `Image` tag-mismatch) — tracked as Group 6 follow-ups, not blockers.

## Sub-agent review log

- **Sonnet correctness review** of Group 1 (post-implementation, pre-push) → 0 P1, 3 P2 (all addressed in `c9a60086`).
- **Opus adversarial review** of Group 1 → 2 P1 (P1-A false-drop, P1-B NPE) — both addressed in TDD pairs `471a2577`/`fceffe2f` and `1f8f89e2`/`0193b4ed`.

## Test plan

- [x] `AUTH_SERVER_URL=… ./gradlew :components-registry-service-server:test` — `BUILD SUCCESSFUL`, 16/16 new tests + 654 existing tests pass
- [x] All RED tests verified failing pre-fix and passing post-fix per commit
- [x] Sub-agent review (Sonnet correctness + Opus adversarial) before push, all P1s closed
- [ ] Subsequent fixup groups (2: literal scrub, 3: import correctness, 4: docs, 5: PR-comments cleanup) land separately
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
