### PR TITLE
ci(teamcity): id17 Local-Stand compat (chain) + standalone id15/id16

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -412,8 +412,13 @@ object id17CompatLocalStandManual : BuildType({
     """.trimIndent()
 
     vcs {
-        // Template's GitHub root inherited; explicitly attach the two
-        // internal-data roots with stable checkout paths the wrapper expects.
+        // id17 does NOT use Octopus_OctopusGradleBuild template (this is a
+        // pure shell-script build, not a gradle one — the wrapper invokes
+        // Gradle from inside) so the GitHub root is not inherited. Attach
+        // it explicitly, same pattern as id20. Default `+:.` rule places
+        // the CRS source (with scripts/local-stands/teamcity-run.sh) at
+        // the checkout root.
+        root(AbsoluteId("Octopus_OctopusComponents_OctopusGithubVcsRoot"))
         root(ComponentsRegistry, "+:. => %COMPONENTS_REGISTRY_CHECKOUT_DIR%")
         root(ServiceConfig, "+:. => service-config")
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -15,6 +15,7 @@ project {
 
     vcsRoot(ComponentsRegistry)
     vcsRoot(CrsCompatTrace)
+    vcsRoot(ServiceConfig)
 
     params {
         param("JDK_VERSION", "11")
@@ -32,6 +33,7 @@ project {
     buildType(id10CompileUtAuto)
     buildType(id15CompatManual)
     buildType(id16CompatTraceReplayManual)
+    buildType(id17CompatLocalStandManual)
     buildType(id20ValidateComponentsRegistryProductionDataAuto)
     buildType(id30DeployToOkdQaDevAuto)
     buildType(id40ReleaseManual)
@@ -44,6 +46,7 @@ project {
         id10CompileUtAuto,
         id15CompatManual,
         id16CompatTraceReplayManual,
+        id17CompatLocalStandManual,
         id20ValidateComponentsRegistryProductionDataAuto,
         id30DeployToOkdQaDevAuto,
         id40ReleaseManual,
@@ -79,6 +82,22 @@ object ComponentsRegistry : GitVcsRoot({
 object CrsCompatTrace : GitVcsRoot({
     name = "Crs_Compat_Trace"
     url = "%CRS_COMPAT_TRACE_REPO_URL%"
+    branch = "refs/heads/master"
+    branchSpec = "+:refs/heads/master"
+    checkoutSubmodules = GitVcsRoot.CheckoutSubmodules.IGNORE
+    authMethod = defaultPrivateKey {
+        userName = "git"
+    }
+})
+
+// VCS root used by id17CompatLocalStandManual to check out the internal
+// service-config repository (per-environment YAML overlays consumed by
+// the CRS server). URL kept in the TC server / parent-project param
+// `SERVICE_CONFIG_REPO_URL` so the open-source DSL stays free of internal
+// identifiers, same pattern as `ComponentsRegistry`.
+object ServiceConfig : GitVcsRoot({
+    name = "Service_Config"
+    url = "%SERVICE_CONFIG_REPO_URL%"
     branch = "refs/heads/master"
     branchSpec = "+:refs/heads/master"
     checkoutSubmodules = GitVcsRoot.CheckoutSubmodules.IGNORE
@@ -261,11 +280,9 @@ object id15CompatManual : BuildType({
         doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
     }
 
-    dependencies {
-        snapshot(id10CompileUtAuto) {
-            onDependencyFailure = FailureAction.CANCEL
-        }
-    }
+    // id15 is standalone-manual: ad-hoc prod-vs-QA via URLs, no auto-trigger,
+    // not part of the release chain. Operator runs it on demand when they
+    // want to spot-check two pre-deployed stands by URL.
 })
 
 // Compatibility Trace Replay — manual, on-demand. Replays the deduplicated
@@ -352,6 +369,139 @@ object id16CompatTraceReplayManual : BuildType({
     }
 
     requirements {
+        doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
+    }
+
+    // id16 is standalone-manual like id15 — no chain dependency. The trace
+    // replay runs against two already-deployed URLs the operator supplies.
+})
+
+// Compatibility Local-Stand — manual, in the chain after id10. Spins TWO
+// CRS instances side-by-side on the agent: baseline (released
+// `%LAST_RELEASE_VERSION%`, docker image from corp registry) and candidate
+// (current chain's image pushed by id10), both pointed at the production
+// Components-Registry DSL + service-config. Then runs the compat-test
+// module's full endpoint matrix against both stands via the existing
+// `scripts/local-stands/teamcity-run.sh` wrapper.
+//
+// Why docker-image extraction (not Artifactory pull) for the baseline:
+// `components-registry-service-server` Maven publication ships the
+// non-bootJar (integration-tests classifier, no embedded deps), which is
+// not runnable. The bootJar — the runnable Spring-Boot fat JAR — lives only
+// inside the docker image at `/app/app.jar` per the module's Dockerfile.
+// Docker pull + `docker cp` is therefore the lowest-friction way to get
+// a runnable baseline JAR onto the agent.
+//
+// VCS roots attached (additive to the template's GitHub root):
+//   - ComponentsRegistry — prod DSL (master branch) under
+//     `%COMPONENTS_REGISTRY_CHECKOUT_DIR%`, exactly like id20.
+//   - ServiceConfig — internal service-config repo under `service-config/`.
+//
+// The wrapper handles postgres-up, both JVM boots, health-poll, compat
+// invocation, and teardown. Its env contract is documented in
+// `scripts/local-stands/TEAMCITY.md`.
+object id17CompatLocalStandManual : BuildType({
+    id("17CompatLocalStandManual")
+    name = "[1.7] Compatibility Local-Stand [MANUAL]"
+
+    artifactRules = """
+        components-registry-compat-test/build/reports/compat/** => reports/compat
+        components-registry-compat-test/build/test-results/**/*.xml => test-results/compat
+        /tmp/crs-baseline-tc.log => logs/baseline.log
+        /tmp/crs-candidate-tc.log => logs/candidate.log
+    """.trimIndent()
+
+    vcs {
+        // Template's GitHub root inherited; explicitly attach the two
+        // internal-data roots with stable checkout paths the wrapper expects.
+        root(ComponentsRegistry, "+:. => %COMPONENTS_REGISTRY_CHECKOUT_DIR%")
+        root(ServiceConfig, "+:. => service-config")
+    }
+
+    params {
+        // Required smoke list — same shape as id15 (CSV of real component
+        // names), but feeds the LOCAL stands, not URLs. Secret per the
+        // `feedback_redacted_identifiers` policy (real names).
+        text("COMPAT_SMOKE_COMPONENTS", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        text("COMPAT_RMS_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        text("COMPAT_FULL", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        // Baseline version is the project-level `LAST_RELEASE_VERSION` (e.g.
+        // `2.0.87`); pinned, not prompted — operator updates the project
+        // param when a new release lands.
+        param("COMPAT_BASELINE_VERSION", "%LAST_RELEASE_VERSION%")
+        // Candidate image tag = the build number of the upstream id10 chain
+        // step that just pushed it via `dockerPushImage`.
+        param("COMPAT_CANDIDATE_VERSION", "${id10CompileUtAuto.depParamRefs.buildNumber}")
+        // Corp docker registry hosting both image tags. Held in the TC
+        // server / parent-project param `DOCKER_REGISTRY` (same value the
+        // gradle Dockerfile arg consumes).
+        param("DOCKER_REGISTRY_INTERNAL", "%DOCKER_REGISTRY%")
+    }
+
+    steps {
+        script {
+            name = "Extract JARs from docker images"
+            id = "extract_jars"
+            // Pull both images, `docker create` an ephemeral container per side,
+            // `docker cp` the fat JAR out to /tmp, then `docker rm`. Both
+            // commands are idempotent across re-runs on the same agent.
+            scriptContent = """
+                set -euo pipefail
+                BASELINE_IMAGE="%DOCKER_REGISTRY_INTERNAL%/octopusden/components-registry-service:%COMPAT_BASELINE_VERSION%"
+                CANDIDATE_IMAGE="%DOCKER_REGISTRY_INTERNAL%/octopusden/components-registry-service:%COMPAT_CANDIDATE_VERSION%"
+                echo "Pulling baseline:  ${'$'}BASELINE_IMAGE"
+                docker pull "${'$'}BASELINE_IMAGE"
+                echo "Pulling candidate: ${'$'}CANDIDATE_IMAGE"
+                docker pull "${'$'}CANDIDATE_IMAGE"
+                rm -f /tmp/baseline.jar /tmp/candidate.jar
+                BCID=${'$'}(docker create "${'$'}BASELINE_IMAGE")
+                docker cp "${'$'}BCID:/app/app.jar" /tmp/baseline.jar
+                docker rm "${'$'}BCID"
+                CCID=${'$'}(docker create "${'$'}CANDIDATE_IMAGE")
+                docker cp "${'$'}CCID:/app/app.jar" /tmp/candidate.jar
+                docker rm "${'$'}CCID"
+                ls -lh /tmp/baseline.jar /tmp/candidate.jar
+            """.trimIndent()
+        }
+        script {
+            name = "Run local-stand compat"
+            id = "run_compat"
+            scriptContent = """
+                set -euo pipefail
+                export BASELINE_JAR=/tmp/baseline.jar
+                export CANDIDATE_JAR=/tmp/candidate.jar
+                export LOCAL_VCS_ROOT="%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%"
+                export SERVICE_CONFIG_DIR="%teamcity.build.checkoutDir%/service-config"
+                export COMPAT_SMOKE_COMPONENTS="%COMPAT_SMOKE_COMPONENTS%"
+                export COMPAT_RMS_URL="%COMPAT_RMS_URL%"
+                export COMPAT_FULL="%COMPAT_FULL%"
+                export COMPAT_PARALLELISM=8
+                export RESET_DB=1
+                export COMPONENTS_REGISTRY_SERVICE_VERSION="%COMPAT_BASELINE_VERSION%"
+                export BUILD_VERSION="%COMPAT_CANDIDATE_VERSION%"
+                bash scripts/local-stands/teamcity-run.sh
+            """.trimIndent()
+        }
+    }
+
+    failureConditions {
+        // Full sweep budget. The 5-component smoke completes in ~5-10 min;
+        // a full ~475-component matrix needs ~15-30 min. Padded to 60 min
+        // for cold-image-pull + first-time postgres volume init.
+        executionTimeoutMin = 60
+    }
+
+    features {
+        xmlReport {
+            reportType = XmlReport.XmlReportType.JUNIT
+            rules = "+:components-registry-compat-test/build/test-results/test/*.xml"
+        }
+    }
+
+    requirements {
+        // The wrapper relies on docker-compose, lsof, bash, and a local
+        // postgres on a Linux/macOS host. Same Windows exclusion as the
+        // sibling compat configs.
         doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -410,8 +410,8 @@ object id17CompatLocalStandManual : BuildType({
     artifactRules = """
         components-registry-compat-test/build/reports/compat/** => reports/compat
         components-registry-compat-test/build/test-results/**/*.xml => test-results/compat
-        /tmp/crs-baseline-tc.log => logs/baseline.log
-        /tmp/crs-candidate-tc.log => logs/candidate.log
+        /tmp/crs-id17-%teamcity.build.id%/baseline.log => logs/baseline.log
+        /tmp/crs-id17-%teamcity.build.id%/candidate.log => logs/candidate.log
     """.trimIndent()
 
     vcs {
@@ -428,8 +428,13 @@ object id17CompatLocalStandManual : BuildType({
 
     params {
         // Required smoke list — same shape as id15 (CSV of real component
-        // names), but feeds the LOCAL stands, not URLs. Secret per the
-        // `feedback_redacted_identifiers` policy (real names).
+        // names), but feeds the LOCAL stands, not URLs. The value contains
+        // identifiers that are forbidden in repo files / commit messages
+        // (`feedback_redacted_identifiers`), but the TC `text(...)` param
+        // itself is fine because the value never lands in version control —
+        // it lives only in the TC build config form. (Not a `password(...)`
+        // type because the value isn't a credential and operators paste it
+        // visibly when triggering the run.)
         text("COMPAT_SMOKE_COMPONENTS", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_RMS_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_FULL", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
@@ -455,8 +460,10 @@ object id17CompatLocalStandManual : BuildType({
             // `docker rm`. The `trap` cleans up the create-container even if
             // `docker cp` fails (e.g. FS full, image lacks /app/app.jar), so
             // we don't leak orphan containers across failed re-runs (Opus
-            // Stage-2 review). The work dir includes %BUILD_NUMBER% so two
-            // builds on the same shared agent never clobber each other's JAR.
+            // Stage-2 review). The work dir includes `%teamcity.build.id%`
+            // (the numeric internal build ID, stable for a run's lifetime)
+            // so two builds on a shared agent host never clobber each
+            // other's JAR or log files.
             scriptContent = """
                 set -euo pipefail
                 BASELINE_IMAGE="%DOCKER_REGISTRY_INTERNAL%/octopusden/components-registry-service:%COMPAT_BASELINE_VERSION%"
@@ -485,11 +492,23 @@ object id17CompatLocalStandManual : BuildType({
         script {
             name = "Run local-stand compat"
             id = "run_compat"
+            // BASELINE_LOG / CANDIDATE_LOG are namespaced under WORK_DIR
+            // (same `%teamcity.build.id%` namespace as the extracted JARs)
+            // so two concurrent id17 builds on a shared agent host don't
+            // overwrite each other's wrapper logs. The artifact rules at
+            // the top of this BuildType pick these paths up via the same
+            // `%teamcity.build.id%` substitution. Ports stay at the
+            // wrapper defaults (4567/4568) — TC's per-config serialization
+            // is sufficient guard against the same id17 running twice in
+            // parallel on one agent, and we don't expect multiple
+            // local-stand configs to coexist.
             scriptContent = """
                 set -euo pipefail
                 WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
                 export BASELINE_JAR="${'$'}WORK_DIR/baseline.jar"
                 export CANDIDATE_JAR="${'$'}WORK_DIR/candidate.jar"
+                export BASELINE_LOG="${'$'}WORK_DIR/baseline.log"
+                export CANDIDATE_LOG="${'$'}WORK_DIR/candidate.log"
                 export LOCAL_VCS_ROOT="%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%"
                 export SERVICE_CONFIG_DIR="%teamcity.build.checkoutDir%/service-config"
                 export COMPAT_SMOKE_COMPONENTS="%COMPAT_SMOKE_COMPONENTS%"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -376,12 +376,15 @@ object id16CompatTraceReplayManual : BuildType({
     // replay runs against two already-deployed URLs the operator supplies.
 })
 
-// Compatibility Local-Stand — manual, in the chain after id10. Spins TWO
-// CRS instances side-by-side on the agent: baseline (released
-// `%LAST_RELEASE_VERSION%`, docker image from corp registry) and candidate
-// (current chain's image pushed by id10), both pointed at the production
-// Components-Registry DSL + service-config. Then runs the compat-test
-// module's full endpoint matrix against both stands via the existing
+// Compatibility Local-Stand — manual-only with a snapshot dep on id10
+// (snapshot only, NOT a `finishBuildTrigger` — operator clicks Run and
+// id10 is pulled in transitively if needed; the build does not
+// auto-fire when id10 finishes). Spins TWO CRS instances side-by-side
+// on the agent: baseline (released `%LAST_RELEASE_VERSION%`, docker
+// image from corp registry) and candidate (current chain's image
+// pushed by id10), both pointed at the production Components-Registry
+// DSL + service-config. Then runs the compat-test module's full
+// endpoint matrix against both stands via the existing
 // `scripts/local-stands/teamcity-run.sh` wrapper.
 //
 // Why docker-image extraction (not Artifactory pull) for the baseline:
@@ -448,24 +451,35 @@ object id17CompatLocalStandManual : BuildType({
             name = "Extract JARs from docker images"
             id = "extract_jars"
             // Pull both images, `docker create` an ephemeral container per side,
-            // `docker cp` the fat JAR out to /tmp, then `docker rm`. Both
-            // commands are idempotent across re-runs on the same agent.
+            // `docker cp` the fat JAR into a build-namespaced /tmp dir, then
+            // `docker rm`. The `trap` cleans up the create-container even if
+            // `docker cp` fails (e.g. FS full, image lacks /app/app.jar), so
+            // we don't leak orphan containers across failed re-runs (Opus
+            // Stage-2 review). The work dir includes %BUILD_NUMBER% so two
+            // builds on the same shared agent never clobber each other's JAR.
             scriptContent = """
                 set -euo pipefail
                 BASELINE_IMAGE="%DOCKER_REGISTRY_INTERNAL%/octopusden/components-registry-service:%COMPAT_BASELINE_VERSION%"
                 CANDIDATE_IMAGE="%DOCKER_REGISTRY_INTERNAL%/octopusden/components-registry-service:%COMPAT_CANDIDATE_VERSION%"
+                WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
+                BCID=""
+                CCID=""
+                cleanup() {
+                    [ -n "${'$'}BCID" ] && docker rm -f "${'$'}BCID" >/dev/null 2>&1 || true
+                    [ -n "${'$'}CCID" ] && docker rm -f "${'$'}CCID" >/dev/null 2>&1 || true
+                }
+                trap cleanup EXIT
+                rm -rf "${'$'}WORK_DIR"
+                mkdir -p "${'$'}WORK_DIR"
                 echo "Pulling baseline:  ${'$'}BASELINE_IMAGE"
                 docker pull "${'$'}BASELINE_IMAGE"
                 echo "Pulling candidate: ${'$'}CANDIDATE_IMAGE"
                 docker pull "${'$'}CANDIDATE_IMAGE"
-                rm -f /tmp/baseline.jar /tmp/candidate.jar
                 BCID=${'$'}(docker create "${'$'}BASELINE_IMAGE")
-                docker cp "${'$'}BCID:/app/app.jar" /tmp/baseline.jar
-                docker rm "${'$'}BCID"
+                docker cp "${'$'}BCID:/app/app.jar" "${'$'}WORK_DIR/baseline.jar"
                 CCID=${'$'}(docker create "${'$'}CANDIDATE_IMAGE")
-                docker cp "${'$'}CCID:/app/app.jar" /tmp/candidate.jar
-                docker rm "${'$'}CCID"
-                ls -lh /tmp/baseline.jar /tmp/candidate.jar
+                docker cp "${'$'}CCID:/app/app.jar" "${'$'}WORK_DIR/candidate.jar"
+                ls -lh "${'$'}WORK_DIR/baseline.jar" "${'$'}WORK_DIR/candidate.jar"
             """.trimIndent()
         }
         script {
@@ -473,8 +487,9 @@ object id17CompatLocalStandManual : BuildType({
             id = "run_compat"
             scriptContent = """
                 set -euo pipefail
-                export BASELINE_JAR=/tmp/baseline.jar
-                export CANDIDATE_JAR=/tmp/candidate.jar
+                WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
+                export BASELINE_JAR="${'$'}WORK_DIR/baseline.jar"
+                export CANDIDATE_JAR="${'$'}WORK_DIR/candidate.jar"
                 export LOCAL_VCS_ROOT="%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%"
                 export SERVICE_CONFIG_DIR="%teamcity.build.checkoutDir%/service-config"
                 export COMPAT_SMOKE_COMPONENTS="%COMPAT_SMOKE_COMPONENTS%"


### PR DESCRIPTION
## Summary

Adds the local-stand compat build type wired into the v3 release chain
after `id10` and detaches `id15`/`id16` from the chain (they are ad-hoc
URL-based tools, not part of every release run).

Three changes, three commits

1. **`id17CompatLocalStandManual` `[1.7] Compatibility Local-Stand [MANUAL]`** —
   spins TWO CRS instances side-by-side on the agent against the
   production Components Registry DSL + service-config:
   - baseline = released `%LAST_RELEASE_VERSION%` docker image,
   - candidate = current chain's docker image (just pushed by `id10`).
   Both runnable JARs are extracted from `/app/app.jar` inside their
   docker images (the Maven publication ships the non-runnable
   integration-test classifier — only the docker image bundles the
   bootJar). Then the existing `scripts/local-stands/teamcity-run.sh`
   wrapper handles postgres-up, both JVM boots, health-poll, compat
   invocation, and teardown. Snapshot-deps on `id10` with
   `FailureAction.CANCEL` so a broken candidate image cancels the job.
2. **`ServiceConfig` GitVcsRoot** — new VCS root for the internal
   service-config repo, URL held in TC server param
   `%SERVICE_CONFIG_REPO_URL%` (same pattern as `ComponentsRegistry` /
   `CrsCompatTrace`).
3. **Detach `id15` / `id16` from the chain** — removed
   `snapshot(id10CompileUtAuto)` from both. They're now true
   standalone-manual configs (prod-vs-QA via URLs; trace replay via
   URLs). No auto-trigger, no chain dependency.

## Review protocol (per `feedback_compat_test_infra_review_protocol`)

- **Stage 1 Sonnet** — flagged one BLOCK: id17 was missing both
  `templates(...)` AND an explicit GitHub VCS root, so the build's
  agent checkout dir would not contain `scripts/local-stands/teamcity-
  run.sh`. Fixed in commit `f0e064b6` by attaching the GitHub root
  explicitly (same pattern as `id20`).
- **Stage 2 Opus (adversarial)** — flagged one FIX + 3 NITs.
  Addressed in commit `bfd33147`:
   - FIX: orphan docker containers on `docker cp` failure — wrapped
     both create+cp+rm sequences in `trap cleanup EXIT`.
   - NIT: `/tmp/baseline.jar` collision on shared agents — namespaced
     the work dir to `/tmp/crs-id17-%teamcity.build.id%/`.
   - NIT: comment claimed "in the chain after id10" — clarified to
     "manual-only with snapshot dep, NOT a `finishBuildTrigger`".

## Verification

- TC Kotlin DSL not locally compilable without a live TC server
  (Maven plugin resolves `configs-dsl-kotlin-*` via `${teamcity.serverUrl}`).
  DSL modelled syntactically on the existing `id20Validate…` block.
  First real validation is the TC configuration import on push.
- Forbidden-literal audit (case-insensitive bracket-class regex over
  the `feedback_redacted_identifiers` list) — zero hits.
- Wrapper env-contract verified against
  `scripts/local-stands/teamcity-run.sh` KDoc + `TEAMCITY.md`.

## What needs to happen in TC after merge

The operator needs to set ONE new TC server / parent-project param
before id17 can run successfully:

- `SERVICE_CONFIG_REPO_URL` — SSH clone URL of the internal
  service-config repo (`bitbucket-internal:.../service-config.git`).

`DOCKER_REGISTRY` is presumed to already exist (the gradle Dockerfile
arg consumes it on every id10 run).

## Test plan

- [x] Diff scanned for forbidden literals — clean.
- [x] Stage-1 Sonnet review applied.
- [x] Stage-2 Opus review applied.
- [ ] After merge + TC config sync: operator sets
      `SERVICE_CONFIG_REPO_URL`, clicks Run on `[1.7]` with the smoke
      CSV, verifies BUILD SUCCESSFUL and artifact reports/compat/
      summary.md is published.
- [ ] Verify the trap-cleanup actually fires by intentionally pointing
      `COMPAT_BASELINE_VERSION` at a non-existent tag — expect RED
      with no orphan containers visible on the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
