### PR TITLE
fix(local-stands): wrapper uses $JAVA_HOME/bin/java (was: PATH default Java 8)

### DIFF
--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -66,6 +66,28 @@ CANDIDATE_WORKTREE="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 [ -f "$BASELINE_JAR" ]  || { echo "ERROR: BASELINE_JAR=$BASELINE_JAR is not a file";   exit 2; }
 [ -f "$CANDIDATE_JAR" ] || { echo "ERROR: CANDIDATE_JAR=$CANDIDATE_JAR is not a file"; exit 2; }
+
+# Resolve `java` once. Both JARs are Spring Boot 3.x → require Java 17+
+# (JarLauncher class-file v61). The TC agent's default `java` on $PATH
+# is often Java 8, but TC exports a usable JDK as $JAVA_HOME (DSL sets
+# env.JAVA_HOME = %env.JDK_21_0_x64%). Prefer $JAVA_HOME/bin/java and
+# fail fast if neither path resolves to a Java 17+ binary.
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  JAVA_BIN="$JAVA_HOME/bin/java"
+else
+  JAVA_BIN="$(command -v java || true)"
+fi
+[ -n "$JAVA_BIN" ] && [ -x "$JAVA_BIN" ] || {
+  echo "ERROR: no usable java binary on this agent (JAVA_HOME=${JAVA_HOME:-unset}, PATH does not contain java)"
+  exit 2
+}
+java_major=$("$JAVA_BIN" -version 2>&1 | awk -F\" '/version/ {print $2}' | awk -F. '{ if ($1 == "1") print $2; else print $1 }')
+if [ -z "$java_major" ] || [ "$java_major" -lt 17 ]; then
+  echo "ERROR: $JAVA_BIN is Java $java_major; baseline + candidate JARs need Java 17+"
+  "$JAVA_BIN" -version 2>&1 || true
+  exit 2
+fi
+echo ">>> using java: $JAVA_BIN  (major=$java_major)"
 [ -d "$LOCAL_VCS_ROOT" ] || { echo "ERROR: LOCAL_VCS_ROOT=$LOCAL_VCS_ROOT is not a directory"; exit 2; }
 [ -d "$SERVICE_CONFIG_DIR" ] || { echo "ERROR: SERVICE_CONFIG_DIR=$SERVICE_CONFIG_DIR is not a directory"; exit 2; }
 [ -f "$SERVICE_CONFIG_DIR/application.yml" ] || {
@@ -131,7 +153,7 @@ BASELINE_ADDITIONAL="file:$CANDIDATE_WORKTREE/components-registry-service-server
 BASELINE_ADDITIONAL="$BASELINE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/application.yml"
 BASELINE_ADDITIONAL="$BASELINE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
 
-nohup java -jar "$BASELINE_JAR" \
+nohup "$JAVA_BIN" -jar "$BASELINE_JAR" \
   --server.port="$BASELINE_PORT" \
   --spring.cloud.config.enabled=false \
   --spring.cloud.bootstrap.enabled=false \
@@ -177,7 +199,7 @@ CANDIDATE_ADDITIONAL="file:$CANDIDATE_WORKTREE/components-registry-service-serve
 CANDIDATE_ADDITIONAL="$CANDIDATE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
 CANDIDATE_PROFILES="dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local"
 
-nohup java -jar "$CANDIDATE_JAR" \
+nohup "$JAVA_BIN" -jar "$CANDIDATE_JAR" \
   --server.port="$CANDIDATE_PORT" \
   --spring.profiles.active="$CANDIDATE_PROFILES" \
   --spring.config.additional-location="$CANDIDATE_ADDITIONAL" \


### PR DESCRIPTION
## Diagnosis (id17 build #7)

Postgres came up cleanly via #282's inspect poll (14 sec). Baseline JAR crashed immediately:

```
java.lang.UnsupportedClassVersionError: org/springframework/boot/loader/launch/JarLauncher
  has been compiled by a more recent version of the Java Runtime
  (class file version 61.0), this version of the Java Runtime only
  recognizes class file versions up to 52.0
```

class file 61 = Java 17. class file 52 = Java 8. Both CRS JARs are Spring Boot 3.x → need Java 17+. The wrapper invoked plain `java -jar`; on this agent the `java` on `$PATH` is Java 8 while the real JDK is exported as `$JAVA_HOME` (DSL `env.JAVA_HOME = %env.JDK_21_0_x64%`). id10 builds via Gradle which honors `$JAVA_HOME`, so the Java-8-on-PATH issue surfaces only in the wrapper.

## Fix

Resolve `$JAVA_BIN` once at the start of the wrapper: prefer `$JAVA_HOME/bin/java`, fall back to PATH only when `JAVA_HOME` is unset. Refuse to start if the resolved binary is Java <17 — fail fast with a readable message instead of the JarLauncher stack trace 5 min later. Both `nohup java -jar ...` calls switch to `nohup "$JAVA_BIN" -jar ...`.

## Test plan

- [x] `bash -n scripts/local-stands/teamcity-run.sh` syntax clean
- [ ] After merge: id17 next run prints `>>> using java: ... (major=21)`, baseline boots, candidate boots, compat runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)