### PR TITLE
test(import): IMP-003 regression guard for KTS-only-build-block shape

### DIFF
--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/KtsOnlyBuildBlockImportTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/KtsOnlyBuildBlockImportTest.kt
@@ -1,0 +1,97 @@
+package org.octopusden.octopus.components.registry.server.migration
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.nio.file.Paths
+
+/**
+ * IMP-003: Regression guard for the KTS-only-build-block component shape.
+ *
+ * The scenario: KTS carries `build { tools { database { oracle {...} } } }` but
+ * the Groovy counterpart has NO `build` block at all. Without `build { }` in
+ * Defaults.groovy, each per-component EscrowModuleConfig gets
+ * buildConfiguration = null after merging. EscrowConfigurationLoader.mergeComponents
+ * then NPEs on `buildConfiguration.buildTools.addAll(...)`, the component is never
+ * persisted, and `attachBuildToolBeans` never fires.
+ *
+ * Uses its own isolated fixture directory (components-registry/imp003) so that
+ * global TestComponents.groovy and Defaults.groovy are NOT touched.
+ * The imp003 profile overrides work-dir; common+ft-db supply shared settings
+ * (supportedSystems, product-type map, H2 datasource, auto-migrate).
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "imp003", "ft-db")
+@Timeout(120)
+class KtsOnlyBuildBlockImportTest {
+
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+
+    @Autowired
+    private lateinit var buildToolBeanRepository: ComponentBuildToolBeanRepository
+
+    init {
+        val testResourcesPath =
+            Paths.get(
+                KtsOnlyBuildBlockImportTest::class.java.getResource("/expected-data")!!.toURI(),
+            ).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    // -------------------------------------------------------------------------
+    // IMP-003: KTS-only build block persists oracle bean via auto-migrate
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName(
+        "IMP-003: TEST_BUILD_KTS_ONLY (KTS has oracle build tool, Groovy has no build block) " +
+            "MUST persist its oracle bean after auto-migrate",
+    )
+    @Transactional
+    fun imp003_ktsOnlyBuildBlock_persistsOracleBean() {
+        val component = componentRepository.findByComponentKey("TEST_BUILD_KTS_ONLY")
+        assertNotNull(component, "TEST_BUILD_KTS_ONLY must be migrated — if null, mergeComponents NPEd")
+
+        val baseRow = configurationRepository.findBaseByComponentId(component!!.id!!)
+        assertNotNull(baseRow, "BASE row must exist for TEST_BUILD_KTS_ONLY")
+
+        val beans = buildToolBeanRepository
+            .findByComponentConfigurationId(baseRow!!.id!!)
+            .sortedBy { it.sortOrder }
+
+        assertEquals(
+            1,
+            beans.size,
+            "Expected 1 build-tool bean (oracleDatabase 12.0); got ${beans.size}. " +
+                "If this is 0, Defaults.groovy is missing `build { }` so buildConfiguration " +
+                "is null when mergeComponents runs and attachBuildToolBeans never fires.",
+        )
+
+        val oracle = beans.firstOrNull { it.beanType == "oracleDatabase" }
+        assertNotNull(oracle, "oracleDatabase bean must be persisted")
+        assertEquals("12.0", oracle!!.versionPattern)
+    }
+}

--- a/components-registry-service-server/src/test/resources/application-imp003.yml
+++ b/components-registry-service-server/src/test/resources/application-imp003.yml
@@ -1,0 +1,4 @@
+components-registry:
+  work-dir: ${COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR}/components-registry/imp003
+  main-groovy-file: Aggregator.groovy
+  groovy-path: ${components-registry.work-dir}

--- a/test-common/src/test/resources/components-registry/imp003/Aggregator.groovy
+++ b/test-common/src/test/resources/components-registry/imp003/Aggregator.groovy
@@ -1,0 +1,11 @@
+import org.octopusden.octopus.escrow.resolvers.ComposedConfigScript
+
+class Aggregator extends ComposedConfigScript {
+    def run() {
+        include("Defaults.groovy")
+        include("Components.groovy")
+    }
+
+    static final ANY_ARTIFACT = /[\w-\.]+/
+    static final ALL_VERSIONS = "(,0),[0,)"
+}

--- a/test-common/src/test/resources/components-registry/imp003/Components.groovy
+++ b/test-common/src/test/resources/components-registry/imp003/Components.groovy
@@ -1,0 +1,19 @@
+// IMP-003 fixture: Groovy side has NO `build` block — oracle tools come from
+// the KTS counterpart exclusively. The absence of a Groovy-side build block
+// means buildConfiguration inherits from Defaults (which must be non-null).
+// If Defaults.groovy loses its `build { }`, mergeComponents NPEs and the
+// component never migrates — turning IMP-003 RED.
+"TEST_BUILD_KTS_ONLY" {
+    componentOwner = "user1"
+    groupId = "org.octopusden.octopus.test.kts.only"
+    artifactId = "test-build-kts-only"
+
+    jira {
+        projectKey = "TBKO"
+    }
+
+    distribution {
+        explicit = false
+        external = false
+    }
+}

--- a/test-common/src/test/resources/components-registry/imp003/Components.kts
+++ b/test-common/src/test/resources/components-registry/imp003/Components.kts
@@ -1,3 +1,5 @@
+import org.octopusden.octopus.components.registry.dsl.*
+
 component("TEST_BUILD_KTS_ONLY") {
     productType = "PT_K"
     build {

--- a/test-common/src/test/resources/components-registry/imp003/Components.kts
+++ b/test-common/src/test/resources/components-registry/imp003/Components.kts
@@ -1,0 +1,12 @@
+component("TEST_BUILD_KTS_ONLY") {
+    productType = "PT_K"
+    build {
+        tools {
+            database {
+                oracle {
+                    version = "12.0"
+                }
+            }
+        }
+    }
+}

--- a/test-common/src/test/resources/components-registry/imp003/Defaults.groovy
+++ b/test-common/src/test/resources/components-registry/imp003/Defaults.groovy
@@ -1,0 +1,27 @@
+import static org.octopusden.octopus.escrow.BuildSystem.*
+
+Defaults {
+    system = "NONE"
+    buildSystem = PROVIDED
+    artifactId = ANY_ARTIFACT
+    jira {
+        majorVersionFormat = '$major.$minor'
+        releaseVersionFormat = '$major.$minor.$service'
+        buildVersionFormat = '$major.$minor.$service-$fix'
+        hotfixVersionFormat = '$major.$minor.$service-$fix.$build'
+        lineVersionFormat = '$major'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+    distribution {
+        explicit = false
+        external = true
+    }
+    // Non-null buildConfiguration clone-base: EscrowConfigurationLoader.mergeComponents
+    // calls buildConfiguration.buildTools.addAll(...) unconditionally when the KTS
+    // component has a build block. Without this, components with no Groovy-side
+    // build block get buildConfiguration = null after merge, triggering NPE in
+    // mergeComponents and silently preventing attachBuildToolBeans from firing.
+    build { }
+}

--- a/test-common/src/test/resources/components-registry/imp003/dependency_mapping.properties
+++ b/test-common/src/test/resources/components-registry/imp003/dependency_mapping.properties
@@ -1,0 +1,1 @@
+# empty — no alias mappings for this isolated test fixture


### PR DESCRIPTION
## Summary

- Adds `KtsOnlyBuildBlockImportTest` — regression guard for the component shape where KTS carries `build { tools { oracle {...} } }` but the Groovy counterpart has **no** `build` block at all
- Uses an isolated fixture directory (`components-registry/imp003`) with its own `Defaults.groovy`, `Components.groovy`, and `Components.kts` — **no changes to global** `TestComponents.groovy`, `TestComponents.kts`, or `Defaults.groovy`
- The `imp003` Spring profile overrides `work-dir` to the isolated fixtures; `common` + `ft-db` supply shared config (product-types, supported systems, H2 datasource, auto-migrate)

## Root cause guarded

`EscrowConfigurationLoader.mergeComponents` calls `buildConfiguration.buildTools.addAll(ktsTools)` unconditionally when the KTS component has a `build` block. If `Defaults.groovy` has no `build { }`, components with no Groovy-side `build` block get `buildConfiguration = null` after clone, causing NPE in `mergeComponents` → component never migrated → `attachBuildToolBeans` never fires.

## Why this PR vs the previous attempt

The earlier implementation (now-deleted branch `fix/buildtools-kts-only-merge`) extended `TestComponents.groovy` and `Defaults.groovy` directly, violating the regression-guard policy (same reason PR #216 was closed). This version is self-contained.

## Test plan

- [ ] `./gradlew :components-registry-service-server:test --tests "*.KtsOnlyBuildBlockImportTest"` passes GREEN
- [ ] Manually remove `build { }` from `imp003/Defaults.groovy` → test turns RED (NPE in migration, component not found)
- [ ] No other tests affected (isolated profile, no global fixture changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)