### PR TITLE
fix(local-stands): postgres-up — compose --wait 180s instead of 60s python-json poll

### DIFF
--- a/scripts/local-stands/postgres-up.sh
+++ b/scripts/local-stands/postgres-up.sh
@@ -20,18 +20,17 @@ else
   exit 1
 fi
 
-echo ">>> ${COMPOSE[*]} up -d  ($COMPOSE_FILE)"
-"${COMPOSE[@]}" -f "$COMPOSE_FILE" up -d
+echo ">>> ${COMPOSE[*]} up -d --wait --wait-timeout 180  ($COMPOSE_FILE)"
+# `--wait` makes compose itself block until every service marked with a
+# healthcheck transitions to `healthy` (or errors); `--wait-timeout 180`
+# caps that at 3 minutes — enough room for a cold-cache `postgres:16`
+# pull + volume init on a TC podman agent, where the previous 60-sec
+# busy-poll (30×2s with python-json parsing of `compose ps`) was both too
+# short AND fragile.
+if ! "${COMPOSE[@]}" -f "$COMPOSE_FILE" up -d --wait --wait-timeout 180; then
+  echo "ERROR: Postgres did not become healthy within 180 sec. Recent container logs:"
+  "${COMPOSE[@]}" -f "$COMPOSE_FILE" logs --tail 80 postgres 2>&1 || true
+  exit 1
+fi
 
-echo ">>> waiting for Postgres healthcheck..."
-for i in $(seq 1 30); do
-  health=$("${COMPOSE[@]}" -f "$COMPOSE_FILE" ps --format json postgres 2>/dev/null | head -1 | python3 -c 'import sys,json; print(json.loads(sys.stdin.read() or "{}").get("Health","unknown"))' 2>/dev/null || echo unknown)
-  if [ "$health" = "healthy" ]; then
-    echo ">>> Postgres healthy (port ${CRS_DB_PORT:-5432})."
-    exit 0
-  fi
-  sleep 2
-done
-
-echo "WARN: Postgres did not become healthy within 60 sec. Check '${COMPOSE[*]} -f $COMPOSE_FILE logs postgres'."
-exit 1
+echo ">>> Postgres healthy (port ${CRS_DB_PORT:-5432})."


### PR DESCRIPTION
## Diagnosis

id17 build #4 made it through the wrapper preflight (all 3 secondary VCS roots show correct origins in the diag block from #277). Postgres step:

```
>>> docker compose up -d  (.../docker-compose.local-postgres.yml)
Pulling postgres (postgres:16)...
Creating aebb84adefd504c8_postgres_1 ... done
>>> waiting for Postgres healthcheck...
WARN: Postgres did not become healthy within 60 sec.
>>> teardown
```

Two problems with the existing wait loop:

1. **60 sec budget is too tight on cold cache.** The image pull alone took 17 sec; container create + first-time volume init + healthcheck `start_period: 10s` + first `pg_isready` cycle adds up. Podman rootless userns on TC agents makes the volume init slower than plain Docker.
2. **Fragile parser.** The old loop pipes `compose ps --format json` through `python3 -c 'json.loads...'`. A Compose v2 format change or a missing `python3` silently makes the loop never see `"healthy"` — same observable as a real timeout, no diagnostic.

## Fix

Use Compose's own `--wait --wait-timeout 180` (Compose v2 feature). Compose blocks until each service with a healthcheck reaches `healthy`, or exits non-zero on timeout. No JSON parsing in our wrapper, no manual polling. On timeout we dump the last 80 lines of `compose logs postgres` to the TC log so the operator sees the real failure without SSHing into the agent.

## Test plan

- [x] `bash -n scripts/local-stands/postgres-up.sh` — syntax clean
- [ ] After merge: id17 next manual Run reaches "Postgres healthy" within ~90 sec (warm cache) or ~150 sec (cold cache), then proceeds to baseline / candidate stand boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)