### PR TITLE
chore(build): enable Gradle build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,14 @@ octopus.github.docker.registry=ghcr.io
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
+# Build cache: keep task outputs across runs. Validated locally cold 2m17s → warm 58s.
+org.gradle.caching=true
+# Configuration cache: deferred. Initial attempt failed with 3 serialization
+# problems rooted in :components-registry-automation:zipMetarunners (a Zip task
+# capturing a Project reference at configuration time, which Gradle cannot
+# serialise). Re-enable only after that task is refactored to not capture Project.
+org.gradle.configuration-cache=false
+
 # ow deps
 octopus-external-systems-clients.version=2.0.90
 octopus-release-management.version=2.0.4


### PR DESCRIPTION
## Summary

- Adds `org.gradle.caching=true` to `gradle.properties` — builds now reuse cached task outputs across runs.
- Configuration cache (`org.gradle.configuration-cache`) is set to `false`: the `:components-registry-automation:zipMetarunners` `Zip` task captures a `Project`/`Task` reference at configuration time, which Gradle configuration cache cannot serialise. The comment documents the root cause and the fix path for a future PR.
- Validated locally: cold-cache build **2m 17s** → warm-cache build **58s** (78 of 96 tasks UP-TO-DATE).
- Per .github/audit/TESTS-REVIEW-2026-05-23.md (Pass 5 quick-win #1).

## Test plan

- [x] Cold-cache full `./gradlew build` green (2m 17s).
- [x] Warm-cache full `./gradlew build` green (58s; 78/96 tasks UP-TO-DATE).
- [x] Independent Sonnet review of diff: **Looks good** — placement consistent, no other line touched, values exact, config-cache disabled with documented root cause.
- [ ] Post-merge: monitor CI for any unexpected build-cache errors over 3–5 builds.
- [ ] Follow-up: refactor `zipMetarunners` to not capture `Project` at config time, then re-enable `org.gradle.configuration-cache=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)