### PR TITLE
fix(schema-v2 + compat-infra): align candidate v3 DB-mode with V1 contract; reporter infra

### DIFF
--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -263,7 +263,11 @@ tasks.register('compatibilityReporter') {
         // path matches reader's). Each test JVM writes one marker per
         // workerFile lazy init.
         def tmpDir = new File("/tmp")
-        def markers = (tmpDir.listFiles({ f -> f.name.startsWith('compat-exec-logger-marker-') && f.name.endsWith('.txt') } as FileFilter) ?: []).sort { it.name }
+        // listFiles({...} as FileFilter) returns File[] (Java array). Force-coerce to a
+        // Groovy List before .sort()/.isEmpty() — id17 #3640 failed mid-doLast with
+        // "No signature of method: [Ljava.lang.Object;.isEmpty()" because File[] has no
+        // .isEmpty() extension method.
+        def markers = (tmpDir.listFiles({ f -> f.name.startsWith('compat-exec-logger-marker-') && f.name.endsWith('.txt') } as FileFilter)?.toList() ?: []).sort { it.name }
         if (markers.isEmpty()) {
             println "[compat-reporter]   /tmp marker files: none (writer init may not have fired)"
         } else {

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -87,13 +87,17 @@ test {
         'junit.jupiter.execution.parallel.config.strategy': 'fixed',
         'junit.jupiter.execution.parallel.config.fixed.parallelism': (project.findProperty('compat.parallelism') ?: '8') as String,
         // Absolute path to the same dir compatibilityReporter aggregates from.
-        // DiffCollector / ExecutionLogger pick this up so the per-worker ndjson
-        // files land where the reporter looks, regardless of the test JVM's
-        // forked CWD. Use `"${projectDir}/..."` (GString interpolation forces
-        // File.toString → absolute) rather than `file(...).absolutePath` —
-        // observed in id17 builds #10 and #13 that the latter still produced
-        // a relative-looking value on this TC agent's gradle/JVM combination.
-        'compat.report-dir': "${projectDir}/build/reports/compat".toString(),
+        // DiffCollector / ExecutionLogger pick this up so the per-worker
+        // ndjson files land where the reporter looks, regardless of the test
+        // JVM's forked CWD. Use `file('build/reports/compat').absolutePath`
+        // (java.io.File.getAbsolutePath()) — this is the only form that
+        // produced a reliably-absolute value on the TC agent's gradle/JVM
+        // combination in id17 build #3620 (the earlier `"${projectDir}/..."`
+        // attempt still landed as the relative module basename).
+        // `resolveReportDir` in the test code asserts the absolute-ness so a
+        // regression is caught at test-JVM startup with a clear message
+        // rather than as a silent vacuously-clean reporter run.
+        'compat.report-dir': file('build/reports/compat').absolutePath,
     ]
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -119,12 +119,19 @@ test {
     // layout.buildDirectory is finalised and `.canonicalPath` returns an
     // absolute path (defence in depth vs `.absolutePath` — canonical
     // resolves through the filesystem rather than going via user.dir).
-    // `systemProperty(name, String)` then registers a normal String value
-    // that the test JVM receives unmolested. The `resolveReportDir` check
-    // in the test code still asserts absolute-ness as a backstop for any
-    // future regression here.
+    //
+    // Wired via `jvmArgs "-D..."` rather than `systemProperty(...)`
+    // because id17 #3634 showed `systemProperty` set inside doFirst not
+    // taking effect — the test JVM kept seeing the (config-phase) value.
+    // `jvmArgs` mutates the JVM command-line that's assembled at fork
+    // time, so a value appended in doFirst lands on the actual JVM args.
+    //
+    // The `resolveReportDir` check in the test code still asserts
+    // absolute-ness as a backstop for any future regression.
     doFirst {
-        systemProperty 'compat.report-dir', layout.buildDirectory.dir('reports/compat').get().asFile.canonicalPath
+        def reportDirAbs = layout.buildDirectory.dir('reports/compat').get().asFile.canonicalPath
+        println "[compat-test] doFirst: setting -Dcompat.report-dir=${reportDirAbs}"
+        jvmArgs "-Dcompat.report-dir=${reportDirAbs}"
     }
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -257,6 +257,43 @@ tasks.register('compatibilityReporter') {
         } else {
             println "[compat-reporter]   no orphan per-worker ndjson under projectDir"
         }
+        // Read marker files left by ExecutionLogger writer-init in /tmp/.
+        // These bypass TC's test-suite System.out capture (which strips the
+        // build-agent path prefix and obscures whether writer's absolute
+        // path matches reader's). Each test JVM writes one marker per
+        // workerFile lazy init.
+        def tmpDir = new File("/tmp")
+        def markers = (tmpDir.listFiles({ f -> f.name.startsWith('compat-exec-logger-marker-') && f.name.endsWith('.txt') } as FileFilter) ?: []).sort { it.name }
+        if (markers.isEmpty()) {
+            println "[compat-reporter]   /tmp marker files: none (writer init may not have fired)"
+        } else {
+            println "[compat-reporter]   /tmp marker files: ${markers.size()} found"
+            markers.each { f ->
+                println "[compat-reporter]   --- ${f.absolutePath} ---"
+                f.text.eachLine { line -> println "[compat-reporter]     $line" }
+            }
+        }
+        // Also walk /tmp looking for orphan per-worker ndjson files outside
+        // both projectDir AND reportDir.
+        def tmpOrphans = []
+        if (tmpDir.exists()) {
+            def stack2 = [[tmpDir, 0] as List]
+            while (!stack2.isEmpty()) {
+                def (f, depth) = stack2.remove(stack2.size() - 1)
+                if (depth > 5) continue
+                if (f.isDirectory()) {
+                    f.listFiles()?.each { stack2 << ([it, depth + 1] as List) }
+                } else if ((f.name.startsWith('exec-worker-') || f.name.startsWith('diff-worker-')) && f.name.endsWith('.ndjson')) {
+                    tmpOrphans << f.absolutePath
+                }
+            }
+        }
+        if (!tmpOrphans.isEmpty()) {
+            println "[compat-reporter]   ORPHAN per-worker ndjson FOUND under /tmp:"
+            tmpOrphans.each { println "[compat-reporter]     $it" }
+        } else {
+            println "[compat-reporter]   no orphan per-worker ndjson under /tmp"
+        }
         println "[compat-reporter] === /diagnostic ==="
 
         if (!dir.exists()) {

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -57,6 +57,11 @@ test {
     // Each run starts with a fresh report dir so per-worker ndjson files don't accumulate
     // across re-runs (the file names contain a UUID — old files would otherwise be merged
     // into summary.md again, double-counting diffs).
+    //
+    // ALSO: this is the place where we set `compat.report-dir` to the same dir
+    // — see the long comment above the second `doFirst` block below for why
+    // it has to happen at task-execution time rather than via the
+    // `systemProperties` map literal.
     doFirst {
         def reportDir = layout.buildDirectory.dir('reports/compat').get().asFile
         if (reportDir.exists()) {
@@ -88,28 +93,38 @@ test {
         'junit.jupiter.execution.parallel.config.fixed.parallelism': (project.findProperty('compat.parallelism') ?: '8') as String,
     ]
     // Absolute path to the same dir compatibilityReporter aggregates from —
-    // wired SEPARATELY from the systemProperties map literal above because
-    // that map evaluates eagerly at configuration phase. On the TC agent in
-    // id17 build #3631, eager evaluation of
-    // `layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath`
-    // returned the RELATIVE module basename `components-registry-compat-test
-    // /build/reports/compat` (confirmed by the diagnostic prints in
-    // ExecutionLogger / DiffCollector and the matching absolute-path output
-    // from the compatibilityReporter task that ran at execution phase). The
-    // value then resolved against the test JVM's relative `user.dir`
-    // (also `components-registry-compat-test`) and the per-worker ndjson
-    // landed in a doubled-prefix path the reporter never read.
+    // wired inside a doFirst block (execution phase) because both earlier
+    // attempts failed on the TC agent's gradle/JVM combination:
     //
-    // The provider form below DEFERS evaluation to task execution time, when
-    // Gradle has finalised the layout properties and `projectDir` is
-    // absolute. `.canonicalPath` (vs `.absolutePath`) additionally guarantees
-    // a true filesystem-resolved absolute path — defence in depth for the
-    // same TC quirk. `resolveReportDir` in the test code asserts
-    // absolute-ness so any future regression surfaces at test-JVM startup
-    // with a clear `IllegalStateException` instead of a silent
-    // vacuously-clean reporter run.
-    systemProperty 'compat.report-dir', providers.provider {
-        layout.buildDirectory.dir('reports/compat').get().asFile.canonicalPath
+    //   - Putting `layout.buildDirectory.dir(...).get().asFile.absolutePath`
+    //     inside the `systemProperties = [...]` map literal evaluated eagerly
+    //     at configuration phase. id17 #3631 showed the result as the
+    //     RELATIVE module basename `components-registry-compat-test/build/
+    //     reports/compat` (while the compatibilityReporter task — same
+    //     expression, but running in doLast at execution phase — saw the
+    //     absolute `/opt/TeamCity/.../components-registry-compat-test/build/
+    //     reports/compat`). The relative value resolved against the test
+    //     JVM's relative `user.dir` and the per-worker ndjson landed in a
+    //     doubled-prefix path the reporter never read.
+    //   - Switching to `systemProperty(name, providers.provider { ... })`
+    //     (a deferred Provider) was a misread of the Gradle API. The Test
+    //     task's `systemProperty(String, Object)` documents the value is
+    //     converted via `Object.toString()`; the Provider is NOT unwrapped,
+    //     so the test JVM received the literal string `provider(?)` as the
+    //     property value. id17 #3633 surfaced this by failing 15834 tests
+    //     with `IllegalStateException: compat.report-dir must be absolute
+    //     — got 'provider(?)'` from `resolveReportDir`.
+    //
+    // The doFirst block below runs at task execution time, by which point
+    // layout.buildDirectory is finalised and `.canonicalPath` returns an
+    // absolute path (defence in depth vs `.absolutePath` — canonical
+    // resolves through the filesystem rather than going via user.dir).
+    // `systemProperty(name, String)` then registers a normal String value
+    // that the test JVM receives unmolested. The `resolveReportDir` check
+    // in the test code still asserts absolute-ness as a backstop for any
+    // future regression here.
+    doFirst {
+        systemProperty 'compat.report-dir', layout.buildDirectory.dir('reports/compat').get().asFile.canonicalPath
     }
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -71,6 +71,17 @@ test {
         } else {
             reportDir.mkdirs()
         }
+        // ALSO wipe the /tmp backup dir used by the workaround below. Without
+        // this, files from a prior aborted run accumulate on persistent TC
+        // agents — and if the current run's primary reportDir gets cleared
+        // mid-run (the known Gradle stale-output quirk we work around), the
+        // reporter's fallback would aggregate stale records from a different
+        // commit / DSL snapshot, producing a falsely-clean or falsely-red
+        // result. PR #297 review (P1): scope to the current run.
+        def tmpBackup = new File("${System.getProperty('java.io.tmpdir')}/crs-compat-backup")
+        if (tmpBackup.exists()) {
+            tmpBackup.listFiles({ f -> (f.name.startsWith('diff-worker-') || f.name.startsWith('exec-worker-')) && f.name.endsWith('.ndjson') } as FileFilter)?.each { it.delete() }
+        }
     }
     useJUnitPlatform {
         // Include-by-tag polarity: `:test` runs ONLY suites that extend

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -198,7 +198,17 @@ tasks.register('compatibilityReporter') {
     // diffs that have nothing to do with the current code.
     onlyIf("at least one of compat.baseline.url / compat.candidate.url is set (partial config triggers explainInvalid)") { compatActivated() }
     def reportDir = layout.buildDirectory.dir('reports/compat')
-    outputs.dir(reportDir)
+    // Intentionally NOT declared as `outputs.dir(reportDir)` — id17 #3642 vs #3640
+    // showed non-deterministic loss of per-worker ndjson between the `test` task
+    // (writer) and `compatibilityReporter` (reader). Root cause: Gradle's
+    // CleanupStaleOutputsExecuter scans declared output dirs at the START of the
+    // owning task and deletes files not registered in `.gradle/buildOutputCleanup/
+    // outputFiles.bin` as known outputs of any task. The per-worker ndjson is
+    // produced by the `test` JVM but NOT declared as that task's output, so
+    // Gradle treats it as stale and deletes it before `compatibilityReporter`
+    // sees it. Removing the `outputs.dir` here deactivates stale-output cleanup
+    // for reportDir — the reporter doesn't need caching/up-to-date since it's
+    // already gated on `compatActivated()` and always re-aggregates.
     doLast {
         def dir = reportDir.get().asFile
 

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -86,24 +86,31 @@ test {
         'junit.jupiter.execution.parallel.mode.default': 'concurrent',
         'junit.jupiter.execution.parallel.config.strategy': 'fixed',
         'junit.jupiter.execution.parallel.config.fixed.parallelism': (project.findProperty('compat.parallelism') ?: '8') as String,
-        // Absolute path to the same dir compatibilityReporter aggregates from.
-        // DiffCollector / ExecutionLogger pick this up so the per-worker
-        // ndjson files land where the reporter looks, regardless of the test
-        // JVM's forked CWD. Use the SAME `layout.buildDirectory.dir(...)`
-        // expression as the `doFirst` cleanup and the compatibilityReporter
-        // task — keeping all three writers/readers anchored to the same
-        // Gradle layout primitive means a custom buildDir (or any future
-        // Gradle change to that primitive) moves them all together.
-        // `.get().asFile.absolutePath` collapses to a `java.io.File`
-        // absolute path (NOT canonical — symlinks/`..` are not resolved),
-        // which works around the TC-agent gradle/JVM combination that
-        // rendered `"${projectDir}/..."` as the relative module basename
-        // in id17 build #3620.
-        // `resolveReportDir` in the test code asserts absolute-ness so a
-        // regression here is caught at test-JVM startup with a clear
-        // message rather than as a silent vacuously-clean reporter run.
-        'compat.report-dir': layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath,
     ]
+    // Absolute path to the same dir compatibilityReporter aggregates from —
+    // wired SEPARATELY from the systemProperties map literal above because
+    // that map evaluates eagerly at configuration phase. On the TC agent in
+    // id17 build #3631, eager evaluation of
+    // `layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath`
+    // returned the RELATIVE module basename `components-registry-compat-test
+    // /build/reports/compat` (confirmed by the diagnostic prints in
+    // ExecutionLogger / DiffCollector and the matching absolute-path output
+    // from the compatibilityReporter task that ran at execution phase). The
+    // value then resolved against the test JVM's relative `user.dir`
+    // (also `components-registry-compat-test`) and the per-worker ndjson
+    // landed in a doubled-prefix path the reporter never read.
+    //
+    // The provider form below DEFERS evaluation to task execution time, when
+    // Gradle has finalised the layout properties and `projectDir` is
+    // absolute. `.canonicalPath` (vs `.absolutePath`) additionally guarantees
+    // a true filesystem-resolved absolute path — defence in depth for the
+    // same TC quirk. `resolveReportDir` in the test code asserts
+    // absolute-ness so any future regression surfaces at test-JVM startup
+    // with a clear `IllegalStateException` instead of a silent
+    // vacuously-clean reporter run.
+    systemProperty 'compat.report-dir', providers.provider {
+        layout.buildDirectory.dir('reports/compat').get().asFile.canonicalPath
+    }
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',
      'compat.full', 'compat.malformed', 'compat.versions-fallback',

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -89,15 +89,19 @@ test {
         // Absolute path to the same dir compatibilityReporter aggregates from.
         // DiffCollector / ExecutionLogger pick this up so the per-worker
         // ndjson files land where the reporter looks, regardless of the test
-        // JVM's forked CWD. Use `file('build/reports/compat').absolutePath`
-        // (java.io.File.getAbsolutePath()) — this is the only form that
-        // produced a reliably-absolute value on the TC agent's gradle/JVM
-        // combination in id17 build #3620 (the earlier `"${projectDir}/..."`
-        // attempt still landed as the relative module basename).
-        // `resolveReportDir` in the test code asserts the absolute-ness so a
-        // regression is caught at test-JVM startup with a clear message
-        // rather than as a silent vacuously-clean reporter run.
-        'compat.report-dir': file('build/reports/compat').absolutePath,
+        // JVM's forked CWD. Use the SAME `layout.buildDirectory.dir(...)`
+        // expression as the `doFirst` cleanup and the compatibilityReporter
+        // task — keeping all three writers/readers anchored to the same
+        // Gradle layout primitive means a custom buildDir (or any future
+        // Gradle change to that primitive) moves them all together.
+        // `.get().asFile.absolutePath` collapses to the canonical absolute
+        // path on `java.io.File`, which works around the TC-agent gradle/JVM
+        // combination that rendered `"${projectDir}/..."` as the relative
+        // module basename in id17 build #3620.
+        // `resolveReportDir` in the test code asserts absolute-ness so a
+        // regression here is caught at test-JVM startup with a clear
+        // message rather than as a silent vacuously-clean reporter run.
+        'compat.report-dir': layout.buildDirectory.dir('reports/compat').get().asFile.absolutePath,
     ]
     // Surface compat config as system properties for the test code.
     ['compat.baseline.url', 'compat.candidate.url', 'compat.rms.url',
@@ -167,6 +171,63 @@ tasks.register('compatibilityReporter') {
     outputs.dir(reportDir)
     doLast {
         def dir = reportDir.get().asFile
+
+        // Diagnostic mirror of [DiffCollector] and [ExecutionLogger] init
+        // traces (in the test JVM). Print the SAME path representations from
+        // the gradle JVM's side so the operator can grep both traces from a
+        // single TC log and confirm whether the test-JVM writers and the
+        // reporter reader agree on the absolute path. Added after id17 #3620
+        // and #3630 both showed empty per-worker ndjson aggregation despite
+        // worker counters claiming 15834 requests / 17 diffs.
+        println "[compat-reporter] === compatibilityReporter doLast diagnostic ==="
+        println "[compat-reporter]   reportDir.absolutePath   = ${dir.absolutePath}"
+        def canonical = "(canon failed)"
+        try { canonical = dir.canonicalPath } catch (Exception ignored) { /* keep placeholder */ }
+        println "[compat-reporter]   reportDir.canonicalPath  = $canonical"
+        println "[compat-reporter]   reportDir.exists()       = ${dir.exists()}"
+        if (dir.exists()) {
+            def names = (dir.listFiles() ?: []).collect { it.name }.sort()
+            println "[compat-reporter]   reportDir.listFiles()    = $names"
+        }
+        // Walk one level up to spot a doubled-prefix path like
+        // `<projectDir>/components-registry-compat-test/build/reports/compat/`
+        // that the test JVM could be writing to while the reporter reads from
+        // the shallow form. Print the parent + grandparent dirs and a one-
+        // level recursive find for any orphan ndjson files outside the dir.
+        def parent = dir.parentFile
+        if (parent != null) {
+            println "[compat-reporter]   parent dir               = ${parent.absolutePath}"
+            def parentNames = (parent.listFiles() ?: []).collect { it.name }.sort()
+            println "[compat-reporter]   parent.listFiles()       = $parentNames"
+        }
+        // Hunt for orphan exec/diff worker ndjson files anywhere under
+        // projectDir — surfaces a doubled-prefix write path or a JVM-CWD
+        // mismatch in one grepable line per file. Caps the walk at depth 6
+        // to keep the trace from drowning the log on a large workspace.
+        def orphans = []
+        def projectRoot = project.projectDir
+        if (projectRoot.exists()) {
+            def stack = [[projectRoot, 0] as List]
+            while (!stack.isEmpty()) {
+                def (f, depth) = stack.remove(stack.size() - 1)
+                if (depth > 6) continue
+                if (f.isDirectory()) {
+                    f.listFiles()?.each { stack << ([it, depth + 1] as List) }
+                } else if ((f.name.startsWith('exec-worker-') || f.name.startsWith('diff-worker-')) && f.name.endsWith('.ndjson')) {
+                    if (f.parentFile?.absolutePath != dir.absolutePath) {
+                        orphans << f.absolutePath
+                    }
+                }
+            }
+        }
+        if (!orphans.isEmpty()) {
+            println "[compat-reporter]   ORPHAN per-worker ndjson FOUND outside reportDir:"
+            orphans.each { println "[compat-reporter]     $it" }
+        } else {
+            println "[compat-reporter]   no orphan per-worker ndjson under projectDir"
+        }
+        println "[compat-reporter] === /diagnostic ==="
+
         if (!dir.exists()) {
             return
         }

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -82,6 +82,13 @@ test {
         if (tmpBackup.exists()) {
             tmpBackup.listFiles({ f -> (f.name.startsWith('diff-worker-') || f.name.startsWith('exec-worker-')) && f.name.endsWith('.ndjson') } as FileFilter)?.each { it.delete() }
         }
+        // Also wipe the writer-init marker files. These accumulate on persistent
+        // TC agents (the reporter walks /tmp for them in its doLast diagnostic)
+        // and would otherwise mix diagnostics across builds.
+        def tmpDir2 = new File(System.getProperty('java.io.tmpdir'))
+        if (tmpDir2.exists()) {
+            tmpDir2.listFiles({ f -> f.name.startsWith('compat-exec-logger-marker-') && f.name.endsWith('.txt') } as FileFilter)?.each { it.delete() }
+        }
     }
     useJUnitPlatform {
         // Include-by-tag polarity: `:test` runs ONLY suites that extend

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -94,10 +94,11 @@ test {
         // task — keeping all three writers/readers anchored to the same
         // Gradle layout primitive means a custom buildDir (or any future
         // Gradle change to that primitive) moves them all together.
-        // `.get().asFile.absolutePath` collapses to the canonical absolute
-        // path on `java.io.File`, which works around the TC-agent gradle/JVM
-        // combination that rendered `"${projectDir}/..."` as the relative
-        // module basename in id17 build #3620.
+        // `.get().asFile.absolutePath` collapses to a `java.io.File`
+        // absolute path (NOT canonical — symlinks/`..` are not resolved),
+        // which works around the TC-agent gradle/JVM combination that
+        // rendered `"${projectDir}/..."` as the relative module basename
+        // in id17 build #3620.
         // `resolveReportDir` in the test code asserts absolute-ness so a
         // regression here is caught at test-JVM startup with a clear
         // message rather than as a silent vacuously-clean reporter run.
@@ -192,8 +193,9 @@ tasks.register('compatibilityReporter') {
         // Walk one level up to spot a doubled-prefix path like
         // `<projectDir>/components-registry-compat-test/build/reports/compat/`
         // that the test JVM could be writing to while the reporter reads from
-        // the shallow form. Print the parent + grandparent dirs and a one-
-        // level recursive find for any orphan ndjson files outside the dir.
+        // the shallow form. Print the parent dir + a bounded-depth recursive
+        // find under `projectDir` for any orphan ndjson files outside the
+        // reader-side dir.
         def parent = dir.parentFile
         if (parent != null) {
             println "[compat-reporter]   parent dir               = ${parent.absolutePath}"

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -361,6 +361,31 @@ tasks.register('compatibilityReporter') {
 
         def diffFiles = dir.listFiles({ f -> f.name.startsWith('diff-worker-') && f.name.endsWith('.ndjson') } as FileFilter) ?: []
         def execFiles = dir.listFiles({ f -> f.name.startsWith('exec-worker-') && f.name.endsWith('.ndjson') } as FileFilter) ?: []
+        // INFRA-WORKAROUND: id17 #3642 confirmed that the per-worker ndjson files
+        // are non-deterministically removed between the test JVM's shutdown hook
+        // (which prints "persisted to ...ndjson") and this doLast. ExecutionLogger /
+        // DiffCollector now copy each worker file to /tmp/crs-compat-backup/ at JVM-
+        // shutdown — fall back to that location when reportDir is empty so the
+        // build doesn't fail with the proof-of-execution guard ("0 cases executed")
+        // when the writer actually ran (15834 cases per the test JVM counter).
+        // Restore both ndjson kinds AND any summary/execution-log artefacts so
+        // existing TC artifactRules pick them up from build/reports/compat.
+        if ((diffFiles.size() + execFiles.size()) == 0) {
+            def backupDir = new File("${System.getProperty('java.io.tmpdir')}/crs-compat-backup")
+            if (backupDir.exists()) {
+                def restored = []
+                backupDir.listFiles({ f -> (f.name.startsWith('diff-worker-') || f.name.startsWith('exec-worker-')) && f.name.endsWith('.ndjson') } as FileFilter)?.each { src ->
+                    def target = new File(dir, src.name)
+                    java.nio.file.Files.copy(src.toPath(), target.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                    restored << src.name
+                }
+                if (!restored.isEmpty()) {
+                    println "[compat-reporter] reportDir was empty; restored ${restored.size()} per-worker file(s) from ${backupDir.absolutePath}: ${restored}"
+                    diffFiles = dir.listFiles({ f -> f.name.startsWith('diff-worker-') && f.name.endsWith('.ndjson') } as FileFilter) ?: []
+                    execFiles = dir.listFiles({ f -> f.name.startsWith('exec-worker-') && f.name.endsWith('.ndjson') } as FileFilter) ?: []
+                }
+            }
+        }
         def summary = new File(dir, 'summary.md')
         def execMd = new File(dir, 'execution-log.md')
         def execNd = new File(dir, 'execution-log.ndjson')

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
@@ -76,6 +76,17 @@ object DiffCollector {
                 runCatching { w.flush() }
                 runCatching { w.close() }
                 System.out.println("[compat-diff] worker pid=${ProcessHandle.current().pid()} totals: ${records.size} diff records persisted to $workerAbs")
+                // INFRA-WORKAROUND: see ExecutionLogger.kt for full context. id17
+                // #3642 confirmed Gradle non-deterministically removes per-worker
+                // ndjson written under reportDir between test-JVM-exit and reporter
+                // doLast. Copy to a stable /tmp location no Gradle task tracks.
+                runCatching {
+                    val backupDir = Path.of(System.getProperty("java.io.tmpdir"), "crs-compat-backup")
+                    Files.createDirectories(backupDir)
+                    val dst = backupDir.resolve(workerFile.fileName)
+                    Files.copy(workerFile, dst, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                    System.out.println("[compat-diff] copied $workerFile -> $dst")
+                }
             }
         })
         w

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
@@ -38,6 +38,30 @@ object DiffCollector {
         reportDir.resolve("diff-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
     }
     private val writer: BufferedWriter by lazy {
+        // Diagnostic mirror of ExecutionLogger — fires once per worker JVM
+        // on the first diff record. Lets the operator compare the path
+        // DiffCollector wrote to against the path compatibilityReporter
+        // read from in the same TC log.
+        val propValue = System.getProperty("compat.report-dir") ?: "(unset)"
+        val cwd = System.getProperty("user.dir") ?: "(unknown)"
+        val workerFileObj = workerFile.toFile()
+        val workerAbs = workerFile.toAbsolutePath().toString()
+        val workerCanon = runCatching { workerFileObj.canonicalPath }.getOrElse { "(canon failed: ${it.message})" }
+        val parentExists = workerFile.parent?.let { Files.exists(it) } ?: false
+        val parentDir = workerFile.parent?.toString() ?: "(no parent)"
+        val parentDirCanon = workerFile.parent?.let { runCatching { it.toFile().canonicalPath }.getOrElse { e -> "(canon failed: ${e.message})" } } ?: "(no parent)"
+        val osCwdCanon = runCatching { java.io.File(".").canonicalPath }.getOrElse { "(canon failed: ${it.message})" }
+        System.out.println("[compat-diff] === DiffCollector init diagnostic ===")
+        System.out.println("[compat-diff]   compat.report-dir (raw)   = $propValue")
+        System.out.println("[compat-diff]   user.dir (sysprop)        = $cwd")
+        System.out.println("[compat-diff]   OS-level CWD (canonical)  = $osCwdCanon")
+        System.out.println("[compat-diff]   workerFile.toAbsolutePath = $workerAbs")
+        System.out.println("[compat-diff]   workerFile.canonicalPath  = $workerCanon")
+        System.out.println("[compat-diff]   parent dir                = $parentDir")
+        System.out.println("[compat-diff]   parent dir canonical      = $parentDirCanon")
+        System.out.println("[compat-diff]   parent dir exists         = $parentExists")
+        System.out.println("[compat-diff] === /diagnostic ===")
+        System.out.flush()
         val w = Files.newBufferedWriter(
             workerFile,
             StandardCharsets.UTF_8,
@@ -51,6 +75,7 @@ object DiffCollector {
             synchronized(writeLock) {
                 runCatching { w.flush() }
                 runCatching { w.close() }
+                System.out.println("[compat-diff] worker pid=${ProcessHandle.current().pid()} totals: ${records.size} diff records persisted to $workerAbs")
             }
         })
         w

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffCollector.kt
@@ -27,15 +27,13 @@ object DiffCollector {
     // sharing the process-wide `records` queue.
     private val threadLocalCount = ThreadLocal.withInitial { 0 }
     private val workerFile: Path by lazy {
-        // Mirror the ExecutionLogger fix: take the gradle-managed absolute path
-        // from `compat.report-dir` system property, fall back to a relative
-        // path only for direct CLI invocations. Without this, the diff-worker
-        // ndjson lands in whatever CWD the test JVM was forked with — sometimes
-        // outside the module's build/ dir — and `compatibilityReporter` aggregates
-        // zero diffs even on a run that produced real divergences.
+        // Delegated to the shared `resolveReportDir` helper (same one
+        // ExecutionLogger uses). Fails fast if `compat.report-dir` is
+        // non-null and relative — observed in id17 build #3620 that a
+        // relative value resolved against a relative `user.dir` writes to
+        // a doubled-prefix path the compatibilityReporter never reads.
         val baseDirProp = System.getProperty("compat.report-dir")
-        val reportDir = (if (baseDirProp != null) Path.of(baseDirProp) else Path.of("build/reports/compat"))
-            .toAbsolutePath()
+        val reportDir = resolveReportDir(baseDirProp, Path.of("build/reports/compat"))
             .also { Files.createDirectories(it) }
         reportDir.resolve("diff-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
     }

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -57,14 +57,20 @@ object ExecutionLogger {
         val parentDir = workerFile.parent?.toString() ?: "(no parent)"
         val parentDirCanon = workerFile.parent?.let { runCatching { it.toFile().canonicalPath }.getOrElse { e -> "(canon failed: ${e.message})" } } ?: "(no parent)"
         val osCwdCanon = runCatching { java.io.File(".").canonicalPath }.getOrElse { "(canon failed: ${it.message})" }
+        val propIsAbsolute = runCatching { java.nio.file.Path.of(propValue).isAbsolute }.getOrElse { false }
+        val osCwdAbsViaFileApi = runCatching { java.io.File("").absoluteFile.path }.getOrElse { "(abs failed: ${it.message})" }
+        // Quote-wrap the strings so any trailing whitespace, hidden control
+        // characters, or TC-log-stripped prefixes become visible.
         System.out.println("[compat-exec] === ExecutionLogger init diagnostic ===")
-        System.out.println("[compat-exec]   compat.report-dir (raw)   = $propValue")
-        System.out.println("[compat-exec]   user.dir (sysprop)        = $cwd")
-        System.out.println("[compat-exec]   OS-level CWD (canonical)  = $osCwdCanon")
-        System.out.println("[compat-exec]   workerFile.toAbsolutePath = $workerAbs")
-        System.out.println("[compat-exec]   workerFile.canonicalPath  = $workerCanon")
-        System.out.println("[compat-exec]   parent dir                = $parentDir")
-        System.out.println("[compat-exec]   parent dir canonical      = $parentDirCanon")
+        System.out.println("[compat-exec]   compat.report-dir (raw)   = >>>${propValue}<<<")
+        System.out.println("[compat-exec]   compat.report-dir absolute? = $propIsAbsolute  (Path.of(raw).isAbsolute)")
+        System.out.println("[compat-exec]   user.dir (sysprop)        = >>>${cwd}<<<")
+        System.out.println("[compat-exec]   OS-level CWD (canonical)  = >>>${osCwdCanon}<<<")
+        System.out.println("[compat-exec]   OS-level CWD (File(\"\").absoluteFile.path) = >>>${osCwdAbsViaFileApi}<<<")
+        System.out.println("[compat-exec]   workerFile.toAbsolutePath = >>>${workerAbs}<<<")
+        System.out.println("[compat-exec]   workerFile.canonicalPath  = >>>${workerCanon}<<<")
+        System.out.println("[compat-exec]   parent dir                = >>>${parentDir}<<<")
+        System.out.println("[compat-exec]   parent dir canonical      = >>>${parentDirCanon}<<<")
         System.out.println("[compat-exec]   parent dir exists         = $parentExists")
         System.out.println("[compat-exec] === /diagnostic ===")
         System.out.flush()

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -29,17 +29,14 @@ object ExecutionLogger {
     private const val PROGRESS_EVERY = 50
 
     private val workerFile: Path by lazy {
-        // System property `compat.report-dir` is set by the gradle test task to
-        // an ABSOLUTE path (layout.buildDirectory/reports/compat). Falling back
-        // to a relative `build/reports/compat` only protects against direct CLI
-        // invocations of the test class — under gradle that fallback would
-        // resolve to whatever JVM CWD gradle picked for the fork (sometimes
-        // the agent's $HOME, not the module dir), and the compatibilityReporter
-        // task would never find the exec-worker file. Symptom observed in id17
-        // build #9: 15834 progress lines on stdout but reporter saw 0 files.
+        // Delegated to `resolveReportDir` (shared with DiffCollector). The
+        // resolver fails fast if `compat.report-dir` is non-null and
+        // relative — observed in id17 build #3620 that a relative value
+        // resolved against a relative `user.dir` writes to a doubled-prefix
+        // path the compatibilityReporter never reads, producing a vacuously-
+        // clean build despite 15834 testcases passing.
         val baseDirProp = System.getProperty("compat.report-dir")
-        val reportDir = (if (baseDirProp != null) Path.of(baseDirProp) else Path.of("build/reports/compat"))
-            .toAbsolutePath()
+        val reportDir = resolveReportDir(baseDirProp, Path.of("build/reports/compat"))
             .also { Files.createDirectories(it) }
         reportDir.resolve("exec-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
     }

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -41,13 +41,32 @@ object ExecutionLogger {
         reportDir.resolve("exec-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
     }
     private val writer: BufferedWriter by lazy {
-        // Log the resolved absolute path + system-property value once on first
-        // write. id17 build #10 surfaced a case where the property looked unset
-        // even though build.gradle set it; print both raw and resolved so the
-        // operator can tell from grep alone which branch fired.
+        // Diagnostic print — fired once per worker JVM on first write. Builds
+        // #3620 and #3630 both showed empty per-worker ndjson in the
+        // aggregated artifact despite the worker counters reporting 15834
+        // requests; this trace captures every path representation we can get
+        // our hands on so the next run can be diffed against the
+        // compatibilityReporter's view (see build.gradle `compatibilityReporter`
+        // task — it prints the matching trace from its end).
         val propValue = System.getProperty("compat.report-dir") ?: "(unset)"
         val cwd = System.getProperty("user.dir") ?: "(unknown)"
-        System.out.println("[compat-exec] Compat exec-log path: ${workerFile.toAbsolutePath()} (compat.report-dir=$propValue, user.dir=$cwd)")
+        val workerFileObj = workerFile.toFile()
+        val workerAbs = workerFile.toAbsolutePath().toString()
+        val workerCanon = runCatching { workerFileObj.canonicalPath }.getOrElse { "(canon failed: ${it.message})" }
+        val parentExists = workerFile.parent?.let { Files.exists(it) } ?: false
+        val parentDir = workerFile.parent?.toString() ?: "(no parent)"
+        val parentDirCanon = workerFile.parent?.let { runCatching { it.toFile().canonicalPath }.getOrElse { e -> "(canon failed: ${e.message})" } } ?: "(no parent)"
+        val osCwdCanon = runCatching { java.io.File(".").canonicalPath }.getOrElse { "(canon failed: ${it.message})" }
+        System.out.println("[compat-exec] === ExecutionLogger init diagnostic ===")
+        System.out.println("[compat-exec]   compat.report-dir (raw)   = $propValue")
+        System.out.println("[compat-exec]   user.dir (sysprop)        = $cwd")
+        System.out.println("[compat-exec]   OS-level CWD (canonical)  = $osCwdCanon")
+        System.out.println("[compat-exec]   workerFile.toAbsolutePath = $workerAbs")
+        System.out.println("[compat-exec]   workerFile.canonicalPath  = $workerCanon")
+        System.out.println("[compat-exec]   parent dir                = $parentDir")
+        System.out.println("[compat-exec]   parent dir canonical      = $parentDirCanon")
+        System.out.println("[compat-exec]   parent dir exists         = $parentExists")
+        System.out.println("[compat-exec] === /diagnostic ===")
         System.out.flush()
         val w = Files.newBufferedWriter(
             workerFile,

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -110,6 +110,24 @@ object ExecutionLogger {
                 runCatching { w.flush() }
                 runCatching { w.close() }
                 System.out.println("[compat-exec] worker pid=${ProcessHandle.current().pid()} totals: $counter requests ($diffCounter with diffs)")
+                // INFRA-WORKAROUND: copy the per-worker ndjson to a stable
+                // /tmp location AFTER close, as a redundant copy that no
+                // Gradle output-tracking touches. id17 #3642 confirmed that
+                // files written to `build/reports/compat/` are
+                // non-deterministically removed between the `test` task's
+                // JVM exit and the `compatibilityReporter` task's doLast —
+                // most likely Gradle's stale-output cleanup acting on
+                // reportDir despite the `outputs.dir` declaration being
+                // removed (cleanup metadata persists from prior builds).
+                // The reporter falls back to this /tmp path when its
+                // primary reportDir is empty.
+                runCatching {
+                    val backupDir = Path.of(System.getProperty("java.io.tmpdir"), "crs-compat-backup")
+                    Files.createDirectories(backupDir)
+                    val dst = backupDir.resolve(workerFile.fileName)
+                    Files.copy(workerFile, dst, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                    System.out.println("[compat-exec] copied $workerFile -> $dst")
+                }
             }
         })
         w

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ExecutionLogger.kt
@@ -38,7 +38,32 @@ object ExecutionLogger {
         val baseDirProp = System.getProperty("compat.report-dir")
         val reportDir = resolveReportDir(baseDirProp, Path.of("build/reports/compat"))
             .also { Files.createDirectories(it) }
-        reportDir.resolve("exec-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
+        val resolved = reportDir.resolve("exec-worker-${ProcessHandle.current().pid()}-${UUID.randomUUID()}.ndjson")
+        // DIAGNOSTIC: also write a marker file under /tmp/ so the
+        // compatibilityReporter doLast can grep it without going through TC
+        // log capture (which strips the build agent path prefix from test
+        // JVM System.out). On id17 #3639 the writer's reportDir looked
+        // identical to the reporter's reportDir in the log, yet the reader
+        // saw an empty listFiles() — we need to confirm the absolute paths
+        // from outside the stripping pipeline.
+        runCatching {
+            val markerPath = Path.of("/tmp/compat-exec-logger-marker-${ProcessHandle.current().pid()}.txt")
+            Files.writeString(
+                markerPath,
+                buildString {
+                    append("compat.report-dir raw   : ").append(baseDirProp).append('\n')
+                    append("reportDir.toString()    : ").append(reportDir).append('\n')
+                    append("reportDir.toAbsolutePath: ").append(reportDir.toAbsolutePath()).append('\n')
+                    append("reportDir canonicalPath : ").append(reportDir.toFile().canonicalPath).append('\n')
+                    append("workerFile.toString()   : ").append(resolved).append('\n')
+                    append("workerFile.toAbsolutePath: ").append(resolved.toAbsolutePath()).append('\n')
+                    append("workerFile canonicalPath: ").append(resolved.toFile().canonicalPath).append('\n')
+                    append("user.dir property       : ").append(System.getProperty("user.dir")).append('\n')
+                    append("OS CWD via File('.')    : ").append(java.io.File(".").canonicalPath).append('\n')
+                },
+            )
+        }
+        resolved
     }
     private val writer: BufferedWriter by lazy {
         // Diagnostic print — fired once per worker JVM on first write. Builds

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolution.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolution.kt
@@ -1,0 +1,45 @@
+package org.octopusden.octopus.components.registry.compat
+
+import java.nio.file.Path
+
+/**
+ * Resolve the per-worker ndjson directory shared between [ExecutionLogger] and
+ * [DiffCollector]. Centralised so a future change to the resolution rule lands
+ * in one place and both writers stay in sync with the dir
+ * `compatibilityReporter` aggregates from.
+ *
+ * Inputs:
+ *  - [reportDirProp] — the raw `compat.report-dir` system-property value from
+ *    the test JVM. `build.gradle` is expected to set this to the absolute path
+ *    of `<projectDir>/build/reports/compat`. `null` means the property was
+ *    never set (direct CLI invocation, no gradle context).
+ *  - [fallback] — used only when [reportDirProp] is `null`. Callers pass a
+ *    sensible relative or absolute default; we normalise to absolute before
+ *    returning.
+ *
+ * Failure mode (fail-fast):
+ *  - If [reportDirProp] is non-null and resolves to a relative `Path`, throw
+ *    [IllegalStateException] immediately. This catches the regression that
+ *    masked id17 build #3620: the test JVM accepted a relative
+ *    `compat.report-dir`, resolved it against a relative `user.dir`, and
+ *    wrote per-worker files to a doubled-prefix path that
+ *    `compatibilityReporter` never inspected. The build then failed the
+ *    proof-of-execution guard with no clear pointer to the actual
+ *    misconfiguration. Failing fast here means the next misconfigured build
+ *    surfaces with a precise error in the first test JVM log line.
+ */
+internal fun resolveReportDir(reportDirProp: String?, fallback: Path): Path {
+    if (reportDirProp != null) {
+        val candidate = Path.of(reportDirProp)
+        check(candidate.isAbsolute) {
+            "compat.report-dir must be absolute — got '$reportDirProp'. " +
+                "build.gradle should pass an absolute path (e.g. via " +
+                "`file('build/reports/compat').absolutePath`); a relative " +
+                "value resolved against the test JVM's user.dir can land " +
+                "per-worker ndjson files where compatibilityReporter never " +
+                "reads them, producing a vacuously-clean build."
+        }
+        return candidate
+    }
+    return fallback.toAbsolutePath()
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolutionTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolutionTest.kt
@@ -25,11 +25,14 @@ import java.nio.file.Path
  * failed the proof-of-execution guard despite 15834 testcases passing.
  *
  * The fix has two layers:
- *   1. `build.gradle` uses `layout.buildDirectory.dir('reports/compat').get()
- *      .asFile.absolutePath`, anchoring the writer property to the same
- *      Gradle layout primitive the `doFirst` cleanup and the
- *      `compatibilityReporter` task use, so a custom `buildDir` (or any
- *      future Gradle change to that primitive) moves all three together.
+ *   1. `build.gradle` resolves the writer property at execution time inside a
+ *      `doFirst` block and passes it via `jvmArgs "-Dcompat.report-dir=…"`,
+ *      using `layout.buildDirectory.dir('reports/compat').get().asFile
+ *      .canonicalPath` (defence-in-depth vs `.absolutePath` — canonical
+ *      resolves through the filesystem rather than via `user.dir`). The same
+ *      Gradle layout primitive backs the `doFirst` cleanup and the
+ *      `compatibilityReporter` task, so all three move together if `buildDir`
+ *      is ever customised.
  *   2. `resolveReportDir` fails fast when its input is non-null and relative,
  *      so any future regression of (1) surfaces as a clear test-JVM startup
  *      error instead of a silent doubled path that only the operator's grep

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolutionTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolutionTest.kt
@@ -1,0 +1,74 @@
+package org.octopusden.octopus.components.registry.compat
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/**
+ * Unit tests for [resolveReportDir] — the pure helper that picks the per-worker
+ * ndjson directory for [ExecutionLogger] and [DiffCollector].
+ *
+ * Pre-fix history (id17 build #3620, May 2026): `compat.report-dir` was set in
+ * build.gradle via `"${projectDir}/build/reports/compat".toString()`, but
+ * Gradle on the TC agent rendered `projectDir.toString()` as the relative
+ * module basename (`components-registry-compat-test`) rather than the absolute
+ * path. The test JVM then received a relative `compat.report-dir`. Combined
+ * with `workingDir = projectDir` (which set `user.dir` to the same relative
+ * basename), `Path.toAbsolutePath()` resolved the relative value against the
+ * relative `user.dir`, landing per-worker ndjson files in a doubled path
+ * like `components-registry-compat-test/components-registry-compat-test/
+ * build/reports/compat/`. `compatibilityReporter` aggregated from the SHALLOW
+ * `<projectDir>/build/reports/compat/` and saw zero entries — the build
+ * failed the proof-of-execution guard despite 15834 testcases passing.
+ *
+ * The fix has two layers:
+ *   1. `build.gradle` uses `file('build/reports/compat').absolutePath`, which
+ *      forces a reliably-absolute path via java.io.File regardless of how
+ *      Gradle renders `projectDir.toString()`.
+ *   2. `resolveReportDir` fails fast when its input is non-null and relative,
+ *      so any future regression of (1) surfaces as a clear test-JVM startup
+ *      error instead of a silent doubled path that only the operator's grep
+ *      of TC artifacts can catch.
+ *
+ * These tests pin layer (2). Layer (1) is exercised via the next id17
+ * compat-test run.
+ */
+@Tag("unit")
+class ReportDirResolutionTest {
+    @Test
+    fun `null prop returns absolute path of fallback`(@TempDir tmp: Path) {
+        val fallback = tmp.resolve("build/reports/compat")
+        val out = resolveReportDir(null, fallback)
+        assertThat(out).isAbsolute()
+        assertThat(out).isEqualTo(fallback.toAbsolutePath())
+    }
+
+    @Test
+    fun `absolute prop is returned as-is`(@TempDir tmp: Path) {
+        val absolute = tmp.resolve("custom/reports").toAbsolutePath()
+        val out = resolveReportDir(absolute.toString(), Path.of("ignored-fallback"))
+        assertThat(out).isEqualTo(absolute)
+    }
+
+    @Test
+    fun `relative prop throws IllegalStateException — fail-fast on misconfigured build gradle`() {
+        assertThatThrownBy {
+            resolveReportDir("components-registry-compat-test/build/reports/compat", Path.of("ignored-fallback"))
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("compat.report-dir must be absolute")
+            .hasMessageContaining("components-registry-compat-test/build/reports/compat")
+    }
+
+    @Test
+    fun `relative prop with single segment also throws`() {
+        assertThatThrownBy {
+            resolveReportDir("build/reports/compat", Path.of("ignored-fallback"))
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("compat.report-dir must be absolute")
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolutionTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ReportDirResolutionTest.kt
@@ -25,9 +25,11 @@ import java.nio.file.Path
  * failed the proof-of-execution guard despite 15834 testcases passing.
  *
  * The fix has two layers:
- *   1. `build.gradle` uses `file('build/reports/compat').absolutePath`, which
- *      forces a reliably-absolute path via java.io.File regardless of how
- *      Gradle renders `projectDir.toString()`.
+ *   1. `build.gradle` uses `layout.buildDirectory.dir('reports/compat').get()
+ *      .asFile.absolutePath`, anchoring the writer property to the same
+ *      Gradle layout primitive the `doFirst` cleanup and the
+ *      `compatibilityReporter` task use, so a custom `buildDir` (or any
+ *      future Gradle change to that primitive) moves all three together.
  *   2. `resolveReportDir` fails fast when its input is non-null and relative,
  *      so any future regression of (1) surfaces as a clear test-JVM startup
  *      error instead of a silent doubled path that only the operator's grep

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -99,7 +99,31 @@ fun ComponentEntity.toEscrowModule(
     val module = EscrowModule()
     module.moduleName = this.componentKey
 
-    val configs = this.configurations.toList()
+    // Sort configurations deterministically before enumeration. `@OneToMany`
+    // collections have no order guarantee; on Postgres they come back in heap-
+    // scan order, which is non-deterministic and not aligned with DSL declaration
+    // order. For a synthetic-base component with multiple overrides (BASE range
+    // is suppressed below), `enumeratedRanges` builds from
+    // `overrides.map { versionRange }.distinct()` in iteration order — and a
+    // wrong first range silently leaks into `moduleConfigurations[0]`, which
+    // `BaseComponentController.createComponent` uses to populate the wire DTO.
+    //
+    // V1 reference iterates the loader's parse list in DSL declaration order;
+    // align v3 to that by sorting on `(rowType != "BASE", createdAt, id)`. The
+    // `@CreationTimestamp` column is monotonically populated by `ImportServiceImpl`
+    // as it persists rows top-to-bottom through the DSL, so `createdAt` is an
+    // accurate proxy for DSL position. The `rowType != "BASE"` leading key keeps
+    // BASE at index 0 of the sorted list (the subsequent `firstOrNull { rowType
+    // == "BASE" }` still works, but the consistent ordering makes the override
+    // enumeration deterministic regardless of heap-scan or test-fixture insertion
+    // order). `id` is the deterministic tiebreaker when createdAt collides.
+    val configs = this.configurations.sortedWith(
+        compareBy(
+            { it.rowType != "BASE" },
+            { it.createdAt ?: java.time.Instant.MIN },
+            { it.id?.toString() ?: "" },
+        ),
+    )
     val base =
         configs.firstOrNull { it.rowType == "BASE" }
             ?: return module

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -303,22 +303,25 @@ class DatabaseComponentRegistryResolver(
 
         // Per-range MARKER rows that carry an explicit per-range maven coordinate.
         //
-        // Two marker types may carry per-range maven artifact rows:
+        // Only GROUP_ARTIFACT_PATTERN markers participate in /maven-artifacts resolution
+        // per V1 contract (see filter below + commit history). The marker name is MIG-047:
+        // it represents the case where the DSL component sets `groupId`/`artifactId` per
+        // range (with or without an accompanying `distribution { gav = … }` block). A
+        // synthetic marker is emitted at import time with `mavenArtifacts` rows built from
+        // the per-range groupId/artifactId. This marker is intentionally NOT registered in
+        // MarkerAttributes.ALL so `buildEscrowModuleConfig` ignores it and
+        // `getAllJiraComponentVersionRanges` is not affected.
         //
-        //   DISTRIBUTION_MAVEN: the DSL component uses an explicit `distribution { gav = … }`
-        //     block per range.  The marker's `mavenArtifacts` collection is populated from
-        //     the GAV.  `getMavenArtifactParameters` reads it the same way as below.
+        // DISTRIBUTION_MAVEN markers also exist (emitted by the importer for every per-
+        // range `distribution { gav = … }` block) but are **not** consumed here — they
+        // feed V4 distribution endpoints (`getResolvedComponentDefinition`,
+        // `/distribution`). The V1 contract for /maven-artifacts is
+        // (EscrowModuleConfig.groupIdPattern, .artifactIdPattern), not GAV-derived;
+        // see filter at line 348 below.
         //
-        //   GROUP_ARTIFACT_PATTERN (MIG-047): the DSL component sets `groupId`/`artifactId`
-        //     per range WITHOUT an explicit `distribution { gav = … }` block.  A synthetic
-        //     marker was emitted at import time with `mavenArtifacts` built from the per-range
-        //     groupId/artifactId.  This marker is intentionally NOT registered in
-        //     MarkerAttributes.ALL so `buildEscrowModuleConfig` ignores it and
-        //     `getAllJiraComponentVersionRanges` is not affected.
-        //
-        // For both types, we extract the artifact configuration directly from the marker
-        // entity's `mavenArtifacts` child collection (sorted by `sortOrder`), bypassing
-        // `config.distribution.GAV()` to avoid the side-effect described above.
+        // We extract the artifact configuration directly from the GROUP_ARTIFACT_PATTERN
+        // marker entity's `mavenArtifacts` child collection (sorted by `sortOrder`),
+        // bypassing `config.distribution.GAV()` to avoid the side-effect described above.
         // V1 contract (component-resolver-core JiraParametersResolver.groovy:67-68):
         // /maven-artifacts returns (groupIdPattern, artifactIdPattern) from the
         // inherited EscrowModuleConfig chain — NEVER derived from distribution.GAV.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -319,27 +319,37 @@ class DatabaseComponentRegistryResolver(
         // For both types, we extract the artifact configuration directly from the marker
         // entity's `mavenArtifacts` child collection (sorted by `sortOrder`), bypassing
         // `config.distribution.GAV()` to avoid the side-effect described above.
-        // Same-range conflict resolution: a V4 user may add a DISTRIBUTION_MAVEN
-        // override on a range that already carries an import-managed
-        // GROUP_ARTIFACT_PATTERN row (V4 createFieldOverride only de-dupes by
-        // overriddenAttribute). `componentEntity.configurations` is a @OneToMany
-        // collection with no specified iteration order, so a naive `associateBy`
-        // makes selection non-deterministic. Resolve deterministically: the
-        // explicit DISTRIBUTION_MAVEN user override always wins; GROUP_ARTIFACT_PATTERN
-        // is the fallback (used only when no DISTRIBUTION_MAVEN exists on the range).
+        // V1 contract (component-resolver-core JiraParametersResolver.groovy:67-68):
+        // /maven-artifacts returns (groupIdPattern, artifactIdPattern) from the
+        // inherited EscrowModuleConfig chain — NEVER derived from distribution.GAV.
+        // Empirically confirmed today (2026-05-24) via curl on prod + QA: every
+        // range emits the inherited top-level (groupId, artifactId), regardless of
+        // whether a version-level `distribution { gav = … }` block exists.
+        //
+        // Per-range override of these fields is meaningful ONLY when the DSL
+        // explicitly redefines groupId/artifactId at the version level — that case
+        // is encoded by the GROUP_ARTIFACT_PATTERN marker (see
+        // EntityMappers.kt:54-65; emitted by ImportServiceImpl.attachMavenArtifacts
+        // FromGroupArtifact). DISTRIBUTION_MAVEN markers, by contrast, carry only
+        // a GAV-token-derived (groupId, artifactId) reconstructed from the per-
+        // range `distribution.GAV()` string — never the V1 contract field. They
+        // are read by V4 distribution endpoints and by `buildEscrowModuleConfig`,
+        // but must NOT influence /maven-artifacts.
+        //
+        // Pre-fix bug (id17 #3640 compat-test diffs for 6 components): the
+        // filter also accepted DISTRIBUTION_MAVEN rows, so any DSL component
+        // with a version-level GAV override silently had its inherited
+        // artifactId discarded in favour of the GAV-derived token list. See
+        // RES-C-007 / RES-C-008 for fixtures pinning the V1 shape.
         val perRangeMarkerRows: Map<String, ComponentConfigurationEntity> =
             componentEntity.configurations
                 .asSequence()
                 .filter {
                     it.rowType == ROW_TYPE_MARKER &&
-                        (it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN ||
-                            it.overriddenAttribute == MarkerAttributes.GROUP_ARTIFACT_PATTERN)
+                        it.overriddenAttribute == MarkerAttributes.GROUP_ARTIFACT_PATTERN
                 }
                 .groupBy { it.versionRange }
-                .mapValues { (_, rows) ->
-                    rows.firstOrNull { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN }
-                        ?: rows.first()
-                }
+                .mapValues { (_, rows) -> rows.first() }
 
         val module = componentEntity.toEscrowModule(versionRangeFactory, numericVersionFactory)
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1316,7 +1316,18 @@ class ImportServiceImpl(
 
         // escrow aspect
         cfg.escrow?.let { escrow ->
-            escrow.generation.orElse(null)?.let { row.escrowGeneration = it.name }
+            // V1-contract: when a component config's escrow.generation is empty,
+            // fall back to the common Defaults.groovy generation (= AUTO per the
+            // shipped DSL). Without this fallback, components whose DSL omits an
+            // explicit `escrow { generation = … }` block (e.g. wscardsmodel) land
+            // with a NULL `escrow_generation` column, the read-path returns
+            // Optional.empty, and the downstream Component view diverges from V1
+            // (which always returns AUTO via Defaults inheritance). Reproduced
+            // today (2026-05-24) on the local candidate v3 schema-v2 DB-mode
+            // stand vs prod + QA + local baseline V1.
+            val genFromCfg = escrow.generation.orElse(null)
+            val genFromDefaults = commonDefaultsCache.escrow?.generation?.orElse(null)
+            (genFromCfg ?: genFromDefaults)?.let { row.escrowGeneration = it.name }
             row.escrowReusable = escrow.isReusable.takeIf { it }
             escrow.diskSpaceRequirement.orElse(null)?.let { row.escrowDiskSpace = it.toString() }
             row.escrowProvidedDependencies =
@@ -1440,18 +1451,26 @@ class ImportServiceImpl(
         val baseDist = base.distribution
         val overDist = override.distribution
 
+        // DISTRIBUTION_MAVEN and GROUP_ARTIFACT_PATTERN are orthogonal markers consumed by
+        // DIFFERENT read-paths (per the comment at DatabaseComponentRegistryResolver.kt:329-343):
+        // - DISTRIBUTION_MAVEN feeds buildEscrowModuleConfig and V4 distribution endpoints
+        //   (`getResolvedComponentDefinition`, `/distribution`); its `mavenArtifacts` rows are
+        //   parsed from `distribution.GAV()` tokens.
+        // - GROUP_ARTIFACT_PATTERN is the SOLE source of per-range overrides for
+        //   `/maven-artifacts` (see resolver fix 95bc74e8); its rows carry the per-range
+        //   DSL `groupId`/`artifactId` verbatim.
+        //
+        // When a DSL range sets BOTH `artifactId` AND `distribution { gav = … }`
+        // simultaneously, both diff conditions hold and BOTH markers must be
+        // emitted. The previous `if … else if …` shape emitted only
+        // DISTRIBUTION_MAVEN; the read-path then fell back to the inherited
+        // component-level CSV instead of the per-range V1 artifactId.
         if (mavenArtifactsDiffer(baseDist, overDist)) {
             saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.DISTRIBUTION_MAVEN) { row ->
                 attachMavenArtifacts(row, overDist)
             }?.let { saved += it }
-        } else if (groupArtifactPatternsDiffer(base, override)) {
-            // MIG-047: DSL sets groupId/artifactId per range without distribution.GAV().
-            // Both distribution.GAV() are null so mavenArtifactsDiffer returns false, but
-            // the effective groupIdPattern/artifactIdPattern differ across ranges.
-            // Emit a GROUP_ARTIFACT_PATTERN marker (NOT distribution.maven) so that
-            // getMavenArtifactParameters can read the per-range values while
-            // getAllJiraComponentVersionRanges / buildEscrowModuleConfig remain unaffected
-            // (they only look at DISTRIBUTION_MAVEN markers for the distribution field).
+        }
+        if (groupArtifactPatternsDiffer(base, override)) {
             saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.GROUP_ARTIFACT_PATTERN) { row ->
                 attachMavenArtifactsFromGroupArtifact(row, override.groupIdPattern, override.artifactIdPattern)
             }?.let { saved += it }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverMavenArtifactsRangeTest.kt
@@ -150,13 +150,23 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
 
     @Test
     @DisplayName(
-        "RES-C-001: per-range DISTRIBUTION_MAVEN marker overrides groupPattern " +
+        "RES-C-001: per-range GROUP_ARTIFACT_PATTERN marker overrides groupPattern " +
             "(bug-C-component-A shape: two ranges with distinct groupId per range)",
     )
     fun `RES-C-001 getMavenArtifactParameters returns per-range groupPattern from marker override`() {
         // bug-C-component-A shape:
         //   BASE at [1.1,) with maven artifact (com.example.ic, bug-C-component-A)
-        //   MARKER distribution.maven at [1.0,1.1) with maven artifact (com.example, bug-C-component-A)
+        //   MARKER GROUP_ARTIFACT_PATTERN at [1.0,1.1) with maven artifact (com.example, bug-C-component-A)
+        //
+        // V1-contract note (RES-C-007/008): only GROUP_ARTIFACT_PATTERN markers
+        // override /maven-artifacts' (groupPattern, artifactPattern). The
+        // historical version of this test used DISTRIBUTION_MAVEN — which is
+        // emitted by the importer for every per-range `distribution { gav = … }`
+        // block, regardless of whether the DSL explicitly redefined
+        // `groupId`/`artifactId` at the version level. That made the read-path
+        // emit GAV-derived tokens instead of the inherited contract field. Now
+        // we model the legitimate override (explicit per-range groupId/artifactId
+        // in the DSL) via GROUP_ARTIFACT_PATTERN.
         val comp = makeComponent("bug-C-component-A-like")
         comp.distributionExplicit = true
 
@@ -167,7 +177,7 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         val base = makeBase(comp, "[1.1,)")
         addMavenArtifact(base, "com.example.ic", "bug-C-component-A")
 
-        val markerOld = makeMarkerRow(comp, "[1.0,1.1)", "distribution.maven")
+        val markerOld = makeMarkerRow(comp, "[1.0,1.1)", MarkerAttributes.GROUP_ARTIFACT_PATTERN)
         addMavenArtifact(markerOld, "com.example", "bug-C-component-A")
 
         comp.configurations.addAll(listOf(base, markerOld))
@@ -194,14 +204,15 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
 
     @Test
     @DisplayName(
-        "RES-C-002: per-range DISTRIBUTION_MAVEN marker override with multiple artifacts " +
+        "RES-C-002: per-range GROUP_ARTIFACT_PATTERN marker override with multiple artifacts " +
             "(bug-C-component-B shape: multi-artifact CSV, two ranges)",
     )
     fun `RES-C-002 getMavenArtifactParameters handles multi-artifact CSV override`() {
         // bug-C-component-B shape:
         //   BASE at [03.51.29.15,) with maven artifact (com.example.cardsmodel2.dummy, bug-C-component-B)
-        //   MARKER distribution.maven at (,03.51.29.15) with two artifacts:
+        //   MARKER GROUP_ARTIFACT_PATTERN at (,03.51.29.15) with two artifacts:
         //     (com.example.cardsmodel2, bug-C-fixture-v2) and (com.example.cardsmodel, bug-C-fixture-legacy)
+        // V1-contract update: switched from DISTRIBUTION_MAVEN to GROUP_ARTIFACT_PATTERN — see RES-C-001 comment.
         val comp = makeComponent("bug-C-fixture-B-shape")
         comp.distributionExplicit = true
 
@@ -211,7 +222,7 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         val base = makeBase(comp, "[03.51.29.15,)")
         addMavenArtifact(base, "com.example.cardsmodel2.dummy", "bug-C-component-B", sortOrder = 0)
 
-        val markerOld = makeMarkerRow(comp, "(,03.51.29.15)", "distribution.maven")
+        val markerOld = makeMarkerRow(comp, "(,03.51.29.15)", MarkerAttributes.GROUP_ARTIFACT_PATTERN)
         addMavenArtifact(markerOld, "com.example.cardsmodel2", "bug-C-fixture-v2", sortOrder = 0)
         addMavenArtifact(markerOld, "com.example.cardsmodel", "bug-C-fixture-legacy", sortOrder = 1)
 
@@ -406,12 +417,15 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
 
     @Test
     @DisplayName(
-        "RES-C-005: mixed — BASE+GAV, MARKER for range B only → range B uses GAV, range A uses fallback",
+        "RES-C-005: mixed — BASE+fallback, MARKER for range B only → range B uses marker, range A uses fallback",
     )
-    fun `RES-C-005 marker-gated GAV extraction only for marked ranges`() {
+    fun `RES-C-005 marker-gated override only for marked ranges`() {
         // Demonstrates that the per-range MARKER gate is the discriminator:
-        //   - range A (BASE, no marker)            → wildcard from component-level fallback
-        //   - range B (DISTRIBUTION_MAVEN marker)  → GAV-derived CSV
+        //   - range A (BASE, no marker)                  → wildcard from component-level fallback
+        //   - range B (GROUP_ARTIFACT_PATTERN marker)    → marker-derived (groupPattern, artifactPattern)
+        // V1-contract update (see RES-C-001): the legitimate per-range override marker
+        // is GROUP_ARTIFACT_PATTERN; DISTRIBUTION_MAVEN no longer participates in
+        // /maven-artifacts resolution.
         val comp = makeComponent("res-c-prime-fixture-mixed")
         comp.distributionExplicit = true
 
@@ -420,7 +434,7 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         val base = makeBase(comp, "(,1.0)")
         addMavenArtifact(base, "com.example.test", "art-x", sortOrder = 0)
 
-        val markerNew = makeMarkerRow(comp, "[1.0,)", "distribution.maven")
+        val markerNew = makeMarkerRow(comp, "[1.0,)", MarkerAttributes.GROUP_ARTIFACT_PATTERN)
         addMavenArtifact(markerNew, "com.example.new", "real-artifact-id", sortOrder = 0)
 
         comp.configurations.addAll(listOf(base, markerNew))
@@ -454,6 +468,132 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
             "real-artifact-id",
             rangeWithMarker.artifactPattern,
             "[1.0,) artifactPattern must come from the marker's GAV (override is active)",
+        )
+    }
+
+    // ========================================================================
+    // V1-contract preservation (RES-C-007, RES-C-008): when a per-range
+    // DISTRIBUTION_MAVEN marker exists BUT the DSL did not redefine
+    // groupId/artifactId at the version level, the V1 contract (see
+    // component-resolver-core JiraParametersResolver.groovy:67-68) returns the
+    // INHERITED top-level (artifactIdPattern, groupIdPattern) — never the
+    // GAV-token-derived values. Reproduced today on prod + QA + local baseline
+    // (curl 2026-05-24); the v3 DB-mode read-path returned GAV-derived strings
+    // and these tests pin V1 parity.
+    // ========================================================================
+
+    @Test
+    @DisplayName(
+        "RES-C-007: 3-token top-level artifactId + version-level DISTRIBUTION_MAVEN-only override " +
+            "preserves the inherited artifactPattern (V1 contract)",
+    )
+    fun `RES-C-007 DISTRIBUTION_MAVEN-only override preserves inherited artifactPattern`() {
+        // DSL shape (mirrors a real 3-artifact-token component):
+        //   "fixture-A" {
+        //       groupId = "com.example.fx"
+        //       artifactId = "art-a,art-b,art-c"          // inherited by every range
+        //       "[4.9.4-4181,)" {
+        //           distribution { gav = "...:lib-sdk:...×15" }
+        //           // NOTE: artifactId is NOT redefined here — only the distribution.GAV
+        //       }
+        //   }
+        //
+        // Import writes:
+        //   - component-level artifactIds row: artifactPattern="art-a,art-b,art-c"
+        //   - DISTRIBUTION_MAVEN marker on [4.9.4-4181,) with 15× (com.example.fx, lib-sdk)
+        //
+        // V1 contract: /maven-artifacts returns the inherited artifactPattern, NOT the GAV-derived one.
+        val comp = makeComponent("fixture-A-3-token")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(comp, "com.example.fx", "art-a", sortOrder = 0)
+        addComponentLevelArtifact(comp, "com.example.fx", "art-b", sortOrder = 1)
+        addComponentLevelArtifact(comp, "com.example.fx", "art-c", sortOrder = 2)
+
+        val base = makeBase(comp, "[4,4.9.4-4181)")
+        addMavenArtifact(base, "com.example.fx", "art-a", sortOrder = 0)
+        addMavenArtifact(base, "com.example.fx", "art-b", sortOrder = 1)
+        addMavenArtifact(base, "com.example.fx", "art-c", sortOrder = 2)
+
+        val distMaven = makeMarkerRow(comp, "[4.9.4-4181,)", MarkerAttributes.DISTRIBUTION_MAVEN)
+        // 15 GAV tokens like the production DSL — all map to (com.example.fx, lib-sdk).
+        repeat(15) { i -> addMavenArtifact(distMaven, "com.example.fx", "lib-sdk", sortOrder = i) }
+
+        comp.configurations.addAll(listOf(base, distMaven))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("fixture-A-3-token")
+
+        val rangeWithOverride = result["[4.9.4-4181,)"]
+        assertNotNull(rangeWithOverride, "[4.9.4-4181,) entry must be present")
+        assertEquals(
+            "com.example.fx",
+            rangeWithOverride!!.groupPattern,
+            "[4.9.4-4181,) groupPattern must be the inherited top-level — DISTRIBUTION_MAVEN does NOT override",
+        )
+        assertEquals(
+            "art-a,art-b,art-c",
+            rangeWithOverride.artifactPattern,
+            "[4.9.4-4181,) artifactPattern must be the inherited top-level — DISTRIBUTION_MAVEN does NOT override",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "RES-C-008: multi-element CSV groupId/artifactId at top-level, " +
+            "per-range DISTRIBUTION_MAVEN override preserves the inherited CSV (V1 contract)",
+    )
+    fun `RES-C-008 DISTRIBUTION_MAVEN-only override on multi-element top-level preserves CSV`() {
+        // DSL shape (mirrors a real two-element groupId CSV component):
+        //   "fixture-B" {
+        //       groupId = "com.example.fx.distrib,com.example.fx.distrib.installer"
+        //       artifactId = "installer-art,main-art"
+        //       "[1.7.3076,1.7.3209]" {
+        //           distribution { gav = "com.example.fx.bundled:main-art:zip:tag1,...×8" }
+        //       }
+        //   }
+        //
+        // V1 contract: /maven-artifacts for the override range returns the inherited
+        // CSV groupId AND CSV artifactId — NOT the single GAV-derived group nor the
+        // 8-token repeated artifact list.
+        val comp = makeComponent("fixture-B-csv")
+        comp.distributionExplicit = true
+
+        addComponentLevelArtifact(
+            comp,
+            "com.example.fx.distrib,com.example.fx.distrib.installer",
+            "installer-art,main-art",
+        )
+
+        val base = makeBase(comp, "[1.7,1.7.3076)")
+        addMavenArtifact(
+            base,
+            "com.example.fx.distrib,com.example.fx.distrib.installer",
+            "installer-art,main-art",
+        )
+
+        val distMaven = makeMarkerRow(comp, "[1.7.3076,1.7.3209]", MarkerAttributes.DISTRIBUTION_MAVEN)
+        // 8 GAV tokens like the production DSL — all map to (com.example.fx.bundled, main-art).
+        repeat(8) { i ->
+            addMavenArtifact(distMaven, "com.example.fx.bundled", "main-art", sortOrder = i)
+        }
+
+        comp.configurations.addAll(listOf(base, distMaven))
+        stubComponent(comp)
+
+        val result = resolver.getMavenArtifactParameters("fixture-B-csv")
+
+        val rangeWithOverride = result["[1.7.3076,1.7.3209]"]
+        assertNotNull(rangeWithOverride, "[1.7.3076,1.7.3209] entry must be present")
+        assertEquals(
+            "com.example.fx.distrib,com.example.fx.distrib.installer",
+            rangeWithOverride!!.groupPattern,
+            "groupPattern must be the inherited 2-element CSV — DISTRIBUTION_MAVEN does NOT collapse it to single GAV groupId",
+        )
+        assertEquals(
+            "installer-art,main-art",
+            rangeWithOverride.artifactPattern,
+            "artifactPattern must be the inherited CSV — DISTRIBUTION_MAVEN does NOT replace it with the GAV artifact-token list",
         )
     }
 
@@ -550,17 +690,15 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
     @Test
     @DisplayName(
         "MIG-047-RES-003: when both DISTRIBUTION_MAVEN and GROUP_ARTIFACT_PATTERN markers " +
-            "exist on the same versionRange, DISTRIBUTION_MAVEN wins deterministically",
+            "exist on the same versionRange, GROUP_ARTIFACT_PATTERN wins (DISTRIBUTION_MAVEN is ignored)",
     )
-    fun `MIG-047-RES-003 same-range conflict — DISTRIBUTION_MAVEN takes precedence over GROUP_ARTIFACT_PATTERN`() {
-        // Conflict shape: a V4 user added a distribution.maven override on a range that
-        // already had an import-managed GROUP_ARTIFACT_PATTERN row (V4 createFieldOverride
-        // only de-dupes by `overriddenAttribute`, so this pair is reachable). With the
-        // pre-fix `associateBy { it.versionRange }`, whichever row sits last in
-        // `componentEntity.configurations` wins — non-deterministic because @OneToMany
-        // does not specify iteration order. Post-fix, the explicit DISTRIBUTION_MAVEN
-        // override wins regardless of row-order (mirrors the V4 user's stated intent;
-        // GROUP_ARTIFACT_PATTERN is import-internal and supplanted).
+    fun `MIG-047-RES-003 same-range conflict — GROUP_ARTIFACT_PATTERN wins, DISTRIBUTION_MAVEN ignored`() {
+        // V1-contract design (RES-C-007/008): DISTRIBUTION_MAVEN does NOT influence
+        // /maven-artifacts at all — only GROUP_ARTIFACT_PATTERN does. So a range
+        // carrying both markers must resolve to the GROUP_ARTIFACT_PATTERN coords,
+        // not the DISTRIBUTION_MAVEN coords. The historical behaviour
+        // (DISTRIBUTION_MAVEN winning) was the source of the v3 DB-mode regression
+        // on 6 production components — see fix commit message for details.
         val comp = makeComponent("gamma-fixture-mig047-conflict")
         comp.distributionExplicit = true
 
@@ -569,9 +707,10 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         val base = makeBase(comp, "[1.0,1.1)")
         addMavenArtifact(base, "com.example", "gamma-fixture")
 
-        // Build a deliberately adversarial ordering: GROUP_ARTIFACT_PATTERN appears AFTER
-        // DISTRIBUTION_MAVEN in the configurations list. The pre-fix `associateBy` keeps
-        // the LAST entry with the same key — so GROUP_ARTIFACT_PATTERN wins under the bug.
+        // Adversarial ordering preserved: DISTRIBUTION_MAVEN sits BEFORE
+        // GROUP_ARTIFACT_PATTERN in the configurations list. With the V1-contract
+        // fix the resolver filters DISTRIBUTION_MAVEN out of the marker set entirely,
+        // so GROUP_ARTIFACT_PATTERN wins regardless of row-order.
         val distributionMaven = makeMarkerRow(comp, "[1.1,)", MarkerAttributes.DISTRIBUTION_MAVEN)
         addMavenArtifact(distributionMaven, "com.example.user-explicit", "gamma-fixture")
 
@@ -588,9 +727,9 @@ class DatabaseComponentRegistryResolverMavenArtifactsRangeTest {
         val rangeOverride = result["[1.1,)"]
         assertNotNull(rangeOverride, "[1.1,) entry must be present")
         assertEquals(
-            "com.example.user-explicit",
+            "com.example.import-internal",
             rangeOverride!!.groupPattern,
-            "DISTRIBUTION_MAVEN must take precedence over GROUP_ARTIFACT_PATTERN on the same range",
+            "GROUP_ARTIFACT_PATTERN wins per V1 contract; DISTRIBUTION_MAVEN is invisible to /maven-artifacts",
         )
         assertEquals("gamma-fixture", rangeOverride.artifactPattern)
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
@@ -471,6 +471,68 @@ class DatabaseComponentRegistryResolverTest {
         assertEquals(ALL_VERSIONS, module.moduleConfigurations.first().versionRangeString)
     }
 
+    @Test
+    fun `(5e MIG-029) synthetic base with multiple overrides - first config follows DSL declaration order (createdAt), not heap-scan`() {
+        // Repros wscardsmodel-shape: synthetic base, multiple version-range blocks where
+        // one declares an explicit scalar override (e.g. escrow.generation = MANUAL) and
+        // others inherit from the synthetic base (escrow.generation = AUTO via Defaults).
+        //
+        // V1 contract (prod = QA = baseline): the controller's createComponent() picks
+        // moduleConfigurations[0], which V1 emits in DSL declaration order. For an archived
+        // component whose first DSL range has no escrow{} block, that's AUTO.
+        //
+        // v3 DB-mode used to iterate Hibernate @OneToMany configurations in DB heap-scan
+        // order — non-deterministic — so moduleConfigurations[0] could become the MANUAL
+        // override range, leaking MANUAL into the wire response and producing 6 stable
+        // diffs on id17 #3662 for wscardsmodel across `/v2/components/{c}`, list endpoints
+        // and `/v3/components`.
+        //
+        // The fixture below inserts rows in an ADVERSARIAL order (MANUAL override BEFORE
+        // the DSL-first RANGE_PRESENCE row) but assigns createdAt timestamps that reflect
+        // DSL declaration order. The fix in EntityMappers.toEscrowModule sorts configs by
+        // (rowType != "BASE", createdAt, id) before enumeration, which restores the V1
+        // contract: moduleConfigurations[0] is the DSL-first range (createdAt-min), not
+        // the adversarially-inserted MANUAL range.
+        val comp = makeComponent("COMP5E")
+        val base = makeBase(comp, isSyntheticBase = true).apply {
+            escrowGeneration = "AUTO"
+            createdAt = java.time.Instant.ofEpochMilli(1000)
+        }
+        // DSL-first override range — RANGE_PRESENCE only, no escrow.generation override.
+        // resolveForRange inherits escrow_generation from the synthetic base → AUTO.
+        val rangePresenceForAutoRange = ComponentConfigurationEntity(
+            component = comp,
+            versionRange = "[1.0,)",
+            overriddenAttribute = null,
+            rowType = "RANGE_PRESENCE",
+        ).apply { createdAt = java.time.Instant.ofEpochMilli(2000) }
+        // DSL-second override range — SCALAR_OVERRIDE for escrow.generation = MANUAL.
+        val manualOverride = makeScalarOverrideRow(comp, "(,1.0)", "escrow.generation").apply {
+            escrowGeneration = "MANUAL"
+            createdAt = java.time.Instant.ofEpochMilli(3000)
+        }
+        // Insertion order DELIBERATELY adversarial: MANUAL row before RANGE_PRESENCE.
+        // Pre-fix Hibernate could surface this same order on real Postgres heap-scan;
+        // post-fix the createdAt-based sort restores DSL order before enumeration.
+        comp.configurations.addAll(listOf(base, manualOverride, rangePresenceForAutoRange))
+        stubComponent(comp)
+
+        val module = resolver.getComponentById("COMP5E")
+        assertNotNull(module)
+        assertEquals(2, module!!.moduleConfigurations.size, "Both override ranges must be enumerated")
+        val first = module.moduleConfigurations.first()
+        assertEquals(
+            "[1.0,)",
+            first.versionRangeString,
+            "moduleConfigurations[0] must be the DSL-first range (lowest createdAt), NOT the adversarially-inserted MANUAL range",
+        )
+        assertEquals(
+            org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode.AUTO,
+            first.escrow!!.generation.orElse(null),
+            "First-enumerated range inherits escrow.generation from synthetic base (AUTO via Defaults), not MANUAL from the other range",
+        )
+    }
+
     // ========================================================================
     // (6) Doc-link resolution
     // ========================================================================

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047PerRangeGroupIdImportTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047PerRangeGroupIdImportTest.kt
@@ -4,6 +4,7 @@ import java.lang.reflect.Method
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -247,12 +248,17 @@ class MIG047PerRangeGroupIdImportTest {
 
     @Test
     @DisplayName(
-        "MIG-047-003 (anti-regression): emitMarkerOverrides does NOT double-create DISTRIBUTION_MAVEN MARKER " +
-            "when distribution.GAV already differs (existing RES-C path must not be duplicated)",
+        "MIG-047-003: when per-range distribution.GAV AND per-range artifactId both differ from base, " +
+            "emit BOTH a DISTRIBUTION_MAVEN MARKER and a GROUP_ARTIFACT_PATTERN MARKER (V1 contract)",
     )
-    fun `MIG-047-003 anti-regression no duplicate MARKER when distribution GAV already differs`() {
-        // If distribution.GAV() already differs, the existing mavenArtifactsDiffer path fires.
-        // The new groupIdPattern-check must NOT fire a second time for the same range.
+    fun `MIG-047-003 emit both markers when both diff conditions hold`() {
+        // V1-contract: per-range DSL overrides for `distribution { gav = … }` AND `artifactId`
+        // are orthogonal and must surface independently in the schema-v2 view. The previous
+        // assertion ("exactly one MARKER, not two") encoded a mutual-exclusion bug:
+        // `emitMarkerOverrides` used `if … else if …` so only DISTRIBUTION_MAVEN was emitted
+        // for the both-diff case. The read-path at /maven-artifacts then fell back to the
+        // inherited component-level artifactId instead of the per-range V1 value.
+        // After the fix, both markers must be present.
         val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "gamma-fixture")
         val savedBase = ComponentConfigurationEntity(
             id = UUID.randomUUID(),
@@ -282,9 +288,67 @@ class MIG047PerRangeGroupIdImportTest {
 
         val result = callEmitMarkerOverrides(component, savedBase, baseConfig, overrideConfig)
 
-        // Must be exactly one DISTRIBUTION_MAVEN MARKER (from the existing GAV path),
-        // NOT two (one for GAV path + one for new groupIdPattern path).
-        assertEquals(1, result.size, "Must emit exactly one DISTRIBUTION_MAVEN MARKER, not two")
-        assertEquals(MarkerAttributes.DISTRIBUTION_MAVEN, result[0].overriddenAttribute)
+        assertEquals(2, result.size, "Must emit BOTH a DISTRIBUTION_MAVEN and a GROUP_ARTIFACT_PATTERN marker")
+        val attributes = result.map { it.overriddenAttribute }.toSet()
+        assertEquals(
+            setOf(MarkerAttributes.DISTRIBUTION_MAVEN, MarkerAttributes.GROUP_ARTIFACT_PATTERN),
+            attributes,
+            "Both marker kinds must be present (different read-paths consume them)",
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "MIG-047-004: per-range artifactId='single-dist' AND distribution.GAV " +
+            "emits a GROUP_ARTIFACT_PATTERN marker carrying the per-range artifactId for /maven-artifacts",
+    )
+    fun `MIG-047-004 single-token per-range artifactId emits GROUP_ARTIFACT_PATTERN`() {
+        // DSL shape:
+        //   "fixture-X" {
+        //       groupId = "com.example.fixture"
+        //       artifactId = "sci_build|sci_utils|fixture_builder"   // top-level CSV fallback
+        //       "[6.22, )" {
+        //           artifactId = "single-dist"                       // per-range override
+        //           distribution { gav = "com.example.fixture:single-dist:zip" }
+        //       }
+        //   }
+        //
+        // V1-contract: /maven-artifacts for [6.22, ) returns artifactPattern="single-dist"
+        // (per-range artifactId), NOT the inherited top-level CSV.
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "fixture-X-single-dist")
+        val savedBase = ComponentConfigurationEntity(
+            id = UUID.randomUUID(),
+            component = component,
+            versionRange = "[5.1, 6.22)",
+            overriddenAttribute = null,
+            rowType = "BASE",
+        )
+
+        val baseDist = org.octopusden.octopus.escrow.model.Distribution(
+            true, false,
+            null,  // base has no GAV
+            null, null, null, null,
+        )
+        val overrideDist = org.octopusden.octopus.escrow.model.Distribution(
+            true, false,
+            "com.example.fixture:single-dist:zip",
+            null, null, null, null,
+        )
+
+        val baseConfig = makeConfig("com.example.fixture", "sci_build|sci_utils|fixture_builder", "[5.1, 6.22)")
+        setGroovyField(baseConfig, "distribution", baseDist)
+
+        val overrideConfig = makeConfig("com.example.fixture", "single-dist", "[6.22, )")
+        setGroovyField(overrideConfig, "distribution", overrideDist)
+
+        val result = callEmitMarkerOverrides(component, savedBase, baseConfig, overrideConfig)
+
+        assertEquals(2, result.size, "Both DISTRIBUTION_MAVEN and GROUP_ARTIFACT_PATTERN markers must be emitted")
+        val gap = result.firstOrNull { it.overriddenAttribute == MarkerAttributes.GROUP_ARTIFACT_PATTERN }
+        assertNotNull(gap, "GROUP_ARTIFACT_PATTERN marker missing (V1-contract gap)")
+        assertEquals(1, gap!!.mavenArtifacts.size, "Single-token artifactId override must produce one marker row")
+        val artifact = gap.mavenArtifacts.first()
+        assertEquals("com.example.fixture", artifact.groupPattern)
+        assertEquals("single-dist", artifact.artifactPattern)
     }
 }

--- a/docker-compose.local-postgres.yml
+++ b/docker-compose.local-postgres.yml
@@ -1,6 +1,12 @@
 services:
   postgres:
-    image: postgres:16
+    # `POSTGRES_IMAGE` lets the caller (TC build step or developer) point
+    # at an artifactory-hosted mirror to bypass Docker Hub's anonymous pull
+    # rate limit (id17 #3636 failed mid-Stage-1 with
+    # `toomanyrequests: You have reached your unauthenticated pull rate
+    # limit`). The fallback `postgres:16` keeps local-stand UX unchanged
+    # for developers running outside TC.
+    image: ${POSTGRES_IMAGE:-postgres:16}
     restart: unless-stopped
     ports:
       - "${CRS_DB_PORT:-5432}:5432"

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -294,13 +294,27 @@ echo ">>> Stage 4/4: compat-test"
 # compat.sh exports COMPAT_BASELINE_URL=http://localhost:$BASELINE_PORT and
 # COMPAT_CANDIDATE_URL=http://localhost:$CANDIDATE_PORT, then invokes the
 # :components-registry-compat-test:test gradle task. It already accepts
-# COMPAT_RMS_URL / COMPAT_FULL / COMPAT_PARALLELISM / COMPAT_SMOKE_COMPONENTS
-# from the parent shell.
+# COMPAT_RMS_URL / COMPAT_FULL / COMPAT_SMOKE_COMPONENTS from the parent
+# shell.
+#
+# COMPAT_PARALLELISM is the env-var name TC uses for the prompted JUnit-5
+# parallelism level (default 8). build.gradle reads it as the gradle
+# property `compat.parallelism` (`project.findProperty('compat.parallelism')`
+# — env vars do NOT auto-translate to gradle properties), so forward it
+# explicitly as `-Pcompat.parallelism=<n>`. Lets the operator drop to 1
+# from the TC prompt when investigating flaky diff counts (#3634 ran
+# twice on the same commit and produced 20 vs 22 active diffs — strong
+# race / VCS-refresh-cycle signal that disappears under sequential
+# execution).
+GRADLE_PARALLELISM_ARG=""
+if [ -n "${COMPAT_PARALLELISM:-}" ]; then
+  GRADLE_PARALLELISM_ARG="-Pcompat.parallelism=${COMPAT_PARALLELISM}"
+fi
 #
 # Run as a foreground child (NOT `exec`) so the EXIT trap fires when compat
 # finishes — Stage-2 review found that `exec` was replacing the shell process
 # and silently discarding the trap, leaking the baseline/candidate JVMs and
 # the postgres container between TC runs on a persistent agent.
-"$SCRIPT_DIR/compat.sh" "$@"
+"$SCRIPT_DIR/compat.sh" $GRADLE_PARALLELISM_ARG "$@"
 COMPAT_EXIT=$?
 exit $COMPAT_EXIT

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -187,6 +187,9 @@ nohup "$JAVA_BIN" -jar "$BASELINE_JAR" \
   --components-registry.vcs.root="file://$LOCAL_VCS_ROOT" \
   --components-registry.work-dir="$BASELINE_WORK_DIR" \
   --components-registry.groovy-path="$BASELINE_WORK_DIR/src/main/resources" \
+  --components-registry.version-name.service-branch=serviceCardsBranch \
+  --components-registry.version-name.service=serviceCards \
+  --components-registry.version-name.minor=minorCards \
   --auth-server.disabled=true \
   >"$BASELINE_LOG" 2>&1 &
 BASELINE_PID=$!
@@ -231,6 +234,9 @@ nohup "$JAVA_BIN" -jar "$CANDIDATE_JAR" \
   --components-registry.vcs.root="file://$LOCAL_VCS_ROOT" \
   --components-registry.work-dir="$CANDIDATE_WORK_DIR" \
   --components-registry.groovy-path="$CANDIDATE_WORK_DIR/src/main/resources" \
+  --components-registry.version-name.service-branch=serviceCardsBranch \
+  --components-registry.version-name.service=serviceCards \
+  --components-registry.version-name.minor=minorCards \
   --auth-server.disabled=true \
   >"$CANDIDATE_LOG" 2>&1 &
 CANDIDATE_PID=$!

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -306,6 +306,14 @@ echo ">>> Stage 4/4: compat-test"
 # twice on the same commit and produced 20 vs 22 active diffs — strong
 # race / VCS-refresh-cycle signal that disappears under sequential
 # execution).
+# TEMPORARY DIAGNOSTIC HARDCODE — revert before merge.
+# TC settings.kts is loaded from the `v3` branch, so the new
+# `COMPAT_PARALLELISM` prompt this PR adds to settings.kts is invisible
+# to the operator on id17 until merge. Hard-pin parallelism to 1 here so
+# the next id17 run on this branch answers the floating-diff-count
+# question (race vs deterministic) using the script that IS picked up
+# from this branch.
+COMPAT_PARALLELISM=1
 GRADLE_PARALLELISM_ARG=""
 if [ -n "${COMPAT_PARALLELISM:-}" ]; then
   GRADLE_PARALLELISM_ARG="-Pcompat.parallelism=${COMPAT_PARALLELISM}"

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -306,14 +306,6 @@ echo ">>> Stage 4/4: compat-test"
 # twice on the same commit and produced 20 vs 22 active diffs — strong
 # race / VCS-refresh-cycle signal that disappears under sequential
 # execution).
-# TEMPORARY DIAGNOSTIC HARDCODE — revert before merge.
-# TC settings.kts is loaded from the `v3` branch, so the new
-# `COMPAT_PARALLELISM` prompt this PR adds to settings.kts is invisible
-# to the operator on id17 until merge. Hard-pin parallelism to 1 here so
-# the next id17 run on this branch answers the floating-diff-count
-# question (race vs deterministic) using the script that IS picked up
-# from this branch.
-COMPAT_PARALLELISM=1
 GRADLE_PARALLELISM_ARG=""
 if [ -n "${COMPAT_PARALLELISM:-}" ]; then
   GRADLE_PARALLELISM_ARG="-Pcompat.parallelism=${COMPAT_PARALLELISM}"

--- a/scripts/local-stands/test/test-teamcity-run.sh
+++ b/scripts/local-stands/test/test-teamcity-run.sh
@@ -82,16 +82,21 @@ run_case() {
   fi
 }
 
-count_in_file() {
+count_in_file_fixed() {
   local needle="$1" file="$2"
   grep -c -F -- "$needle" "$file"
+}
+
+count_in_file_regex() {
+  local pattern="$1" file="$2"
+  grep -c -E -- "$pattern" "$file"
 }
 
 case_each_flag_appears_at_least_twice() {
   local rc=0
   for flag in "${REQUIRED_FLAGS[@]}"; do
     local n
-    n=$(count_in_file "$flag" "$TEAMCITY_RUN_SH")
+    n=$(count_in_file_fixed "$flag" "$TEAMCITY_RUN_SH")
     if [ "$n" -lt 2 ]; then
       echo "    flag missing or single-stand-only (count=$n, expected >=2): $flag"
       rc=1
@@ -103,21 +108,27 @@ case_each_flag_appears_at_least_twice() {
 # Sanity guard: dev-profile values must NOT be hard-coded in teamcity-run.sh
 # itself. They live in components-registry-service-server/dev/application-
 # dev.yml; this guard catches a future drift where someone copy-pastes the
-# dev values into the start command. Trailing space matches the shell
-# line-continuation form `... \\` while avoiding a substring false-positive
-# against the prod literal `...=minorCards \\`.
+# dev values into the start command.
+#
+# Boundary heuristic: each dev value ends in `C`. The matching prod value
+# starts with `Cards`. To match `...=minorC` followed by space, backslash,
+# newline, end-of-line, or quote — but NOT followed by `a` (the start of
+# `Cards`) — anchor the regex on a NON-LETTER boundary character or
+# end-of-line. This catches all the realistic positions the dev value
+# could land (mid-CLI continuation, last arg with no trailing `\`, inside
+# an HEREDOC, etc.) without false-positives against the prod literal.
 case_dev_override_values_not_hardcoded() {
   local forbidden=(
-    "version-name.minor=minorC "
-    "version-name.service=serviceC "
-    "version-name.service-branch=serviceCBranch "
+    'version-name\.minor=minorC([^A-Za-z]|$)'
+    'version-name\.service=serviceC([^A-Za-z]|$)'
+    'version-name\.service-branch=serviceCBranch([^A-Za-z]|$)'
   )
   local rc=0
-  for needle in "${forbidden[@]}"; do
+  for pattern in "${forbidden[@]}"; do
     local n
-    n=$(count_in_file "$needle" "$TEAMCITY_RUN_SH")
+    n=$(count_in_file_regex "$pattern" "$TEAMCITY_RUN_SH")
     if [ "$n" -ne 0 ]; then
-      echo "    dev-profile value leaked into teamcity-run.sh (count=$n): $needle"
+      echo "    dev-profile value leaked into teamcity-run.sh (count=$n): $pattern"
       rc=1
     fi
   done

--- a/scripts/local-stands/test/test-teamcity-run.sh
+++ b/scripts/local-stands/test/test-teamcity-run.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Static-text contract test for scripts/local-stands/teamcity-run.sh.
+#
+# Pins the prod-alignment Spring property overrides that MUST appear in BOTH
+# the baseline AND candidate JVM start commands. BOTH dev profile yamls
+# loaded via --spring.config.additional-location set the same dev values:
+#   components-registry-service-server/dev/application-dev.yml
+#   components-registry-service-server/dev/application-dev-vcs-local.yml
+# Each writes components-registry.version-name.{service-branch,service,
+# minor} = serviceCBranch/serviceC/minorC. Prod (cloud-prod) and QA
+# (cloud-qa) profiles do not activate either of these and inherit *Cards
+# values from service-config/components-registry-service.yml.
+#
+# Why version-name affects the compat surface — `version-name.*` are
+# template-placeholder NAMES used by KotlinVersionFormatter and
+# JiraComponentVersionFormatter.normalizeVersion when matching DSL
+# `releaseVersionFormat`/`majorVersionFormat` patterns (e.g.
+# `$major.$minor.$service`) against concrete versions. With mismatched
+# token names, matchesFormat / normalizeVersion / getPatchedFormat can
+# resolve a given version into a different DSL version-range, which shifts
+# which `moduleConfigurations` entry ends up at index [0] for components
+# that mix AUTO and MANUAL escrow ranges (e.g. wscardsmodel).
+# BaseComponentController picks [0]-th moduleConfiguration verbatim when
+# rendering a versionless Component — so the local-baseline JAR can return
+# escrow.generation=MANUAL while prod V1 (same code, same DSL revision)
+# returns AUTO. Numeric range-string parsing in NumericVersionFactory /
+# VersionRangeImpl is independent of version-name — only the format
+# template/placeholder pipeline is affected.
+#
+# The CLI overrides restore prod-equivalent values at the highest Spring
+# property precedence, defeating both dev yamls without removing them from
+# the profile chain (dev-vcs-local is still needed for the file:// VCS
+# root override).
+#
+# Note on supportedGroupIds / supportedSystems: the dev yaml sets these at
+# the YAML root (`supportedGroupIds: ...`), but the application code reads
+# them through ConfigHelper at the nested path
+# `components-registry.supportedGroupIds`. The root-level dev values do not
+# bind to the nested code path, so they have no observable effect on the
+# compat surface and do NOT need a CLI override.
+#
+# Static-text check: parses the script text and counts occurrences. No JVM,
+# no live stand. Runs in <1s.
+#
+# Usage:
+#   bash scripts/local-stands/test/test-teamcity-run.sh
+#   → exit 0 on green, non-zero on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEAMCITY_RUN_SH="$SCRIPT_DIR/../teamcity-run.sh"
+
+if [ ! -f "$TEAMCITY_RUN_SH" ]; then
+  echo "FAIL: $TEAMCITY_RUN_SH not found"
+  exit 2
+fi
+
+# Each prod-alignment override must appear at least TWICE in teamcity-run.sh
+# — once in the baseline `nohup ... -jar "$BASELINE_JAR" ...` block, once
+# in the candidate block. Counting `grep -c -F` matches lines; with one
+# flag per CLI line, line count and occurrence count agree.
+REQUIRED_FLAGS=(
+  "--components-registry.version-name.service-branch=serviceCardsBranch"
+  "--components-registry.version-name.service=serviceCards"
+  "--components-registry.version-name.minor=minorCards"
+)
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+run_case() {
+  local name="$1"; shift
+  if ( "$@" ); then
+    PASS=$((PASS + 1))
+    printf '  PASS  %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$name")
+    printf '  FAIL  %s\n' "$name"
+  fi
+}
+
+count_in_file() {
+  local needle="$1" file="$2"
+  grep -c -F -- "$needle" "$file"
+}
+
+case_each_flag_appears_at_least_twice() {
+  local rc=0
+  for flag in "${REQUIRED_FLAGS[@]}"; do
+    local n
+    n=$(count_in_file "$flag" "$TEAMCITY_RUN_SH")
+    if [ "$n" -lt 2 ]; then
+      echo "    flag missing or single-stand-only (count=$n, expected >=2): $flag"
+      rc=1
+    fi
+  done
+  return $rc
+}
+
+# Sanity guard: dev-profile values must NOT be hard-coded in teamcity-run.sh
+# itself. They live in components-registry-service-server/dev/application-
+# dev.yml; this guard catches a future drift where someone copy-pastes the
+# dev values into the start command. Trailing space matches the shell
+# line-continuation form `... \\` while avoiding a substring false-positive
+# against the prod literal `...=minorCards \\`.
+case_dev_override_values_not_hardcoded() {
+  local forbidden=(
+    "version-name.minor=minorC "
+    "version-name.service=serviceC "
+    "version-name.service-branch=serviceCBranch "
+  )
+  local rc=0
+  for needle in "${forbidden[@]}"; do
+    local n
+    n=$(count_in_file "$needle" "$TEAMCITY_RUN_SH")
+    if [ "$n" -ne 0 ]; then
+      echo "    dev-profile value leaked into teamcity-run.sh (count=$n): $needle"
+      rc=1
+    fi
+  done
+  return $rc
+}
+
+echo "=== teamcity-run.sh prod-alignment overrides ==="
+run_case "each version-name override appears in both baseline and candidate start commands" case_each_flag_appears_at_least_twice
+run_case "dev-profile values not hard-coded in teamcity-run.sh" case_dev_override_values_not_hardcoded
+
+echo
+echo "=== summary ==="
+echo "  pass: $PASS"
+echo "  fail: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "  failed cases:"
+  for n in "${FAIL_NAMES[@]}"; do echo "    - $n"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Branch evolved from the initial local-stand env-alignment fix into a series of schema-v2 contract fixes plus a compat-test infra workaround. After landing the env-alignment fix in the candidate stand, the compat-test exposed a sequence of real v3 DB-mode regressions against V1 (= prod = QA baseline). Each was localised with a parallel research-agent pass, fixed test-first per `feedback_tdd_mandatory`, and verified GREEN end-to-end on id17 #3663: **0 active diffs** across all 15834 cases (1 suppressed updateCache known-delta).

Cross-validated each cluster via curl on prod + QA — V1 reference behaviour is the contract this PR pins.

## Fixes (5 commits over the env-alignment base)

1. **`fix(resolver)` — drop DISTRIBUTION_MAVEN from /maven-artifacts marker filter** (V1 contract).
   - V1 reference (`component-resolver-core/.../JiraParametersResolver.groovy:67-68`) emits `(EscrowModuleConfig.groupIdPattern, .artifactIdPattern)` — DSL-inherited fields, never `distribution.GAV`-derived.
   - v3 DB-mode read-path was preferring DISTRIBUTION_MAVEN marker rows over the inherited component-level fallback; those marker rows carry GAV-token-derived `(groupId, artifactId)`, NOT the V1 contract field.
   - Fix in `DatabaseComponentRegistryResolver.getMavenArtifactParameters` filter — only GROUP_ARTIFACT_PATTERN markers participate; DISTRIBUTION_MAVEN markers continue to feed V4 distribution endpoints unchanged.
   - New tests (RES-C-007, RES-C-008) pin V1-contract preservation for two real shapes (3-token CSV artifactId; multi-element CSV groupId/artifactId at top-level).

2. **`fix(import)` — two import-side bugs folded into one commit** (`ImportServiceImpl`).
   - **escrow.generation defaults fallback** — when `cfg.escrow.generation` is `Optional.empty()`, fall back to `commonDefaultsCache.escrow.generation` (= AUTO per Defaults.groovy). Prior `?.let { … }` chain silently no-oped and left the column NULL.
   - **Both-markers emission** — for DSL ranges that set BOTH per-range `artifactId` AND `distribution { gav = … }`, emit both DISTRIBUTION_MAVEN AND GROUP_ARTIFACT_PATTERN markers (was `if … else if …`, only one fired). MIG-047-003 reworked accordingly; MIG-047-004 added.

3. **`fix(compat-infra)` — /tmp backup copy of per-worker ndjson + reporter fallback**.
   - id17 #3642 confirmed Gradle non-deterministically removes per-worker ndjson between test-JVM exit and `compatibilityReporter` doLast. After ruling out `outputs.dir(reportDir)` declaration / doFirst cleanup / stale-output metadata removal at the resolver level, fall back to writing each ndjson to `${java.io.tmpdir}/crs-compat-backup/` at shutdown; reporter restores from there if the primary reportDir is empty.

4. **`fix(resolver)` — deterministic configurations enumeration in toEscrowModule** (createdAt-based sort).
   - `ComponentEntity.configurations` is `@OneToMany` with no `@OrderBy` → Postgres heap-scan order. For a synthetic-base component with multiple overrides (BASE range suppressed per MIG-029), `moduleConfigurations[0]` non-deterministically ended up being one of the override ranges. V1 iterates DSL declaration order.
   - Sort `configurations` by `(rowType != \"BASE\", createdAt, id)` before the BASE/overrides split. `@CreationTimestamp` is monotonic across `ImportServiceImpl` row-by-row persistence, so it is an accurate DSL-order proxy. New test (5e) pins the contract with an adversarial fixture.

## Test plan

- [x] Local: all touched test classes GREEN (`*DatabaseComponentRegistryResolverTest*`, `*MavenArtifactsRangeTest*`, `*MIG047*`, `*MIG*`, `*EntityMappers*`, `*Migration*`).
- [x] Per-bug RED-then-GREEN demo: each fix has a paired `test:` commit asserting the V1-contract behaviour, verified RED on the prior code and GREEN after the fix.
- [x] id17 #3663 (live compat stand on this branch tip): **0 active diff(s) (1 suppressed, 0 env), 15834 cases executed — status NORMAL**.
- [x] Cross-validation via curl against prod V1 + QA v3 (both in `serviceMode=VCS`) for every affected endpoint; both match the local baseline 2.0.87 stand, confirming the bugs are genuine v3 DB-mode regressions, not local-stand artifacts.

## Architecture note

A side-discussion with the team established that the candidate stand already models the future prod schema-v2 rollout faithfully: same `default-source=db` + `auto-migrate=true` flags, one-shot startup, subsequent boots are idempotent. Profiles differ (candidate uses `dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local`; prod will use `cloud-prod` + service-config overlay) but the schema-v2 code paths exercised are identical. Discussion captured in conversation; no PR-level change required.

## Follow-ups (NOT in this PR)

- Move `compat-infra` /tmp workaround to a proper fix once the Gradle lifecycle quirk is fully diagnosed (current backup approach is robust but unsightly).
- Consider promoting `createdAt`-based sort to a persisted `sortOrder` column on `ComponentConfigurationEntity` for clarity. Read-path sort is fine for now (no schema migration).
- Tighter contract test that parses the two `nohup ... -jar` blocks separately (Opus H2 from the initial env-alignment review).
- Comment in `baseline.sh` / `candidate.sh` pointing readers at `teamcity-run.sh` for the prod-equivalent invocation (Opus M2).
- Trailing-space heuristic in `case_dev_override_values_not_hardcoded` (Opus M3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)