### PR TITLE
ci(teamcity): id17 reads components + versions from CrsCompatTrace VCS root

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -428,7 +428,7 @@ object id17CompatLocalStandManual : BuildType({
         // sets and the `versions/component-versions.json` snapshot so id17
         // doesn't need an RMS URL prompt or a CSV-paste of component names
         // from the operator every run.
-        root(CrsCompatTrace, "+:. => trace-data")
+        root(CrsCompatTrace, "+:. => trace-data/")
     }
 
     params {
@@ -509,15 +509,39 @@ object id17CompatLocalStandManual : BuildType({
                 TRACE_DATA_DIR="%teamcity.build.checkoutDir%/trace-data"
                 COMPONENTS_FILE_PATH="${'$'}TRACE_DATA_DIR/%COMPAT_COMPONENTS_FILE%"
                 VERSIONS_FILE_PATH="${'$'}TRACE_DATA_DIR/versions/component-versions.json"
-                # Read the components file: strip comment-only and blank lines,
-                # join the rest with commas. The wrapper hands this CSV to
-                # gradle as `-Pcompat.smoke-components=...`.
-                COMPONENTS_CSV=${'$'}(grep -vE '^[[:space:]]*(#|${'$'})' "${'$'}COMPONENTS_FILE_PATH" | tr '\n' ',' | sed 's/,${'$'}//')
-                if [ -z "${'$'}COMPONENTS_CSV" ]; then
+
+                # Fail-fast on missing files (Opus Stage-2 review). Without these
+                # guards a checkout failure on the CrsCompatTrace VCS root would
+                # silently produce zero components AND zero versions → every
+                # per-component test would skip via assumeTrue → vacuous green.
+                if [ ! -f "${'$'}COMPONENTS_FILE_PATH" ]; then
+                    echo "ERROR: COMPAT_COMPONENTS_FILE=${'$'}COMPONENTS_FILE_PATH does not exist (CrsCompatTrace checkout failed or file renamed)" >&2
+                    exit 2
+                fi
+                if [ ! -f "${'$'}VERSIONS_FILE_PATH" ]; then
+                    echo "ERROR: versions snapshot ${'$'}VERSIONS_FILE_PATH does not exist (CrsCompatTrace checkout failed or path renamed)" >&2
+                    exit 2
+                fi
+
+                # Read the components file: strip CRs (Windows-saved files),
+                # trim per-line whitespace, drop blank and comment-only lines.
+                # awk is one pass and won't trip set-e's pipefail on no-match.
+                TMP_LIST=${'$'}(awk '
+                    { sub(/\r${'$'}/, ""); gsub(/^[[:space:]]+|[[:space:]]+${'$'}/, "") }
+                    ${'$'}0 == "" || /^#/ { next }
+                    { print }
+                ' "${'$'}COMPONENTS_FILE_PATH")
+                if [ -z "${'$'}TMP_LIST" ]; then
                     echo "ERROR: COMPAT_COMPONENTS_FILE=${'$'}COMPONENTS_FILE_PATH produced zero IDs after filtering blanks/comments" >&2
                     exit 2
                 fi
-                echo "Component set:   %COMPAT_COMPONENTS_FILE% (${'$'}(echo "${'$'}COMPONENTS_CSV" | tr ',' '\n' | wc -l) IDs)"
+                COMPONENTS_CSV=${'$'}(printf '%s' "${'$'}TMP_LIST" | tr '\n' ',')
+                # Strip the trailing comma that `tr` adds when the input has a
+                # final newline (which `awk` always emits unless the input was
+                # empty — guarded above).
+                COMPONENTS_CSV="${'$'}{COMPONENTS_CSV%,}"
+                COMPONENTS_COUNT=${'$'}(printf '%s\n' "${'$'}TMP_LIST" | wc -l | tr -d ' ')
+                echo "Component set:   %COMPAT_COMPONENTS_FILE% (${'$'}COMPONENTS_COUNT IDs)"
                 echo "Versions file:   ${'$'}VERSIONS_FILE_PATH"
                 export BASELINE_JAR="${'$'}WORK_DIR/baseline.jar"
                 export CANDIDATE_JAR="${'$'}WORK_DIR/candidate.jar"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -507,6 +507,21 @@ object id17CompatLocalStandManual : BuildType({
                 set -euo pipefail
                 WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
                 TRACE_DATA_DIR="%teamcity.build.checkoutDir%/trace-data"
+
+                # Path-traversal guard on the prompted COMPAT_COMPONENTS_FILE
+                # value. Manual TC builds are operated by trusted release
+                # engineers, but a cheap defensive check beats a confusing
+                # "no such file" trail when a typo or stray paste resolves to
+                # something outside the CrsCompatTrace checkout. Reject any
+                # value containing `..` (which would let the resolved path
+                # escape trace-data/) or starting with `/` (absolute path).
+                case "%COMPAT_COMPONENTS_FILE%" in
+                    *..*|/*)
+                        echo "ERROR: COMPAT_COMPONENTS_FILE=%COMPAT_COMPONENTS_FILE% must be a relative path inside trace-data/ (no '..' segments, no leading '/')" >&2
+                        exit 2
+                        ;;
+                esac
+
                 COMPONENTS_FILE_PATH="${'$'}TRACE_DATA_DIR/%COMPAT_COMPONENTS_FILE%"
                 VERSIONS_FILE_PATH="${'$'}TRACE_DATA_DIR/versions/component-versions.json"
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -424,19 +424,20 @@ object id17CompatLocalStandManual : BuildType({
         root(AbsoluteId("Octopus_OctopusComponents_OctopusGithubVcsRoot"))
         root(ComponentsRegistry, "+:. => %COMPONENTS_REGISTRY_CHECKOUT_DIR%")
         root(ServiceConfig, "+:. => service-config")
+        // CrsCompatTrace ships the curated `components/{smoke,extended,all}.txt`
+        // sets and the `versions/component-versions.json` snapshot so id17
+        // doesn't need an RMS URL prompt or a CSV-paste of component names
+        // from the operator every run.
+        root(CrsCompatTrace, "+:. => trace-data")
     }
 
     params {
-        // Required smoke list — same shape as id15 (CSV of real component
-        // names), but feeds the LOCAL stands, not URLs. The value contains
-        // identifiers that are forbidden in repo files / commit messages
-        // (`feedback_redacted_identifiers`), but the TC `text(...)` param
-        // itself is fine because the value never lands in version control —
-        // it lives only in the TC build config form. (Not a `password(...)`
-        // type because the value isn't a credential and operators paste it
-        // visibly when triggering the run.)
-        text("COMPAT_SMOKE_COMPONENTS", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
-        text("COMPAT_RMS_URL", "", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        // Path (relative to the CrsCompatTrace checkout) to the file listing
+        // component IDs to exercise. One ID per line; blank lines and lines
+        // starting with `#` are ignored. Pick `components/smoke.txt` for a
+        // ~5-component fast run, `components/extended.txt` for ~50, or
+        // `components/all.txt` for the full sweep.
+        text("COMPAT_COMPONENTS_FILE", "components/smoke.txt", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_FULL", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
         // Baseline version is the project-level `LAST_RELEASE_VERSION` (e.g.
         // `2.0.87`); pinned, not prompted — operator updates the project
@@ -505,14 +506,30 @@ object id17CompatLocalStandManual : BuildType({
             scriptContent = """
                 set -euo pipefail
                 WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
+                TRACE_DATA_DIR="%teamcity.build.checkoutDir%/trace-data"
+                COMPONENTS_FILE_PATH="${'$'}TRACE_DATA_DIR/%COMPAT_COMPONENTS_FILE%"
+                VERSIONS_FILE_PATH="${'$'}TRACE_DATA_DIR/versions/component-versions.json"
+                # Read the components file: strip comment-only and blank lines,
+                # join the rest with commas. The wrapper hands this CSV to
+                # gradle as `-Pcompat.smoke-components=...`.
+                COMPONENTS_CSV=${'$'}(grep -vE '^[[:space:]]*(#|${'$'})' "${'$'}COMPONENTS_FILE_PATH" | tr '\n' ',' | sed 's/,${'$'}//')
+                if [ -z "${'$'}COMPONENTS_CSV" ]; then
+                    echo "ERROR: COMPAT_COMPONENTS_FILE=${'$'}COMPONENTS_FILE_PATH produced zero IDs after filtering blanks/comments" >&2
+                    exit 2
+                fi
+                echo "Component set:   %COMPAT_COMPONENTS_FILE% (${'$'}(echo "${'$'}COMPONENTS_CSV" | tr ',' '\n' | wc -l) IDs)"
+                echo "Versions file:   ${'$'}VERSIONS_FILE_PATH"
                 export BASELINE_JAR="${'$'}WORK_DIR/baseline.jar"
                 export CANDIDATE_JAR="${'$'}WORK_DIR/candidate.jar"
                 export BASELINE_LOG="${'$'}WORK_DIR/baseline.log"
                 export CANDIDATE_LOG="${'$'}WORK_DIR/candidate.log"
                 export LOCAL_VCS_ROOT="%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%"
                 export SERVICE_CONFIG_DIR="%teamcity.build.checkoutDir%/service-config"
-                export COMPAT_SMOKE_COMPONENTS="%COMPAT_SMOKE_COMPONENTS%"
-                export COMPAT_RMS_URL="%COMPAT_RMS_URL%"
+                export COMPAT_SMOKE_COMPONENTS="${'$'}COMPONENTS_CSV"
+                # VersionSampler reads from the file directly (no RMS round-trip
+                # per call) when this is set. See loadVersionsFile in
+                # components-registry-compat-test for the contract.
+                export COMPAT_VERSIONS_FILE="${'$'}VERSIONS_FILE_PATH"
                 export COMPAT_FULL="%COMPAT_FULL%"
                 export COMPAT_PARALLELISM=8
                 export RESET_DB=1


### PR DESCRIPTION
## Summary

Final step of the "compat-test data from internal trace repo, not live
RMS" workflow (steps 1+2 already merged in
`creg/crs-compat-trace` master and PR #273 respectively).

`[1.7] Compatibility Local-Stand` now reads:
- the component-ID set to exercise — from a file in the
  `CrsCompatTrace` VCS root (default `components/smoke.txt`),
- the per-component version snapshot — from
  `versions/component-versions.json` in the same root, via the
  `compat.versions.file` system property `VersionSampler` honors
  since PR #273.

## Operator UX change

`[1.7]` prompts shrink from 4 fields (URL × 3 + smoke CSV) to **3**:

| Param                     | Default                      | What it does                              |
|---------------------------|------------------------------|-------------------------------------------|
| `COMPAT_COMPONENTS_FILE`  | `components/smoke.txt`       | Path inside `trace-data/`. Pick `extended.txt` for ~50 IDs or `all.txt` for the full sweep. |
| `COMPAT_FULL`             | `false`                      | Switch from smoke to full endpoint matrix.|
| `COMPAT_BASELINE_VERSION` | `%LAST_RELEASE_VERSION%`     | Pinned to the project param (today: `2.0.87`). Operator updates the project param when a new release lands. |

No more pasting CSV component lists or RMS URLs every run. Both come
from VCS-tracked data refreshed weekly via
`crs-compat-trace/scripts/dump-*.py`.

## What the build does internally

1. Pulls baseline + candidate docker images, extracts `/app/app.jar`
   from each (unchanged from previous id17 — Opus Stage-2 trap-cleanup
   pattern preserved).
2. NEW: reads `COMPAT_COMPONENTS_FILE` from `trace-data/`, strips
   comment/blank lines, joins with commas → `COMPAT_SMOKE_COMPONENTS`
   env. **Fails fast with `exit 2`** when the file produces zero IDs
   (operator picked a deleted / empty file), instead of silently
   skipping every per-component test.
3. NEW: exports `COMPAT_VERSIONS_FILE=trace-data/versions/component-versions.json`
   so `VersionSampler.versionsFor()` (PR #273) reads from the
   snapshot, not RMS.
4. Hands env to the existing `scripts/local-stands/teamcity-run.sh`
   wrapper, which boots both JVMs + postgres + gradle.

## Verification

- Forbidden-literal audit on the diff (bracket-class regex over the
  full `feedback_redacted_identifiers` set) — zero hits.
- TC Kotlin DSL not locally compilable without a live TC server (Maven
  plugin resolves `configs-dsl-kotlin-*` via `${teamcity.serverUrl}`);
  first real validation is the TC configuration import on push.
- Companion components/versions files in `creg/crs-compat-trace` are
  already populated (948 IDs in `all.txt`, 762 components × ≤3
  versions in the JSON).

## Out of scope (follow-ups noted in PR #273 KDoc)

- Freshness guard on `versions/component-versions.json` (stale snapshot
  silently passes wrong versions on both stands).
- File-vs-RMS drift sentinel (file says component X exists, RMS says
  retired → silent green).
- Real coverage-floor enforcement that fires when the file is empty /
  wrong-path (currently `loadVersionsFile` returns empty map, downstream
  tests skip silently — vacuous-green vector).

## Test plan (post-merge)

- [x] Diff scanned for forbidden literals — clean.
- [ ] After merge + TC config sync: operator runs `[1.7]` with default
      prompts. Expect:
      - Build header logs `Component set: components/smoke.txt (5 IDs)`.
      - `VersionSampler` info-line: `compat.versions.file: loaded N
        components from .../versions/component-versions.json`.
      - No RMS calls in the wrapper log.
- [ ] Operator deliberately sets `COMPAT_COMPONENTS_FILE` to a non-
      existent path → expect RED with `ERROR: COMPAT_COMPONENTS_FILE=
      ... produced zero IDs after filtering` (the new fail-fast).
- [ ] Operator runs once with `COMPAT_COMPONENTS_FILE=components/all.txt`
      + `COMPAT_FULL=true` to time the full sweep against the 60-min
      execution timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
