### PR TITLE
fix(routing): post-#192 review Group 3 — setComponentSource whitelist + TD-011 spec

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
@@ -26,11 +26,19 @@ class ComponentSourceRegistryImpl(
         name: String,
         source: String,
     ) {
+        // Normalize THEN whitelist: `findBySource("db")` is case-sensitive and
+        // `ComponentRoutingResolver.resolverFor` checks `== "db"` exactly, so any
+        // casing/whitespace variant would route the component to gitResolver and
+        // silently exclude it from getDbComponentNames() → 404 blackhole.
+        val normalized = source.trim().lowercase()
+        require(normalized in ALLOWED_SOURCES) {
+            "Invalid component source '$source'; allowed values: ${ALLOWED_SOURCES.joinToString(", ")}"
+        }
         val entity =
             componentSourceRepository.findById(name).orElse(
                 ComponentSourceEntity(componentKey = name),
             )
-        entity.source = source
+        entity.source = normalized
         entity.migratedAt = Instant.now()
         componentSourceRepository.save(entity)
     }
@@ -45,4 +53,8 @@ class ComponentSourceRegistryImpl(
     override fun getDbComponentNames(): Set<String> = componentSourceRepository.findBySource("db").map { it.componentKey }.toSet()
 
     override fun getGitComponentNames(): Set<String> = componentSourceRepository.findBySource("git").map { it.componentKey }.toSet()
+
+    private companion object {
+        private val ALLOWED_SOURCES = setOf("git", "db")
+    }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1485,6 +1485,14 @@ class ImportServiceImpl(
                 // persist the marker row first (to get the ID), then attach tools.
                 // saveMarkerRowWithChildren detects that row.id is non-null after this
                 // save and skips the redundant second save in its own body.
+                //
+                // Safe because ComponentConfigurationEntity uses GenerationType.UUID:
+                // Hibernate assigns row.id BEFORE the persist() call (in-memory UUID),
+                // so the mutation is visible on the same `row` reference. Switching to
+                // IDENTITY/SEQUENCE in the future would require capturing
+                // `val saved = configurationRepository.save(row)` and passing `saved`
+                // to attachRequiredTools — track as Group 6-J if such a change ever
+                // lands.
                 configurationRepository.save(row)
                 attachRequiredTools(row, override.buildConfiguration?.tools)
             }?.let { saved += it }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
@@ -1,0 +1,114 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.any
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
+import org.octopusden.octopus.components.registry.server.entity.ComponentSourceEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
+
+/**
+ * PR #192 review fixup 3.5: `setComponentSource` must case-normalize and
+ * whitelist the `source` argument so a routing blackhole cannot be created
+ * by writing an unexpected casing.
+ *
+ * The Opus adversarial review (P1-C on Group 1 + plan v3 Sonnet review)
+ * flagged that the previous implementation persisted any string verbatim.
+ * `ComponentRoutingResolver.resolverFor` does an exact `getSource(name) ==
+ * "db"` check, and `getDbComponentNames()` calls `findBySource("db")`
+ * (case-sensitive query). Storing `"DB"`, `"DB "`, or any whitespace-
+ * decorated variant routes the affected component to gitResolver and
+ * excludes it from the db-routing set → 404 for any DB-only data.
+ *
+ * Pure Mockito test: no Spring context.
+ */
+@Timeout(10, unit = TimeUnit.SECONDS)
+class ComponentSourceRegistryWhitelistTest {
+    private lateinit var repository: ComponentSourceRepository
+    private lateinit var properties: ComponentsRegistryProperties
+    private lateinit var registry: ComponentSourceRegistryImpl
+
+    @BeforeEach
+    fun setUp() {
+        repository = mock(ComponentSourceRepository::class.java)
+        properties = mock(ComponentsRegistryProperties::class.java)
+        doReturn(Optional.empty<ComponentSourceEntity>()).`when`(repository).findById(any())
+        registry = ComponentSourceRegistryImpl(repository, properties)
+    }
+
+    @Test
+    @DisplayName("setComponentSource — uppercase 'DB' is case-normalized to lowercase 'db'")
+    fun setComponentSource_uppercaseDb_normalizedToDb() {
+        registry.setComponentSource("widget", "DB")
+
+        val captor = ArgumentCaptor.forClass(ComponentSourceEntity::class.java)
+        verify(repository).save(captor.capture())
+        assertEquals("db", captor.value.source)
+    }
+
+    @Test
+    @DisplayName("setComponentSource — uppercase 'GIT' is case-normalized to lowercase 'git'")
+    fun setComponentSource_uppercaseGit_normalizedToGit() {
+        registry.setComponentSource("widget", "GIT")
+
+        val captor = ArgumentCaptor.forClass(ComponentSourceEntity::class.java)
+        verify(repository).save(captor.capture())
+        assertEquals("git", captor.value.source)
+    }
+
+    @Test
+    @DisplayName("setComponentSource — trailing whitespace is trimmed and normalized ('  Db ' → 'db')")
+    fun setComponentSource_whitespaceWrapped_trimmedAndNormalized() {
+        registry.setComponentSource("widget", "  Db ")
+
+        val captor = ArgumentCaptor.forClass(ComponentSourceEntity::class.java)
+        verify(repository).save(captor.capture())
+        assertEquals("db", captor.value.source)
+    }
+
+    @Test
+    @DisplayName("setComponentSource — already-canonical 'db' passes through unchanged")
+    fun setComponentSource_canonicalDb_unchanged() {
+        registry.setComponentSource("widget", "db")
+
+        val captor = ArgumentCaptor.forClass(ComponentSourceEntity::class.java)
+        verify(repository).save(captor.capture())
+        assertEquals("db", captor.value.source)
+    }
+
+    @Test
+    @DisplayName("setComponentSource — non-whitelist value 'vcs' rejected with IllegalArgumentException")
+    fun setComponentSource_nonWhitelistVcs_rejected() {
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.setComponentSource("widget", "vcs")
+            }
+        assertEquals(true, ex.message?.contains("vcs"), "Error message must echo the rejected source: '${ex.message}'")
+    }
+
+    @Test
+    @DisplayName("setComponentSource — empty string rejected")
+    fun setComponentSource_emptyString_rejected() {
+        assertThrows(IllegalArgumentException::class.java) {
+            registry.setComponentSource("widget", "")
+        }
+    }
+
+    @Test
+    @DisplayName("setComponentSource — random uppercase 'DATABASE' rejected (not in whitelist after lowercase)")
+    fun setComponentSource_uppercaseDatabase_rejected() {
+        assertThrows(IllegalArgumentException::class.java) {
+            registry.setComponentSource("widget", "DATABASE")
+        }
+    }
+}

--- a/docs/db-migration/tech-debt/011-gav-group-id-only-support.md
+++ b/docs/db-migration/tech-debt/011-gav-group-id-only-support.md
@@ -1,0 +1,74 @@
+# TD-011: groupId-only Maven GAV round-trip (SYS-030)
+
+## Status
+
+Open · P1 · backward-compat regression · sister to PR #192 review Group 3 (item 3.6).
+
+## Problem
+
+V1 Groovy DSL supports a `distribution.GAV` value that is a bare groupId (no `artifactId`), e.g. `"org.example.teamcity.ee"`. Schema-v2's import + resolver pipeline silently drops these entries, breaking SYS-030 round-trip.
+
+Failure points (current state on `feat/schema-v2-sql`):
+
+- **Parser:** `GavParsing.parseMavenGavEntry()` (line 35) returns `null` for any entry with fewer than two `:` segments, AND the `MavenCoords.artifactId: String` field is non-nullable.
+- **Schema:** `V1__schema.sql:348` declares `artifact_pattern TEXT NOT NULL` — there is no representation for "no artifactId".
+- **Entity:** `DistributionMavenArtifactEntity.artifactPattern: String = ""` mirrors the NOT NULL constraint.
+- **Import path:** `ImportServiceImpl.attachMavenArtifacts` line 1572 reads `parseMavenGavEntry(entry) ?: continue` — the `?: continue` silently drops groupId-only entries.
+- **Read path:** `DatabaseComponentRegistryResolver.getMavenArtifactParameters()` line 358 does `coords.joinToString(",") { it.artifactPattern }` — would produce `null` literal or compile-fail if `artifactPattern` becomes nullable.
+- **Write path:** `ComponentManagementServiceImpl.replaceMavenArtifacts()` accepts only the current shape; no validation for groupId-only entries.
+- **V4 DTO:** `MavenArtifactRequest` / `DistributionResponse` declare `artifactPattern: String` (non-nullable).
+
+## Why deferred from PR #192 Group 3
+
+Group 3 of the post-review plan budgeted minimal-scope changes. Item 3.6 expanded to a 8+ file feature-scope change spanning schema, entity, parser, composer, read mapper, write validation, OpenAPI/DTO, and round-trip tests. The work is genuinely SYS-030 feature support, not a small fixup.
+
+Tracking here so the spec doesn't decay. Implementation lands as a separate PR after PR #192 merges.
+
+## Implementation spec
+
+### Path chosen: nullable `artifact_pattern` (mapper-side null)
+
+Considered alternatives:
+- **String sentinel** (e.g., `""` to mean "no artifactId") — fragile, easy to confuse with "valid empty string".
+- **Synthetic placeholder** — cascading representation problem, breaks round-trip readability.
+- **Nullable** — direct, type-system enforced. Chosen.
+
+### Required changes
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `V1__schema.sql:348` | `artifact_pattern TEXT` (drop `NOT NULL`); keep TEXT type — column stores DSL patterns / regex, not short codes. Optionally add CHECK `(artifact_pattern IS NULL OR length(artifact_pattern) > 0)` so null and empty-string remain distinguishable. |
+| 2 | `DistributionMavenArtifactEntity.kt:27-28` | `var artifactPattern: String? = null`. Keep `columnDefinition = "TEXT"`. |
+| 3 | `util/GavParsing.kt` | (a) `data class MavenCoords(val groupId: String, val artifactId: String?, …)`. (b) `parseMavenGavEntry` for 1-segment input returns `MavenCoords(groupId, null, null, null)` (drop the `parts.size < 2` reject when groupId non-blank). (c) If the entry has 2+ segments, current logic stays — groupId AND artifactId both non-blank. |
+| 4 | `GavParsing.composeGavCsv` (or call-site in `EntityMappers`) | `if (artifactId == null) groupId else "$groupId:$artifactId[:extension][:classifier]"`. |
+| 5 | `ImportServiceImpl.attachMavenArtifacts` lines 1566-1580 | After `parseMavenGavEntry`, write `DistributionMavenArtifactEntity` with `artifactPattern = coords.artifactId` (was non-null; now String?). |
+| 6 | `EntityMappers` read path (`buildDistribution` / equivalent) | Handle `artifactPattern == null` without NPE; emit pure `groupId` in DSL/DTO. |
+| 7 | `DatabaseComponentRegistryResolver.getMavenArtifactParameters()` line 358 | **Confirm V1 behaviour first via compat/fixture test.** What does V1 put in `ComponentArtifactConfiguration.artifactPattern` for a groupId-only entry? Variants: `""`, no entry at all, or duplicate of `groupPattern`. Pin V1 ground truth via fixture-test, then mirror in V2. **Do NOT encode GAV-CSV into `artifactPattern`** — the field is historically a CSV of artifactId-pattern regexes, not GAV tokens. |
+| 8 | `ComponentManagementServiceImpl.replaceMavenArtifacts()` | Validation: (a) `artifactPattern: String?` accepted as null. (b) Reject blank (`""` / whitespace-only) — distinguish from null. (c) Reject `artifactPattern=null + extension != null` or `+ classifier != null` (invalid coords: `group::ext:cls` cannot be serialised back to GAV). Preserve normal `group:artifact` behaviour for non-null values. |
+| 9 | `V4Mappers` + `MavenArtifactRequest` / `DistributionResponse` DTOs | `artifactPattern: String?` in JSON schema. Update OpenAPI generated artifact. |
+| 10 | Tests | Round-trip: `"org.example.teamcity.ee"` → import → DB row with `artifactPattern = NULL` → resolver → `"org.example.teamcity.ee"` byte-equal. Mixed CSV (one groupId-only + one `group:artifact`). V4-write: POST `artifactPattern=null` → 200; POST `artifactPattern=""` → 400; POST `artifactPattern=null + extension=jar` → 400. |
+
+### Re-import sanity (per `project_crs_schema_v2_migration_policy`)
+
+DB is recreated from scratch from `V1__schema.sql` and reseeded from the Groovy DSL — no backfill / migration script needed. The fix is read-side and import-side: a fresh import on a clean DB after this change puts groupId-only GAV entries as `artifact_pattern = NULL` rather than silently dropping them.
+
+## Acceptance
+
+- [ ] All 10 changes landed in a single PR titled `feat(schema-v2): SYS-030 — groupId-only Maven GAV round-trip`.
+- [ ] Fixture/compat test pins V1 behaviour for a known groupId-only component (preferably an existing prod component with `distribution.GAV = "<group>"` — pick from `Components.groovy` once literals are scrubbed in Group 2).
+- [ ] V2 resolver returns the same `ComponentArtifactConfiguration` shape as V1 byte-for-byte.
+- [ ] V4-write validation tests pass (3 cases).
+- [ ] Full `:components-registry-service-server:test` green.
+- [ ] Sonnet correctness + Opus adversarial review per `feedback_pr_review_via_subagent`.
+
+## Why this isn't a merge blocker for PR #192
+
+V1 baseline returns `200` with the groupId-only entry. Schema-v2 currently returns `200` with the entry **silently absent** from the distribution list. This is a **value-level** divergence visible only on `distribution.gav`-using endpoints (`/components/{name}` v2, `/components/{name}/distribution`). Trace-replay will catch it as STRUCTURAL_DIFF or VALUE_DIFF on a small set of components (those whose DSL uses bare groupIds in `distribution.GAV`).
+
+No data corruption beyond the missing entries. Operators get the `groupPattern` (which is enough to compute distribution URLs in many cases). Full SYS-030 round-trip is the right bar but doesn't block other compat fixes.
+
+## Related
+
+- `docs/db-migration/todo.md` SYS-030 row.
+- `~/.claude/plans/pr-192-review-fixup-plan.md` Group 3 item 3.6 (this file is the spec referenced from there).
+- `util/GavParsing.kt` — current implementation that needs amending.


### PR DESCRIPTION
## Summary

Third fixup wave addressing post-#192-review Group 3 (import-correctness P1s). Independent of PR #245 and #246 — different files, no overlap.

Source: 8-agent review of PR #192 + Opus adversarial findings on Group 1 + Sonnet plan-review. Full plan at `~/.claude/plans/pr-192-review-fixup-plan.md` (Group 3).

### What lands

| # | Where | Change |
|---|-------|--------|
| 3.5 | `ComponentSourceRegistryImpl.setComponentSource` | Trim + lowercase BEFORE whitelist check. Reject non-canonical values (`{"git", "db"}`-only) with `IllegalArgumentException`. Closes **Opus P1-C** (blackhole routing on `"DB"` / whitespace-wrapped values: `findBySource("db")` is case-sensitive and `resolverFor` does exact `== "db"`). Production callers already use canonical values; no behaviour change for them. |
| 3.1 | `ImportServiceImpl.attachRequiredTools` (BUILD_REQUIRED_TOOLS marker) | **Doc-only anchor.** Verified `ComponentConfigurationEntity` uses `GenerationType.UUID` → `row.id` is assigned in-memory before `save()`, so the existing code path is correct. Anchor comment makes the assumption explicit and points at Group 6-J as a follow-up guard if anyone ever switches to IDENTITY/SEQUENCE. |
| TD-011 | `docs/db-migration/tech-debt/011-gav-group-id-only-support.md` | New spec for SYS-030 round-trip (groupId-only `distribution.GAV` entries silently dropped on import). 10-change implementation list spanning schema (`artifact_pattern TEXT` nullable), entity, parser, composer, EntityMappers read path, V4-write validation, OpenAPI/DTO, and round-trip tests. Lands as a separate PR after #192 merges. |

### Deferred to Group 6 (with rationale in plan)

- **3.3** `ComponentManagementServiceImpl.updateComponent` rename ghost guard → **6-K**. Needs new constructor dep + heavy Mockito wiring; better as a small `RenameGhostGuard` class + focused unit test in a follow-up.
- **3.4** Partial-migration parent-after-child + skip-path repair → **6-L**. Needs `@SpringBootTest` integration-test infrastructure + transaction-boundary analysis; QA-stand pererecreates from clean state per `project_crs_schema_v2_migration_policy` so the operator workflow has a no-op recovery already.
- **3.6** Full implementation of SYS-030 → **TD-011** (spec added in this PR, implementation lands separately).

3.2 was already converted to TD-010 in PR #246.

### TDD log

- **3.5**: RED commit `af8dd289` (6 failing, 1 anti-regression passing), GREEN commit `729aa529`. Full RED/GREEN gradle output captured in the commit message of `af8dd289`.
- **3.1**: chore-only commit `6d725250` (no behaviour change → no TDD pair, anchor comment justification).
- **TD-011**: docs-only commit `1bf4e8d2`.

## Test plan

- [x] `AUTH_SERVER_URL=… ./gradlew :components-registry-service-server:test` — `BUILD SUCCESSFUL`, full module green (~660 tests).
- [x] `ComponentSourceRegistryWhitelistTest` — 7/7 pass after fix.
- [x] No production caller broken: all `setComponentSource()` call sites pass canonical lowercase values (`ComponentManagementServiceImpl:185`, `ImportServiceImpl:191,211`, `GitVsDbValidationTest`, `DbBackedComponentsRegistryServiceControllerTest`, `ComponentSourceRegistryMultiPodTest`).
- [ ] CI green on push.

## Out of scope

- Implementing TD-011 (groupId-only GAV round-trip) — separate follow-up PR.
- Implementing Group 6-J / 6-K / 6-L — separate follow-up issues.
- Group 2 (literal scrub + force-push) — runs last before #192 merges to v3.
- Group 5 (PR-comments cleanup) — gated, prepared payload at `/tmp/pr-192-comments-cleanup-plan.json` awaiting explicit user approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
