### PR TITLE
feat(compat): id17 defaults to full sweep + proof-of-exec guard + live TC progress

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -448,11 +448,18 @@ object id17CompatLocalStandManual : BuildType({
     params {
         // Path (relative to the CrsCompatTrace checkout) to the file listing
         // component IDs to exercise. One ID per line; blank lines and lines
-        // starting with `#` are ignored. Pick `components/smoke.txt` for a
-        // ~5-component fast run, `components/extended.txt` for ~50, or
-        // `components/all.txt` for the full sweep.
-        text("COMPAT_COMPONENTS_FILE", "components/smoke.txt", allowEmpty = false, display = ParameterDisplay.PROMPT)
-        text("COMPAT_FULL", "false", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        // starting with `#` are ignored. `components/smoke.txt` is ~5 IDs and
+        // `components/extended.txt` is ~50; default to `components/all.txt`
+        // — the full sweep is what gives id17 actual signal (smoke produced
+        // 0 ExecutionLogger entries because the 5 picks didn't intersect with
+        // anything baseline V1 could resolve cleanly). Operator can still
+        // narrow at run time via the prompt.
+        text("COMPAT_COMPONENTS_FILE", "components/all.txt", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        // Default to the full endpoint matrix per business request: every
+        // component × every compat-test class, no per-test skipping under
+        // assumeTrue. Same prompt as before for operator overrides; flip to
+        // `false` to bypass parameterised endpoints for a quick env check.
+        text("COMPAT_FULL", "true", allowEmpty = false, display = ParameterDisplay.PROMPT)
         // Baseline version is the project-level `LAST_RELEASE_VERSION` (e.g.
         // `2.0.87`); pinned, not prompted — operator updates the project
         // param when a new release lands.
@@ -619,10 +626,11 @@ object id17CompatLocalStandManual : BuildType({
     }
 
     failureConditions {
-        // Full sweep budget. The 5-component smoke completes in ~5-10 min;
-        // a full ~475-component matrix needs ~15-30 min. Padded to 60 min
-        // for cold-image-pull + first-time postgres volume init.
-        executionTimeoutMin = 60
+        // Full sweep budget. With `components/all.txt` (~475 IDs) and
+        // COMPAT_FULL=true the per-test-class matrix is ~30-50 min after
+        // cold-pull + postgres + auto-migrate (~5-7 min upfront). Headroom
+        // for slow agents or congested registry → cap at 120 min.
+        executionTimeoutMin = 120
     }
 
     features {

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -338,6 +338,26 @@ Generated: ${new Date().format("yyyy-MM-dd HH:mm:ss Z")}
 Raw per-line records: `execution-log.ndjson`
 """
         logger.lifecycle("[compat] ${suppressedTotal} suppressed via known-deltas, ${activeTotal} active diffs (${envTotal} env-warnings)")
+        logger.lifecycle("[compat] ${total} execution-log entries (${withDiffs} with diffs, ${total - withDiffs} clean)")
+
+        // Proof-of-execution guard: a green build with zero exec records means
+        // the wrapper booted both stands but no compareResponses → ExecutionLogger
+        // path ever ran (smoke component set didn't intersect, all tests
+        // skipped via assumeTrue, or compat URLs weren't passed through to the
+        // base class). Without this guard, "Tests passed: 93" with all-skip
+        // looks identical to a real clean sweep. Fail loudly so the operator
+        // KNOWS the old-vs-new comparison was actually exercised.
+        if (total == 0) {
+            throw new GradleException(
+                "Compatibility run logged ZERO execution cases — both stands came up but " +
+                "no per-endpoint comparison ran. Likely causes: smoke list didn't intersect " +
+                "with components baseline V1 resolves; -Pcompat.baseline.url / -Pcompat.candidate.url " +
+                "not threaded through to CompatibilityTestBase; or every test class skipped via " +
+                "assumeTrue. Verify build/reports/compat/exec-worker-*.ndjson exists and is non-empty " +
+                "before trusting the 'Tests passed: N' line."
+            )
+        }
+
         if (activeTotal > 0) {
             throw new GradleException(
                 "Compatibility run produced ${activeTotal} active divergence(s) " +

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -18,6 +18,16 @@ import java.util.UUID
 object ExecutionLogger {
     private val mapper = jacksonObjectMapper()
     private val writeLock = Any()
+    private var counter = 0
+    private var diffCounter = 0
+    // Per-worker JVM counter; combine across workers in `compatibilityReporter` for
+    // a cross-fork total. The progress line below is best-effort visibility for the
+    // TC log, not a hard count for the operator (use execution-log.md for that).
+    // Print every 50 entries — at parallelism=8 that's roughly every ~5 sec of
+    // wall-clock for typical endpoint latencies, fast enough to feel live in TC
+    // without flooding the log on a 10k-request full sweep.
+    private const val PROGRESS_EVERY = 50
+
     private val workerFile: Path by lazy {
         val reportDir = Path.of("build/reports/compat").also { Files.createDirectories(it) }
         reportDir.resolve("exec-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
@@ -33,6 +43,7 @@ object ExecutionLogger {
             synchronized(writeLock) {
                 runCatching { w.flush() }
                 runCatching { w.close() }
+                System.out.println("[compat-exec] worker pid=${ProcessHandle.current().pid()} totals: $counter requests ($diffCounter with diffs)")
             }
         })
         w
@@ -43,6 +54,19 @@ object ExecutionLogger {
             writer.write(mapper.writeValueAsString(entry))
             writer.newLine()
             writer.flush()
+            counter++
+            if (entry.diffCount > 0) diffCounter++
+            if (counter == 1 || counter % PROGRESS_EVERY == 0) {
+                // Brief one-line progress so TC's build log shows the run is doing
+                // real work. Last endpoint + status pair is enough to debug
+                // "stuck at N" cases (e.g. baseline timing out on a single path).
+                System.out.println(
+                    "[compat-exec] $counter requests ($diffCounter with diffs) — " +
+                        "last: ${entry.endpoint} b=${entry.baselineStatus} c=${entry.candidateStatus} " +
+                        "b=${entry.baselineMs}ms c=${entry.candidateMs}ms diffs=${entry.diffCount}",
+                )
+                System.out.flush()
+            }
         }
     }
 


### PR DESCRIPTION
## Diagnosis (id17 build #8)

Build #8 was status NORMAL with "Tests passed: 93, ignored: 1", but `execution-log.md` showed:

```
- Total test cases executed: 0
- Cases with diffs: 0
- Cases clean: 0
```

`execution-log.ndjson` in the artifact ZIP was 0 bytes. The 93 JUnit passes were env-checks and `assumeTrue`-skipped parameterised cases — the 5-component smoke list didn't intersect with anything baseline V1 resolves cleanly, so no `compareResponses → ExecutionLogger.log` path ever ran. "Tests passed" was misleading.

## Changes

### 1. id17 DSL defaults (`.teamcity/settings.kts`)
- `COMPAT_COMPONENTS_FILE`: `components/smoke.txt` → `components/all.txt` (full ~475-component sweep — gives signal).
- `COMPAT_FULL`: `"false"` → `"true"` (every component × every compat-test class, no assumeTrue-skipping).
- `executionTimeoutMin`: 60 → 120 (full sweep needs ~30-50 min after cold pull + auto-migrate ~5-7 min upfront).

### 2. Proof-of-execution guard (`components-registry-compat-test/build.gradle`)
`compatibilityReporter` task now throws `GradleException` if `total exec-log entries == 0`:

```
Compatibility run logged ZERO execution cases — both stands came up but no per-endpoint
comparison ran. Likely causes: smoke list didn't intersect with components baseline V1
resolves; -Pcompat.baseline.url / -Pcompat.candidate.url not threaded through to
CompatibilityTestBase; or every test class skipped via assumeTrue. Verify
build/reports/compat/exec-worker-*.ndjson exists and is non-empty before trusting the
'Tests passed: N' line.
```

A vacuous green run now fails loudly with a readable diagnosis.

### 3. Live progress to stdout (`ExecutionLogger.kt`)
Print to stdout from `ExecutionLogger.log`:
- Every 50 requests (and at request #1): `[compat-exec] 150 requests (3 with diffs) — last: GET /api/component/foo b=200 c=200 b=12ms c=15ms diffs=0`
- At JVM shutdown: `[compat-exec] worker pid=12345 totals: 1234 requests (5 with diffs)`

TC will show real-time signal of the comparison loop running, not just silent gradle test output for 30-50 min. Same lock as the file write; 50 × ~100ms × parallelism=8 ≈ ~5 sec between lines.

## Test plan

- [x] `mvn -f .teamcity/pom.xml teamcity-configs:generate` → BUILD SUCCESS
- [ ] After merge: next id17 run prints `[compat-exec] ...` lines as comparison progresses; final `execution-log.md` shows non-zero `Total test cases executed`; old proof-of-exec issue cannot recur silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)