### PR TITLE
fix: post-#192 final-review P1-2/P1-3 — truncate-before-sanitize + MultiPod guard docstring

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
@@ -32,17 +32,17 @@ class ComponentSourceRegistryImpl(
         // silently exclude it from getDbComponentNames() → 404 blackhole.
         val normalized = source.trim().lowercase()
         require(normalized in ALLOWED_SOURCES) {
-            // Sanitize THEN truncate the echoed value to avoid log-injection +
-            // oversized payload landing verbatim in ControllerExceptionHandler's
-            // HTTP response body and the WARN log line. Sanitization replaces any
-            // CR/LF/TAB/other ISO C0/C1 control character with an escaped \xNN
-            // form (so `bad\nWARN forged` cannot inject a fake log line),
-            // truncation caps the result at MAX_ERROR_ECHO_CHARS.
-            // (PR #248 follow-up to PR #247 Opus review P2-A.)
-            val sanitized = sanitizeForEcho(source)
-            val echo = sanitized.take(MAX_ERROR_ECHO_CHARS)
-            val ellipsis = if (sanitized.length > MAX_ERROR_ECHO_CHARS) "…" else ""
-            "Invalid component source '$echo$ellipsis'; allowed values: ${ALLOWED_SOURCES.joinToString(", ")}"
+            // Truncate the RAW value first, then sanitize. Order matters: if we
+            // sanitize first and then `take(N)`, a `\xNN` escape can be split
+            // mid-sequence at the cap boundary, leaving a dangling `\x` or
+            // `\x0` in the output. Also drop a lone high surrogate at the
+            // boundary if `take` split a UTF-16 surrogate pair.
+            //
+            // (PR #248 → final-review Opus P1-2: truncate-before-sanitize.)
+            val truncatedRaw = truncateRaw(source, MAX_ERROR_ECHO_CHARS)
+            val sanitized = sanitizeForEcho(truncatedRaw)
+            val ellipsis = if (source.length > truncatedRaw.length) "…" else ""
+            "Invalid component source '$sanitized$ellipsis'; allowed values: ${ALLOWED_SOURCES.joinToString(", ")}"
         }
         val entity =
             componentSourceRepository.findById(name).orElse(
@@ -72,8 +72,12 @@ class ComponentSourceRegistryImpl(
          * Replaces every ISO C0/C1 control character (0x00..0x1F and 0x7F..0x9F)
          * with an escaped `\xNN` literal so a value like `bad\nWARN forged` can
          * never inject a fake log line nor break the JSON-rendered HTTP body.
-         * Printable characters are preserved verbatim; the result is then safely
-         * truncated by the caller without re-introducing partial escapes.
+         * Printable characters (including Latin-1 0xA0..0xFF and astral-plane
+         * code points represented as well-formed UTF-16 surrogate pairs) are
+         * preserved verbatim.
+         *
+         * Callers MUST truncate before calling this (see [truncateRaw]); doing
+         * the opposite would let `.take(N)` split a `\xNN` escape mid-sequence.
          */
         internal fun sanitizeForEcho(value: String): String =
             buildString(value.length) {
@@ -86,5 +90,21 @@ class ComponentSourceRegistryImpl(
                     }
                 }
             }
+
+        /**
+         * Caps `value` at `maxChars` UTF-16 code units. If the cut point falls
+         * between the high and low halves of a UTF-16 surrogate pair, drops the
+         * lone high surrogate so Jackson (or any UTF-8 serializer) never sees
+         * malformed input.
+         */
+        internal fun truncateRaw(value: String, maxChars: Int): String {
+            if (value.length <= maxChars) return value
+            val raw = value.substring(0, maxChars)
+            return if (raw.isNotEmpty() && raw.last().isHighSurrogate()) {
+                raw.dropLast(1)
+            } else {
+                raw
+            }
+        }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
@@ -92,18 +92,28 @@ class ComponentSourceRegistryImpl(
             }
 
         /**
-         * Caps `value` at `maxChars` UTF-16 code units. If the cut point falls
-         * between the high and low halves of a UTF-16 surrogate pair, drops the
-         * lone high surrogate so Jackson (or any UTF-8 serializer) never sees
-         * malformed input.
+         * Caps `value` at `maxChars` UTF-16 code units, then sanitizes the
+         * boundary against malformed UTF-16:
+         *
+         *  - If the cut split a well-formed surrogate pair (last char is a high
+         *    surrogate but its low partner was at `maxChars`, beyond the cut),
+         *    drop the lone high surrogate.
+         *  - If the input itself was malformed and the cut landed on a lone
+         *    low surrogate (no high partner at `maxChars - 2`), drop the lone
+         *    low surrogate.
+         *
+         * Either way, Jackson (or any UTF-8 serializer) never sees a half-pair.
          */
         internal fun truncateRaw(value: String, maxChars: Int): String {
             if (value.length <= maxChars) return value
             val raw = value.substring(0, maxChars)
-            return if (raw.isNotEmpty() && raw.last().isHighSurrogate()) {
-                raw.dropLast(1)
-            } else {
-                raw
+            if (raw.isEmpty()) return raw
+            val last = raw.last()
+            return when {
+                last.isHighSurrogate() -> raw.dropLast(1)
+                last.isLowSurrogate() && (raw.length < 2 || !raw[raw.length - 2].isHighSurrogate()) ->
+                    raw.dropLast(1)
+                else -> raw
             }
         }
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryMultiPodTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryMultiPodTest.kt
@@ -19,21 +19,29 @@ import java.nio.file.Paths
 import java.util.UUID
 
 /**
- * Review finding #2 — `ComponentSourceRegistryImpl.sourceCache` is a per-JVM
- * Caffeine cache with a 5-minute write-expiry. CRS is deployed behind a
- * horizontally-scaled pod set sharing one database: a `component_source`
- * write on pod A is invisible to pod B's routing decision (via `getSource`)
- * until the cached entry expires. This re-introduces the ghost that SYS-029
- * eliminated on a single-JVM setup, for up to five minutes per rename.
+ * **Regression guard against re-introducing per-JVM caching of `getSource`.**
+ *
+ * History: an earlier `ComponentSourceRegistryImpl` carried a `sourceCache`
+ * (Caffeine, 5-minute write-expiry). With CRS deployed behind a horizontally-
+ * scaled pod set sharing one database, a `component_source` write on pod A
+ * was invisible to pod B's routing decision via `getSource` until the cached
+ * entry expired. SYS-029 removed that cache; the current `getSource`
+ * (`ComponentSourceRegistryImpl.kt:19-23`) goes directly to the repository on
+ * every call. This test class exists **to keep it that way** — any future
+ * "let's cache for perf" change (cf. Group 6-A) must also keep this test
+ * green, which it cannot unless reads are pod-coherent (per-request cache,
+ * coordinated invalidation, etc.).
  *
  * `ComponentRoutingResolver.resolverFor` calls `getSource`, so this is the
  * hot read path the tests exercise. (`isDbComponent` goes straight to the
- * repository since the SYS-029 fix and is not affected.)
+ * repository as well and is therefore unaffected by the historical cache.)
  *
- * The test writes directly through the `ComponentSourceRepository`
- * (simulating another pod) after the in-process registry has populated its
- * cache, then asserts the registry reflects the new state on the very next
- * `getSource` read.
+ * Each test writes directly through the `ComponentSourceRepository`
+ * (simulating another pod) AFTER the in-process registry has observed an
+ * initial state via `getSource`, then asserts the registry reflects the new
+ * state on the very next read. Today the assertion passes trivially because
+ * `getSource` is a direct DB read; if caching is ever re-introduced without
+ * cross-pod invalidation, the SAME assertion will fail loudly.
  *
  * Under `ft-db` the default source is `db`, which collapses the before/after
  * outcomes for a missing row; the test therefore forces `default-source=git`

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
@@ -253,5 +253,37 @@ class ComponentSourceRegistryWhitelistTest {
         assertEquals(false, msg.contains("TAIL"), "TAIL must not survive truncation; msg='${msg.take(200)}'")
     }
 
+    @Test
+    @DisplayName(
+        "setComponentSource — lone low surrogate at cut boundary (malformed UTF-16) is dropped " +
+            "(Sonnet review P2 follow-up)",
+    )
+    fun setComponentSource_loneLowSurrogateAtBoundary_droppedCleanly() {
+        // Build a deliberately-malformed input where a lone LOW surrogate
+        // (no preceding high partner) lands at position 79 — the last char of
+        // the truncated result. Without the low-surrogate guard, the message
+        // would echo the lone low surrogate and Jackson would emit invalid JSON.
+        val payload = "a".repeat(79) + 0xDC00.toChar() + "TAIL"
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.setComponentSource("widget", payload)
+            }
+        val msg = ex.message ?: ""
+        // No lone low surrogate must appear in the message.
+        for (i in msg.indices) {
+            val c = msg[i]
+            if (c.isLowSurrogate()) {
+                val prev = msg.getOrNull(i - 1)
+                assertEquals(
+                    true,
+                    prev != null && prev.isHighSurrogate(),
+                    "lone low surrogate at index $i; msg='${msg.take(200)}'",
+                )
+            }
+        }
+        // TAIL was past the cap, so it must not survive.
+        assertEquals(false, msg.contains("TAIL"), "TAIL must not survive truncation; msg='${msg.take(200)}'")
+    }
+
     private fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'A'..'F' || this in 'a'..'f'
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
@@ -178,4 +178,80 @@ class ComponentSourceRegistryWhitelistTest {
         assertEquals(true, msg.contains("\\x7F"), "DEL escaped; msg='${msg.take(200)}'")
         assertEquals(true, msg.contains("\\x85"), "NEL escaped; msg='${msg.take(200)}'")
     }
+
+    @Test
+    @DisplayName(
+        "setComponentSource — truncation at cap boundary never splits a \\xNN escape mid-sequence " +
+            "(final-review Opus P1-2 boundary guard)",
+    )
+    fun setComponentSource_truncationAtBoundary_neverSplitsEscape() {
+        // 100 SOH (0x01) controls followed by an INJECT marker. With the previous
+        // sanitize-then-truncate order, sanitized output was 100×4+6 = 406 chars and
+        // take(80) cut INSIDE the 20th `\x01`. After truncate-then-sanitize, take is
+        // applied to the raw 100×SOH+INJECT (=106 chars) capped at 80 (still 80×SOH),
+        // then sanitized → exactly 80 `\x01` escapes, no INJECT, no dangling escape.
+        val payload = 0x01.toChar().toString().repeat(100) + "INJECT"
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.setComponentSource("widget", payload)
+            }
+        val msg = ex.message ?: ""
+        // No INJECT (truncated out of scope).
+        assertEquals(false, msg.contains("INJECT"), "INJECT must not survive truncation; msg='${msg.take(200)}'")
+        // Ellipsis marker for truncated payload.
+        assertEquals(true, msg.contains("…"), "ellipsis must mark truncation; msg='${msg.take(200)}'")
+        // Guard against dangling `\x` or `\x0` — every `\x` must be followed by exactly
+        // 2 hex digits. Walk forward through the message collecting actual `\x` positions.
+        val backslashXIndices = mutableListOf<Int>()
+        var searchFrom = 0
+        while (true) {
+            val idx = msg.indexOf("\\x", searchFrom)
+            if (idx < 0) break
+            backslashXIndices += idx
+            searchFrom = idx + 2
+        }
+        // At least one `\x01` escape must be present (sanity check the payload reached the message).
+        assertEquals(true, backslashXIndices.isNotEmpty(), "no \\x escape in message; msg='${msg.take(200)}'")
+        for (idx in backslashXIndices) {
+            val tail = msg.substring(idx)
+            assertEquals(
+                true,
+                tail.length >= 4 && tail[2].isHexDigit() && tail[3].isHexDigit(),
+                "dangling \\x escape at idx $idx; tail='${tail.take(10)}'",
+            )
+        }
+    }
+
+    @Test
+    @DisplayName(
+        "setComponentSource — UTF-16 surrogate pair at the cap boundary is dropped cleanly " +
+            "(no lone high surrogate in echoed message)",
+    )
+    fun setComponentSource_surrogateAtBoundary_droppedCleanly() {
+        // Build a payload where a surrogate pair lands exactly at position 79..80.
+        // Astral-plane code point U+1F600 (😀) is one such pair (high=0xD83D, low=0xDE00).
+        // 79 printable ASCII chars + the emoji (2 UTF-16 code units) = position 79 high, 80 low.
+        val payload = "a".repeat(79) + "😀" + "TAIL"
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                registry.setComponentSource("widget", payload)
+            }
+        val msg = ex.message ?: ""
+        // No lone high surrogate in the message.
+        for (i in msg.indices) {
+            val c = msg[i]
+            if (c.isHighSurrogate()) {
+                val next = msg.getOrNull(i + 1)
+                assertEquals(
+                    true,
+                    next != null && next.isLowSurrogate(),
+                    "lone high surrogate at index $i; msg='${msg.take(200)}'",
+                )
+            }
+        }
+        // TAIL was past the cap, so it must not survive.
+        assertEquals(false, msg.contains("TAIL"), "TAIL must not survive truncation; msg='${msg.take(200)}'")
+    }
+
+    private fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'A'..'F' || this in 'a'..'f'
 }


### PR DESCRIPTION
Closes two findings from the final pre-merge Opus adversarial review of PR #192.

## P1-2: truncate-before-sanitize

The previous `sanitize → take(80)` order could split a `\xNN` escape mid-sequence on adversarial input. For a payload `100×0x01 + INJECT`, sanitized output is 406 chars and `take(80)` cut INSIDE the 20th `\x01` → dangling `…\x0` or `…\` in the error message, potentially malformed JSON in the HTTP response.

Same boundary issue for UTF-16 surrogate pairs: a 😀 astral emoji landing at position 79..80 would be split, leaving a lone high surrogate → invalid JSON from Jackson.

**Fix:** truncate RAW value FIRST (`truncateRaw(value, maxChars)` also drops a lone high surrogate at the boundary), THEN sanitize. Sanitize operates on the bounded result so it can never split its own escape. Output may exceed the cap (controls expand 1→4 chars) but is fully-formed.

Two new boundary tests:
- `setComponentSource_truncationAtBoundary_neverSplitsEscape` — 100 SOH chars + INJECT; walks every `\x` occurrence and asserts each is followed by 2 hex digits.
- `setComponentSource_surrogateAtBoundary_droppedCleanly` — payload with a 😀 at position 79..80; asserts no lone high surrogate.

KDoc on `sanitizeForEcho` updated to note callers MUST truncate first.

## P1-3: MultiPod regression-guard docstring

`ComponentSourceRegistryMultiPodTest` docstring still referenced a Caffeine cache that SYS-029 removed. The test was passing as a no-op tautology, and Group 6-A (perf tracker) explicitly proposes re-introducing caching — this test would have shipped that regression silently.

Reframed KDoc as an explicit **regression guard against re-introducing per-JVM caching**. Test code unchanged.

## Test plan

- [x] `./gradlew :components-registry-service-server:test --tests *ComponentSourceRegistryWhitelistTest*` — 11/11 pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)