### PR TITLE
feat(compat-test): VersionSampler reads versions from JSON snapshot when configured

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -86,7 +86,8 @@ test {
      'compat.smoke-components',
      'compat.trace.file',
      'compat.verbose',
-     'compat.allow-non-db-candidate'].each { name ->
+     'compat.allow-non-db-candidate',
+     'compat.versions.file'].each { name ->
         def value = project.findProperty(name) ?: System.getenv(name.toUpperCase().replace('.', '_').replace('-', '_'))
         if (value != null) {
             systemProperty name, value

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatConfig.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatConfig.kt
@@ -13,6 +13,14 @@ data class CompatConfig(
     val versionsFallback: Boolean,
     /** Hard cap on the number of components iterated per test class. Null = no cap. */
     val maxComponents: Int?,
+    /**
+     * Absolute path to a `{componentId: [v1, v2, v3]}` JSON snapshot produced by
+     * `crs-compat-trace/scripts/dump-versions.py`. When set, [VersionSampler]
+     * reads from this file instead of querying [rmsUrl] on every call — TC runs
+     * stay reproducible across days and don't burn RMS round-trips. `null`
+     * (default) keeps the RMS fallback for local dev.
+     */
+    val versionsFile: String?,
 ) {
     /** Either both URLs are set (active run), or neither (skipped). */
     val active: Boolean get() = !baselineUrl.isNullOrBlank() && !candidateUrl.isNullOrBlank()
@@ -51,6 +59,7 @@ data class CompatConfig(
                 malformed = read("compat.malformed")?.toBooleanStrictOrNull() ?: false,
                 versionsFallback = read("compat.versions-fallback")?.toBooleanStrictOrNull() ?: false,
                 maxComponents = maxComponents,
+                versionsFile = read("compat.versions.file"),
             )
         }
 

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
@@ -86,7 +86,8 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
      *  - `batchArtifacts`: same approach, 5 distinct components in one list.
      *    Used for `POST /v3/components/find-by-artifacts` (and the v2
      *    `findByArtifacts` alias).
-     *  - `versionsFor(componentId)`: lazy per-component lookup via RMS.
+     *  - `versionsFor(componentId)`: lazy per-component lookup — file map
+     *    when `compat.versions.file` is set, else RMS (see VersionSampler).
      *    Used for `POST /v2/components/{c}/detailed-versions`.
      *
      * Without these fixtures the trace replayer falls back to `{}` empty body,

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/VersionSampler.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/VersionSampler.kt
@@ -5,20 +5,74 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.slf4j.LoggerFactory
+import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 /**
- * Per-component version discovery via Release Management Service.
+ * Per-component version discovery — two sources, priority in this order:
  *
- * Hits `GET {rms.url}/rest/api/1/builds/component/{c}?statuses=RELEASE&descending=true&limit=N`
- * and returns up to N release versions, newest first. Cached per component for the whole test run.
+ *   1. A pre-computed `{componentId: [v1, v2, ...]}` JSON snapshot when
+ *      `compat.versions.file` is configured (set by TC builds via the
+ *      `crs-compat-trace` VCS root). Read once, cached for the run. No HTTP
+ *      hits — repeatable across days and isolated from RMS availability.
+ *   2. Live `GET {rms.url}/rest/api/1/builds/component/{c}?statuses=RELEASE&descending=true&limit=N`
+ *      when no file is configured (kept for local dev so an operator with an
+ *      RMS URL can still drive the sampler).
  *
- * Fail mode (per plan §RMS coverage guard): if [config.rmsUrl] is unset, all calls return
- * `emptyList()` and downstream tests should treat the component as "no real versions". The
- * smoke-mode `each component must have ≥1 real version` rule is enforced by [coverage] check
- * called from the test that uses VersionSampler.
+ * Per-component cache (`ConcurrentHashMap`) is shared between the two paths.
+ *
+ * Fail mode (per plan §RMS coverage guard): if neither source is reachable
+ * for a component, [versionsFor] returns `emptyList()` and downstream tests
+ * treat the component as "no real versions". The smoke-mode `each component
+ * must have ≥1 real version` rule is enforced by the calling test's coverage
+ * check, not here.
  */
+/**
+ * Pure loader for the versions JSON. Extracted from [VersionSampler] so unit
+ * tests can exercise it without the by-lazy singleton state of the object.
+ *
+ * Contract:
+ * - `path = null` → returns `null` (caller should fall back to RMS).
+ * - path doesn't exist / not readable → returns empty map (operator opted into
+ *   file mode and put the wrong path; do not silently fall back to RMS, that
+ *   would defeat reproducibility — empty map makes downstream tests see
+ *   "0 real versions" so the coverage-floor check fires).
+ * - File present but not a JSON object (e.g. `[]`, `"foo"`) → empty map.
+ * - File present, valid JSON object → `{componentId: [v1, ...]}`. Entries
+ *   whose value is not a JSON array are skipped. Array elements that are
+ *   not non-blank strings are filtered out.
+ */
+internal fun loadVersionsFile(
+    path: String?,
+    mapper: com.fasterxml.jackson.databind.ObjectMapper,
+    warn: (String) -> Unit = {},
+    info: (String) -> Unit = {},
+): Map<String, List<String>>? {
+    if (path == null) return null
+    val f = File(path)
+    if (!f.isFile || !f.canRead()) {
+        warn("compat.versions.file=$path is not a readable file; version-file path is empty for ALL components")
+        return emptyMap()
+    }
+    return runCatching {
+        val node = mapper.readTree(f)
+        if (!node.isObject) {
+            warn("compat.versions.file=$path is not a JSON object; treating as empty")
+            return@runCatching emptyMap<String, List<String>>()
+        }
+        buildMap<String, List<String>> {
+            node.fields().forEach { (k, v) ->
+                if (v.isArray) {
+                    put(k, v.mapNotNull { it.takeIf(JsonNode::isTextual)?.asText()?.takeIf(String::isNotBlank) })
+                }
+            }
+        }.also { info("compat.versions.file: loaded ${it.size} components from $path") }
+    }.onFailure {
+        warn("compat.versions.file=$path failed to parse: ${it.message}; treating as empty")
+    }.getOrDefault(emptyMap())
+}
+
 object VersionSampler {
     private val log = LoggerFactory.getLogger(VersionSampler::class.java)
     private val mapper = jacksonObjectMapper()
@@ -31,13 +85,36 @@ object VersionSampler {
         .build()
 
     /**
+     * Lazily-loaded `{componentId: [version, ...]}` map, populated on first
+     * lookup when `compat.versions.file` is configured. `null` once-and-for-all
+     * when no file is configured. The lazy initialiser also handles file-not-
+     * found / unparseable JSON by logging a warning and returning an empty map
+     * (the RMS path is not used as a fallback in that case — the operator
+     * explicitly asked for the file mode, so a missing file is operator
+     * error, not a reason to silently fall back).
+     */
+    private val fileMap: Map<String, List<String>>? by lazy {
+        // Wrap log methods in lambdas because slf4j's Logger has overloads
+        // that make `log::warn` / `log::info` references ambiguous.
+        loadVersionsFile(
+            CompatConfig.load().versionsFile,
+            mapper,
+            warn = { msg -> log.warn(msg) },
+            info = { msg -> log.info(msg) },
+        )
+    }
+
+    /**
      * Fetch up to [limit] real release versions for [componentName]. Cached per call regardless
-     * of [limit] (first caller wins). Returns empty list when RMS is unreachable / unset / has
-     * no releases for the component.
+     * of [limit] (first caller wins). Returns empty list when neither source has the component.
      */
     fun versionsFor(componentName: String, limit: Int = 5, rmsUrl: String? = CompatConfig.load().rmsUrl): List<String> {
-        if (rmsUrl.isNullOrBlank()) return emptyList()
         return cache.computeIfAbsent(componentName) {
+            // File path wins when configured: operator explicitly opted into
+            // the snapshot, so we don't sneak past it to RMS even if RMS is
+            // available (would defeat reproducibility).
+            fileMap?.let { return@computeIfAbsent (it[componentName] ?: emptyList()).take(limit) }
+            if (rmsUrl.isNullOrBlank()) return@computeIfAbsent emptyList()
             fetchFromRms(componentName, limit, rmsUrl)
         }
     }

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/VersionSampler.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/VersionSampler.kt
@@ -10,38 +10,29 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 /**
- * Per-component version discovery — two sources, priority in this order:
- *
- *   1. A pre-computed `{componentId: [v1, v2, ...]}` JSON snapshot when
- *      `compat.versions.file` is configured (set by TC builds via the
- *      `crs-compat-trace` VCS root). Read once, cached for the run. No HTTP
- *      hits — repeatable across days and isolated from RMS availability.
- *   2. Live `GET {rms.url}/rest/api/1/builds/component/{c}?statuses=RELEASE&descending=true&limit=N`
- *      when no file is configured (kept for local dev so an operator with an
- *      RMS URL can still drive the sampler).
- *
- * Per-component cache (`ConcurrentHashMap`) is shared between the two paths.
- *
- * Fail mode (per plan §RMS coverage guard): if neither source is reachable
- * for a component, [versionsFor] returns `emptyList()` and downstream tests
- * treat the component as "no real versions". The smoke-mode `each component
- * must have ≥1 real version` rule is enforced by the calling test's coverage
- * check, not here.
- */
-/**
  * Pure loader for the versions JSON. Extracted from [VersionSampler] so unit
  * tests can exercise it without the by-lazy singleton state of the object.
  *
  * Contract:
  * - `path = null` → returns `null` (caller should fall back to RMS).
  * - path doesn't exist / not readable → returns empty map (operator opted into
- *   file mode and put the wrong path; do not silently fall back to RMS, that
- *   would defeat reproducibility — empty map makes downstream tests see
- *   "0 real versions" so the coverage-floor check fires).
+ *   file mode and put the wrong path; the loader does NOT silently fall back
+ *   to RMS in this case — that would defeat the reproducibility-vs-RMS
+ *   priority the file mode promises).
  * - File present but not a JSON object (e.g. `[]`, `"foo"`) → empty map.
  * - File present, valid JSON object → `{componentId: [v1, ...]}`. Entries
  *   whose value is not a JSON array are skipped. Array elements that are
  *   not non-blank strings are filtered out.
+ *
+ * KNOWN GAP: the "operator opted into file mode and put the wrong path → 0
+ * real versions for every component" outcome does NOT fire any enforcement
+ * check today. The plan §RMS coverage guard speaks of a smoke-floor
+ * (`each component must have ≥1 real version`), but no such gate is
+ * implemented in any consumer of [versionsFor] — they all `log.warn` +
+ * skip per-component tests via `assumeTrue` / `pairArgsOrSentinel`. A
+ * vacuous-green run is therefore possible if the file is empty / wrong-
+ * path. Follow-up: lift the floor into `SnapshotPreconditionTest` so a
+ * misconfigured file fails fast instead of silently skipping.
  */
 internal fun loadVersionsFile(
     path: String?,
@@ -73,6 +64,35 @@ internal fun loadVersionsFile(
     }.getOrDefault(emptyMap())
 }
 
+/**
+ * Per-component version discovery — two sources, priority in this order:
+ *
+ *   1. A pre-computed `{componentId: [v1, v2, ...]}` JSON snapshot when
+ *      `compat.versions.file` is configured (set by TC builds via the
+ *      `crs-compat-trace` VCS root). Read once, cached for the run. No HTTP
+ *      hits — repeatable across days and isolated from RMS availability.
+ *   2. Live `GET {rms.url}/rest/api/1/builds/component/{c}?statuses=RELEASE&descending=true&limit=N`
+ *      when no file is configured (kept for local dev so an operator with an
+ *      RMS URL can still drive the sampler).
+ *
+ * Per-component cache (`ConcurrentHashMap`) is shared between the two paths.
+ *
+ * Lifecycle / scoping:
+ *   - The file-mode map is read ONCE at first [versionsFor] call via
+ *     `by lazy`. `compat.versions.file` MUST be set before that first call;
+ *     subsequent property changes are silently ignored. Always true in
+ *     production (TC sets the env before the JVM starts), but a unit test
+ *     that flips the property between cases will not observe the new value.
+ *   - The version cache (`ConcurrentHashMap`) is per-JVM. If gradle reuses
+ *     a worker JVM across `:test` and `:unitTest` invocations with
+ *     different `compat.versions.file` values, the second invocation sees
+ *     the first's cached map. Pre-existing behaviour for the RMS path;
+ *     unchanged here.
+ *
+ * Fail mode: if neither source has a component, [versionsFor] returns
+ * `emptyList()` — see [loadVersionsFile] KDoc for the documented "vacuous-
+ * green path on wrong file-mode config" gap and follow-up.
+ */
 object VersionSampler {
     private val log = LoggerFactory.getLogger(VersionSampler::class.java)
     private val mapper = jacksonObjectMapper()

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/VersionSamplerLoaderTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/VersionSamplerLoaderTest.kt
@@ -1,0 +1,95 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+/**
+ * Unit tests for [loadVersionsFile]. The integration with [VersionSampler.versionsFor]
+ * is harder to exercise (lazy-initialised singleton state) — these tests cover the
+ * pure-function loader directly, which is the whole non-trivial part.
+ */
+@Tag("unit")
+class VersionSamplerLoaderTest {
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    fun `null path returns null — caller falls back to RMS`() {
+        assertThat(loadVersionsFile(null, mapper)).isNull()
+    }
+
+    @Test
+    fun `non-existent path returns empty map — operator opted into file mode, missing file is operator error`(
+        @TempDir tmp: Path,
+    ) {
+        val out = loadVersionsFile(tmp.resolve("does-not-exist.json").toString(), mapper)
+        assertThat(out).isEqualTo(emptyMap<String, List<String>>())
+    }
+
+    @Test
+    fun `directory at path returns empty map`(@TempDir tmp: Path) {
+        // canRead() may return true on a directory; isFile() must reject it.
+        val out = loadVersionsFile(tmp.toString(), mapper)
+        assertThat(out).isEqualTo(emptyMap<String, List<String>>())
+    }
+
+    @Test
+    fun `unparseable JSON returns empty map and logs warning`(@TempDir tmp: Path) {
+        val f = tmp.resolve("bad.json")
+        f.writeText("{not json")
+        val warnings = mutableListOf<String>()
+        val out = loadVersionsFile(f.toString(), mapper, warn = { warnings += it })
+        assertThat(out).isEqualTo(emptyMap<String, List<String>>())
+        assertThat(warnings).anyMatch { it.contains("failed to parse") }
+    }
+
+    @Test
+    fun `non-object JSON (array root) returns empty map`(@TempDir tmp: Path) {
+        val f = tmp.resolve("array.json")
+        f.writeText("""["a", "b"]""")
+        val out = loadVersionsFile(f.toString(), mapper)
+        assertThat(out).isEqualTo(emptyMap<String, List<String>>())
+    }
+
+    @Test
+    fun `happy path — JSON object of string arrays loaded into map`(@TempDir tmp: Path) {
+        val f = tmp.resolve("ok.json")
+        f.writeText("""{"comp-a": ["1.0.0", "0.9.0"], "comp-b": ["2.1.5"]}""")
+        val out = loadVersionsFile(f.toString(), mapper)
+        assertThat(out).containsExactlyInAnyOrderEntriesOf(
+            mapOf("comp-a" to listOf("1.0.0", "0.9.0"), "comp-b" to listOf("2.1.5")),
+        )
+    }
+
+    @Test
+    fun `non-array entry values are skipped — partial files don't crash`(@TempDir tmp: Path) {
+        val f = tmp.resolve("mixed.json")
+        f.writeText("""{"comp-a": ["1.0"], "comp-b": "not-an-array", "comp-c": null, "comp-d": []}""")
+        val out = loadVersionsFile(f.toString(), mapper)
+        // comp-a kept; comp-b/c skipped (non-array); comp-d kept with empty list.
+        assertThat(out).containsExactlyInAnyOrderEntriesOf(
+            mapOf("comp-a" to listOf("1.0"), "comp-d" to emptyList()),
+        )
+    }
+
+    @Test
+    fun `array elements that are not non-blank strings are filtered out`(@TempDir tmp: Path) {
+        val f = tmp.resolve("dirty.json")
+        f.writeText("""{"comp": ["1.0", "", "   ", null, 42, "2.0", true]}""")
+        val out = loadVersionsFile(f.toString(), mapper)
+        assertThat(out).isEqualTo(mapOf("comp" to listOf("1.0", "2.0")))
+    }
+
+    @Test
+    fun `info logger receives the count of loaded components on success`(@TempDir tmp: Path) {
+        val f = tmp.resolve("ok.json")
+        f.writeText("""{"a": ["1"], "b": ["2"], "c": ["3"]}""")
+        val infos = mutableListOf<String>()
+        loadVersionsFile(f.toString(), mapper, info = { infos += it })
+        assertThat(infos).anyMatch { it.contains("loaded 3 components") }
+    }
+}


### PR DESCRIPTION
## Summary

Step 2 of 3 in the "compat-test data from `crs-compat-trace` repo, not
live RMS" workflow:

1. ✅ Step 1 (`crs-compat-trace` PR, merged) — dump scripts + populated
   `components/` and `versions/` data dirs.
2. **This PR** — `VersionSampler` reads from the JSON snapshot when
   `compat.versions.file` is configured; falls back to live RMS only
   when no file is configured (local dev).
3. Next PR — `[1.7]` TC build attaches the `crs-compat-trace` VCS root,
   exports `compat.versions.file`, drops the `COMPAT_RMS_URL` prompt.

## What changed

- `CompatConfig.versionsFile` — new field, sourced from
  `compat.versions.file` system property / `COMPAT_VERSIONS_FILE` env.
  Null default keeps existing behaviour for local dev.
- `loadVersionsFile()` — pure function extracted as `internal` for
  testability. Contract: `null path → null (RMS fallback)`,
  `missing/unparseable/non-object → empty map (no silent RMS fallback)`,
  valid object → `{componentId: [v1, ...]}`.
- `VersionSampler.versionsFor()` priority: **file (when configured) →
  RMS (when only URL set) → empty list**. The file path does NOT
  cross-fall-back to RMS — operator explicitly choosing file mode
  trumps RMS availability, otherwise the reproducibility promise is
  broken.
- `build.gradle` — `compat.versions.file` system-property pass-through
  alongside the other `compat.*` properties.

## Tests

- New `VersionSamplerLoaderTest` (9 cases, `@Tag("unit")`):
  - null path → null
  - non-existent path → empty map
  - directory at path → empty map
  - unparseable JSON → empty map + warn-log
  - non-object JSON (array root) → empty map
  - happy path
  - non-array entry values skipped
  - array elements not non-blank-string filtered out
  - info-logger receives the count
- All 70 pre-existing unit tests still green; **79 total**.

## Review protocol

`feedback_compat_test_infra_review_protocol` will be applied to this
PR (Sonnet correctness + Opus adversarial) once it's open. The loader
is fully covered by unit tests; the integration path (`VersionSampler`'s
lazy singleton state) is not unit-tested but is exercised by the
existing `TraceReplayCompatTest` whenever it runs against a real stand.

## Verification

- `./gradlew :components-registry-compat-test:unitTest` — 79 green.
- Forbidden-literal audit (`grep -nE` bracket-class regex) — zero hits.

## Test plan (post-merge)

- [x] Unit tests green.
- [ ] Once step 3 lands and id17 runs in TC: confirm
      `[1.7]` build logs show the
      `compat.versions.file: loaded N components from <path>` info-line
      from `loadVersionsFile`, and that RMS is NOT contacted during
      `TraceReplayCompatTest` / per-component fixture lookups.
- [ ] Run id17 with a deliberately-wrong `compat.versions.file` path
      to confirm the warn-log + empty-map fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
