### PR TITLE
feat(teamcity): id17 finish-build-trigger from id10, excluding main

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -666,6 +666,24 @@ object id17CompatLocalStandManual : BuildType({
         doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
     }
 
+    triggers {
+        // Auto-fire id17 whenever id10 finishes successfully on a branch
+        // OTHER than main. v3 is the schema-v2 trunk where local-stand
+        // compat actually has signal; on main the legacy V1 candidate vs
+        // V1 baseline is a tautological pass and would just burn agent
+        // minutes (cold pulls, postgres init, two stand boots). Manual
+        // Run from any branch — including main — still works because
+        // the snapshot dep is the only hard requirement.
+        finishBuildTrigger {
+            buildType = "${id10CompileUtAuto.id}"
+            successfulOnly = true
+            branchFilter = """
+                +:*
+                -:main
+            """.trimIndent()
+        }
+    }
+
     dependencies {
         snapshot(id10CompileUtAuto) {
             onDependencyFailure = FailureAction.CANCEL


### PR DESCRIPTION
## Summary

Add a `finishBuildTrigger` on id17 so it auto-fires whenever id10 finishes successfully on a branch OTHER than `main`. Manual button still works from any branch (snapshot dep is the only hard requirement).

```kotlin
triggers {
    finishBuildTrigger {
        buildType = "${id10CompileUtAuto.id}"
        successfulOnly = true
        branchFilter = """
            +:*
            -:main
        """.trimIndent()
    }
}
```

## Why exclude main

id17 is a candidate-vs-baseline compat check. On main, both candidate (current build's image) and baseline (`%LAST_RELEASE_VERSION%`) are V1 implementations — V1-vs-V1 is tautologically a pass and would burn ~20-30 min of agent time per main commit on cold image pulls + postgres + two stand boots. v3 is where the schema-v2 candidate diverges from the V1 baseline and the compat check has real signal.

## Test plan

- [x] `mvn -f .teamcity/pom.xml teamcity-configs:generate` → BUILD SUCCESS
- [ ] After merge: next id10 success on v3 auto-triggers id17
- [ ] Push a commit to main → id10 runs but id17 does NOT auto-fire
- [ ] Manual Run on id17 from any branch (including main) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)