### PR TITLE
feat(local-stands): record CR / service-config / trace-data git revisions in wrapper banner

### DIFF
--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -110,6 +110,27 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Helper: print short git revision + describe for a checkout dir. Both stands
+# share the SAME LOCAL_VCS_ROOT / SERVICE_CONFIG_DIR / trace-data — recording
+# the revision in the banner makes "same CR version" guarantee auditable
+# without grepping for `Start computing revisions` in the TC log.
+git_id() {
+    local dir="$1"
+    if [ -d "$dir/.git" ] || git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
+        local rev describe
+        rev=$(git -C "$dir" rev-parse --short=12 HEAD 2>/dev/null || echo "<unknown>")
+        describe=$(git -C "$dir" describe --tags --always --dirty 2>/dev/null || echo "")
+        printf "%s (%s)" "$rev" "${describe:-no-describe}"
+    else
+        printf "<not a git checkout>"
+    fi
+}
+
+LOCAL_VCS_ROOT_REV=$(git_id "$LOCAL_VCS_ROOT")
+SERVICE_CONFIG_REV=$(git_id "$SERVICE_CONFIG_DIR")
+TRACE_DATA_DIR="${TRACE_DATA_DIR:-${PWD}/trace-data}"
+TRACE_DATA_REV=$(git_id "$TRACE_DATA_DIR")
+
 echo "============================================================"
 echo "TeamCity compat run"
 echo "  baseline version:  ${COMPONENTS_REGISTRY_SERVICE_VERSION:-<unset>}"
@@ -117,7 +138,11 @@ echo "  baseline JAR:      $BASELINE_JAR"
 echo "  candidate version: ${BUILD_VERSION:-<unset>}"
 echo "  candidate JAR:     $CANDIDATE_JAR"
 echo "  DSL root:          $LOCAL_VCS_ROOT"
+echo "  DSL revision:      $LOCAL_VCS_ROOT_REV   ← shared by baseline AND candidate"
 echo "  service-config:    $SERVICE_CONFIG_DIR"
+echo "  service-cfg rev:   $SERVICE_CONFIG_REV"
+echo "  trace-data:        $TRACE_DATA_DIR"
+echo "  trace-data rev:    $TRACE_DATA_REV"
 echo "  ports:             baseline=$BASELINE_PORT  candidate=$CANDIDATE_PORT"
 echo "  compat.full:       ${COMPAT_FULL:-false}    parallelism=${COMPAT_PARALLELISM:-8}"
 echo "============================================================"


### PR DESCRIPTION
## Why

User asked to guarantee that an id17 run uses ONE CR (Components-Registry) version across baseline AND candidate. The wrapper already does this — both stands read from the SAME `LOCAL_VCS_ROOT` checkout dir, so a single TC VCS root checkout pins the revision for the whole run.

But the guarantee was implicit: the operator had to grep `Start computing revisions` in TC's log to learn which revision was used. Make it auditable from the wrapper's own banner.

## Change

`teamcity-run.sh` banner now prints, for each of the three secondary VCS root checkouts (`Components-Registry`, `service-config`, `trace-data`):
- `git rev-parse --short=12 HEAD`
- `git describe --tags --always --dirty`

```
============================================================
TeamCity compat run
  baseline version:  2.0.87
  ...
  DSL root:          /opt/TeamCity/.../Components-Registry
  DSL revision:      2d853ba9e34a (Pull request #1822: CREG-480 ...) ← shared by baseline AND candidate
  service-config:    /opt/TeamCity/.../service-config
  service-cfg rev:   872cf3e13447 (...migrate portal Spring Cloud Gateway prefix...)
  trace-data:        /opt/TeamCity/.../trace-data
  trace-data rev:    3433291f9f61 (Pull request #1: add components/ + versions/ ...)
  ports:             baseline=4567  candidate=4568
============================================================
```

The annotation `← shared by baseline AND candidate` makes the consistency property explicit. The three revisions are sufficient input to reproduce any specific run's diff set.

## Test plan

- [x] `bash -n scripts/local-stands/teamcity-run.sh` syntax clean
- [ ] Next id17 run's banner shows revisions; rest of pipeline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)