### PR TITLE
feat(compat): emit TeamCity service messages with diff/exec counts

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -349,6 +349,31 @@ Raw per-line records: `execution-log.ndjson`
         logger.lifecycle("[compat] ${suppressedTotal} suppressed via known-deltas, ${activeTotal} active diffs (${envTotal} env-warnings)")
         logger.lifecycle("[compat] ${total} execution-log entries (${withDiffs} with diffs, ${total - withDiffs} clean)")
 
+        // TeamCity service messages (https://www.jetbrains.com/help/teamcity/service-messages.html):
+        // surface the compat numbers in TC's build status line / problems tab so an
+        // operator scanning the build dashboard sees the diff count without opening
+        // summary.md. {build.status.text} keeps TC's auto-generated test-count
+        // prefix ("Tests passed: N, ignored: M"), we append our own.
+        def statusBody = "compat: ${activeTotal} active diff(s)" +
+            " (${suppressedTotal} suppressed, ${envTotal} env), " +
+            "${total} cases executed"
+        // Escape `'`, `[`, `]`, `|`, `\n` per the service-message escaping rules.
+        def escape = { String s -> s
+            .replace('|', '||')
+            .replace("'", "|'")
+            .replace('\n', '|n')
+            .replace('\r', '|r')
+            .replace('[', '|[')
+            .replace(']', '|]')
+        }
+        println "##teamcity[buildStatus text='{build.status.text}; ${escape(statusBody)}']"
+        if (activeTotal > 0) {
+            // buildProblem surfaces in the build's Problems tab and tags the
+            // build as having a real failure category, separate from the
+            // gradle-task-failed default classification.
+            println "##teamcity[buildProblem description='Compat: ${escape(statusBody)} — see summary.md']"
+        }
+
         // Proof-of-execution guard: a green build with zero exec records means
         // the wrapper booted both stands but no compareResponses → ExecutionLogger
         // path ever ran (smoke component set didn't intersect, all tests


### PR DESCRIPTION
## Why

id17 build #11 status line: `Tests passed: 15834, ignored: 1; exit code 1 (Step: Run local-stand compat (Command Line))`. Operator scanning the TC build dashboard couldn't tell whether the run found 0 / 19 / 15000 actual divergences — only `summary.md` had the breakdown, and only after opening the artifacts.

## Change

`compatibilityReporter` task now emits two TC service messages:

1. **`buildStatus`** override, ALWAYS:
   ```
   ##teamcity[buildStatus text='{build.status.text}; compat: N active diff(s) (M suppressed, E env), K cases executed']
   ```
   TC substitutes `{build.status.text}` with its default test-count prefix. Final status line:
   ```
   Tests passed: 15834, ignored: 1; compat: 19 active diff(s) (1 suppressed, 0 env), 15834 cases executed
   ```

2. **`buildProblem`** when `activeTotal > 0`:
   ```
   ##teamcity[buildProblem description='Compat: N active diff(s) ... — see summary.md']
   ```
   Surfaces in the build's Problems tab; tags the build with a typed problem separate from the default "gradle task failed" classification.

Standard service-message escaping handled inline (`'`, `[`, `]`, `|`, newlines).

## Test plan

- [ ] Next id17 run with active diffs: TC status shows full count breakdown; Problems tab lists the compat problem with the same summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)