### PR TITLE
chore(compat): revert reporter diag + drop double Compat: prefix from buildProblem

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -214,40 +214,6 @@ tasks.register('compatibilityReporter') {
 
         def diffFiles = dir.listFiles({ f -> f.name.startsWith('diff-worker-') && f.name.endsWith('.ndjson') } as FileFilter) ?: []
         def execFiles = dir.listFiles({ f -> f.name.startsWith('exec-worker-') && f.name.endsWith('.ndjson') } as FileFilter) ?: []
-
-        // DIAG (temporary, remove after exec-log mystery resolved):
-        // id17 builds #13 and #14 (`2.0.84-3604`) showed `Tests passed: 15834`
-        // with the ExecutionLogger shutdown hook reporting 15834 totals, yet
-        // execFiles aggregated to 0. The worker files must exist somewhere,
-        // but reporter's `dir` (= layout.buildDirectory.dir('reports/compat'))
-        // sees an empty list. Print the absolute path of `dir` and `ls -la`
-        // it from the gradle JVM perspective so we can compare against where
-        // the test JVM actually wrote.
-        logger.lifecycle("[compat-diag] reporter dir absolute: ${dir.absolutePath}")
-        logger.lifecycle("[compat-diag] reporter dir exists  : ${dir.exists()}")
-        if (dir.exists()) {
-            dir.listFiles()?.sort()?.each { f ->
-                logger.lifecycle("[compat-diag]   ${f.length()}\t${f.name}")
-            }
-        }
-        logger.lifecycle("[compat-diag] execFiles count = ${execFiles.size()}, diffFiles count = ${diffFiles.size()}")
-        // Also scan `${rootProject.projectDir}/build/reports/compat` and
-        // `${System.getProperty('user.dir')}/build/reports/compat` to catch
-        // the case where workers wrote to a doubled or unexpected path.
-        [
-            new File(rootProject.projectDir, 'build/reports/compat'),
-            new File(rootProject.projectDir, 'components-registry-compat-test/build/reports/compat'),
-            new File(System.getProperty('user.dir'), 'build/reports/compat'),
-            new File(System.getProperty('user.dir'), 'components-registry-compat-test/build/reports/compat'),
-        ].unique { it.absolutePath }.each { altDir ->
-            if (altDir.absolutePath != dir.absolutePath && altDir.exists()) {
-                def workers = altDir.listFiles({ f -> f.name.startsWith('exec-worker-') } as FileFilter) ?: []
-                if (workers) {
-                    logger.lifecycle("[compat-diag] FOUND ${workers.size()} exec-worker file(s) at UNEXPECTED path: ${altDir.absolutePath}")
-                    workers.each { logger.lifecycle("[compat-diag]   ${it.length()}\t${it.name}") }
-                }
-            }
-        }
         def summary = new File(dir, 'summary.md')
         def execMd = new File(dir, 'execution-log.md')
         def execNd = new File(dir, 'execution-log.ndjson')
@@ -412,7 +378,8 @@ Raw per-line records: `execution-log.ndjson`
             // buildProblem surfaces in the build's Problems tab and tags the
             // build as having a real failure category, separate from the
             // gradle-task-failed default classification.
-            println "##teamcity[buildProblem description='Compat: ${escape(statusBody)} — see summary.md']"
+            // statusBody already starts with "compat:" — don't double-prefix.
+            println "##teamcity[buildProblem description='${escape(statusBody)} — see summary.md']"
         }
 
         // Proof-of-execution guard: a green build with zero exec records means


### PR DESCRIPTION
## What

id17 build `2.0.84-3605` confirmed exec-worker / diff-worker files are now where the reporter looks (PR #290 diag showed `exec-worker-...ndjson` at 5.27 MB inside `components-registry-compat-test/build/reports/compat`, `execFiles count = 1`). Status line now shows `15834 cases executed, 19 active diff(s) (1 suppressed, 0 env)`.

This PR cleans up:
- **Remove diag block from compatibilityReporter** (added in #290) — its job is done, just adds noise to every future id17 log.
- **Drop the `Compat:` prefix from buildProblem description** — `statusBody` already begins with `"compat:"`, the prefix produced the doubled `"Compat: compat: 19 active diff(s) …"` in the TC status line.

## Test plan

- [ ] Next id17 run: status line shows single `compat:` prefix, no `[compat-diag]` lines, exec-log report unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)