### PR TITLE
test(v4): pin per-range hotfixVersionFormat propagation regression UT

### DIFF
--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -334,6 +334,55 @@ class ComponentsRegistryServiceControllerTest : MockMvcRegistryTestSupport() {
         )
     }
 
+    /**
+     * Regression-pin for the per-range `hotfixVersionFormat` propagation
+     * chain — the v1-v2 jira-component endpoint must surface the value
+     * exactly as the DSL declared it, byte-for-byte.
+     *
+     * This test exercises the full propagation chain against the LOCAL
+     * test DSL fixture (independent of any production DSL state):
+     *
+     *   DSL `hotfixVersionFormat` (Defaults or per-component)
+     *   → `EscrowConfigurationLoader` merge
+     *   → `ImportServiceImpl.buildComponentEntity` writes
+     *     `entity.jiraHotfixVersionFormat` → `components.jira_hotfix_version_format`
+     *   → `DatabaseComponentRegistryResolver` reads the column into
+     *     `JiraComponent.componentVersionFormat.hotfixVersionFormat`
+     *   → GET `/rest/api/2/components/{c}/versions/{v}/jira-component`
+     *     surfaces it as
+     *     `component.componentVersionFormat.hotfixVersionFormat`
+     *
+     * Component `SUB` (`test-common/.../common/TestComponents.groovy`)
+     * declares `hotfixVersionFormat = '$major.$minor.$service-$build'`.
+     * A break anywhere in the propagation chain — service mapper change,
+     * resolver merge-order regression, JSON serialisation tweak — produces
+     * a different format string here, before the slow TC-only compat job
+     * notices the same break against the production DSL.
+     */
+    @Test
+    fun testHotfixVersionFormatRoundTripsThroughResolver() {
+        val response =
+            mvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .get("/rest/api/2/components/SUB/versions/1.0.0/jira-component")
+                        .accept(APPLICATION_JSON),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        // Use a substring assertion rather than full DTO unmarshalling — the
+        // surface under test is the format-string propagation, not the
+        // full JiraComponentVersionDTO shape. The Groovy literal is single-
+        // quoted, so the `$` placeholders are preserved verbatim through
+        // DSL parse + JSON serialisation.
+        val expectedFormat = "\$major.\$minor.\$service-\$build"
+        Assertions.assertTrue(
+            response.contains("\"hotfixVersionFormat\":\"$expectedFormat\""),
+            "expected jira-component response to carry SUB's DSL-declared " +
+                "hotfixVersionFormat='$expectedFormat'; got: ${response.take(800)}",
+        )
+    }
+
     @Test
     fun testGetComponentVersionDoc() {
         val actualComponent =


### PR DESCRIPTION
## Summary

Adds one new unit test, `ComponentsRegistryServiceControllerTest.testHotfixVersionFormatRoundTripsThroughResolver`, pinning the DSL → import → DB → resolver → `/rest/api/2/components/{c}/versions/{v}/jira-component` propagation chain for `component.componentVersionFormat.hotfixVersionFormat`. Exercised against the LOCAL test fixture `SUB`, which declares its own non-trivial `hotfixVersionFormat` in `test-common/.../common/TestComponents.groovy`.

A break anywhere in the propagation chain (mapper change, resolver merge-order regression, JSON serialisation tweak) produces a different format string here, before the slow TC-only compat job notices the same break against the production DSL.

## What this PR is NOT

The original scope was a `known-deltas.json` suppression for diffs on the compat job (tag `2.0.84-3681`) caused by recent DSL drift on `Components-Registry/master`. After two iterations the user ruled out every suppression form: even JSON `\u`-escapes get decoded by the CI Content Validation scanner.

Bumping the compat baseline to a newer release tag is also blocked: `v2.0.87` is the absolute latest release tag, and the v3 schema-v2 resolver code (which correctly handles the DSL change) lives only on the unreleased v3 branch. Cutting a v3-based alpha release + bumping `LAST_RELEASE_VERSION` (in `.teamcity/settings.kts:23`) is a release-management effort, out of scope here.

> **The compat job (1.7_Compat_Local_Stand_baseline_candidate_JARs_AUTO) will remain red on v3 builds due to DSL drift against the frozen `v2.0.87` baseline.** Bumping the baseline to a v3-based tag requires cutting and publishing a v3 alpha release (multi-PR release-management effort, separate ticket). This PR adds only the unit-level regression net for the resolver code path; the suppression / baseline-rebuild decision is deferred.

## Test plan

- [x] New UT passes locally: `./gradlew :components-registry-service-server:test --tests "*testHotfixVersionFormatRoundTripsThroughResolver"` → BUILD SUCCESSFUL.
- [x] Pre-push forbidden-token scan against the working tree returned no matches.
- [x] Sonnet review on the slim diff at high effort: 1 KDoc inaccuracy fixed before amend (named a non-existent ImportService method); no other blockers or warnings.

## Diff

One file, +49 / -0:
- `components-registry-service-server/src/test/kotlin/.../ComponentsRegistryServiceControllerTest.kt` — adds the test method + KDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)