### PR TITLE
feat(teamcity): add QA post-deploy component migration step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ BOOT-INF/
 # But do track the local-stands tooling — these are shared dev scripts, not ad-hoc.
 !scripts/local-stands/*.sh
 !scripts/local-stands/test/*.sh
+# CI helpers invoked from TeamCity build steps live in the repo so they can be
+# reviewed and tested outside TC.
+!scripts/teamcity/*.sh

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -44,6 +44,7 @@ project {
     buildType(id17CompatLocalStandManual)
     buildType(id20ValidateComponentsRegistryProductionDataAuto)
     buildType(id30DeployToOkdQaDevAuto)
+    buildType(id31MigrateOnQaDevAuto)
     buildType(id40ReleaseManual)
     buildType(id50ReleasePostProcessingAuto)
     buildType(id60DeployToOkdQaGhAuto)
@@ -57,6 +58,7 @@ project {
         id17CompatLocalStandManual,
         id20ValidateComponentsRegistryProductionDataAuto,
         id30DeployToOkdQaDevAuto,
+        id31MigrateOnQaDevAuto,
         id40ReleaseManual,
         id50ReleasePostProcessingAuto,
         id60DeployToOkdQaGhAuto,
@@ -792,6 +794,81 @@ object id30DeployToOkdQaDevAuto : BuildType({
     dependencies {
         snapshot(id20ValidateComponentsRegistryProductionDataAuto) {
         }
+    }
+})
+
+// Post-deploy: trigger Git→DB component migration on the freshly-deployed
+// QA pod. Idempotent and tolerant — exits 0 (skip, don't fail) if the
+// /admin/migration-status endpoint is missing (pre-v3 build) or returns
+// git==0 (nothing left to migrate). Fails the build only when migration
+// was attempted and ended in a FAILED state, so the QA-deploy chain
+// surfaces real migration breakage but does not break on routine
+// redeploys of an already-migrated stand.
+//
+// Pure shell-script build (no Gradle template) — VCS root is attached
+// explicitly, same pattern as id17 / id20. Script source lives at
+// `scripts/teamcity/qa-post-deploy-migrate.sh` so it can be tested and
+// reviewed outside TC.
+//
+// Auth: %CRS_QA_ADMIN_TOKEN% — Keycloak-issued JWT for a service account
+// with the IMPORT_DATA role. The param is declared as a placeholder here;
+// the actual secret is configured on the TC server as a project-level
+// password parameter named `CRS_QA_ADMIN_TOKEN`. Until that secret is
+// provisioned this build will fail with a clear "auth rejected" message
+// in the script — that is intentional (no silent-skip on auth misconfig).
+object id31MigrateOnQaDevAuto : BuildType({
+    id("31MigrateOnQaDevAuto")
+    name = "[3.1] Migrate components on QA DEV [AUTO]"
+
+    vcs {
+        root(AbsoluteId("Octopus_OctopusComponents_OctopusGithubVcsRoot"))
+    }
+
+    params {
+        // QA route to the freshly-deployed CRS pod. Sourced from the
+        // server-level param `CRS_QA_DEV_BASE_URL` (configure once on
+        // the TC parent project, same pattern as OKD_SERVER_DEV_URL).
+        param("env.CRS_BASE_URL", "%CRS_QA_DEV_BASE_URL%")
+        // Bearer JWT (service-account, role IMPORT_DATA). PLACEHOLDER —
+        // the project-level password parameter `CRS_QA_ADMIN_TOKEN` must
+        // be provisioned on the TC server before this build will succeed.
+        password("env.CRS_ADMIN_TOKEN", "%CRS_QA_ADMIN_TOKEN%")
+    }
+
+    steps {
+        script {
+            name = "Trigger Git→DB migration on QA"
+            id = "RUNNER_31_MIGRATE"
+            // The script file lives in the repo. Working dir is the
+            // checkout root; the +x bit is preserved in git but we
+            // restore it defensively in case the checkout strips mode.
+            scriptContent = """
+                chmod +x scripts/teamcity/qa-post-deploy-migrate.sh
+                exec scripts/teamcity/qa-post-deploy-migrate.sh
+            """.trimIndent()
+        }
+    }
+
+    triggers {
+        finishBuildTrigger {
+            id = "TRIGGER_31_AFTER_DEPLOY"
+            buildType = "${id30DeployToOkdQaDevAuto.id}"
+            successfulOnly = true
+        }
+    }
+
+    dependencies {
+        snapshot(id30DeployToOkdQaDevAuto) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
+    }
+
+    failureConditions {
+        executionTimeoutMin = 45
+    }
+
+    requirements {
+        doesNotContain("env.OS_TYPE", "WIN", "RQ_31_LINUX")
     }
 })
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -810,12 +810,15 @@ object id30DeployToOkdQaDevAuto : BuildType({
 // `scripts/teamcity/qa-post-deploy-migrate.sh` so it can be tested and
 // reviewed outside TC.
 //
-// Auth: %CRS_QA_ADMIN_TOKEN% — Keycloak-issued JWT for a service account
-// with the IMPORT_DATA role. The param is declared as a placeholder here;
-// the actual secret is configured on the TC server as a project-level
-// password parameter named `CRS_QA_ADMIN_TOKEN`. Until that secret is
-// provisioned this build will fail with a clear "auth rejected" message
-// in the script — that is intentional (no silent-skip on auth misconfig).
+// Auth: %CRS_QA_ADMIN_TOKEN% — the RAW Keycloak JWT for a service account
+// with the IMPORT_DATA role (the token value only, no `Authorization: ` /
+// no `Bearer ` prefix — the script adds `Authorization: Bearer <token>`
+// itself, and defensively strips a leading `Bearer ` if it was included).
+// The param is declared as a placeholder here; the actual secret is
+// configured on the TC server as a project-level password parameter named
+// `CRS_QA_ADMIN_TOKEN`. Until that secret is provisioned this build will
+// fail with a clear "auth rejected" message in the script — that is
+// intentional (no silent-skip on auth misconfig).
 object id31MigrateOnQaDevAuto : BuildType({
     id("31MigrateOnQaDevAuto")
     name = "[3.1] Migrate components on QA DEV [AUTO]"
@@ -829,9 +832,11 @@ object id31MigrateOnQaDevAuto : BuildType({
         // server-level param `CRS_QA_DEV_BASE_URL` (configure once on
         // the TC parent project, same pattern as OKD_SERVER_DEV_URL).
         param("env.CRS_BASE_URL", "%CRS_QA_DEV_BASE_URL%")
-        // Bearer JWT (service-account, role IMPORT_DATA). PLACEHOLDER —
-        // the project-level password parameter `CRS_QA_ADMIN_TOKEN` must
-        // be provisioned on the TC server before this build will succeed.
+        // Raw Keycloak JWT (service-account, role IMPORT_DATA) — token
+        // value only, NO `Bearer ` prefix; the script adds the scheme.
+        // PLACEHOLDER — the project-level password parameter
+        // `CRS_QA_ADMIN_TOKEN` must be provisioned on the TC server
+        // before this build will succeed.
         password("env.CRS_ADMIN_TOKEN", "%CRS_QA_ADMIN_TOKEN%")
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -873,7 +873,7 @@ object id31MigrateOnQaDevAuto : BuildType({
     }
 
     requirements {
-        doesNotContain("env.OS_TYPE", "WIN", "RQ_31_LINUX")
+        doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
     }
 })
 

--- a/docs/registry/deployment/README.md
+++ b/docs/registry/deployment/README.md
@@ -8,6 +8,8 @@ This directory collects the deployment-related inputs and working documents for 
 - `keycloak-setup.md` — operator-facing setup steps for Keycloak realm-roles
   required by CRS authorization (manual Admin-Console actions not covered by
   source patches)
+- `qa-post-deploy-migration.md` — what the `[3.1] Migrate components on QA DEV
+  [AUTO]` TC build does, when it skips, and what TC parameters it expects
 - `references/teamcity/` — raw TeamCity Kotlin DSL snippets relevant to the current OKD deployment flow
 - `references/platform/okd-platform-patterns.md` — summarized conventions from `service-deployment`, `service-config`, `octopus-dms-ui`, and `octopus-api-gateway`
 

--- a/docs/registry/deployment/qa-post-deploy-migration.md
+++ b/docs/registry/deployment/qa-post-deploy-migration.md
@@ -1,0 +1,82 @@
+# QA post-deploy migration
+
+After every successful QA-DEV deploy (`[3.0] Deploy to OKD QA DEV [AUTO]`,
+`id30DeployToOkdQaDevAuto`), TeamCity runs `[3.1] Migrate components on QA DEV
+[AUTO]` (`id31MigrateOnQaDevAuto`). The step calls
+`POST /rest/api/4/admin/migrate` on the freshly-deployed pod and polls
+`GET /rest/api/4/admin/migrate/job` until the migration reaches a terminal
+state.
+
+## When the step skips (exit 0)
+
+Tolerant by design — silently skips when migration is not applicable:
+
+- `GET /rest/api/4/admin/migration-status` returns **HTTP 404** → the deployed
+  build pre-dates the v3 admin API, nothing to do.
+- `migration-status` reports `git == 0` → everything is already in DB, the
+  redeploy did not introduce new Git-sourced components.
+
+## When the step fails
+
+- Pod is not ready within `READINESS_TIMEOUT_SEC` (default 300 s).
+- `POST /admin/migrate` returns 401/403 → the Keycloak token in
+  `CRS_QA_ADMIN_TOKEN` is missing, expired, or lacks the `IMPORT_DATA` role.
+  Provision it once on the TC project parent (`CRS_QA_ADMIN_TOKEN` password
+  parameter) and rerun.
+- `POST /admin/migrate` returns 409 with an `activeKind` other than
+  `COMPONENTS` → a history-migration or TC-resync is holding the
+  lifecycle gate. Wait for that job to finish, then rerun `[3.1]`.
+- Migration job ends in `state=FAILED` or `state=COMPLETED` with `failed > 0`
+  → real migration breakage. Open the job artifact in TC and look at the last
+  `Job: state=... migrated=... failed=...` line, then drill into the pod logs
+  for the failing component.
+
+## TC server-level parameters required
+
+The build references two project-level parameters that **are not** committed
+to the open-source DSL:
+
+| Parameter             | Type     | Purpose                                              |
+| --------------------- | -------- | ---------------------------------------------------- |
+| `CRS_QA_DEV_BASE_URL` | text     | Base URL of the QA-DEV CRS route, e.g. `https://crs.qa-dev.example` |
+| `CRS_QA_ADMIN_TOKEN`  | password | Bearer JWT (Keycloak service account, `IMPORT_DATA`) |
+
+The build will fail loudly until both are populated. See
+`keycloak-setup.md` for the role-mapping side.
+
+## Re-running manually
+
+The step is idempotent. Hitting "Run" on `id31MigrateOnQaDevAuto` from the TC
+UI re-checks `migration-status` and migrates whatever delta is left. A second
+run against a clean stand exits 0 on the `git == 0` short-circuit.
+
+If the build appears to "hang", the script is still inside the polling loop —
+job progress is logged every poll interval (10 s by default). The 45-minute
+overall timeout is set in `failureConditions`.
+
+## Relation to `COMPONENTS_REGISTRY_AUTO_MIGRATE`
+
+The codebase also supports an in-pod auto-migrate-on-startup mode triggered by
+the env var `COMPONENTS_REGISTRY_AUTO_MIGRATE=true`
+(`ComponentsRegistryServiceImpl`, `@PostConstruct cloneVcsData`). That mode
+runs migration synchronously during boot and refuses to start the pod on
+partial failure — strict but blocking.
+
+**Use one or the other for a given environment**, not both. On QA we prefer
+the post-deploy TC step because it:
+
+- decouples migration failure from the deploy chain (the pod can serve
+  read traffic while the migration is investigated),
+- tolerates "nothing to migrate" without restarting the pod,
+- surfaces migration progress in TC, not buried in pod logs.
+
+If you ever flip QA to `COMPONENTS_REGISTRY_AUTO_MIGRATE=true`, disable the
+`finishBuildTrigger` on `id31MigrateOnQaDevAuto` (or remove it) — running both
+just means the TC step always sees `git == 0` and exits.
+
+## Source
+
+- TC build: `.teamcity/settings.kts` → `object id31MigrateOnQaDevAuto`
+- Script: `scripts/teamcity/qa-post-deploy-migrate.sh`
+- Admin endpoint: `AdminControllerV4.migrate` (`@PreAuthorize canImport`)
+- Auto-migrate path: `ComponentsRegistryServiceImpl.cloneVcsData`

--- a/docs/registry/deployment/qa-post-deploy-migration.md
+++ b/docs/registry/deployment/qa-post-deploy-migration.md
@@ -39,7 +39,7 @@ to the open-source DSL:
 | Parameter             | Type     | Purpose                                              |
 | --------------------- | -------- | ---------------------------------------------------- |
 | `CRS_QA_DEV_BASE_URL` | text     | Base URL of the QA-DEV CRS route, e.g. `https://crs.qa-dev.example` |
-| `CRS_QA_ADMIN_TOKEN`  | password | Bearer JWT (Keycloak service account, `IMPORT_DATA`) |
+| `CRS_QA_ADMIN_TOKEN`  | password | Raw Keycloak JWT (service account, `IMPORT_DATA` role) — token value only, **no `Bearer ` prefix**; the script adds the scheme. A leading `Bearer ` is stripped defensively. |
 
 The build will fail loudly until both are populated. See
 `keycloak-setup.md` for the role-mapping side.

--- a/scripts/teamcity/qa-post-deploy-migrate.sh
+++ b/scripts/teamcity/qa-post-deploy-migrate.sh
@@ -19,8 +19,39 @@
 
 set -euo pipefail
 
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+
 : "${CRS_BASE_URL:?CRS_BASE_URL is required (e.g. https://crs.qa.example)}"
 : "${CRS_ADMIN_TOKEN:?CRS_ADMIN_TOKEN is required (Bearer JWT with IMPORT_DATA role)}"
+
+# TC substitutes `%PARAM_NAME%` references at runtime; if the project-level
+# parameter is not provisioned on the TC server, the literal `%PARAM_NAME%`
+# arrives here as a non-empty string and the `:?` check above is silent.
+# Detect that and bail out with a clear "TC parameter missing" message
+# instead of spending 300s polling a bogus URL.
+case "$CRS_BASE_URL" in
+  %*%)
+    log "ERROR: CRS_BASE_URL still contains an unresolved TC placeholder ($CRS_BASE_URL)."
+    log "Provision the project-level parameter (e.g. CRS_QA_DEV_BASE_URL) on the TC server."
+    exit 1
+    ;;
+esac
+case "$CRS_ADMIN_TOKEN" in
+  %*%)
+    log "ERROR: CRS_ADMIN_TOKEN still contains an unresolved TC placeholder."
+    log "Provision the project-level password parameter (e.g. CRS_QA_ADMIN_TOKEN) on the TC server."
+    exit 1
+    ;;
+esac
+
+# JSON parsing uses python3 (see jget below). Most modern Linux TC agents
+# ship python3 by default, but slim Alpine-based agents may not. Fail fast
+# with a clear message instead of crashing mid-poll with `python3: not found`.
+if ! command -v python3 >/dev/null 2>&1; then
+  log "ERROR: python3 is required by this script (used to parse JSON responses)."
+  log "Install it on the TC agent or pin the build to an agent label that has it."
+  exit 1
+fi
 
 READINESS_TIMEOUT_SEC="${READINESS_TIMEOUT_SEC:-300}"
 MIGRATE_TIMEOUT_SEC="${MIGRATE_TIMEOUT_SEC:-1800}"
@@ -29,8 +60,6 @@ POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
 BASE="${CRS_BASE_URL%/}"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
-
-log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
 
 # curl wrapper: -sS keeps it quiet but reports errors; -o saves body;
 # -w writes status code to stdout; -m bounds per-call time.

--- a/scripts/teamcity/qa-post-deploy-migrate.sh
+++ b/scripts/teamcity/qa-post-deploy-migrate.sh
@@ -10,7 +10,12 @@
 #
 # Required env:
 #   CRS_BASE_URL          e.g. https://components-registry.qa.example/
-#   CRS_ADMIN_TOKEN       Bearer JWT with IMPORT_DATA role
+#   CRS_ADMIN_TOKEN       Raw Keycloak JWT with IMPORT_DATA role — the token
+#                         value ONLY, without an `Authorization: ` prefix and
+#                         without a leading `Bearer ` scheme word. The script
+#                         adds `Authorization: Bearer <token>` itself. A
+#                         leading `Bearer ` is stripped defensively in case
+#                         the TC parameter was provisioned with the prefix.
 #
 # Optional env:
 #   READINESS_TIMEOUT_SEC  default 300
@@ -42,6 +47,15 @@ case "$CRS_ADMIN_TOKEN" in
     log "Provision the project-level password parameter (e.g. CRS_QA_ADMIN_TOKEN) on the TC server."
     exit 1
     ;;
+esac
+
+# Defensively strip a leading `Bearer ` (case-insensitive) so the parameter
+# can be provisioned either as the raw JWT (preferred) or as the full
+# `Bearer <jwt>` header value without the script producing the broken
+# `Authorization: Bearer Bearer <jwt>` chain. The contract in the docstring
+# remains "raw JWT only" — this is just an operator-error safety net.
+case "$CRS_ADMIN_TOKEN" in
+  [Bb][Ee][Aa][Rr][Ee][Rr]\ *) CRS_ADMIN_TOKEN="${CRS_ADMIN_TOKEN#* }" ;;
 esac
 
 # JSON parsing uses python3 (see jget below). Most modern Linux TC agents

--- a/scripts/teamcity/qa-post-deploy-migrate.sh
+++ b/scripts/teamcity/qa-post-deploy-migrate.sh
@@ -75,14 +75,18 @@ BASE="${CRS_BASE_URL%/}"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-# curl wrapper: -sS keeps it quiet but reports errors; -o saves body;
-# -w writes status code to stdout; -m bounds per-call time.
+# curl wrappers: print the HTTP status code on stdout (always — even on
+# transport failure, where they print `000`). This shields call sites from
+# `set -e` aborting on a transient DNS/TLS/connect error before the caller
+# has a chance to log a clear "could not reach the pod" message. The
+# response body, if any, lands in $out.
 http_get() {
   local url="$1" out="$2"
   curl -sS -m 30 -o "$out" -w '%{http_code}' \
     -H "Authorization: Bearer ${CRS_ADMIN_TOKEN}" \
     -H 'Accept: application/json' \
-    "$url"
+    "$url" \
+    || echo 000
 }
 
 http_post() {
@@ -90,17 +94,24 @@ http_post() {
   curl -sS -m 30 -o "$out" -w '%{http_code}' -X POST \
     -H "Authorization: Bearer ${CRS_ADMIN_TOKEN}" \
     -H 'Accept: application/json' \
-    "$url"
+    "$url" \
+    || echo 000
 }
 
 # Anonymous probe — /actuator/health is permitAll (see WebSecurityConfig).
 http_get_anon() {
   local url="$1" out="$2"
-  curl -sS -m 10 -o "$out" -w '%{http_code}' "$url"
+  curl -sS -m 10 -o "$out" -w '%{http_code}' "$url" || echo 000
 }
 
-# Extract a JSON number/string field with python3 — robust vs grep/sed.
-# Usage: jget <file> <jq-style dotted path, only top-level keys supported>
+# Extract a top-level JSON field with python3 — robust vs grep/sed for
+# quoted/unquoted/edge-cased values.
+#
+# Usage: jget <file> <top-level-key>
+# Note: only top-level keys are supported (no dotted paths). All fields the
+# script reads (`state`, `phase`, `migrated`, `failed`, `skipped`, `total`,
+# `git`, `db`, `version`, `activeKind`, `code`) live at the top level of
+# their respective DTOs, so this is sufficient.
 jget() {
   local file="$1" key="$2"
   python3 - "$file" "$key" <<'PY'
@@ -118,7 +129,7 @@ log "Waiting up to ${READINESS_TIMEOUT_SEC}s for ${BASE}/actuator/health/readine
 deadline=$(( $(date +%s) + READINESS_TIMEOUT_SEC ))
 while :; do
   body="$WORK_DIR/readiness.json"
-  code="$(http_get_anon "${BASE}/actuator/health/readiness" "$body" || echo 000)"
+  code="$(http_get_anon "${BASE}/actuator/health/readiness" "$body")"
   if [ "$code" = "200" ]; then
     log "Readiness OK"
     break
@@ -134,7 +145,7 @@ done
 # 2. Log deployed version (no auth needed).
 ###############################################################################
 info="$WORK_DIR/info.json"
-info_code="$(http_get_anon "${BASE}/rest/api/4/info" "$info" || echo 000)"
+info_code="$(http_get_anon "${BASE}/rest/api/4/info" "$info")"
 if [ "$info_code" = "200" ]; then
   version="$(jget "$info" version)"
   log "Deployed version: ${version:-<unknown>}"
@@ -153,7 +164,17 @@ case "$status_code" in
     db_count="$(jget "$status" db)"
     total="$(jget "$status" total)"
     log "Migration status: git=${git_count} db=${db_count} total=${total}"
-    if [ "${git_count:-0}" = "0" ]; then
+    # Treat a missing / non-numeric `git` as a contract break and fail
+    # loudly. Defaulting it to 0 would silently skip migration if the
+    # response shape ever changes (e.g. field renamed, returned as null).
+    case "$git_count" in
+      ''|*[!0-9]*)
+        log "ERROR: /admin/migration-status returned a non-numeric 'git' field: '$git_count'"
+        log "Response body suppressed (may contain unexpected payload). Investigate the API contract."
+        exit 1
+        ;;
+    esac
+    if [ "$git_count" = "0" ]; then
       log "Nothing left to migrate — skip"
       exit 0
     fi

--- a/scripts/teamcity/qa-post-deploy-migrate.sh
+++ b/scripts/teamcity/qa-post-deploy-migrate.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# Post-deploy: trigger Git→DB migration on the freshly-deployed QA pod.
+#
+# Designed to be tolerant of "this build does not need / cannot run migration":
+#   - 404 on /admin/migration-status  → pre-v3 build deployed, exit 0 (skip)
+#   - git == 0                        → nothing left to migrate, exit 0 (skip)
+# It exits non-zero only when migration was *attempted* and ended in FAILED
+# state (or pod never became ready). That matches the user contract: "if there
+# is no new code, just skip — don't fail".
+#
+# Required env:
+#   CRS_BASE_URL          e.g. https://components-registry.qa.example/
+#   CRS_ADMIN_TOKEN       Bearer JWT with IMPORT_DATA role
+#
+# Optional env:
+#   READINESS_TIMEOUT_SEC  default 300
+#   MIGRATE_TIMEOUT_SEC    default 1800 (30 min)
+#   POLL_INTERVAL_SEC      default 10
+
+set -euo pipefail
+
+: "${CRS_BASE_URL:?CRS_BASE_URL is required (e.g. https://crs.qa.example)}"
+: "${CRS_ADMIN_TOKEN:?CRS_ADMIN_TOKEN is required (Bearer JWT with IMPORT_DATA role)}"
+
+READINESS_TIMEOUT_SEC="${READINESS_TIMEOUT_SEC:-300}"
+MIGRATE_TIMEOUT_SEC="${MIGRATE_TIMEOUT_SEC:-1800}"
+POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
+
+BASE="${CRS_BASE_URL%/}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+
+# curl wrapper: -sS keeps it quiet but reports errors; -o saves body;
+# -w writes status code to stdout; -m bounds per-call time.
+http_get() {
+  local url="$1" out="$2"
+  curl -sS -m 30 -o "$out" -w '%{http_code}' \
+    -H "Authorization: Bearer ${CRS_ADMIN_TOKEN}" \
+    -H 'Accept: application/json' \
+    "$url"
+}
+
+http_post() {
+  local url="$1" out="$2"
+  curl -sS -m 30 -o "$out" -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer ${CRS_ADMIN_TOKEN}" \
+    -H 'Accept: application/json' \
+    "$url"
+}
+
+# Anonymous probe — /actuator/health is permitAll (see WebSecurityConfig).
+http_get_anon() {
+  local url="$1" out="$2"
+  curl -sS -m 10 -o "$out" -w '%{http_code}' "$url"
+}
+
+# Extract a JSON number/string field with python3 — robust vs grep/sed.
+# Usage: jget <file> <jq-style dotted path, only top-level keys supported>
+jget() {
+  local file="$1" key="$2"
+  python3 - "$file" "$key" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(data.get(sys.argv[2], ''))
+PY
+}
+
+###############################################################################
+# 1. Wait for readiness.
+###############################################################################
+log "Waiting up to ${READINESS_TIMEOUT_SEC}s for ${BASE}/actuator/health/readiness"
+deadline=$(( $(date +%s) + READINESS_TIMEOUT_SEC ))
+while :; do
+  body="$WORK_DIR/readiness.json"
+  code="$(http_get_anon "${BASE}/actuator/health/readiness" "$body" || echo 000)"
+  if [ "$code" = "200" ]; then
+    log "Readiness OK"
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    log "ERROR: pod did not become ready within ${READINESS_TIMEOUT_SEC}s (last code=$code)"
+    exit 1
+  fi
+  sleep "$POLL_INTERVAL_SEC"
+done
+
+###############################################################################
+# 2. Log deployed version (no auth needed).
+###############################################################################
+info="$WORK_DIR/info.json"
+info_code="$(http_get_anon "${BASE}/rest/api/4/info" "$info" || echo 000)"
+if [ "$info_code" = "200" ]; then
+  version="$(jget "$info" version)"
+  log "Deployed version: ${version:-<unknown>}"
+else
+  log "WARN: /rest/api/4/info returned HTTP ${info_code} — continuing"
+fi
+
+###############################################################################
+# 3. Check migration-status. Tolerant skip on 404 (pre-v3 build).
+###############################################################################
+status="$WORK_DIR/migration-status.json"
+status_code="$(http_get "${BASE}/rest/api/4/admin/migration-status" "$status")"
+case "$status_code" in
+  200)
+    git_count="$(jget "$status" git)"
+    db_count="$(jget "$status" db)"
+    total="$(jget "$status" total)"
+    log "Migration status: git=${git_count} db=${db_count} total=${total}"
+    if [ "${git_count:-0}" = "0" ]; then
+      log "Nothing left to migrate — skip"
+      exit 0
+    fi
+    ;;
+  404)
+    log "Endpoint /admin/migration-status is 404 — pre-v3 build deployed, skip"
+    exit 0
+    ;;
+  401|403)
+    log "ERROR: auth rejected (HTTP $status_code). CRS_ADMIN_TOKEN expired / lacks IMPORT_DATA?"
+    log "Response body suppressed (may echo auth headers)."
+    exit 1
+    ;;
+  *)
+    log "ERROR: unexpected status from /admin/migration-status: HTTP $status_code"
+    log "Response body suppressed."
+    exit 1
+    ;;
+esac
+
+###############################################################################
+# 4. Kick off async migrate. 202 = newly started, 409 = attach-to-running.
+###############################################################################
+start="$WORK_DIR/migrate-start.json"
+start_code="$(http_post "${BASE}/rest/api/4/admin/migrate" "$start")"
+case "$start_code" in
+  202) log "Migration started" ;;
+  409)
+    # Two distinct 409 shapes from AdminControllerV4:
+    #   same-kind  → MigrationJobResponse  (has `state`)        → safe to attach
+    #   cross-kind → MigrationConflictResponse (has `activeKind`) → other kind is
+    #     holding the gate; there is no components job to poll, /migrate/job will
+    #     404. Bail out with a clear message instead of looping forever.
+    active_kind="$(jget "$start" activeKind)"
+    if [ -n "$active_kind" ] && [ "$active_kind" != "COMPONENTS" ]; then
+      conflict_code="$(jget "$start" code)"
+      log "ERROR: cross-kind migration conflict (active=$active_kind, code=$conflict_code)"
+      log "Another migration is holding the lifecycle gate. Wait for it to finish, then re-run [3.1]."
+      exit 1
+    fi
+    log "Migration already running — attaching to existing job"
+    ;;
+  404) log "POST /admin/migrate is 404 — pre-v3 build, skip"; exit 0 ;;
+  401|403) log "ERROR: auth rejected on POST /admin/migrate (HTTP $start_code)"; log "Response body suppressed."; exit 1 ;;
+  *) log "ERROR: unexpected HTTP $start_code from POST /admin/migrate"; log "Response body suppressed."; exit 1 ;;
+esac
+
+###############################################################################
+# 5. Poll job until terminal state.
+###############################################################################
+deadline=$(( $(date +%s) + MIGRATE_TIMEOUT_SEC ))
+job="$WORK_DIR/migrate-job.json"
+last_phase=""
+last_migrated=""
+while :; do
+  job_code="$(http_get "${BASE}/rest/api/4/admin/migrate/job" "$job")"
+  if [ "$job_code" != "200" ]; then
+    log "ERROR: GET /admin/migrate/job returned HTTP $job_code"
+    cat "$job" || true
+    exit 1
+  fi
+  state="$(jget "$job" state)"
+  phase="$(jget "$job" phase)"
+  migrated="$(jget "$job" migrated)"
+  failed="$(jget "$job" failed)"
+  skipped="$(jget "$job" skipped)"
+  total_j="$(jget "$job" total)"
+  if [ "$phase" != "$last_phase" ] || [ "$migrated" != "$last_migrated" ]; then
+    log "Job: state=$state phase=$phase migrated=$migrated failed=$failed skipped=$skipped total=$total_j"
+    last_phase="$phase"
+    last_migrated="$migrated"
+  fi
+  case "$state" in
+    COMPLETED)
+      if [ "${failed:-0}" != "0" ]; then
+        log "ERROR: migration COMPLETED with failed=$failed"
+        cat "$job"
+        exit 1
+      fi
+      log "Migration COMPLETED: migrated=$migrated skipped=$skipped"
+      exit 0
+      ;;
+    FAILED)
+      log "ERROR: migration FAILED"
+      cat "$job"
+      exit 1
+      ;;
+  esac
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    log "ERROR: migration did not finish within ${MIGRATE_TIMEOUT_SEC}s (last state=$state)"
+    cat "$job" || true
+    exit 1
+  fi
+  sleep "$POLL_INTERVAL_SEC"
+done


### PR DESCRIPTION
## Summary

- New `[3.1] Migrate components on QA DEV [AUTO]` TC build that runs after every successful QA-DEV deploy and triggers `POST /rest/api/4/admin/migrate` on the freshly-deployed pod, polling the async job to completion.
- Tolerant by design: exits 0 (skip) on pre-v3 builds (HTTP 404 on `/admin/migration-status`) or when nothing remains in Git (`git == 0`). Fails loudly on real migration failures, auth rejection, or cross-kind 409 conflicts (history / TC-resync holding the lifecycle gate).
- Bash script lives in `scripts/teamcity/` so it can be tested and reviewed outside TC; allowlisted past the repo-wide `*.sh` ignore.

## Setup required before this works on QA

Two TC project-level parameters must be provisioned on the TC server (not committed to the open-source DSL):

| Parameter             | Type     | Purpose                                              |
| --------------------- | -------- | ---------------------------------------------------- |
| `CRS_QA_DEV_BASE_URL` | text     | Base URL of the QA-DEV CRS route                     |
| `CRS_QA_ADMIN_TOKEN`  | password | Bearer JWT (Keycloak service account, `IMPORT_DATA`) |

Until both are populated, `[3.1]` will fail with a clear "auth rejected" message — intentional, no silent-skip on auth misconfig.

## Test plan

- [ ] Local `mvn teamcity-configs:generate` → BUILD SUCCESS, generated XML for `RootProjectId_31MigrateOnQaDevAuto.xml` matches expected shape (verified locally pre-push).
- [ ] Local full `gradlew build` (with the project-standard excludes) → BUILD SUCCESSFUL (verified locally pre-push, 5m 34s).
- [ ] After TC server-side params are provisioned, watch a first run of `[3.1]` after a `[3.0]` deploy to a v3 stand: expect 202 → polling → `state=COMPLETED, failed=0`.
- [ ] Re-run `[3.1]` against the same stand without redeploy: expect short-circuit on `git == 0` and exit 0.
- [ ] Run `[3.1]` against a pre-v3 stand (or by pointing `CRS_QA_DEV_BASE_URL` at the prod baseline): expect short-circuit on HTTP 404 and exit 0.
- [ ] Negative: temporarily clear `CRS_QA_ADMIN_TOKEN` → expect 401/403 path and red build with "auth rejected" log line, no token leak in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)