### PR TITLE
fix(local-stands): postgres-up — compose-v1-compatible inspect poll

### DIFF
--- a/scripts/local-stands/postgres-up.sh
+++ b/scripts/local-stands/postgres-up.sh
@@ -20,17 +20,42 @@ else
   exit 1
 fi
 
-echo ">>> ${COMPOSE[*]} up -d --wait --wait-timeout 180  ($COMPOSE_FILE)"
-# `--wait` makes compose itself block until every service marked with a
-# healthcheck transitions to `healthy` (or errors); `--wait-timeout 180`
-# caps that at 3 minutes — enough room for a cold-cache `postgres:16`
-# pull + volume init on a TC podman agent, where the previous 60-sec
-# busy-poll (30×2s with python-json parsing of `compose ps`) was both too
-# short AND fragile.
-if ! "${COMPOSE[@]}" -f "$COMPOSE_FILE" up -d --wait --wait-timeout 180; then
-  echo "ERROR: Postgres did not become healthy within 180 sec. Recent container logs:"
-  "${COMPOSE[@]}" -f "$COMPOSE_FILE" logs --tail 80 postgres 2>&1 || true
+echo ">>> ${COMPOSE[*]} up -d  ($COMPOSE_FILE)"
+# Plain `up -d` without `--wait`: TC agents here delegate `docker compose`
+# through podman to the v1 `docker-compose` binary which silently ignores
+# `--wait` (prints help and exits 0 without starting the container).
+# Compose v2's `--wait` is the cleaner API, but until every agent has v2
+# we poll explicitly using `docker inspect` — works on both v1 and v2 and
+# doesn't depend on `compose ps --format json` shape.
+"${COMPOSE[@]}" -f "$COMPOSE_FILE" up -d
+
+echo ">>> waiting for Postgres healthcheck (up to 180 sec)..."
+# Resolve the postgres container ID once. `compose ps -q postgres` returns
+# the bare container id on both v1 and v2.
+CID=$("${COMPOSE[@]}" -f "$COMPOSE_FILE" ps -q postgres 2>/dev/null | head -1 || true)
+if [ -z "$CID" ]; then
+  echo "ERROR: postgres container not found after 'compose up -d'."
+  "${COMPOSE[@]}" -f "$COMPOSE_FILE" ps || true
   exit 1
 fi
 
-echo ">>> Postgres healthy (port ${CRS_DB_PORT:-5432})."
+# 90 iterations × 2 sec = 180 sec total. Generous enough for cold-cache
+# postgres:16 pull + volume init on a podman rootless agent (line in TC
+# log: `Pulling postgres (postgres:16)... 17s`, then volume create +
+# container start + start_period 10s + first pg_isready can land near
+# 60-90s in practice).
+for i in $(seq 1 90); do
+  health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' "$CID" 2>/dev/null || echo unknown)
+  if [ "$health" = "healthy" ]; then
+    echo ">>> Postgres healthy (port ${CRS_DB_PORT:-5432}, container $CID, after ${i}×2s)."
+    exit 0
+  fi
+  if [ $((i % 10)) -eq 0 ]; then
+    echo "    ${i}/90 iterations  health=$health"
+  fi
+  sleep 2
+done
+
+echo "ERROR: Postgres did not become healthy within 180 sec. Recent container logs:"
+"${COMPOSE[@]}" -f "$COMPOSE_FILE" logs --tail 80 postgres 2>&1 || true
+exit 1


### PR DESCRIPTION
## Diagnosis (id17 build #5)

`docker` on this TC agent is podman, whose `compose` subcommand delegates to `/usr/local/bin/docker-compose` v1. That binary silently ignores `--wait`, prints `up` help, and exits 0 WITHOUT starting the container. Log lines 1324-1378:

```
>>> docker compose up -d --wait --wait-timeout 180  (...)
Emulate Docker CLI using podman.
Executing external compose provider "/usr/local/bin/docker-compose".
Builds, (re)creates, starts, and attaches to containers for a service.
...
Usage: up [options] [--scale SERVICE=NUM...] [--] [SERVICE...]
...
--no-log-prefix            Don't print prefix in logs.
>>> Postgres healthy (port 5432).            ← BOGUS, container never came up
```

Postgres never ran. Baseline (V1 mode, no DB) was fine at :4567 in 32s. Candidate (DB-mode) crashed after 8 min waiting for health:

```
Caused by: org.flywaydb.core.internal.exception.FlywaySqlException:
  Unable to obtain connection from database: Connection to localhost:5432 refused.
```

## Fix

Drop `--wait` (compose-v2-only). Poll `docker inspect --format='{{.State.Health.Status}}'` on the container ID returned by `compose ps -q postgres` — works on both compose v1 and v2, doesn't depend on `compose ps --format json` shape (the fragility we wanted to fix in #280). 90 × 2 sec = 180 sec budget, same as #280. On failure, dump last 80 lines of `compose logs postgres`.

## Test plan

- [x] `bash -n scripts/local-stands/postgres-up.sh` — syntax clean
- [ ] After merge: id17 next auto-trigger reaches "Postgres healthy" within ~30-90 sec, candidate JAR boots, compat run proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)