### PR TITLE
fix(compat): restore Compat: prefix in buildProblem description

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -377,9 +377,14 @@ Raw per-line records: `execution-log.ndjson`
         if (activeTotal > 0) {
             // buildProblem surfaces in the build's Problems tab and tags the
             // build as having a real failure category, separate from the
-            // gradle-task-failed default classification.
-            // statusBody already starts with "compat:" — don't double-prefix.
-            println "##teamcity[buildProblem description='${escape(statusBody)} — see summary.md']"
+            // gradle-task-failed default classification. The "Compat:"
+            // prefix is kept (re-added in this PR after #293 dropped it):
+            // user reported the red status info disappeared on the next
+            // build after that drop — TC may classify or dedupe problems
+            // by description-hash and need a stable identifying prefix.
+            // Cosmetic doubling ("compat: compat:" in the displayed line)
+            // is the lesser cost vs losing the typed problem entirely.
+            println "##teamcity[buildProblem description='Compat: ${escape(statusBody)} — see summary.md']"
         }
 
         // Proof-of-execution guard: a green build with zero exec records means


### PR DESCRIPTION
## Why

PR #293 dropped the `"Compat:"` prefix from `##teamcity[buildProblem description='...']` purely for cosmetic deduplication (statusBody already starts with `"compat:"`, the displayed status line showed `"Compat: compat: 19 active diff(s)..."`).

User reports that on the next id17 build after #293, the red status info about divergences disappeared from the TC build summary. The direct cause is unclear — `##teamcity[buildStatus]` and `##teamcity[buildProblem]` service-message **lines themselves were untouched** in #293, only the inner description text — but TC may classify or dedupe problems by description-hash and require a stable identifying prefix.

Restoring the prefix is cheap and reversible. The cosmetic doubling (`"compat: compat: ..."` in the displayed line) is the lesser cost vs losing the typed problem classification entirely.

## What

Single one-line change: re-add `Compat: ` to the buildProblem description. Diag block removed in #293 stays out (that was unrelated debug logging).

## Test plan

- [ ] Next id17 run after merge: TC status line back to showing `"compat: ..."` info in red as in #2.0.84-3605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)