### PR TITLE
fix(compat): pin test workingDir + absolute compat.report-dir; id17 buildNumberPattern from id10

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -421,6 +421,13 @@ object id17CompatLocalStandManual : BuildType({
     id("17CompatLocalStandManual")
     name = "[1.7] Compatibility Local-Stand [MANUAL]"
 
+    // Mirror id20's pattern: surface the upstream id10 build number as id17's
+    // own build number so the TC dashboard / build chain UI shows the SAME
+    // version tag across the whole chain (id10 = id17 = id20 = … = id70).
+    // Without this id17 builds increment a separate counter and an operator
+    // looking at the chain view sees disconnected numbers.
+    buildNumberPattern = "%BUILD_NUMBER%"
+
     artifactRules = """
         **/build/reports/** => reports
         **/build/test-results/**/*.xml => test-results
@@ -465,8 +472,11 @@ object id17CompatLocalStandManual : BuildType({
         // param when a new release lands.
         param("COMPAT_BASELINE_VERSION", "%LAST_RELEASE_VERSION%")
         // Candidate image tag = the build number of the upstream id10 chain
-        // step that just pushed it via `dockerPushImage`.
-        param("COMPAT_CANDIDATE_VERSION", "${id10CompileUtAuto.depParamRefs.buildNumber}")
+        // step that just pushed it via `dockerPushImage`. Also reused as
+        // %BUILD_NUMBER% so id17's own build number (set above via
+        // `buildNumberPattern`) matches id10's.
+        param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
+        param("COMPAT_CANDIDATE_VERSION", "%BUILD_NUMBER%")
         // Corp docker registry hosting both image tags. Held in the TC
         // server / parent-project param `DOCKER_REGISTRY` (same value the
         // gradle Dockerfile arg consumes).

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -46,6 +46,14 @@ test {
     // back-to-back invocations identical and skips the second one — leaving the previous
     // ndjson on disk for compatibilityReporter to re-aggregate. Always re-run.
     outputs.upToDateWhen { false }
+    // Pin the test JVM's CWD to this subproject's root so the relative-path
+    // fallback inside ExecutionLogger/DiffCollector (`Path.of("build/reports/compat")`)
+    // always resolves to the SAME absolute directory the compatibilityReporter
+    // task aggregates from. Without this, id17 build #13 showed JVM CWD as
+    // something deeper than projectDir on the TC agent, the .ndjson files
+    // landed in a doubled `components-registry-compat-test/components-registry-compat-test/...`
+    // path, and reporter saw zero files.
+    workingDir = projectDir
     // Each run starts with a fresh report dir so per-worker ndjson files don't accumulate
     // across re-runs (the file names contain a UUID — old files would otherwise be merged
     // into summary.md again, double-counting diffs).
@@ -81,12 +89,11 @@ test {
         // Absolute path to the same dir compatibilityReporter aggregates from.
         // DiffCollector / ExecutionLogger pick this up so the per-worker ndjson
         // files land where the reporter looks, regardless of the test JVM's
-        // forked CWD. Use `file()` (resolves against this subproject) rather
-        // than `layout.buildDirectory.dir(...).get().asFile.absolutePath` —
-        // observed in id17 build #10 that the latter ended up as a path that
-        // Path.toAbsolutePath() didn't normalise to a leading-slash absolute
-        // form, so the reporter still saw zero files.
-        'compat.report-dir': file('build/reports/compat').absolutePath,
+        // forked CWD. Use `"${projectDir}/..."` (GString interpolation forces
+        // File.toString → absolute) rather than `file(...).absolutePath` —
+        // observed in id17 builds #10 and #13 that the latter still produced
+        // a relative-looking value on this TC agent's gradle/JVM combination.
+        'compat.report-dir': "${projectDir}/build/reports/compat".toString(),
     ]
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',


### PR DESCRIPTION
## Two related bundled fixes

### 1. Exec-log aggregation regressed in #13 (15834 → 0)

#11 and #12 successfully aggregated 15834 exec entries with the same code that #13 now reports as 0 cases — even though the in-JVM counter at shutdown said 15834. Diag line in #13:

```
compat.report-dir=components-registry-compat-test/build/reports/compat,
user.dir=components-registry-compat-test
```

Both relative-looking. `Path.of("components-registry-compat-test/build/reports/compat").toAbsolutePath()` on this TC podman agent apparently resolved against an unexpected CWD, producing a doubled `components-registry-compat-test/components-registry-compat-test/...` path the reporter doesn't aggregate from.

**Fix**:
- `test { workingDir = projectDir }` — pin the test JVM's CWD to the subproject root, no longer agent-dependent.
- `compat.report-dir` via `"${projectDir}/build/reports/compat".toString()` — GString interpolation guarantees absolute, no `file().absolutePath` quirks.

### 2. id17 buildNumberPattern (user request)

id17 had no `buildNumberPattern` set, so its TC build number was a separate counter (1, 2, 3, …) while id10/id20 use `%BUILD_NUMBER%` = id10's number (e.g. `2.0.87-3593`). Build Chain UI showed disconnected version tags.

Mirror id20: add `buildNumberPattern = "%BUILD_NUMBER%"` plus a `BUILD_NUMBER` param resolved from `id10CompileUtAuto.depParamRefs.buildNumber`. `COMPAT_CANDIDATE_VERSION` now reuses `%BUILD_NUMBER%` so the docker tag and TC build number stay in lockstep.

## Test plan

- [x] `mvn -f .teamcity/pom.xml teamcity-configs:generate` → BUILD SUCCESS
- [ ] Next id17 run: TC build number matches id10's (e.g. `2.0.87-3594` not `14`); exec-log reports non-zero cases; per-worker ndjson files in artifact zip under `components-registry-compat-test/build/reports/compat/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)