### PR TITLE
chore(test): remove 2 always-ignored Groovy methods + fix stale FtDbProfileWriteTest comment

### DIFF
--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/ConfigLoaderTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/ConfigLoaderTest.groovy
@@ -8,7 +8,6 @@ import org.octopusden.octopus.escrow.exceptions.EscrowConfigurationException
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Test
 import org.octopusden.releng.versions.VersionNames
 
@@ -72,18 +71,6 @@ class ConfigLoaderTest {
         checkAggregatorConfig(loader)
     }
 
-
-    @Test
-    @Ignore
-    void stressTest() {
-        def loader = new ConfigLoader(createFromFileSystem("vcs-resolver/src/test/resources", "testModuleConfig.groovy"),
-                VERSION_NAMES, PRODUCT_TYPES)
-        for (int i = 0; i < 10000; i++) {
-            println i;
-            loader.loadModuleConfig()
-        }
-        assert true
-    }
 
     @Test
     void testInvalidAttributesInSubComponent() {

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/MavenArtifactResolverTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/MavenArtifactResolverTest.groovy
@@ -10,7 +10,6 @@ import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
 import org.apache.maven.artifact.DefaultArtifact
 import org.apache.maven.artifact.versioning.VersionRange
-import org.junit.Ignore
 import org.junit.Test
 
 import java.util.regex.Pattern
@@ -36,24 +35,6 @@ class MavenArtifactResolverTest {
 
     IModuleByArtifactResolver resolver
     //= new ModuleByArtifactResolver(new EscrowConfigurationLoader(new ConfigLoader(getClass().getClassLoader().getResource("testModuleConfig.groovy"))));
-
-    @Test
-    @Ignore
-    void testProdConfig() {
-        URL url = new File("C:\\projects\\escrow\\components-registry\\src\\main\\resources\\Aggregator.groovy").toURI().toURL()
-
-        def loader = new EscrowConfigurationLoader(
-                new ConfigLoader(ComponentRegistryInfo.createFromURL(url), VERSION_NAMES, PRODUCT_TYPES),
-                SUPPORTED_GROUP_IDS,
-                SUPPORTED_SYSTEMS,
-                VERSION_NAMES,
-                COPYRIGHT_PATH
-        )
-        JiraParametersResolver jiraParametersResolver = new JiraParametersResolver(loader, new HashMap<String, String>());
-        def vcsRoots = jiraParametersResolver.getVersionControlSystemRootsByJiraProject(JiraProjectVersion.create("MCOMPONENT", "1.0"))
-        assert vcsRoots.getVersionControlSystemRoots().size() == 1
-        assert "default" == vcsRoots.getVersionControlSystemRoots()[1].branch
-    }
 
     @Test
     public void testExistingArtifact() {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/FtDbProfileWriteTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/FtDbProfileWriteTest.kt
@@ -33,15 +33,16 @@ import java.nio.file.Paths
  * The companion read-only test `FtDbProfileTest` already proves auto-migrate populates the DB
  * and read endpoints work under ft-db; this test exercises the write path.
  *
- * TODO(MIG-039): Re-enable once ImportServiceImpl.migrate() actually seeds the DB at startup
- *   under the ft-db profile. The Phase 5 ImportServiceImpl stub returns an empty result, so
- *   GET /rest/api/4/components returns an empty page and `firstComponent()` fails.
- *   Either wait for MIG-039 to land the §6 import pipeline, or rewrite @BeforeAll to seed
- *   at least one component via the v4 CRUD API before the write tests run.
+ * TODO(MIG-039 follow-up): The original disable reason ("Phase 5 ImportServiceImpl stub returns
+ *   an empty result") is now stale — `ImportServiceImpl.migrate()` runs `migrateDefaults()` +
+ *   `migrateAllComponents()` on top of the import pipeline that landed in `51ea4937`/`0c563755`,
+ *   and `FtDbProfileTest` confirms components are reachable via v1/v3 APIs under ft-db. This
+ *   test may pass with `@Disabled` lifted; if it still fails, capture the new failure reason
+ *   before re-disabling. Tracked as the experimental PR-A2 in .github/audit/TESTS-REVIEW-2026-05-23.md.
  */
 @Disabled(
-    "Phase 6: depends on auto-migrate seeding — re-enable when MIG-039 lands the §6 import " +
-        "pipeline, or rewrite to seed via v4 API in @BeforeAll.",
+    "Re-enable attempt deferred to PR-A2 (experimental). Original Phase 5 stub rationale is " +
+        "stale — see KDoc above for the current verification path.",
 )
 @AutoConfigureMockMvc
 @SpringBootTest(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/FtDbProfileWriteTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/FtDbProfileWriteTest.kt
@@ -35,14 +35,13 @@ import java.nio.file.Paths
  *
  * TODO(MIG-039): Re-enable once ImportServiceImpl.migrate() actually seeds the DB at startup
  *   under the ft-db profile. The Phase 5 ImportServiceImpl stub returns an empty result, so
- *   GET /rest/api/4/components returns an empty page and `firstComponent()` fails. This is the
- *   same blocker as FtDbProfileTest (which is already @Disabled for the same reason).
+ *   GET /rest/api/4/components returns an empty page and `firstComponent()` fails.
  *   Either wait for MIG-039 to land the §6 import pipeline, or rewrite @BeforeAll to seed
  *   at least one component via the v4 CRUD API before the write tests run.
  */
 @Disabled(
     "Phase 6: depends on auto-migrate seeding — re-enable when MIG-039 lands the §6 import " +
-        "pipeline, or rewrite to seed via v4 API in @BeforeAll. Same blocker as FtDbProfileTest.",
+        "pipeline, or rewrite to seed via v4 API in @BeforeAll.",
 )
 @AutoConfigureMockMvc
 @SpringBootTest(


### PR DESCRIPTION
## Summary

**Originally** this PR was scoped to delete 8 Groovy legacy tests per .github/audit/TESTS-REVIEW-2026-05-23.md Pass 1. Copilot review (and a follow-up deep-dive subagent on the remaining 5) showed that **every one of those 8 files holds unique assertions** with no Kotlin/Java coverage at any layer (unit, mapper, controller, HTTP IT). All 8 are demoted to the keep+rewrite backlog for PR-H (Kotlin port), and the audit doc is updated in PR #294 accordingly.

**This PR** keeps only the safe, file-preserving cleanup:

- Remove `ConfigLoaderTest#stressTest()` — `@Ignore`d 10 000-iteration perf loop.
- Remove `MavenArtifactResolverTest#testProdConfig()` — `@Ignore`d test pointing at a hard-coded `C:\\projects\\escrow\\…` Windows path.
- Drop the now-unused `org.junit.Ignore` import from both files.
- Fix the stale comment in `components-registry-service-server/src/test/kotlin/.../migration/FtDbProfileWriteTest.kt:39` (it falsely claimed `FtDbProfileTest` is `@Disabled` — it never has been).

Parent classes `ConfigLoaderTest.groovy` and `MavenArtifactResolverTest.groovy` STAY — they hold unique coverage for ambiguous-config validation, `artifactId.trim()` behaviour, and `JiraParametersResolver` methods that no Kotlin test exercises. Queued for PR-H Kotlin port.

## Test plan

- [x] Full `./gradlew build` green (5m 34s with `-x docker* -x oc* -x automation:test`).
- [x] component-resolver-core test report shows ignored count drops from 2 to 0, passing count unchanged.
- [ ] Post-merge: confirm TC `Tests passed: 1772, ignored: 6` on next green build (passing count unchanged because the removed methods were ignored, not passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)