### PR TITLE
diag(teamcity): id17 emit VCS checkout state to surface mirror mismatch

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -516,6 +516,28 @@ object id17CompatLocalStandManual : BuildType({
                 WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
                 TRACE_DATA_DIR="%teamcity.build.checkoutDir%/trace-data"
 
+                # ---- VCS root diagnostics (temporary) ---------------------
+                # Print what TC actually checked out into each secondary VCS
+                # root dir. Catches misconfigured %XXX_REPO_URL% server params
+                # (e.g. service-deployment vs service-config) and stale git
+                # mirror caches that don't re-clone after a param value change.
+                echo "===== id17 VCS checkout diagnostics ====="
+                for d in "%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%" \
+                         "%teamcity.build.checkoutDir%/service-config" \
+                         "${'$'}TRACE_DATA_DIR"; do
+                    echo "--- ${'$'}d ---"
+                    if [ -d "${'$'}d" ]; then
+                        ls -la "${'$'}d" | head -25
+                        if [ -d "${'$'}d/.git" ]; then
+                            (cd "${'$'}d" && git remote -v && git log -1 --oneline 2>/dev/null) || true
+                        fi
+                    else
+                        echo "(directory does not exist)"
+                    fi
+                done
+                echo "===== /diagnostics ====="
+                # ---- end VCS root diagnostics -----------------------------
+
                 # Path-traversal guard on the prompted COMPAT_COMPONENTS_FILE
                 # value. Manual TC builds are operated by trusted release
                 # engineers, but a cheap defensive check beats a confusing


### PR DESCRIPTION
## Summary

id17 reached the wrapper preflight but fails with `service-config/application.yml not found`. Suspect: TC's local git mirror for `Service_Config` (`/opt/TeamCity/system/git/git-2BFE5043.git`) was created when `%SERVICE_CONFIG_REPO_URL%` pointed at `f1/service-deployment.git`, and didn't re-clone after the param value was changed to `f1/service-config.git` on the parent project.

This PR adds a temporary diagnostic block to id17's `Run local-stand compat` step that prints, for each of the three secondary VCS root checkouts:
- `ls -la <dir>` (top 25 entries)
- `git remote -v`
- `git log -1 --oneline`

After the next id17 run we'll know which remote URL the on-disk checkout actually came from and revert.

## Test plan

- [x] `mvn -f .teamcity/pom.xml teamcity-configs:generate` → BUILD SUCCESS
- [ ] After merge + TC apply: trigger id17 → log shows the diag block before the preflight error → confirm `service-config/.git` remote URL matches the param value
- [ ] Revert the diag block in a follow-up once the root cause is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)