### PR TITLE
fix(compat): ExecutionLogger + DiffCollector resolve report dir via absolute path

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -78,6 +78,11 @@ test {
         'junit.jupiter.execution.parallel.mode.default': 'concurrent',
         'junit.jupiter.execution.parallel.config.strategy': 'fixed',
         'junit.jupiter.execution.parallel.config.fixed.parallelism': (project.findProperty('compat.parallelism') ?: '8') as String,
+        // Absolute path to the same dir compatibilityReporter aggregates from.
+        // DiffCollector / ExecutionLogger pick this up so the per-worker ndjson
+        // files land where the reporter looks, regardless of the test JVM's
+        // forked CWD.
+        'compat.report-dir': layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath,
     ]
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
@@ -27,7 +27,16 @@ object DiffCollector {
     // sharing the process-wide `records` queue.
     private val threadLocalCount = ThreadLocal.withInitial { 0 }
     private val workerFile: Path by lazy {
-        val reportDir = Path.of("build/reports/compat").also { Files.createDirectories(it) }
+        // Mirror the ExecutionLogger fix: take the gradle-managed absolute path
+        // from `compat.report-dir` system property, fall back to a relative
+        // path only for direct CLI invocations. Without this, the diff-worker
+        // ndjson lands in whatever CWD the test JVM was forked with — sometimes
+        // outside the module's build/ dir — and `compatibilityReporter` aggregates
+        // zero diffs even on a run that produced real divergences.
+        val baseDirProp = System.getProperty("compat.report-dir")
+        val reportDir = (if (baseDirProp != null) Path.of(baseDirProp) else Path.of("build/reports/compat"))
+            .toAbsolutePath()
+            .also { Files.createDirectories(it) }
         reportDir.resolve("diff-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
     }
     private val writer: BufferedWriter by lazy {

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -29,10 +29,26 @@ object ExecutionLogger {
     private const val PROGRESS_EVERY = 50
 
     private val workerFile: Path by lazy {
-        val reportDir = Path.of("build/reports/compat").also { Files.createDirectories(it) }
+        // System property `compat.report-dir` is set by the gradle test task to
+        // an ABSOLUTE path (layout.buildDirectory/reports/compat). Falling back
+        // to a relative `build/reports/compat` only protects against direct CLI
+        // invocations of the test class — under gradle that fallback would
+        // resolve to whatever JVM CWD gradle picked for the fork (sometimes
+        // the agent's $HOME, not the module dir), and the compatibilityReporter
+        // task would never find the exec-worker file. Symptom observed in id17
+        // build #9: 15834 progress lines on stdout but reporter saw 0 files.
+        val baseDirProp = System.getProperty("compat.report-dir")
+        val reportDir = (if (baseDirProp != null) Path.of(baseDirProp) else Path.of("build/reports/compat"))
+            .toAbsolutePath()
+            .also { Files.createDirectories(it) }
         reportDir.resolve("exec-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
     }
     private val writer: BufferedWriter by lazy {
+        // Log the resolved absolute path once on first write — gives the
+        // operator a single grep target ("Compat exec-log path:") in the TC
+        // build log if the path-vs-reporter mismatch ever recurs.
+        System.out.println("[compat-exec] Compat exec-log path: ${workerFile.toAbsolutePath()}")
+        System.out.flush()
         val w = Files.newBufferedWriter(
             workerFile,
             StandardCharsets.UTF_8,


### PR DESCRIPTION
## Diagnosis

id17 build #9 showed the wrapper-vs-reporter path mismatch:

- **stdout**: `[compat-exec] worker pid=16894 totals: 15834 requests (13 with diffs)` — real comparison work happened.
- **execution-log.md** artifact: "Total test cases executed: 0" — the reporter aggregated nothing.
- **summary.md** artifact: "Total recorded diffs: 0" — DiffCollector records also lost.

Both `ExecutionLogger` and `DiffCollector` used `Path.of("build/reports/compat")` — a path relative to the test JVM's CWD. The `compatibilityReporter` task uses `layout.buildDirectory.dir('reports/compat')` (absolute, under the subproject). On this TC agent the test fork's CWD apparently differs from the subproject dir, so the per-worker ndjson files landed in a directory the artifact rule `**/build/reports/**` also missed — only the rolled-up `execution-log.ndjson` (empty, written by the reporter into the right dir) made it into the zip.

## Fix

- `components-registry-compat-test/build.gradle`: test task sets `systemProperty 'compat.report-dir'` to `layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath`.
- `ExecutionLogger.kt` and `DiffCollector.kt`: take `compat.report-dir` when present, fall back to the old relative path for direct CLI invocations. Both `.toAbsolutePath()` before `createDirectories`.
- `ExecutionLogger.kt` also prints the resolved absolute path on first write — single-grep diagnosis if the mismatch ever recurs:
  ```
  [compat-exec] Compat exec-log path: /opt/TeamCity/work/.../components-registry-compat-test/build/reports/compat/exec-worker-12345-uuid.ndjson
  ```

## Test plan

- [ ] Next id17 run prints `Compat exec-log path: ...` line, then progress lines, then `execution-log.md` shows non-zero totals.
- [ ] `summary.md` reports the real diff categories from the 13 diff-marked cases (if still present after candidate stabilises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)