### PR TITLE
feat(v4): server-side groupId prefix validation + groupKey trim + seeder containsKey

### DIFF
--- a/components-registry-service-client/src/test/resources/application-common.yml
+++ b/components-registry-service-client/src/test/resources/application-common.yml
@@ -10,7 +10,10 @@ components-registry:
   groovy-path: ${components-registry.work-dir}
   dependency-mapping-file: dependency_mapping.properties
 
-  supportedGroupIds: org.octopusden.octopus,io.bcomponent
+  # Mirrors the server module's test config; the shared
+  # `BaseComponentsRegistryServiceTest.testGetSupportedGroupIds` asserts
+  # the full list, so it must match the server's 3-element form.
+  supportedGroupIds: org.octopusden.octopus,io.bcomponent,org.example
   supportedSystems: NONE,CLASSIC,ALFA
   version-name:
     service-branch: serviceCBranch

--- a/components-registry-service-client/src/test/resources/application-v3.yml
+++ b/components-registry-service-client/src/test/resources/application-v3.yml
@@ -9,7 +9,9 @@ components-registry:
   main-groovy-file: Aggregator.groovy
   groovy-path: ${components-registry.work-dir}
 
-  supportedGroupIds: org.octopusden.octopus,io.bcomponent
+  # Same 3-element list as application-common.yml — keeps the v3-profile
+  # variant in sync with the shared base test's expected value.
+  supportedGroupIds: org.octopusden.octopus,io.bcomponent,org.example
   supportedSystems: NONE,CLASSIC,ALFA
   version-name:
     service-branch: serviceCBranch

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/listener/FieldConfigSeeder.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/listener/FieldConfigSeeder.kt
@@ -111,8 +111,13 @@ class FieldConfigSeeder(
         val groupIdField: MutableMap<String, Any?> =
             (componentSection[FIELD_GROUP_ID] as? Map<String, Any?>)?.toMutableMap() ?: mutableMapOf()
 
-        if (groupIdField[KEY_DEFAULT_VALUE] != null) {
+        if (groupIdField.containsKey(KEY_DEFAULT_VALUE)) {
             // Admin- or prior-seed-set value already present — never clobber.
+            // Use key-presence (not `!= null`) so an explicit `defaultValue: null`
+            // is honoured as an intentional opt-out from the auto-suggest
+            // default. Previously the seeder treated `null` as "missing" and
+            // silently re-seeded it on every restart, which made the
+            // opt-out impossible.
             log.debug(
                 "FieldConfigSeeder: component.groupId.defaultValue already set to '{}'; preserved.",
                 groupIdField[KEY_DEFAULT_VALUE],

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1333,10 +1333,29 @@ class ComponentManagementServiceImpl(
      * source of truth: a CLI / automation client that bypasses the UI
      * cannot land a component on a disallowed prefix.
      *
-     * Allowed iff `groupKey == prefix` OR `groupKey.startsWith(prefix + ".")`.
-     * The trailing-dot boundary is critical: without it, allowed=`com.example`
-     * would let `com.exampleextra.foo` slip through. Mirrors the
-     * frontend's `useSupportedGroups` check (`v === lp || v.startsWith(lp + '.')`).
+     * Allowed iff `groupKey == prefix` OR `groupKey.startsWith(prefix + ".")`,
+     * **compared case-insensitively** (both sides lowercased before the
+     * compare). The trailing-dot boundary is critical: without it,
+     * allowed=`org.example` would let `org.exampleextra.foo` slip through.
+     * Mirrors the frontend's `useSupportedGroups` check exactly —
+     * `CreateComponentDialog.tsx` and `GeneralTab.tsx` both lowercase
+     * `groupId` and each `prefix` before `v === lp || v.startsWith(lp + '.')`.
+     * Without case-insensitive comparison on the CRS side, the portal
+     * passes its pre-check on `ORG.EXAMPLE.foo` and the server then
+     * returns 400 — confusing UX.
+     *
+     * Case is preserved on storage: the caller passes the user-typed
+     * value (trimmed) and persistence happens with that value, NOT the
+     * lowercased form. Lowercasing is a validation-time comparison only.
+     *
+     * Known trade-off: because `upsertGroup` does a case-sensitive
+     * `findByGroupKey`, a user can land `org.example.foo` AND
+     * `ORG.EXAMPLE.foo` as two distinct `component_groups` rows that
+     * both validate against the same prefix. If a future requirement
+     * surfaces (e.g. "same logical groupKey must dedupe regardless of
+     * case"), the fix is either (a) a case-insensitive lookup in
+     * `upsertGroup`, or (b) a DB-level `UNIQUE LOWER(group_key)`
+     * constraint. Out of scope here — the spec keeps user-typed case.
      *
      * The error message names the allowed prefixes verbatim so non-UI
      * clients see actionable feedback (the frontend can also surface the
@@ -1349,8 +1368,12 @@ class ComponentManagementServiceImpl(
      */
     private fun validateGroupKeyPrefix(value: String) {
         val allowed = configHelper.supportedGroupIds().toList()
+        val lowerValue = value.lowercase()
         val matches =
-            allowed.any { prefix -> value == prefix || value.startsWith("$prefix.") }
+            allowed.any { prefix ->
+                val lowerPrefix = prefix.lowercase()
+                lowerValue == lowerPrefix || lowerValue.startsWith("$lowerPrefix.")
+            }
         require(matches) {
             "group.groupKey '$value' is not in the configured supportedGroupIds. Allowed: $allowed"
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -67,8 +67,10 @@ import org.octopusden.octopus.components.registry.server.security.CurrentUserRes
 import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
+import org.octopusden.octopus.escrow.config.ConfigHelper
 import org.octopusden.releng.versions.VersionRangeFactory
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.core.env.Environment
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -105,7 +107,16 @@ class ComponentManagementServiceImpl(
     private val fieldConfigService: FieldConfigService,
     private val teamcityProperties: TeamcityProperties,
     private val versionRangeFactory: VersionRangeFactory,
+    private val environment: Environment,
 ) : ComponentManagementService {
+    // ConfigHelper is constructed lazily because it touches the Spring
+    // Environment on first access; mirrors the pattern used by
+    // CommonControllerV2 and FieldConfigSeeder. The supported group-id
+    // list is environment-config-driven (read from
+    // `components-registry.supportedGroupIds`), so building it once at
+    // first access is sufficient — admins re-config via redeploy, not
+    // hot-reload.
+    private val configHelper: ConfigHelper by lazy { ConfigHelper(environment) }
     // ============================================================
     // Create
     // ============================================================
@@ -126,9 +137,18 @@ class ComponentManagementServiceImpl(
         requireNotNull(request.group) {
             "group is required: every component must belong to a group (groupKey is mandatory)"
         }
-        require(request.group.groupKey.isNotBlank()) {
+        // Trim first so leading/trailing whitespace doesn't survive into the
+        // `component_groups.group_key` UNIQUE index — a key like
+        // `"org.example.test "` and `"org.example.test"` would otherwise be
+        // two distinct group rows and silently fragment aggregator queries.
+        // Leniency for clients (we trim instead of rejecting), strict
+        // canonicalisation on storage.
+        val normalizedGroupKey = request.group.groupKey.trim()
+        require(normalizedGroupKey.isNotBlank()) {
             "group.groupKey must not be blank"
         }
+        validateGroupKeyPrefix(normalizedGroupKey)
+        val normalizedGroupRequest = request.group.copy(groupKey = normalizedGroupKey)
         val baseConfigRequest =
             requireNotNull(request.baseConfiguration) {
                 "baseConfiguration is required: provide baseConfiguration.build.buildSystem on create"
@@ -167,7 +187,7 @@ class ComponentManagementServiceImpl(
                     ?: throw NotFoundException("Parent component '$parentKey' not found")
             }
 
-        val group = upsertGroup(request.group)
+        val group = upsertGroup(normalizedGroupRequest)
 
         val entity =
             ComponentEntity(
@@ -279,20 +299,22 @@ class ComponentManagementServiceImpl(
         require(!request.clearGroup) {
             "clearGroup: true is no longer allowed — every component must belong to a group"
         }
-        // Mirror the create-side `group.groupKey.isNotBlank()` validation:
-        // when PATCH carries `group: {...}`, the new key must be a real
-        // identifier. Otherwise a payload like
-        // `{"version": N, "clearGroup": false, "group": {"groupKey": "  "}}`
-        // would slip past the controller and persist a whitespace
-        // groupKey via `upsertGroup` (component_groups.group_key has only
-        // NOT NULL + UNIQUE constraints — no blank-rejection at the DB
-        // level). Keeping the check at the service layer also yields the
-        // same 400 + error-shape envelope the create path emits.
-        request.group?.let {
-            require(it.groupKey.isNotBlank()) {
-                "group.groupKey must not be blank"
+        // Mirror the create-side validation on the PATCH path. Same
+        // trim-then-validate-then-canonicalise pipeline so a PATCH that
+        // sets `groupKey = "org.example.test "` rounds to the canonical
+        // form before it reaches `upsertGroup`. The trimmed value is also
+        // what's used for prefix validation and persistence, so the rest
+        // of the method must read from `normalizedGroupRequest` rather
+        // than `request.group`.
+        val normalizedGroupRequest =
+            request.group?.let { req ->
+                val trimmed = req.groupKey.trim()
+                require(trimmed.isNotBlank()) {
+                    "group.groupKey must not be blank"
+                }
+                validateGroupKeyPrefix(trimmed)
+                req.copy(groupKey = trimmed)
             }
-        }
 
         val oldKey = entity.componentKey
         val normalizedNewKey = request.name?.trim()
@@ -370,7 +392,9 @@ class ComponentManagementServiceImpl(
         // (strict contract — every component must belong to a group), so the
         // only reachable shapes here are "no change" (request.group == null)
         // or "replace with a new/upserted group" (request.group != null).
-        request.group?.let { entity.componentGroup = upsertGroup(it) }
+        // The normalised (trimmed + prefix-validated) form is used so the
+        // upserted row is byte-stable across whitespace-y inputs.
+        normalizedGroupRequest?.let { entity.componentGroup = upsertGroup(it) }
 
         // Per-component child REPLACE — present collection wipes and refills
         request.artifactIds?.let {
@@ -1298,6 +1322,37 @@ class ComponentManagementServiceImpl(
         require(value.isNotBlank()) { "productType must not be blank" }
         require(value in PRODUCT_TYPE_NAMES) {
             "Invalid productType: '$value'. Allowed: $PRODUCT_TYPE_NAMES"
+        }
+    }
+
+    /**
+     * Reject group keys whose prefix is not in
+     * `components-registry.supportedGroupIds`. The frontend already gates
+     * the Submit button on the same check (via
+     * `GET /rest/api/2/common/supported-groups`), but the server is the
+     * source of truth: a CLI / automation client that bypasses the UI
+     * cannot land a component on a disallowed prefix.
+     *
+     * Allowed iff `groupKey == prefix` OR `groupKey.startsWith(prefix + ".")`.
+     * The trailing-dot boundary is critical: without it, allowed=`com.example`
+     * would let `com.exampleextra.foo` slip through. Mirrors the
+     * frontend's `useSupportedGroups` check (`v === lp || v.startsWith(lp + '.')`).
+     *
+     * The error message names the allowed prefixes verbatim so non-UI
+     * clients see actionable feedback (the frontend can also surface the
+     * server message when its own pre-check disagrees with the server).
+     *
+     * Assumes `value` is already trimmed by the caller (see CREATE/PATCH
+     * blocks). An empty `supportedGroupIds` list rejects everything —
+     * misconfigured envs produce a clear 400 rather than silently
+     * accepting any prefix.
+     */
+    private fun validateGroupKeyPrefix(value: String) {
+        val allowed = configHelper.supportedGroupIds().toList()
+        val matches =
+            allowed.any { prefix -> value == prefix || value.startsWith("$prefix.") }
+        require(matches) {
+            "group.groupKey '$value' is not in the configured supportedGroupIds. Allowed: $allowed"
         }
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
@@ -348,6 +348,66 @@ class StrictContractTest {
     }
 
     @Test
+    @DisplayName("CREATE accepts an upper-case groupKey when the allowed prefix matches case-insensitively (case is preserved on storage)")
+    fun create_accepts_uppercased_groupId_when_allowed_prefix_matches_case_insensitively() {
+        // Frontend (CreateComponentDialog.tsx / GeneralTab.tsx) lowercases
+        // both sides before comparing the user-typed groupId against the
+        // supportedGroupIds list. Without the same case-insensitive compare
+        // on the CRS side, a user who types `ORG.EXAMPLE.test` passes the
+        // portal pre-check (lowercased to `org.example.test` which matches
+        // `org.example`) and then sees a 400 from the server — confusing UX.
+        // This test pins the case-insensitive match. Additionally,
+        // case must be PRESERVED on storage: the persisted groupKey is
+        // exactly what the user typed (`ORG.EXAMPLE.test`), not the
+        // lowercased form (we don't want silent renaming).
+        val typedKey = "ORG.EXAMPLE.test.${UUID.randomUUID().toString().take(6)}"
+        val body =
+            """
+            {
+              "name": "${unique("strict-case-insensitive-create")}",
+              "group": {"groupKey": "$typedKey", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
+            }
+            """.trimIndent()
+        val created =
+            postCreate(body).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val persistedKey = objectMapper.readTree(created)["group"]["groupKey"].asText()
+        assert(persistedKey == typedKey) {
+            "expected user-typed case to be preserved on storage; typed='$typedKey', got='$persistedKey'"
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH accepts an upper-case groupKey when the allowed prefix matches case-insensitively (case is preserved on storage)")
+    fun patch_accepts_uppercased_groupId_when_allowed_prefix_matches_case_insensitively() {
+        val name = unique("strict-case-insensitive-patch")
+        val seedResponse =
+            postCreate(validCreateBody(name)).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val seed = objectMapper.readTree(seedResponse)
+        val id = seed["id"].asText()
+        val versionLock = seed["version"].asLong()
+
+        val typedKey = "ORG.EXAMPLE.other.${UUID.randomUUID().toString().take(6)}"
+        val patchBody =
+            """{"version": $versionLock, "clearGroup": false, "group": {"groupKey": "$typedKey", "isFake": false}}"""
+        val patched =
+            mvc.perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(patchBody),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.group.groupKey").value(typedKey))
+                .andReturn().response.contentAsString
+        val persistedKey = objectMapper.readTree(patched)["group"]["groupKey"].asText()
+        assert(persistedKey == typedKey) {
+            "expected user-typed case to be preserved on storage; typed='$typedKey', got='$persistedKey'"
+        }
+    }
+
+    @Test
     @DisplayName("PATCH returns 400 when the new groupKey is outside supportedGroupIds")
     fun patch_rejects_disallowed_groupId_prefix() {
         val name = unique("strict-patch-bad-prefix")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
@@ -92,8 +92,12 @@ class StrictContractTest {
         """.trimIndent()
 
     @Test
-    @DisplayName("CREATE rejects payload missing 'group' (400 with group-required hint)")
+    @DisplayName("CREATE returns 400 when 'group' is missing")
     fun create_rejects_missingGroup() {
+        // The @DisplayName lists 400 status; the error message naming `group`
+        // is also part of the contract (the frontend / non-UI clients rely
+        // on the field name being mentioned). Asserting both pins the
+        // contract surface.
         val body =
             """
             {
@@ -101,11 +105,13 @@ class StrictContractTest {
               "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
             }
             """.trimIndent()
-        postCreate(body).andExpect(status().isBadRequest)
+        postCreate(body)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("group")))
     }
 
     @Test
-    @DisplayName("CREATE rejects payload missing 'baseConfiguration' entirely")
+    @DisplayName("CREATE returns 400 when 'baseConfiguration' is missing")
     fun create_rejects_missingBaseConfiguration() {
         val body =
             """
@@ -118,7 +124,7 @@ class StrictContractTest {
     }
 
     @Test
-    @DisplayName("CREATE rejects payload missing 'baseConfiguration.build.buildSystem'")
+    @DisplayName("CREATE returns 400 when 'baseConfiguration.build.buildSystem' is missing")
     fun create_rejects_missingBuildSystem() {
         val body =
             """
@@ -132,7 +138,7 @@ class StrictContractTest {
     }
 
     @Test
-    @DisplayName("CREATE rejects 'baseConfiguration.build' absent (no build block)")
+    @DisplayName("CREATE returns 400 when 'baseConfiguration.build' is missing")
     fun create_rejects_missingBuildBlock() {
         val body =
             """
@@ -146,7 +152,7 @@ class StrictContractTest {
     }
 
     @Test
-    @DisplayName("CREATE rejects 'group' present but groupKey blank")
+    @DisplayName("CREATE returns 400 when group.groupKey is blank (whitespace-only)")
     fun create_rejects_blankGroupKey() {
         val body =
             """
@@ -156,7 +162,9 @@ class StrictContractTest {
               "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
             }
             """.trimIndent()
-        postCreate(body).andExpect(status().isBadRequest)
+        postCreate(body)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("groupKey")))
     }
 
     @Test
@@ -265,5 +273,267 @@ class StrictContractTest {
                 .content(patchBody),
         ).andExpect(status().isOk)
             .andExpect(jsonPath("$.group.groupKey").value(newKey))
+    }
+
+    // -------------------------------------------------------------------
+    // Prefix validation against configHelper.supportedGroupIds()
+    //
+    // Frontend already validates against `GET /rest/api/2/common/supported-groups`,
+    // but a non-UI client (CLI, automation) could submit any prefix the
+    // frontend never would. The server is the source of truth and must
+    // reject prefixes that aren't in `components-registry.supportedGroupIds`.
+    //
+    // Test config (`application-common.yml`) sets the allowed list to
+    // `org.octopusden.octopus,io.bcomponent,org.example` — so any other
+    // prefix must produce a 400. Rejection-case fixtures use
+    // `com.someoneelse.*` (RFC 2606-style placeholder, deliberately NOT
+    // in the test allowed list).
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("CREATE returns 400 when groupKey is outside the configured supportedGroupIds")
+    fun create_rejects_disallowed_groupId_prefix() {
+        val body =
+            """
+            {
+              "name": "${unique("strict-bad-prefix")}",
+              "group": {"groupKey": "com.someoneelse.legacy", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
+            }
+            """.trimIndent()
+        postCreate(body)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("supportedGroupIds")))
+    }
+
+    @Test
+    @DisplayName("CREATE rejects 'org.exampleextra.foo' even though 'org.example' is an allowed prefix (no fuzzy prefix matching)")
+    fun create_rejects_prefix_with_extra_letters() {
+        // Specifically guards against `startsWith(prefix)` without a `.` separator,
+        // which would let allowed=`org.example` match `org.exampleextra.foo`. The
+        // validator must require an exact match OR `prefix + "."` — the test
+        // input `org.exampleextra.foo` starts with the allowed `org.example`
+        // characters but on a non-`.` boundary, so it must be rejected.
+        val body =
+            """
+            {
+              "name": "${unique("strict-fuzzy-prefix")}",
+              "group": {"groupKey": "org.exampleextra.foo", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
+            }
+            """.trimIndent()
+        postCreate(body)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("supportedGroupIds")))
+    }
+
+    @Test
+    @DisplayName("CREATE accepts a groupKey whose entire value equals one of the supported prefixes")
+    fun create_accepts_exact_prefix_match() {
+        // `groupKey == prefix` (no trailing segments) must be accepted —
+        // not just `prefix + "."` form. Mirrors the frontend's
+        // `useSupportedGroups` check: `v === lp || v.startsWith(lp + '.')`.
+        val body =
+            """
+            {
+              "name": "${unique("strict-exact-prefix")}",
+              "group": {"groupKey": "org.example", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
+            }
+            """.trimIndent()
+        // 201 (Created) specifically — the rest of the create-success
+        // cases in this file use `isCreated`; keep the assertion
+        // consistent so an accidental 200 regression would surface.
+        postCreate(body).andExpect(status().isCreated)
+    }
+
+    @Test
+    @DisplayName("PATCH returns 400 when the new groupKey is outside supportedGroupIds")
+    fun patch_rejects_disallowed_groupId_prefix() {
+        val name = unique("strict-patch-bad-prefix")
+        val seedResponse =
+            postCreate(validCreateBody(name)).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val seed = objectMapper.readTree(seedResponse)
+        val id = seed["id"].asText()
+        val versionLock = seed["version"].asLong()
+
+        val patchBody =
+            """{"version": $versionLock, "clearGroup": false, "group": {"groupKey": "com.someoneelse.legacy", "isFake": false}}"""
+        mvc.perform(
+            patch("/rest/api/4/components/$id")
+                .with(adminJwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(patchBody),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("supportedGroupIds")))
+    }
+
+    // -------------------------------------------------------------------
+    // groupKey whitespace normalisation (Copilot review)
+    //
+    // `isNotBlank()` accepts `"org.example.test "` with trailing whitespace.
+    // Without trimming on the way in, `component_groups.group_key` UNIQUE
+    // would persist a distinct row from the canonical `"org.example.test"` —
+    // the kind of duplication that breaks aggregator queries silently.
+    // The fix is to trim the incoming key and use the trimmed form for
+    // both validation and persistence. CREATE and PATCH share the
+    // semantic.
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("CREATE trims whitespace around groupKey before validating and persisting")
+    fun create_normalises_groupKey_whitespace() {
+        val name = unique("strict-create-trim")
+        val body =
+            """
+            {
+              "name": "$name",
+              "group": {"groupKey": "  org.example.trim.${UUID.randomUUID().toString().take(6)}  ", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
+            }
+            """.trimIndent()
+        val created =
+            postCreate(body).andExpect(status().isCreated).andReturn().response.contentAsString
+        val groupKey = objectMapper.readTree(created)["group"]["groupKey"].asText()
+        // Asserts trimming applied: the persisted key has no leading/trailing
+        // whitespace. The leading/trailing-trim cases are both covered by the
+        // single quoted-whitespace input above.
+        assert(groupKey == groupKey.trim()) {
+            "expected persisted groupKey to be trimmed; got '$groupKey'"
+        }
+        assert(groupKey.startsWith("org.example.trim.")) {
+            "expected the canonical (trimmed) prefix to survive; got '$groupKey'"
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // PATCH labels: explicit-clear vs no-op contract
+    //
+    // The portal's `buildUpdateRequest.ts` emits `labels: []` (literal empty
+    // array, NOT absent / undefined) when the user toggles every label off
+    // via the dictionary multi-select Clear action. This is an explicit
+    // clear. When the labels field is untouched, the wire shape omits the
+    // `labels` key entirely (Jackson + Kotlin nullability map this to
+    // `request.labels == null` → "don't touch").
+    //
+    // These tests pin both branches against the current service-layer
+    // implementation: `syncLabels(emptySet)` deletes all existing rows and
+    // adds none → cleared; `request.labels == null` short-circuits the
+    // sync entirely → preserved. Without these tests the contract was
+    // only documented in `buildUpdateRequest.ts` comments.
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH with labels: [] (explicit empty array) clears all existing labels")
+    fun patch_with_labels_empty_array_clears_labels() {
+        val name = unique("strict-patch-labels-clear")
+        val seedBody =
+            """
+            {
+              "name": "$name",
+              "group": {"groupKey": "org.example.test", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}},
+              "labels": ["lblA_${UUID.randomUUID().toString().take(6)}",
+                         "lblB_${UUID.randomUUID().toString().take(6)}"]
+            }
+            """.trimIndent()
+        val seedResponse =
+            postCreate(seedBody).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val seed = objectMapper.readTree(seedResponse)
+        val id = seed["id"].asText()
+        val versionLock = seed["version"].asLong()
+        val seededLabels = seed["labels"].map { it.asText() }
+        assert(seededLabels.size == 2) {
+            "precondition: seeded component should have 2 labels; got $seededLabels"
+        }
+
+        // The portal sends this exact shape from `buildUpdateRequest.ts` when
+        // the user toggles every label off — `labels: []` is the explicit-clear
+        // signal, and `clearGroup: false` is always present in the wire schema.
+        val patchBody =
+            """{"version": $versionLock, "clearGroup": false, "labels": []}"""
+        val patched =
+            mvc.perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(patchBody),
+            ).andExpect(status().isOk)
+                .andReturn().response.contentAsString
+        val labelsAfter = objectMapper.readTree(patched)["labels"].map { it.asText() }
+        assert(labelsAfter.isEmpty()) {
+            "expected labels cleared to []; got $labelsAfter"
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH without 'labels' key (field absent) preserves existing labels — no-op contract")
+    fun patch_with_labels_absent_preserves_labels() {
+        val name = unique("strict-patch-labels-noop")
+        val labelA = "lblA_${UUID.randomUUID().toString().take(6)}"
+        val labelB = "lblB_${UUID.randomUUID().toString().take(6)}"
+        val seedBody =
+            """
+            {
+              "name": "$name",
+              "group": {"groupKey": "org.example.test", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}},
+              "labels": ["$labelA", "$labelB"]
+            }
+            """.trimIndent()
+        val seedResponse =
+            postCreate(seedBody).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val seed = objectMapper.readTree(seedResponse)
+        val id = seed["id"].asText()
+        val versionLock = seed["version"].asLong()
+
+        // No `labels` key at all — Kotlin/Jackson sees `request.labels == null`,
+        // which means "don't touch" per the PATCH no-op contract.
+        val patchBody = """{"version": $versionLock, "clearGroup": false}"""
+        val patched =
+            mvc.perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(patchBody),
+            ).andExpect(status().isOk)
+                .andReturn().response.contentAsString
+        val labelsAfter = objectMapper.readTree(patched)["labels"].map { it.asText() }.toSet()
+        assert(labelsAfter == setOf(labelA, labelB)) {
+            "expected labels preserved as [$labelA, $labelB]; got $labelsAfter"
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH trims whitespace around groupKey before validating and persisting")
+    fun patch_normalises_groupKey_whitespace() {
+        val name = unique("strict-patch-trim")
+        val seedResponse =
+            postCreate(validCreateBody(name)).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val seed = objectMapper.readTree(seedResponse)
+        val id = seed["id"].asText()
+        val versionLock = seed["version"].asLong()
+
+        val newKey = "org.example.patchtrim.${UUID.randomUUID().toString().take(6)}"
+        val patchBody =
+            """{"version": $versionLock, "clearGroup": false, "group": {"groupKey": "  $newKey  ", "isFake": false}}"""
+        val patched =
+            mvc.perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(patchBody),
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.group.groupKey").value(newKey))
+                .andReturn().response.contentAsString
+        val persistedKey = objectMapper.readTree(patched)["group"]["groupKey"].asText()
+        assert(persistedKey == newKey) {
+            "expected PATCH to persist trimmed key '$newKey'; got '$persistedKey'"
+        }
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/listener/FieldConfigSeederTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/listener/FieldConfigSeederTest.kt
@@ -21,9 +21,11 @@ import java.nio.file.Paths
  * `ConfigHelper.supportedGroupIds()`.
  *
  * `application-common.yml` sets `components-registry.supportedGroupIds:
- * org.octopusden.octopus,io.bcomponent`, so the first prefix is
- * `org.octopusden.octopus` (RFC 2606 placeholder — never a real customer
- * domain).
+ * org.octopusden.octopus,io.bcomponent,org.example`, so the first prefix is
+ * `org.octopusden.octopus`. (`org.example` was added by the validation
+ * follow-up so existing test fixtures using `org.example.test` still pass
+ * the new server-side `validateGroupKeyPrefix` check; the seeder still
+ * picks the FIRST entry, which is unchanged.)
  *
  * The seeder fires on `ApplicationReadyEvent`, so by the time @SpringBootTest
  * wires up the context the field-config row exists.
@@ -112,6 +114,47 @@ class FieldConfigSeederTest {
 
         assert(readDefaultValue() == overrideValue) {
             "expected admin-set value '$overrideValue' to be preserved; got '${readDefaultValue()}'"
+        }
+    }
+
+    @Test
+    @DisplayName("Seeder preserves an admin-set defaultValue = null (key present with null value, treated as intentional opt-out)")
+    fun preservesExplicitNullDefaultValue() {
+        // Copilot review note (#298): the previous idempotency check was
+        // `if (groupIdField[KEY_DEFAULT_VALUE] != null) return`, which
+        // treated `defaultValue: null` as "missing" and silently re-seeded
+        // it. But an admin who explicitly set `null` may have done so to
+        // disable the Portal's auto-suggest default. Switching the check
+        // to key-presence (`containsKey`) preserves that intent.
+        @Suppress("UNCHECKED_CAST")
+        val nullDefault =
+            mapOf<String, Any?>(
+                "component" to mapOf<String, Any?>(
+                    "groupId" to mapOf<String, Any?>("defaultValue" to null),
+                ),
+            )
+        val entity =
+            registryConfigRepository.findById("field-config")
+                .orElse(RegistryConfigEntity(key = "field-config"))
+        entity.value = nullDefault
+        registryConfigRepository.save(entity)
+
+        seeder.seedComponentGroupIdDefault()
+
+        // The seeded key still resolves to null — NOT to the
+        // `org.octopusden.octopus` first-prefix that the seeder would
+        // produce on a blank DB.
+        assert(readDefaultValue() == null) {
+            "expected admin's explicit null defaultValue to be preserved; got '${readDefaultValue()}'"
+        }
+        // And the key must still be present in the blob.
+        val reloaded = registryConfigRepository.findById("field-config").orElse(null)!!
+        @Suppress("UNCHECKED_CAST")
+        val groupId =
+            ((reloaded.value as Map<String, Any?>)["component"] as Map<String, Any?>)["groupId"]
+                as Map<String, Any?>
+        assert(groupId.containsKey("defaultValue")) {
+            "expected 'defaultValue' key to remain present after seed; got $groupId"
         }
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
@@ -95,6 +95,7 @@ class MIG047FieldOverrideWriteGuardTest {
                 fieldConfigService = mock(FieldConfigService::class.java),
                 teamcityProperties = mock(TeamcityProperties::class.java),
                 versionRangeFactory = VersionRangeFactory(versionNames),
+                environment = mock(org.springframework.core.env.Environment::class.java),
             )
 
         component = ComponentEntity(id = componentId, componentKey = "alpha-fixture")

--- a/components-registry-service-server/src/test/resources/application-common.yml
+++ b/components-registry-service-server/src/test/resources/application-common.yml
@@ -9,7 +9,12 @@ components-registry:
   groovy-path: ${components-registry.work-dir}
   dependency-mapping-file: dependency_mapping.properties
 
-  supportedGroupIds: org.octopusden.octopus,io.bcomponent
+  # `org.example` is included so the broad test-fixture convention
+  # (`org.example.test` as the standard RFC 2606 placeholder, used by 14
+  # test files) passes the new server-side `validateGroupKeyPrefix` check.
+  # Rejection tests use a prefix that is NOT in this list (e.g.
+  # `com.someoneelse.*`).
+  supportedGroupIds: org.octopusden.octopus,io.bcomponent,org.example
   supportedSystems: NONE,CLASSIC,ALFA
   version-name:
     service-branch: serviceCBranch

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -200,7 +200,14 @@ abstract class BaseComponentsRegistryServiceTest {
     @Test
     @DisplayName("RES-002: Supported group IDs returned")
     fun testGetSupportedGroupIds() {
-        Assertions.assertEquals(Arrays.asList("org.octopusden.octopus", "io.bcomponent").sorted(), getSupportedGroupIds().sorted())
+        // `org.example` was added to `application-common.yml` supportedGroupIds
+        // so the 14 server-side test fixtures using `org.example.test` keep
+        // passing the new server-side `validateGroupKeyPrefix` check. The
+        // /supported-groups endpoint surfaces the configured list as-is.
+        Assertions.assertEquals(
+            Arrays.asList("org.octopusden.octopus", "io.bcomponent", "org.example").sorted(),
+            getSupportedGroupIds().sorted(),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #298 closing the server-side validation gap + four Copilot review nits + two `labels: []` contract tests.

- **Server-side groupId prefix validation** (the main gap): new `validateGroupKeyPrefix(value)` in `ComponentManagementServiceImpl` rejects keys outside `components-registry.supportedGroupIds` with 400. Applied on both CREATE and PATCH, mirroring the frontend's `useSupportedGroups` check (`v === lp || v.startsWith(lp + '.')` — exact match OR `prefix + "."` boundary, no fuzzy startsWith).
- **groupKey whitespace normalisation** (Copilot): incoming key is trimmed at CREATE + PATCH entry points; trimmed form used for validation and persistence. Stops `"org.example.test "` from landing as a distinct `component_groups` row from `"org.example.test"`.
- **`FieldConfigSeeder` idempotency** (Copilot): switched from `defaultValue != null` to `groupIdField.containsKey("defaultValue")`. Explicit `defaultValue: null` is honoured as an intentional admin opt-out, not silently re-seeded.
- **`StrictContractTest` `@DisplayName` cleanup** (Copilot): names that overclaimed an "X-required hint" check either match the assertion exactly now, or the corresponding test gained an `errorMessage` body assertion (so the hint IS a contract guarantee).
- **`labels: []` explicit-clear contract** (team-lead ask): two new tests (`patch_with_labels_empty_array_clears_labels` / `patch_with_labels_absent_preserves_labels`) pin the existing service-layer behaviour that `buildUpdateRequest.ts` relies on. No production change — the impl already handles both branches correctly; the tests just lock the contract.

Test-config tweak: `application-common.yml` adds `org.example` to `supportedGroupIds` so existing fixtures using `org.example.test` continue passing under the new validator. Rejection tests use `com.someoneelse.legacy` (NOT in the allowed list).

## Test plan

- [x] `./gradlew :components-registry-service-server:test :components-registry-service-light-client:test` → BUILD SUCCESSFUL
- [x] Sonnet review on the full diff at high effort (1 blocker / 1 warning fixed pre-push)
- [x] `git status` clean; no `org/` bytecode dirs

## Notes

- RFC 2606 placeholders only (`org.example.*` for allowed, `com.someoneelse.*` for rejected). No forbidden product/org tokens.
- Branch carries no internal Jira keys; commit subject + PR title are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)