### PR TITLE
ci(teamcity): move COMPONENTS_REGISTRY + CRS_COMPAT_TRACE repo URLs into DSL

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -28,6 +28,13 @@ project {
         param("env.JAVA_HOME", "%env.JDK_21_0_x64%")
         param("COMPONENTS_REGISTRY_CHECKOUT_DIR", "Components-Registry")
         param("COMPONENT_NAME", "components-registry-service")
+        // Bitbucket repo URLs are CRS-specific (only used by this project's
+        // VCS roots), so they live in the DSL. The bitbucket hostname itself
+        // is shared across many TC projects and stays on the TC server as
+        // %GIT_SERVER_HOSTNAME%; substitution at runtime keeps the host
+        // out of the open-source repo while letting the slugs be readable.
+        param("COMPONENTS_REGISTRY_REPO_URL", "ssh://git@%GIT_SERVER_HOSTNAME%/CREG/components-registry.git")
+        param("CRS_COMPAT_TRACE_REPO_URL", "ssh://git@%GIT_SERVER_HOSTNAME%/CREG/crs-compat-trace.git")
     }
 
     buildType(id10CompileUtAuto)


### PR DESCRIPTION
## Summary

- Declare `COMPONENTS_REGISTRY_REPO_URL` and `CRS_COMPAT_TRACE_REPO_URL` in the project-level `params { }` block, using `%GIT_SERVER_HOSTNAME%` for the host substitution.
- Removes the need to manually maintain these two URLs on the TC parent project — DSL becomes the single source of truth for CRS-specific repo locations.
- `SERVICE_CONFIG_REPO_URL` stays on TC parent (different ownership boundary, touched by other consumers).

## Test plan

- [x] `mvn -f .teamcity/pom.xml teamcity-configs:generate` → BUILD SUCCESS
- [ ] After merge + TC sync: id20 (uses ComponentsRegistry root) still pulls from `%COMPONENTS_REGISTRY_REPO_URL%` correctly
- [ ] id16/id17 (use CrsCompatTrace root) still pull from `%CRS_COMPAT_TRACE_REPO_URL%` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)