### PR TITLE
chore: post-#247 review followup — anchor wording + error-msg truncation

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
@@ -32,7 +32,12 @@ class ComponentSourceRegistryImpl(
         // silently exclude it from getDbComponentNames() → 404 blackhole.
         val normalized = source.trim().lowercase()
         require(normalized in ALLOWED_SOURCES) {
-            "Invalid component source '$source'; allowed values: ${ALLOWED_SOURCES.joinToString(", ")}"
+            // Truncate echoed value to avoid log-injection / oversized payload landing
+            // verbatim in ControllerExceptionHandler's HTTP response body and the WARN
+            // log line (PR #247 Opus review P2-A). Hard ceiling of MAX_ERROR_ECHO_CHARS.
+            val echo = source.take(MAX_ERROR_ECHO_CHARS)
+            val ellipsis = if (source.length > MAX_ERROR_ECHO_CHARS) "…" else ""
+            "Invalid component source '$echo$ellipsis'; allowed values: ${ALLOWED_SOURCES.joinToString(", ")}"
         }
         val entity =
             componentSourceRepository.findById(name).orElse(
@@ -54,7 +59,8 @@ class ComponentSourceRegistryImpl(
 
     override fun getGitComponentNames(): Set<String> = componentSourceRepository.findBySource("git").map { it.componentKey }.toSet()
 
-    private companion object {
+    companion object {
         private val ALLOWED_SOURCES = setOf("git", "db")
+        private const val MAX_ERROR_ECHO_CHARS = 80
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
@@ -32,11 +32,16 @@ class ComponentSourceRegistryImpl(
         // silently exclude it from getDbComponentNames() → 404 blackhole.
         val normalized = source.trim().lowercase()
         require(normalized in ALLOWED_SOURCES) {
-            // Truncate echoed value to avoid log-injection / oversized payload landing
-            // verbatim in ControllerExceptionHandler's HTTP response body and the WARN
-            // log line (PR #247 Opus review P2-A). Hard ceiling of MAX_ERROR_ECHO_CHARS.
-            val echo = source.take(MAX_ERROR_ECHO_CHARS)
-            val ellipsis = if (source.length > MAX_ERROR_ECHO_CHARS) "…" else ""
+            // Sanitize THEN truncate the echoed value to avoid log-injection +
+            // oversized payload landing verbatim in ControllerExceptionHandler's
+            // HTTP response body and the WARN log line. Sanitization replaces any
+            // CR/LF/TAB/other ISO C0/C1 control character with an escaped \xNN
+            // form (so `bad\nWARN forged` cannot inject a fake log line),
+            // truncation caps the result at MAX_ERROR_ECHO_CHARS.
+            // (PR #248 follow-up to PR #247 Opus review P2-A.)
+            val sanitized = sanitizeForEcho(source)
+            val echo = sanitized.take(MAX_ERROR_ECHO_CHARS)
+            val ellipsis = if (sanitized.length > MAX_ERROR_ECHO_CHARS) "…" else ""
             "Invalid component source '$echo$ellipsis'; allowed values: ${ALLOWED_SOURCES.joinToString(", ")}"
         }
         val entity =
@@ -62,5 +67,24 @@ class ComponentSourceRegistryImpl(
     companion object {
         private val ALLOWED_SOURCES = setOf("git", "db")
         private const val MAX_ERROR_ECHO_CHARS = 80
+
+        /**
+         * Replaces every ISO C0/C1 control character (0x00..0x1F and 0x7F..0x9F)
+         * with an escaped `\xNN` literal so a value like `bad\nWARN forged` can
+         * never inject a fake log line nor break the JSON-rendered HTTP body.
+         * Printable characters are preserved verbatim; the result is then safely
+         * truncated by the caller without re-introducing partial escapes.
+         */
+        internal fun sanitizeForEcho(value: String): String =
+            buildString(value.length) {
+                for (ch in value) {
+                    val code = ch.code
+                    if (code in 0x00..0x1F || code in 0x7F..0x9F) {
+                        append("\\x").append(code.toString(16).uppercase().padStart(2, '0'))
+                    } else {
+                        append(ch)
+                    }
+                }
+            }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1488,13 +1488,18 @@ class ImportServiceImpl(
                 // saveMarkerRowWithChildren detects that row.id is non-null after this
                 // save and skips the redundant second save in its own body.
                 //
-                // Safe because ComponentConfigurationEntity uses GenerationType.UUID:
-                // Hibernate assigns row.id BEFORE the persist() call (in-memory UUID),
-                // so the mutation is visible on the same `row` reference. Switching to
-                // IDENTITY/SEQUENCE in the future would require capturing
-                // `val saved = configurationRepository.save(row)` and passing `saved`
-                // to attachRequiredTools — track as Group 6-J if such a change ever
-                // lands.
+                // Safe because Spring Data's SimpleJpaRepository.save(...) returns the
+                // same in-memory reference for new entities (calls em.persist on the
+                // arg), so `row.id` is observable on the same `row` after the call.
+                // With UUID-strategy the id is assigned during persist; with IDENTITY/
+                // SEQUENCE strategies the id is also written back to the same instance.
+                // The latent regression is anything that breaks reference identity (an
+                // entity-listener returning a fresh DTO-mapped instance, a custom
+                // BeforeExecutionGenerator returning a new entity, a @Version-merge
+                // path on the audit-aware repository). `attachRequiredTools` then does
+                // `row.id ?: return` and the override's required tools are silently
+                // dropped. Tracked as Group 6-J: capture `val saved = save(row)` and
+                // pass `saved` if/when the repository contract ever changes.
                 configurationRepository.save(row)
                 attachRequiredTools(row, override.buildConfiguration?.tools)
             }?.let { saved += it }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
@@ -134,4 +134,48 @@ class ComponentSourceRegistryWhitelistTest {
             "Error message must include ellipsis marker for truncated payloads; got: '${msg.take(200)}'",
         )
     }
+
+    @Test
+    @DisplayName(
+        "setComponentSource — short newline-injected source is sanitized in error (no raw \\n, escaped as \\x0A)",
+    )
+    fun setComponentSource_newlineInjected_sanitized() {
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.setComponentSource("widget", "bad\nWARN forged")
+            }
+        val msg = ex.message ?: ""
+        assertEquals(
+            false,
+            msg.contains("\n"),
+            "Error message must NOT contain a raw newline (log-injection guard); got: '${msg.take(200)}'",
+        )
+        assertEquals(
+            true,
+            msg.contains("\\x0A"),
+            "Error message must escape the newline as '\\\\x0A'; got: '${msg.take(200)}'",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "setComponentSource — CR / TAB / DEL / C1-control chars all escaped, never echoed raw",
+    )
+    fun setComponentSource_assortedControls_sanitized() {
+        // CR (0x0D), TAB (0x09), DEL (0x7F), C1 control NEL (0x85) — none should land verbatim.
+        val payload = "v" + 0x0D.toChar() + "A" + 0x09.toChar() + "B" + 0x7F.toChar() + "C" + 0x85.toChar() + "D"
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.setComponentSource("widget", payload)
+            }
+        val msg = ex.message ?: ""
+        assertEquals(false, msg.contains(0x0D.toChar()), "no raw CR; msg='${msg.take(200)}'")
+        assertEquals(false, msg.contains(0x09.toChar()), "no raw TAB; msg='${msg.take(200)}'")
+        assertEquals(false, msg.contains(0x7F.toChar()), "no raw DEL; msg='${msg.take(200)}'")
+        assertEquals(false, msg.contains(0x85.toChar()), "no raw NEL; msg='${msg.take(200)}'")
+        assertEquals(true, msg.contains("\\x0D"), "CR escaped; msg='${msg.take(200)}'")
+        assertEquals(true, msg.contains("\\x09"), "TAB escaped; msg='${msg.take(200)}'")
+        assertEquals(true, msg.contains("\\x7F"), "DEL escaped; msg='${msg.take(200)}'")
+        assertEquals(true, msg.contains("\\x85"), "NEL escaped; msg='${msg.take(200)}'")
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
@@ -111,4 +111,27 @@ class ComponentSourceRegistryWhitelistTest {
             registry.setComponentSource("widget", "DATABASE")
         }
     }
+
+    @Test
+    @DisplayName(
+        "setComponentSource — error message truncates an oversized rejected source (PR #247 P2-A guard)",
+    )
+    fun setComponentSource_oversizedRejected_messageTruncated() {
+        val huge = "x".repeat(500) + "INJECT"
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.setComponentSource("widget", huge)
+            }
+        val msg = ex.message ?: ""
+        assertEquals(
+            false,
+            msg.contains("INJECT"),
+            "Error message must NOT echo the full payload; got first 200 chars: '${msg.take(200)}'",
+        )
+        assertEquals(
+            true,
+            msg.contains("…"),
+            "Error message must include ellipsis marker for truncated payloads; got: '${msg.take(200)}'",
+        )
+    }
 }


### PR DESCRIPTION
Small post-merge cleanups from the Opus adversarial review of PR #247:

- **P1-B** `ImportServiceImpl.kt:1486-1500` — anchor comment rewritten. UUID-strategy wasn't the actual safety property; reference identity from `SimpleJpaRepository.save` is. Updated to describe the real invariant + real regression class.
- **P2-A** `ComponentSourceRegistryImpl.kt` — truncate echoed `source` in the `IllegalArgumentException` message to 80 chars with `…` marker. Defensive against a future V4 endpoint exposing user-controlled `source` (none today; TD-011 might add one).
- Style: dropped redundant double-`private` on the companion; added `MAX_ERROR_ECHO_CHARS` constant.

New test `setComponentSource_oversizedRejected_messageTruncated` (8 total in the class) pins the truncation.

## Test plan

- [x] `./gradlew :components-registry-service-server:test --tests *ComponentSourceRegistryWhitelistTest*` — 8/8 pass.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)