### PR TITLE
ci(teamcity): chain id15CompatManual after id10 via snapshot dependency

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -219,6 +219,12 @@ object id15CompatManual : BuildType({
     requirements {
         doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
     }
+
+    dependencies {
+        snapshot(id10CompileUtAuto) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
+    }
 })
 
 object id20ValidateComponentsRegistryProductionDataAuto : BuildType({

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -222,7 +222,7 @@ object id15CompatManual : BuildType({
 
     dependencies {
         snapshot(id10CompileUtAuto) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
+            onDependencyFailure = FailureAction.CANCEL
         }
     }
 })


### PR DESCRIPTION
## Summary

- `id15CompatManual` ([1.5] Compatibility Test [MANUAL]) gains a `snapshot(id10CompileUtAuto)` dependency.
- No new auto-trigger — id15 stays manual / button-only.
- Visually pins id15 as a downstream of id10 in TC's Build Chain view; manual runs anchor to id10's most-recent successful build.
- `onDependencyFailure = FAIL_TO_START` mirrors the existing id20 → id10 pattern.

## Test plan

- [x] `mvn -f .teamcity/pom.xml teamcity-configs:generate` → BUILD SUCCESS
- [ ] After merge + TC versioned-settings re-apply on `[h] OCRS`: id15 appears as a child of id10 in the Build Chain visualization
- [ ] Manually trigger id15 with the four COMPAT_* params filled — confirm id10 is reused (or triggered first if absent), compat-test runs, JUnit XML lands in `test-results/compat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)