### PR TITLE
fix(compat): compat.report-dir via file() + diag print of property + user.dir

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -81,8 +81,12 @@ test {
         // Absolute path to the same dir compatibilityReporter aggregates from.
         // DiffCollector / ExecutionLogger pick this up so the per-worker ndjson
         // files land where the reporter looks, regardless of the test JVM's
-        // forked CWD.
-        'compat.report-dir': layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath,
+        // forked CWD. Use `file()` (resolves against this subproject) rather
+        // than `layout.buildDirectory.dir(...).get().asFile.absolutePath` —
+        // observed in id17 build #10 that the latter ended up as a path that
+        // Path.toAbsolutePath() didn't normalise to a leading-slash absolute
+        // form, so the reporter still saw zero files.
+        'compat.report-dir': file('build/reports/compat').absolutePath,
     ]
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -44,10 +44,13 @@ object ExecutionLogger {
         reportDir.resolve("exec-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
     }
     private val writer: BufferedWriter by lazy {
-        // Log the resolved absolute path once on first write — gives the
-        // operator a single grep target ("Compat exec-log path:") in the TC
-        // build log if the path-vs-reporter mismatch ever recurs.
-        System.out.println("[compat-exec] Compat exec-log path: ${workerFile.toAbsolutePath()}")
+        // Log the resolved absolute path + system-property value once on first
+        // write. id17 build #10 surfaced a case where the property looked unset
+        // even though build.gradle set it; print both raw and resolved so the
+        // operator can tell from grep alone which branch fired.
+        val propValue = System.getProperty("compat.report-dir") ?: "(unset)"
+        val cwd = System.getProperty("user.dir") ?: "(unknown)"
+        System.out.println("[compat-exec] Compat exec-log path: ${workerFile.toAbsolutePath()} (compat.report-dir=$propValue, user.dir=$cwd)")
         System.out.flush()
         val w = Files.newBufferedWriter(
             workerFile,


### PR DESCRIPTION
## Diagnosis

id17 build #10 — first run on the #285 fix — still showed `Total test cases executed: 0` and printed:

```
[compat-exec] Compat exec-log path: components-registry-compat-test/build/reports/compat/exec-worker-2733521-...ndjson
```

— a path without leading slash. Two possible causes:

1. `layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath` produced something `Path.toAbsolutePath()` didn't normalise to leading-slash absolute (Gradle/Groovy quirk).
2. The system property didn't reach the test JVM at all (DSL cached, system-property assignment failed, etc.).

## Changes

- **build.gradle**: switch `compat.report-dir` to `file('build/reports/compat').absolutePath`. `project.file()` resolves against the subproject dir and always returns absolute.
- **ExecutionLogger.kt**: lazy-init writer now prints both raw `compat.report-dir` value AND `user.dir` (test JVM CWD) alongside the resolved workerFile path:
  ```
  [compat-exec] Compat exec-log path: /abs/path/exec-worker-...ndjson (compat.report-dir=/abs/path, user.dir=/test/jvm/cwd)
  ```

Next run disambiguates immediately: property unset → DSL change didn't apply; property set but still relative-looking → JVM/Path quirk; both look right → path-vs-reporter mismatch is somewhere else.

## Test plan

- [ ] Next id17 run prints `[compat-exec] Compat exec-log path: ... (compat.report-dir=..., user.dir=...)` once, then `execution-log.md` shows non-zero totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)