### PR TITLE
fix(teamcity): id16 inline --tests filter into GRADLE_TASK

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -347,10 +347,16 @@ object id16CompatTraceReplayManual : BuildType({
             components-registry-compat-test/build/reports/compat/** => reports/compat
             components-registry-compat-test/build/test-results/**/*.xml => test-results/compat
         """.trimIndent())
-        param("GRADLE_TASK", ":components-registry-compat-test:test :components-registry-compat-test:compatibilityReporter")
-        param("GRADLE_TEST_FILTER", "--tests *TraceReplayCompatTest*")
+        // `--tests <pattern>` is a TASK-level Gradle option — it must appear
+        // AFTER the `:test` task on the command line. TC's gradle runner
+        // composes the line as `gradlew <gradleParams> <tasks>`, so anything
+        // in GRADLE_EXTRA_PARAMETERS lands BEFORE the tasks and Gradle treats
+        // `--tests` as an unknown global option (observed in build 2.0.84-4:
+        // "Unknown command-line option '--tests'"). Inline the filter into
+        // GRADLE_TASK between the test and reporter task refs so the option
+        // attaches to the correct task; do NOT move it back into the extras.
+        param("GRADLE_TASK", ":components-registry-compat-test:test --tests *TraceReplayCompatTest* :components-registry-compat-test:compatibilityReporter")
         param("GRADLE_EXTRA_PARAMETERS", """
-            %GRADLE_TEST_FILTER%
             -Pcompat.baseline.url=%COMPAT_BASELINE_URL%
             -Pcompat.candidate.url=%COMPAT_CANDIDATE_URL%
             -Pcompat.rms.url=%COMPAT_RMS_URL%

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -518,9 +518,12 @@ object id17CompatLocalStandManual : BuildType({
 
                 # ---- VCS root diagnostics (temporary) ---------------------
                 # Print what TC actually checked out into each secondary VCS
-                # root dir. Catches misconfigured %XXX_REPO_URL% server params
-                # (e.g. service-deployment vs service-config) and stale git
-                # mirror caches that don't re-clone after a param value change.
+                # root dir. Catches misconfigured XXX_REPO_URL-style server
+                # params (e.g. service-deployment vs service-config) and stale
+                # git mirror caches that don't re-clone after a param value
+                # change. (Names written without the percent delimiters here
+                # so TC doesn't read the comment as an implicit-requirement
+                # reference and mark every agent incompatible.)
                 echo "===== id17 VCS checkout diagnostics ====="
                 for d in "%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%" \
                          "%teamcity.build.checkoutDir%/service-config" \


### PR DESCRIPTION
## Diagnosis

id16 build #2.0.84-4 (triggered by `Git` after the previous v3 commit) failed at `Step 2/2: Gradle Build & UT (Gradle)` with:

    Unknown command-line option '--tests'.
    USAGE: gradlew [option...] [task...]

`--tests <pattern>` is a Gradle **task-level** option — it must appear AFTER the `:test` task on the command line. TC's gradle runner composes the line as `gradlew <gradleParams> <tasks>`, so anything in `GRADLE_EXTRA_PARAMETERS` lands BEFORE the tasks. The previous DSL had `GRADLE_TEST_FILTER = "--tests *TraceReplayCompatTest*"` templated into `GRADLE_EXTRA_PARAMETERS`, putting `--tests` on the wrong side.

## Fix

Move the filter inline into `GRADLE_TASK`, between the `:test` and `:compatibilityReporter` task refs:

    :components-registry-compat-test:test --tests *TraceReplayCompatTest* :components-registry-compat-test:compatibilityReporter

Remove the now-empty `GRADLE_TEST_FILTER` param. Inline comment explains why this must stay in `GRADLE_TASK` so a future edit doesn't "tidy" it back into extras.

## Test plan

- [x] `mvn -f .teamcity/pom.xml teamcity-configs:generate` → BUILD SUCCESS
- [ ] After merge: id16 next auto-trigger (or manual Run) parses the gradle command line cleanly, reaches `TraceReplayCompatTest` and proceeds to compat run.

## Out of scope

- The id17 diagnostic block from #277 will produce output on the next id17 run; that's still pending observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)