### PR TITLE
chore: scrub forbidden fixture literals per redaction policy (Group 2)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1339,9 +1339,10 @@ class ImportServiceImpl(
             }
             jira.componentInfo?.let { info ->
                 // Do NOT collapse empty string to null for versionPrefix/versionFormat:
-                // bug-G-component DSL sets versionPrefix="" (override range clears "wallet") and baseline
-                // preserves "". Collapsing "" → null would prevent the null-clear diff from being
-                // emitted and the value would bleed from the base range (bug G).
+                // bug-G-component DSL sets versionPrefix="" (override range clears a non-empty
+                // base value) and baseline preserves "". Collapsing "" → null would prevent the
+                // null-clear diff from being emitted and the value would bleed from the base
+                // range (bug G).
                 row.jiraVersionPrefix = info.versionPrefix
                 row.jiraVersionFormat = info.versionFormat
             }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ScalarNullOverrideRoundTripTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ScalarNullOverrideRoundTripTest.kt
@@ -30,8 +30,8 @@ import org.octopusden.releng.versions.VersionRangeFactory
  * bleed into all ranges.
  *
  * Three scalar families covered:
- *   (A) String column — `build.buildFilePath`   (bug-F-component bug: "PlSqlPa" bleeding)
- *   (B) String column — `jira.versionPrefix`    (bug-G-component bug: "wallet" bleeding)
+ *   (A) String column — `build.buildFilePath`   (bug-F-component bug: "BuildPath" bleeding)
+ *   (B) String column — `jira.versionPrefix`    (bug-G-component bug: "vps" bleeding)
  *   (C) String column — `escrow.buildTask`      (general escrow scalar)
  *
  * Also verifies that the four inline-boolean scalar paths (`build.deprecated`,
@@ -104,7 +104,7 @@ class ScalarNullOverrideRoundTripTest {
     fun `MIG-040-A null buildFilePath override - override range returns null, base range returns original`() {
         val comp = makeComponent("NULL_OVERRIDE_A")
         val base = makeBase(comp)
-        base.buildFilePath = "PlSqlPa"
+        base.buildFilePath = "BuildPath"
 
         // Override row with null buildFilePath — represents "clear for this range"
         val nullOverrideRow = makeNullScalarOverrideRow(comp, "[3.54.99-12.65,)", "build.buildFilePath")
@@ -113,10 +113,10 @@ class ScalarNullOverrideRoundTripTest {
         comp.configurations.addAll(listOf(base, nullOverrideRow))
         stubComponent(comp)
 
-        // Base range: should still have "PlSqlPa"
+        // Base range: should still have "BuildPath"
         val baseCfg = resolver.getResolvedComponentDefinition("NULL_OVERRIDE_A", "1.0.0")
         assertNotNull(baseCfg)
-        assertEquals("PlSqlPa", baseCfg!!.buildFilePath)
+        assertEquals("BuildPath", baseCfg!!.buildFilePath)
 
         // Override range: null override row should clear the value → null
         val overrideCfg = resolver.getResolvedComponentDefinition("NULL_OVERRIDE_A", "3.54.99-12.65")
@@ -138,8 +138,8 @@ class ScalarNullOverrideRoundTripTest {
         val comp = makeComponent("NULL_OVERRIDE_B")
         val base = makeBase(comp)
         // jiraProjectKey is required for JiraComponent to be emitted
-        base.jiraProjectKey = "WALLET"
-        base.jiraVersionPrefix = "wallet"
+        base.jiraProjectKey = "VPS"
+        base.jiraVersionPrefix = "vps"
 
         // Override row: explicitly clears jiraVersionPrefix for the newer range
         val nullOverrideRow = makeNullScalarOverrideRow(comp, "[5.1.1475,)", "jira.versionPrefix")
@@ -148,10 +148,10 @@ class ScalarNullOverrideRoundTripTest {
         comp.configurations.addAll(listOf(base, nullOverrideRow))
         stubComponent(comp)
 
-        // Base range: legacy range keeps "wallet"
+        // Base range: legacy range keeps "vps"
         val baseCfg = resolver.getResolvedComponentDefinition("NULL_OVERRIDE_B", "3.0.0")
         assertNotNull(baseCfg)
-        assertEquals("wallet", baseCfg!!.jiraConfiguration?.componentInfo?.versionPrefix)
+        assertEquals("vps", baseCfg!!.jiraConfiguration?.componentInfo?.versionPrefix)
 
         // Override range: null override should clear jiraVersionPrefix.
         // After the fix, ComponentInfo is not created at all if both prefix and format are null

--- a/test-common/src/test/resources/components-registry/production-like/Components.groovy
+++ b/test-common/src/test/resources/components-registry/production-like/Components.groovy
@@ -712,12 +712,12 @@ import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
     }
 }
 
-"customer-gamma-wallet" {
-    componentDisplayName = "Customer Gamma Wallet"
+"customer-gamma-vault" {
+    componentDisplayName = "Customer Gamma Vault"
     clientCode = "GAMMA"
     componentOwner = "owner-f"
     groupId = "org.octopusden.octopus.customers.GAMMA"
-    artifactId = "customer-gamma-wallet"
+    artifactId = "customer-gamma-vault"
 
     jira {
         projectKey = "PROJ_G"
@@ -752,9 +752,9 @@ import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
     distribution {
         explicit = true
         external = true
-        GAV = "org.octopusden.octopus.customers.GAMMA:customer-gamma-wallet:wim"
+        GAV = "org.octopusden.octopus.customers.GAMMA:customer-gamma-vault:wim"
         securityGroups {
-            read = "team-f#wallet-rd"
+            read = "team-f#vault-rd"
         }
     }
 }


### PR DESCRIPTION
Replaces three flagged fixture literals with neutral synthetic stand-ins per the project redaction policy.

## Changes

| File | Replacement |
|------|-------------|
| `ScalarNullOverrideRoundTripTest.kt` | bug-F sentinel × 4 → `BuildPath`; bug-G sentinel × 5 mixed case → `vps`/`VPS` |
| `ImportServiceImpl.kt:1342` | Comment generalized — no behaviour change |
| `test-common/.../Components.groovy:715-757` | Component renamed (5 refs in one definition: name, displayName, artifactId, GAV, security-group read). No source code references the prior name. |

The fixture literals serve only as opaque bleed-sentinels in null-override round-trip tests; assertion shapes are unchanged. The fixture rename has no callers in the rest of the codebase.

## Forbidden-literal scan post-edit

```
git grep -niE '[Pp][Ll][Ss][Qq][Ll][Pp][Aa]|[Ww][Aa][Ll][Ll][Ee][Tt]'
→ empty
```

History rewrite: NOT performed in this PR. The literals remain in older commits. If TeamCity content-validation later flags the history, a separate force-push cycle on `feat/schema-v2-sql` is the canonical fix (detach → amend → rebase --onto with the `pre-group2-tip` safety tag flow described in the original Group 2 plan).

## Test plan

- [x] `./gradlew :components-registry-service-server:test` — `BUILD SUCCESSFUL`, full module green
- [x] `./gradlew :components-registry-service-server:test --tests *ScalarNullOverrideRoundTripTest*` — passes with the renamed sentinels
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)