### PR TITLE
ci(teamcity): wire compat-trace-replay build + extend id15 flag set

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -14,6 +14,7 @@ project {
     description = "https://github.com/octopusden/octopus-components-registry-service"
 
     vcsRoot(ComponentsRegistry)
+    vcsRoot(CrsCompatTrace)
 
     params {
         param("JDK_VERSION", "11")
@@ -30,6 +31,7 @@ project {
 
     buildType(id10CompileUtAuto)
     buildType(id15CompatManual)
+    buildType(id16CompatTraceReplayManual)
     buildType(id20ValidateComponentsRegistryProductionDataAuto)
     buildType(id30DeployToOkdQaDevAuto)
     buildType(id40ReleaseManual)
@@ -41,6 +43,7 @@ project {
     buildTypesOrder = arrayListOf(
         id10CompileUtAuto,
         id15CompatManual,
+        id16CompatTraceReplayManual,
         id20ValidateComponentsRegistryProductionDataAuto,
         id30DeployToOkdQaDevAuto,
         id40ReleaseManual,
@@ -61,6 +64,23 @@ object ComponentsRegistry : GitVcsRoot({
     url = "%COMPONENTS_REGISTRY_REPO_URL%"
     branch = "%COMPONENTS_REGISTRY_BRANCH%"
     branchSpec = "+:%COMPONENTS_REGISTRY_BRANCH%"
+    checkoutSubmodules = GitVcsRoot.CheckoutSubmodules.IGNORE
+    authMethod = defaultPrivateKey {
+        userName = "git"
+    }
+})
+
+// VCS root used by id16CompatTraceReplayManual to check out the internal
+// trace-data repo (deduplicated `<count>\t<METHOD>\t<path>` tables, refreshed
+// from prod access-log captures). Held off-repo as a separate Bitbucket repo
+// because the trace files contain real component names; the URL is kept in
+// the TC server / parent-project param `CRS_COMPAT_TRACE_REPO_URL` so the
+// open-source DSL stays free of internal identifiers.
+object CrsCompatTrace : GitVcsRoot({
+    name = "Crs_Compat_Trace"
+    url = "%CRS_COMPAT_TRACE_REPO_URL%"
+    branch = "refs/heads/master"
+    branchSpec = "+:refs/heads/master"
     checkoutSubmodules = GitVcsRoot.CheckoutSubmodules.IGNORE
     authMethod = defaultPrivateKey {
         userName = "git"
@@ -169,9 +189,20 @@ object id10CompileUtAuto : BuildType({
 })
 
 // Compatibility Test — manual, on-demand. Runs the compat-test module against
-// a baseline (production / main) and candidate (v3 stand) deployment pair.
-// All four COMPAT_* params are prompted on every run; without them the
-// task either skips silently (smoke list empty) or reports only env
+// a baseline (production / main) and candidate (v3 stand) deployment pair via
+// HTTP URLs (no JAR launch on the agent).
+//
+// Modes (all opt-in via prompt params, default smoke):
+//   - default: smoke list (COMPAT_SMOKE_COMPONENTS, ~5 components) → ~1-3 min.
+//   - COMPAT_FULL=true: full endpoint matrix (every component × every
+//     compat-test class) → ~10-30 min.
+//   - COMPAT_ALLOW_NON_DB_CANDIDATE=true: documented escape hatch when the
+//     candidate intentionally serves V1 (parity-debug runs). Suppresses the
+//     CANDIDATE_NOT_DB_MODE env-warning that would otherwise fail the build
+//     even though all endpoint diffs are clean.
+//
+// All four COMPAT_* required params are prompted on every run; without them
+// the task either skips silently (smoke list empty) or reports only env
 // preconditions, producing misleading green builds.
 object id15CompatManual : BuildType({
     templates(AbsoluteId("Octopus_OctopusGradleBuild"))
@@ -187,6 +218,8 @@ object id15CompatManual : BuildType({
         text("COMPAT_CANDIDATE_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_RMS_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_SMOKE_COMPONENTS", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        text("COMPAT_FULL", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        text("COMPAT_ALLOW_NON_DB_CANDIDATE", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
         param("ARTIFACT_PATH", """
             components-registry-compat-test/build/reports/compat/** => reports/compat
             components-registry-compat-test/build/test-results/**/*.xml => test-results/compat
@@ -202,11 +235,97 @@ object id15CompatManual : BuildType({
             -Pcompat.candidate.url=%COMPAT_CANDIDATE_URL%
             -Pcompat.rms.url=%COMPAT_RMS_URL%
             -Pcompat.smoke-components=%COMPAT_SMOKE_COMPONENTS%
+            -Pcompat.full=%COMPAT_FULL%
+            -Pcompat.allow-non-db-candidate=%COMPAT_ALLOW_NON_DB_CANDIDATE%
         """.trimIndent())
     }
 
     failureConditions {
         executionTimeoutMin = 60
+    }
+
+    features {
+        xmlReport {
+            reportType = XmlReport.XmlReportType.JUNIT
+            rules = "+:components-registry-compat-test/build/test-results/test/*.xml"
+        }
+    }
+
+    requirements {
+        doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
+    }
+
+    dependencies {
+        snapshot(id10CompileUtAuto) {
+            onDependencyFailure = FailureAction.CANCEL
+        }
+    }
+})
+
+// Compatibility Trace Replay — manual, on-demand. Replays the deduplicated
+// production HTTP-traffic dump from the internal `crs-compat-trace` repo
+// against a baseline (prod) and candidate (v3 stand) URL pair, recording
+// diffs per tuple weighted by frequency.
+//
+// Two VCS roots:
+//   1. ComponentsRegistry / GitHub root (inherited from the template) —
+//      compat-test source code.
+//   2. CrsCompatTrace (Bitbucket, internal) — the (count, METHOD, path) table
+//      under `latest-top.txt`. Symlink to the most recent dated subdir.
+//
+// The TraceReplayCompatTest skips via Assumptions.assumeTrue when
+// `COMPAT_TRACE_FILE` is unset, so the build always sets it explicitly.
+//
+// Distinct from id15CompatManual: weights diffs by real production traffic
+// frequency (vs. uniform per-component matrix coverage). Both tests are
+// complementary — keep one build type per concern so artifacts and timeouts
+// don't collide.
+object id16CompatTraceReplayManual : BuildType({
+    templates(AbsoluteId("Octopus_OctopusGradleBuild"))
+    id("16CompatTraceReplayManual")
+    name = "[1.6] Compatibility Trace Replay [MANUAL]"
+
+    artifactRules = """
+        %ARTIFACT_PATH%
+    """.trimIndent()
+
+    vcs {
+        // ComponentsRegistry / template's GitHub root is inherited; explicitly
+        // attach the trace-data root with a checkout rule so the tuples land
+        // under a predictable path relative to the build's checkout dir.
+        root(CrsCompatTrace, "+:. => trace-data/")
+    }
+
+    params {
+        text("COMPAT_BASELINE_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        text("COMPAT_CANDIDATE_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        text("COMPAT_RMS_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        text("COMPAT_ALLOW_NON_DB_CANDIDATE", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        // `latest-top.txt` is a symlink (in the trace repo) to the most recent
+        // dated subdir. Operator can override at run time (e.g. to a specific
+        // snapshot for reproducibility).
+        text("COMPAT_TRACE_FILE_RELATIVE", "latest-top.txt", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        param("ARTIFACT_PATH", """
+            components-registry-compat-test/build/reports/compat/** => reports/compat
+            components-registry-compat-test/build/test-results/**/*.xml => test-results/compat
+        """.trimIndent())
+        param("GRADLE_TASK", ":components-registry-compat-test:test :components-registry-compat-test:compatibilityReporter")
+        param("GRADLE_TEST_FILTER", "--tests *TraceReplayCompatTest*")
+        param("GRADLE_EXTRA_PARAMETERS", """
+            %GRADLE_TEST_FILTER%
+            -Pcompat.baseline.url=%COMPAT_BASELINE_URL%
+            -Pcompat.candidate.url=%COMPAT_CANDIDATE_URL%
+            -Pcompat.rms.url=%COMPAT_RMS_URL%
+            -Pcompat.allow-non-db-candidate=%COMPAT_ALLOW_NON_DB_CANDIDATE%
+            -Pcompat.trace.file=%teamcity.build.checkoutDir%/trace-data/%COMPAT_TRACE_FILE_RELATIVE%
+            -Pcompat.parallelism=10
+        """.trimIndent())
+    }
+
+    failureConditions {
+        // 20 000 tuples × parallelism 10 took ~13 min in the 2026-05-17 run;
+        // pad to 45 min for cold-cache agents + slower DB-mode candidate.
+        executionTimeoutMin = 45
     }
 
     features {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -300,7 +300,14 @@ object id16CompatTraceReplayManual : BuildType({
         text("COMPAT_BASELINE_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_CANDIDATE_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_RMS_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
-        text("COMPAT_ALLOW_NON_DB_CANDIDATE", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        // Default `true` for this build type, unlike id15. The trace was
+        // captured from a prod V1 stand and replaying it against today's
+        // candidate (still serving V1 per the merge state) is by definition
+        // a V1-vs-V1 measurement — the CANDIDATE_NOT_DB_MODE env-warning
+        // would fire on every run and fail the build before the trace ever
+        // executes. Operator flips to `false` once the candidate is in real
+        // DB mode (`default-source=db`).
+        text("COMPAT_ALLOW_NON_DB_CANDIDATE", "true", allowEmpty = false, display = ParameterDisplay.PROMPT)
         // `latest-top.txt` is a symlink (in the trace repo) to the most recent
         // dated subdir. Operator can override at run time (e.g. to a specific
         // snapshot for reproducibility).
@@ -325,6 +332,9 @@ object id16CompatTraceReplayManual : BuildType({
     failureConditions {
         // 20 000 tuples × parallelism 10 took ~13 min in the 2026-05-17 run;
         // pad to 45 min for cold-cache agents + slower DB-mode candidate.
+        // TODO(post-first-runs): revisit after 2-3 real TC runs establish
+        //   an empirical ceiling on a DB-mode candidate under load. id15 uses
+        //   60 min — bump here if 45 turns out to be marginal.
         executionTimeoutMin = 45
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -201,9 +201,15 @@ object id10CompileUtAuto : BuildType({
 //     CANDIDATE_NOT_DB_MODE env-warning that would otherwise fail the build
 //     even though all endpoint diffs are clean.
 //
-// All four COMPAT_* required params are prompted on every run; without them
-// the task either skips silently (smoke list empty) or reports only env
-// preconditions, producing misleading green builds.
+// Prompted on every run:
+//   - 4 required (no defaults — `allowEmpty = false` rejects blanks):
+//     COMPAT_BASELINE_URL, COMPAT_CANDIDATE_URL, COMPAT_RMS_URL,
+//     COMPAT_SMOKE_COMPONENTS. Without them the task either skips silently
+//     (smoke list empty) or reports only env preconditions, producing
+//     misleading green builds.
+//   - 2 boolean flags with `"false"` defaults (COMPAT_FULL,
+//     COMPAT_ALLOW_NON_DB_CANDIDATE) — the operator only flips them when
+//     they want the corresponding mode (full sweep / parity-debug).
 object id15CompatManual : BuildType({
     templates(AbsoluteId("Octopus_OctopusGradleBuild"))
     id("15CompatManual")

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
@@ -111,6 +111,18 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
     private fun loadBodyFixtures(): BodyFixtures {
         log.info("body-fixtures: fetching /v2/components for GAV discovery…")
         val resp = baselineRaw.get("rest/api/2/components")
+        // Distinguish transport failure (`status == 0` — see `RawHttp.kt`: catches
+        // `IOException` and returns synthetic 0) from a legitimate empty/error
+        // response. With a typo in `COMPAT_BASELINE_URL`, both `loadBodyFixtures`
+        // AND the trace replay itself would symmetrically miss the same wrong
+        // host and produce a vacuously-green run. Fail-hard so the operator
+        // gets a red build with a clear cause, not a SKIPPED test downstream.
+        check(resp.status != 0) {
+            "body-fixtures: GET ${baselineRaw.baseUrl}/rest/api/2/components returned " +
+                "status=0 (transport failure). Check COMPAT_BASELINE_URL is reachable from this " +
+                "agent — a vacuous-green replay would otherwise look identical to a clean one. " +
+                "Underlying error: ${resp.headers["X-Compat-Transport-Error"] ?: "<not captured>"}"
+        }
         // Wire shape on V1: { "components": [ {id, distribution: {GAV: "g:a:p,..."}, ...}, ... ] }
         // The field is `GAV` (UPPERCASE) on the wire — V1's @JsonProperty annotation.
         // `/v3/components` is unsuitable: V1 returns `distribution: null` at the wrapper level.


### PR DESCRIPTION
## Summary

Wires the compat-test trace-replay path into the v3 TC chain and adds the
flag set the compat module gained in PR #244 (full / allow-non-db-candidate).

Two changes, four commits

1. **`.teamcity/settings.kts`** — new VCS root `CrsCompatTrace` (URL held
   in `%CRS_COMPAT_TRACE_REPO_URL%` TC-server param; the internal Bitbucket
   trace repo is referenced indirectly so the open-source DSL stays clean
   of internal identifiers). New build type
   `id16CompatTraceReplayManual` `[1.6] Compatibility Trace Replay [MANUAL]`
   attaches the trace root with checkout rule `+:. => trace-data/`, runs
   `*TraceReplayCompatTest*` against operator-supplied baseline / candidate
   URLs, defaults `COMPAT_ALLOW_NON_DB_CANDIDATE=true` for today's V1-vs-V1
   reality.
2. **`id15CompatManual` extension** — two new prompt params (`COMPAT_FULL`,
   `COMPAT_ALLOW_NON_DB_CANDIDATE`), both default `false`. Wires them as
   `-Pcompat.full` / `-Pcompat.allow-non-db-candidate` to gradle. Existing
   smoke behaviour preserved.
3. **`TraceReplayCompatTest.kt`** — fail-hard on baseline `status=0`
   (transport failure) in `loadBodyFixtures`. Without this guard, a typoed
   `COMPAT_BASELINE_URL` would skip the test via `assumeTrue` and the
   reporter would call the run GREEN — Opus Stage-2 reviewer surfaced this
   as the only vacuous-pass path the new build type would have exposed to
   operators.

## Review protocol (per `feedback_compat_test_infra_review_protocol`)

- **Stage 1 Sonnet** — flagged one FIX (default for `COMPAT_ALLOW_NON_DB_CANDIDATE`
  on id16 was wrong polarity for today's V1-vs-V1 measurement) + 4 NITs
  (3 confirmations of correctness, 1 TODO around the 45-min timeout).
  Addressed in commit `15d21a05`.
- **Stage 2 Opus (adversarial)** — flagged one FIX (vacuous-green on
  baseline transport failure) + 1 pre-existing NIT in id15 + 2 LGTM.
  Addressed in commit `23adfeff`.
- **Copilot inline** — flagged stale "four required params" KDoc on id15
  (now six params); addressed in commit `ab60bd49`.

## Verification

- `./gradlew :components-registry-compat-test:unitTest` — 70 tests green
  (includes 14 `EnvironmentPreflightEvaluatorTest` cases + 7
  `TraceReplayParsingTest` cases).
- TC Kotlin DSL is not locally compilable without a live TC server (Maven
  plugin resolves `configs-dsl-kotlin-*` via `${teamcity.serverUrl}`).
  DSL is modelled syntactically on the existing `ComponentsRegistry` /
  `id20Validate…` blocks above it; first real validation is the TC
  configuration import on push.
- Diff + commit messages scanned for the forbidden-identifier set
  (`feedback_redacted_identifiers`) — zero matches.

## Out of scope (follow-up)

- Local-stand JAR-vs-JAR build type (`id17`) — already specified in
  `scripts/local-stands/TEAMCITY.md`; will port to Kotlin DSL in a
  separate PR once `id16` is exercised in TC and rough edges shake out.
- Symmetric-failure blind spot for the WIDER compat test (both stands
  returning identical 4xx/5xx with identical bodies) — pre-existing,
  noted in `TraceReplayCompatTest.kt` as a `FOLLOW-UP` inline comment
  since PR #244. Out of scope here; deserves its own classification
  category and known-deltas extension.

## Test plan

- [x] Unit tests green.
- [ ] After merge: operator imports the new build type in TC, sets
      `CRS_COMPAT_TRACE_REPO_URL` to the internal clone URL of
      `creg/crs-compat-trace`, runs `[1.6] Compatibility Trace Replay`
      with `COMPAT_BASELINE_URL` = prod, `COMPAT_CANDIDATE_URL` = QA.
- [ ] Verify the trace-data VCS root checkout lands under `trace-data/`
      and `latest-top.txt` symlink resolves on the Linux agent.
- [ ] Verify the build is GREEN on a clean run (the existing 20k-tuple
      replay against prod-vs-QA produced 0 active diffs on 2026-05-17).
- [ ] Verify the build is RED with a clear "transport failure" message
      when given a deliberately-typoed `COMPAT_BASELINE_URL` — the Opus
      Stage-2 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
