### PR TITLE
fix(teamcity): id17 diag comment — drop %...% so TC doesn't add implicit req

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -518,9 +518,12 @@ object id17CompatLocalStandManual : BuildType({
 
                 # ---- VCS root diagnostics (temporary) ---------------------
                 # Print what TC actually checked out into each secondary VCS
-                # root dir. Catches misconfigured %XXX_REPO_URL% server params
-                # (e.g. service-deployment vs service-config) and stale git
-                # mirror caches that don't re-clone after a param value change.
+                # root dir. Catches misconfigured XXX_REPO_URL-style server
+                # params (e.g. service-deployment vs service-config) and stale
+                # git mirror caches that don't re-clone after a param value
+                # change. (Names written without the percent delimiters here
+                # so TC doesn't read the comment as an implicit-requirement
+                # reference and mark every agent incompatible.)
                 echo "===== id17 VCS checkout diagnostics ====="
                 for d in "%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%" \
                          "%teamcity.build.checkoutDir%/service-config" \


### PR DESCRIPTION
The diag block I landed in #277 had a comment example `%XXX_REPO_URL%`. TC's scriptContent parser scans for `%PARAM%` regex matches anywhere in the string (comments included) and registers them as implicit build requirements. With XXX_REPO_URL undefined on any agent, ALL agents show as incompatible (`XXX_REPO_URL must have a value`) and id17 won't start.

Drop the percent delimiters from the comment so TC treats `XXX_REPO_URL` as plain text.

Validation: `mvn teamcity-configs:generate` → BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)