### PR TITLE
fix(v4): preserve per-range hotfixVersionFormat through schema-v2 import + resolver

### DIFF
--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -155,9 +155,10 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     @Test
     fun testGetAllComponents() {
-        // 56 pre-MIG-041 + 2 new aggregator-handling fixtures (TEST_AGGREGATOR_FAKE +
-        // TEST_AGGREGATOR_MEMBER) which inherit the Defaults `system = "NONE"`.
-        assertEquals(58, componentsRegistryClient.getAllComponents().components.size)
+        // 56 pre-MIG-041 + 2 aggregator-handling fixtures (TEST_AGGREGATOR_FAKE +
+        // TEST_AGGREGATOR_MEMBER) + 1 task-#16 fixture (TEST_PER_RANGE_HOTFIX_FORMAT)
+        // which all inherit the Defaults `system = "NONE"`.
+        assertEquals(59, componentsRegistryClient.getAllComponents().components.size)
         assertEquals(
             3,
             componentsRegistryClient.getAllComponents("ssh://hg@mercurial/technical", null).components.size,
@@ -173,11 +174,11 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         )
         assertEquals(2, componentsRegistryClient.getAllComponents(systems = listOf("ALFA")).components.size)
         assertEquals(6, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC")).components.size)
-        assertEquals(52, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
+        assertEquals(53, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
         assertEquals(6, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC")).components.size)
-        assertEquals(54, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "NONE")).components.size)
-        assertEquals(58, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
-        assertEquals(58, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC", "NONE", "TEST")).components.size)
+        assertEquals(55, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "NONE")).components.size)
+        assertEquals(59, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
+        assertEquals(59, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC", "NONE", "TEST")).components.size)
     }
 
     @Test

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
@@ -96,6 +96,14 @@ data class JiraAspectResponse(
     val lineVersionFormat: String? = null,
     val versionPrefix: String? = null,
     val versionFormat: String? = null,
+    /**
+     * Per-range override for `componentVersionFormat.hotfixVersionFormat`.
+     * `null` here means "no per-range override for this range" — consumers
+     * MUST fall back to the per-component base on
+     * `ComponentDetailResponse.jiraHotfixVersionFormat` (which is itself
+     * inherited from `Defaults.groovy` if the DSL declared none).
+     */
+    val hotfixVersionFormat: String? = null,
 )
 
 data class VcsEntryResponse(
@@ -201,6 +209,12 @@ data class JiraAspectRequest(
     val lineVersionFormat: String? = null,
     val versionPrefix: String? = null,
     val versionFormat: String? = null,
+    // Intentionally NOT exposing per-range hotfixVersionFormat as a V4
+    // editor-write field — DSL import is currently the only producer in
+    // production and there's no UI for per-range hotfix overrides. The
+    // applyScalarValue plumbing on the entity side is available to
+    // a follow-up ticket if/when a UI need surfaces. Read-side exposure
+    // (`JiraAspectResponse.hotfixVersionFormat`) is unaffected.
 )
 
 data class VcsEntryRequest(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
@@ -169,6 +169,16 @@ class ComponentConfigurationEntity(
     @Column(name = "jira_version_format")
     var jiraVersionFormat: String? = null,
 
+    /**
+     * Per-range override for `jira.componentVersionFormat.hotfixVersionFormat`.
+     * Sibling column to `jira_release_version_format` etc. The per-component
+     * base value (Defaults / top-level DSL) lives on
+     * `components.jira_hotfix_version_format`; the resolver layers this column
+     * on top when the row applies for the requested version range.
+     */
+    @Column(name = "jira_hotfix_version_format")
+    var jiraHotfixVersionFormat: String? = null,
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     var createdAt: Instant? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
@@ -59,6 +59,7 @@ internal val SCALAR_ATTRIBUTE_PATHS: Set<String> =
         "jira.lineVersionFormat",
         "jira.versionPrefix",
         "jira.versionFormat",
+        "jira.hotfixVersionFormat",
     )
 
 /**
@@ -106,6 +107,7 @@ internal fun ComponentConfigurationEntity.extractScalarValue(): Any? =
         "jira.lineVersionFormat" -> jiraLineVersionFormat
         "jira.versionPrefix" -> jiraVersionPrefix
         "jira.versionFormat" -> jiraVersionFormat
+        "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat
         else -> null
     }
 
@@ -164,6 +166,7 @@ internal fun ComponentConfigurationEntity.applyScalarValue(
         "jira.lineVersionFormat" -> jiraLineVersionFormat = requireString(attributePath, value)
         "jira.versionPrefix" -> jiraVersionPrefix = requireString(attributePath, value)
         "jira.versionFormat" -> jiraVersionFormat = requireString(attributePath, value)
+        "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat = requireString(attributePath, value)
     }
 }
 
@@ -197,6 +200,7 @@ private fun ComponentConfigurationEntity.clearAllScalarColumns() {
     jiraLineVersionFormat = null
     jiraVersionPrefix = null
     jiraVersionFormat = null
+    jiraHotfixVersionFormat = null
 }
 
 private fun requireString(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -465,6 +465,7 @@ internal class ComponentConfigurationView {
     var jiraLineVersionFormat: String? = null
     var jiraVersionPrefix: String? = null
     var jiraVersionFormat: String? = null
+    var jiraHotfixVersionFormat: String? = null
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     fun applyScalarOverride(override: ComponentConfigurationEntity) {
@@ -503,6 +504,7 @@ internal class ComponentConfigurationView {
             "jira.lineVersionFormat" -> jiraLineVersionFormat = override.jiraLineVersionFormat
             "jira.versionPrefix" -> jiraVersionPrefix = override.jiraVersionPrefix
             "jira.versionFormat" -> jiraVersionFormat = override.jiraVersionFormat
+            "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat = override.jiraHotfixVersionFormat
 
             else -> Unit // unknown attribute path; ignore for forward-compat
         }
@@ -637,6 +639,7 @@ internal class ComponentConfigurationView {
                 jiraLineVersionFormat = base.jiraLineVersionFormat
                 jiraVersionPrefix = base.jiraVersionPrefix
                 jiraVersionFormat = base.jiraVersionFormat
+                jiraHotfixVersionFormat = base.jiraHotfixVersionFormat
             }
     }
 }
@@ -752,7 +755,12 @@ private fun buildJiraComponent(
     val releaseFmt = merged.jiraReleaseVersionFormat ?: "\$major.\$minor"
     val buildFmt = merged.jiraBuildVersionFormat ?: releaseFmt
     val lineFmt = merged.jiraLineVersionFormat ?: majorFmt
-    val hotfixFmt = component.jiraHotfixVersionFormat ?: ""
+    // Per-range override (from a SCALAR_OVERRIDE row on component_configurations
+    // for the matching range) takes precedence; falls back to the per-component
+    // base value stored on `components.jira_hotfix_version_format` (Defaults /
+    // top-level DSL). Empty string preserves the pre-existing "no format string"
+    // contract for components that declare no hotfixVersionFormat anywhere.
+    val hotfixFmt = merged.jiraHotfixVersionFormat ?: component.jiraHotfixVersionFormat ?: ""
 
     val format =
         ComponentVersionFormat.create(majorFmt, releaseFmt, buildFmt, lineFmt, hotfixFmt)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -467,6 +467,24 @@ internal class ComponentConfigurationView {
     var jiraVersionFormat: String? = null
     var jiraHotfixVersionFormat: String? = null
 
+    /**
+     * Tracks presence (not value) of a per-range SCALAR_OVERRIDE for
+     * `jira.hotfixVersionFormat`. Set to `true` only when
+     * [applyScalarOverride] processes a row whose `overriddenAttribute ==
+     * "jira.hotfixVersionFormat"`. Required because this field has a
+     * per-component fallback layer (`components.jira_hotfix_version_format`)
+     * that the resolver consults when no per-range override is present —
+     * without the presence flag, an explicit null-clear (override row with
+     * NULL value) is silently undone by the Kotlin `?:` fallback chain in
+     * [buildJiraComponent], defeating the import-only null-clear contract.
+     *
+     * Sibling per-range scalars (e.g. `jiraReleaseVersionFormat`) do not
+     * need this flag — their resolver fallback is a hardcoded sentinel
+     * (`"$major.$minor"` etc.), not a per-component column, so a null
+     * value on the merged view is itself the null-clear result.
+     */
+    var jiraHotfixVersionFormatOverridden: Boolean = false
+
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     fun applyScalarOverride(override: ComponentConfigurationEntity) {
         // Unconditional assignment: the `overriddenAttribute` discriminator is the source of truth.
@@ -504,7 +522,13 @@ internal class ComponentConfigurationView {
             "jira.lineVersionFormat" -> jiraLineVersionFormat = override.jiraLineVersionFormat
             "jira.versionPrefix" -> jiraVersionPrefix = override.jiraVersionPrefix
             "jira.versionFormat" -> jiraVersionFormat = override.jiraVersionFormat
-            "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat = override.jiraHotfixVersionFormat
+            "jira.hotfixVersionFormat" -> {
+                jiraHotfixVersionFormat = override.jiraHotfixVersionFormat
+                // Set presence regardless of value so a null-clear row
+                // (NULL on the typed column) is preserved by the resolver
+                // instead of being swallowed by the per-component fallback.
+                jiraHotfixVersionFormatOverridden = true
+            }
 
             else -> Unit // unknown attribute path; ignore for forward-compat
         }
@@ -760,7 +784,19 @@ private fun buildJiraComponent(
     // base value stored on `components.jira_hotfix_version_format` (Defaults /
     // top-level DSL). Empty string preserves the pre-existing "no format string"
     // contract for components that declare no hotfixVersionFormat anywhere.
-    val hotfixFmt = merged.jiraHotfixVersionFormat ?: component.jiraHotfixVersionFormat ?: ""
+    //
+    // When [merged.jiraHotfixVersionFormatOverridden] is true the per-range
+    // SCALAR_OVERRIDE row took effect for this range — including a null-clear
+    // override (NULL typed column = "explicitly clear inherited value"). In
+    // that case the per-component fallback MUST NOT be consulted, otherwise
+    // the null-clear is silently undone. See the KDoc on
+    // [ComponentConfigurationView.jiraHotfixVersionFormatOverridden].
+    val hotfixFmt =
+        if (merged.jiraHotfixVersionFormatOverridden) {
+            merged.jiraHotfixVersionFormat ?: ""
+        } else {
+            merged.jiraHotfixVersionFormat ?: component.jiraHotfixVersionFormat ?: ""
+        }
 
     val format =
         ComponentVersionFormat.create(majorFmt, releaseFmt, buildFmt, lineFmt, hotfixFmt)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -283,6 +283,7 @@ private fun ComponentConfigurationEntity.jiraAspectResponse(): JiraAspectRespons
         lineVersionFormat = jiraLineVersionFormat,
         versionPrefix = jiraVersionPrefix,
         versionFormat = jiraVersionFormat,
+        hotfixVersionFormat = jiraHotfixVersionFormat,
     )
 
 private fun ComponentConfigurationEntity.toMarkerChildrenPayload(): MarkerChildrenPayload =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1059,6 +1059,9 @@ class ComponentManagementServiceImpl(
             config.jiraLineVersionFormat = j.lineVersionFormat
             config.jiraVersionPrefix = j.versionPrefix
             config.jiraVersionFormat = j.versionFormat
+            // jiraHotfixVersionFormat per-range write is intentionally not
+            // exposed via V4 (no UI need today); DSL import is the only
+            // producer of the per-range column.
         }
         request.vcsEntries?.let { replaceVcsEntries(config, it) }
         request.mavenArtifacts?.let { replaceMavenArtifacts(config, it) }
@@ -1113,6 +1116,8 @@ class ComponentManagementServiceImpl(
             j.lineVersionFormat?.let { config.jiraLineVersionFormat = it }
             j.versionPrefix?.let { config.jiraVersionPrefix = it }
             j.versionFormat?.let { config.jiraVersionFormat = it }
+            // jiraHotfixVersionFormat per-range PATCH is intentionally not
+            // exposed via V4; see applyBaseConfigurationCreate above.
         }
         patch.vcsEntries?.let { replaceVcsEntries(config, it) }
         patch.mavenArtifacts?.let { replaceMavenArtifacts(config, it) }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1363,7 +1363,12 @@ class ImportServiceImpl(
                 row.jiraReleaseVersionFormat = cvf.releaseVersionFormat
                 row.jiraBuildVersionFormat = cvf.buildVersionFormat
                 row.jiraLineVersionFormat = cvf.lineVersionFormat
-                // hotfixVersionFormat goes to component level; skip here
+                // hotfixVersionFormat is also stored per-range so per-range DSL
+                // overrides survive into component_configurations. The
+                // per-component base value (Defaults / top-level DSL) is
+                // additionally captured on components.jira_hotfix_version_format
+                // in buildComponentEntity; the resolver layers per-range over base.
+                row.jiraHotfixVersionFormat = cvf.hotfixVersionFormat
             }
             jira.componentInfo?.let { info ->
                 // Do NOT collapse empty string to null for versionPrefix/versionFormat:
@@ -1928,6 +1933,7 @@ class ImportServiceImpl(
         diffScalar("jira.lineVersionFormat", base.jiraLineVersionFormat, override.jiraLineVersionFormat)
         diffScalar("jira.versionPrefix", base.jiraVersionPrefix, override.jiraVersionPrefix)
         diffScalar("jira.versionFormat", base.jiraVersionFormat, override.jiraVersionFormat)
+        diffScalar("jira.hotfixVersionFormat", base.jiraHotfixVersionFormat, override.jiraHotfixVersionFormat)
 
         return diffs
     }
@@ -1975,6 +1981,7 @@ class ImportServiceImpl(
             "jira.lineVersionFormat" -> row.jiraLineVersionFormat = value?.toString()
             "jira.versionPrefix" -> row.jiraVersionPrefix = value?.toString()
             "jira.versionFormat" -> row.jiraVersionFormat = value?.toString()
+            "jira.hotfixVersionFormat" -> row.jiraHotfixVersionFormat = value?.toString()
             else -> LOG.warn("Unknown scalar attribute path: '{}'", attrPath)
         }
     }

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -58,7 +58,11 @@ CREATE TABLE components (
     releases_in_default_branch  BOOLEAN,
     -- jira fields that never vary per-version:
     jira_display_name           VARCHAR(255),
-    jira_hotfix_version_format  VARCHAR(255),                           -- UI read-only (inherited from Defaults)
+    -- Per-component base value for jira.componentVersionFormat.hotfixVersionFormat;
+    -- inherited from Defaults at import time. Per-range overrides live on
+    -- component_configurations.jira_hotfix_version_format and take precedence
+    -- when present (see EntityMappers.buildJiraComponent).
+    jira_hotfix_version_format  VARCHAR(255),
     vcs_external_registry       TEXT,
     -- distribution fields that never vary per-version:
     distribution_explicit       BOOLEAN,
@@ -150,6 +154,10 @@ CREATE TABLE component_configurations (
     jira_line_version_format                    VARCHAR(255),
     jira_version_prefix                         VARCHAR(255),
     jira_version_format                         VARCHAR(255),
+    -- Per-range override for jira.componentVersionFormat.hotfixVersionFormat.
+    -- Defaults / per-component base lives on components.jira_hotfix_version_format.
+    -- The resolver layers this on top of the base when present.
+    jira_hotfix_version_format                  VARCHAR(255),
     created_at                                  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at                                  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 
@@ -210,6 +218,7 @@ CREATE TABLE component_configurations (
         AND jira_major_version_format IS NULL AND jira_release_version_format IS NULL
         AND jira_build_version_format IS NULL AND jira_line_version_format IS NULL
         AND jira_version_prefix IS NULL AND jira_version_format IS NULL
+        AND jira_hotfix_version_format IS NULL
     )),
 
     -- UI-swift-sloth: BASE rows must declare a build_system. Column-level

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -107,7 +107,7 @@ class ComponentsRegistryServiceControllerTest : MockMvcRegistryTestSupport() {
         expectedComponent.copyright = "companyName1"
         expectedComponent.labels = setOf("Label2")
 
-        Assertions.assertEquals(58, components.components.size)
+        Assertions.assertEquals(59, components.components.size)
         Assertions.assertTrue(expectedComponent in components.components) {
             components.components.toString()
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
@@ -175,6 +175,34 @@ class DbBackedComponentsRegistryServiceControllerTest : MockMvcRegistryTestSuppo
         )
     }
 
+    /**
+     * Boundary companion to `testPerRangeHotfixVersionFormatOverridesBase_dbMode`:
+     * a version OUTSIDE the override range must fall back to the per-component
+     * (base) value on the DB-backed resolver. Pins that the fix does not
+     * regress the inheritance path for ranges without an explicit per-range
+     * override.
+     */
+    @Test
+    @DisplayName(
+        "GET /jira-component for version outside override range falls back to base hotfixVersionFormat (DB resolver)",
+    )
+    fun testVersionOutsidePerRangeHotfixOverrideFallsBackToBase_dbMode() {
+        val response =
+            mvc
+                .perform(
+                    get("/rest/api/2/components/TEST_PER_RANGE_HOTFIX_FORMAT/versions/1.5.0/jira-component")
+                        .accept(APPLICATION_JSON),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val expected = "\$major.\$minor.\$service-\$fix"
+        assertTrue(
+            response.contains("\"hotfixVersionFormat\":\"$expected\""),
+            "expected jira-component for version 1.5.0 (outside range [2.0,), in [1.0,2.0)) to carry " +
+                "the per-component base hotfixVersionFormat='$expected'; got: ${response.take(800)}",
+        )
+    }
+
     companion object {
         @JvmStatic
         val postgres =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
@@ -132,6 +132,49 @@ class DbBackedComponentsRegistryServiceControllerTest : MockMvcRegistryTestSuppo
             ).andExpect(status().isOk)
     }
 
+    /**
+     * Regression pin for the per-range `hotfixVersionFormat` override
+     * propagation chain (task #16) on the DB-backed resolver path.
+     *
+     * The fixture component `TEST_PER_RANGE_HOTFIX_FORMAT` declares a
+     * per-component (base) `hotfixVersionFormat = '$major.$minor.$service-$fix'`
+     * and an override on version range `[2.0,)`:
+     *   `hotfixVersionFormat = '$major.$minor.$service-$fix-$build'`.
+     *
+     * For a version IN the override range (e.g. `2.0.0-1234`) the DB-backed
+     * resolver must surface the per-range value. v3 currently surfaces the
+     * per-component base value instead, because
+     * `ImportServiceImpl.populateScalarsFromConfig` explicitly skips writing
+     * `hotfixVersionFormat` to the per-range row, and
+     * `EntityMappers.buildJiraComponent` reads only the per-component scalar.
+     *
+     * The Git-backed resolver (`Mappers.kt` + `ComponentRegistryResolverImpl`)
+     * surfaces the per-range value correctly via the upstream Groovy loader,
+     * which is why the same UT passes in `ComponentsRegistryServiceControllerTest`
+     * (Git-mode profile). The DB-backed path is the one that diverges from
+     * v2.0.87 prod (= `f1-gateway` baseline); this test pins parity.
+     */
+    @Test
+    @DisplayName(
+        "GET /jira-component surfaces per-range hotfixVersionFormat override (DB resolver)",
+    )
+    fun testPerRangeHotfixVersionFormatOverridesBase_dbMode() {
+        val response =
+            mvc
+                .perform(
+                    get("/rest/api/2/components/TEST_PER_RANGE_HOTFIX_FORMAT/versions/2.0.0-1234/jira-component")
+                        .accept(APPLICATION_JSON),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val expected = "\$major.\$minor.\$service-\$fix-\$build"
+        assertTrue(
+            response.contains("\"hotfixVersionFormat\":\"$expected\""),
+            "expected jira-component for version 2.0.0-1234 (in range [2.0,)) to carry " +
+                "the per-range hotfixVersionFormat='$expected'; got: ${response.take(800)}",
+        )
+    }
+
     companion object {
         @JvmStatic
         val postgres =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -49,7 +49,7 @@ class MetricsTest {
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(56.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(57.0))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -424,6 +424,7 @@ class MigrationIntegrationTest {
         assertNull(presence.jiraMajorVersionFormat); assertNull(presence.jiraReleaseVersionFormat)
         assertNull(presence.jiraBuildVersionFormat); assertNull(presence.jiraLineVersionFormat)
         assertNull(presence.jiraVersionPrefix); assertNull(presence.jiraVersionFormat)
+        assertNull(presence.jiraHotfixVersionFormat)
 
         // `[1.0.107,)` must NOT get an extra presence row — it has real overrides.
         val rangeRows = allRows.filter { it.versionRange == "[1.0.107,)" }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ScalarNullOverrideRoundTripTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ScalarNullOverrideRoundTripTest.kt
@@ -200,6 +200,72 @@ class ScalarNullOverrideRoundTripTest {
     }
 
     // ========================================================================
+    // (E) jira.hotfixVersionFormat null override — task #16
+    // ========================================================================
+
+    /**
+     * `jira.hotfixVersionFormat` is the one scalar with TWO storage layers:
+     * a per-component column on `components` (Defaults / top-level DSL) and a
+     * per-range column on `component_configurations` (per-range overrides
+     * introduced in task #16). The resolver layers per-range over per-component.
+     *
+     * A SCALAR_OVERRIDE row with NULL `jira_hotfix_version_format` must
+     * **explicitly clear** the inherited per-range value for the matched range
+     * — the resolver MUST NOT silently fall back to the per-component base
+     * (that would defeat the import-only null-clear contract documented on
+     * `ConfigurationRowAccessors.SCALAR_ATTRIBUTE_PATHS`).
+     *
+     * Sibling scalars (e.g. `releaseVersionFormat`) get the no-format sentinel
+     * `"$major.$minor"` for null-clear via the resolver's hardcoded fallback;
+     * `hotfixVersionFormat` has no hardcoded default, so the sentinel is empty
+     * string (matches the pre-task-#16 contract for components that declare no
+     * hotfixVersionFormat anywhere).
+     */
+    @Test
+    @DisplayName("Task #16: null jiraHotfixVersionFormat override clears inherited base value on override range")
+    fun `task-16 null jiraHotfixVersionFormat override - override range returns empty, base range returns base value`() {
+        val comp = makeComponent("NULL_OVERRIDE_HOTFIX")
+        // Per-component base on `components.jira_hotfix_version_format`.
+        comp.jiraHotfixVersionFormat = "\$major.\$minor.\$service-\$fix"
+        val base = makeBase(comp)
+        base.jiraProjectKey = "HF"
+        // Per-range base on `component_configurations.jira_hotfix_version_format`
+        // (mirrors what ImportServiceImpl.populateScalarsFromConfig writes for
+        // the base config).
+        base.jiraHotfixVersionFormat = "\$major.\$minor.\$service-\$fix"
+
+        // Override row: explicitly clears jiraHotfixVersionFormat for [2.0,)
+        val nullOverrideRow = makeNullScalarOverrideRow(comp, "[2.0,)", "jira.hotfixVersionFormat")
+        // jiraHotfixVersionFormat intentionally left null on this row
+
+        comp.configurations.addAll(listOf(base, nullOverrideRow))
+        stubComponent(comp)
+
+        // Base range (1.0): legacy range keeps the base value.
+        val baseCfg = resolver.getResolvedComponentDefinition("NULL_OVERRIDE_HOTFIX", "1.0.0")
+        assertNotNull(baseCfg)
+        assertEquals(
+            "\$major.\$minor.\$service-\$fix",
+            baseCfg!!.jiraConfiguration?.componentVersionFormat?.hotfixVersionFormat,
+        )
+
+        // Override range (2.0): null-clear must resolve to empty string, NOT
+        // fall back to the per-component base. Falling back would defeat the
+        // null-clear contract — a Kotlin `?:` chain in buildJiraComponent
+        // (`merged.jira... ?: component.jira... ?: ""`) treats the explicit
+        // null override as "no override at all", which is the bug this test
+        // pins against.
+        val overrideCfg = resolver.getResolvedComponentDefinition("NULL_OVERRIDE_HOTFIX", "2.0.0")
+        assertNotNull(overrideCfg)
+        assertEquals(
+            "",
+            overrideCfg!!.jiraConfiguration?.componentVersionFormat?.hotfixVersionFormat,
+            "jiraHotfixVersionFormat null-clear override must resolve to empty string for the override range; " +
+                "was: ${overrideCfg.jiraConfiguration?.componentVersionFormat?.hotfixVersionFormat}",
+        )
+    }
+
+    // ========================================================================
     // (D) Null-clear override does NOT disturb non-overlapping ranges
     // ========================================================================
 

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -1167,6 +1167,43 @@ ARCHIVED_TEST_COMPONENT_WITH_DISPLAY_NAME {
 }
 
 
+// Regression fixture for the per-range `hotfixVersionFormat` override propagation
+// chain (task #16). The DSL declares a per-component (base) `hotfixVersionFormat`
+// and then OVERRIDES it for the version range `[2.0,)`. The v3 schema-v2 import
+// flow is expected to store the per-range value as a SCALAR_OVERRIDE row on
+// `component_configurations` (column `jira_hotfix_version_format`) rather than
+// flattening it into the per-component `components.jira_hotfix_version_format`
+// column. The resolver must surface the per-range value for versions IN the range
+// and fall back to the per-component base for versions OUTSIDE the range.
+//
+// All identifiers are RFC 2606 placeholders; no real product/customer names.
+TEST_PER_RANGE_HOTFIX_FORMAT {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.hotfix.range"
+    artifactId = "test-per-range-hotfix"
+    jira {
+        projectKey = "PRHF"
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        buildVersionFormat = '$major.$minor.$service-$fix'
+        lineVersionFormat = '$major'
+        hotfixVersionFormat = '$major.$minor.$service-$fix'
+    }
+    distribution {
+        explicit = false
+        external = true
+    }
+    "[1.0,2.0)" {
+        // Mirror the base values so the lower range has a present row.
+    }
+    "[2.0,)" {
+        jira {
+            hotfixVersionFormat = '$major.$minor.$service-$fix-$build'
+        }
+    }
+}
+
+
 NON_ARCHIVED_TEST_COMPONENT {
     jira {
         projectKey = "TEST_ARCHIVED"

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -1194,7 +1194,8 @@ TEST_PER_RANGE_HOTFIX_FORMAT {
         external = true
     }
     "[1.0,2.0)" {
-        // Mirror the base values so the lower range has a present row.
+        // Empty body — produces a RANGE_PRESENCE row; no per-range override.
+        // Versions in this range fall back to the per-component base hotfixVersionFormat.
     }
     "[2.0,)" {
         jira {

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -2001,5 +2001,71 @@
       ],
       "externalRegistry": null
     }
+  },
+  {
+    "componentName": "TEST_PER_RANGE_HOTFIX_FORMAT",
+    "versionRange": "[1.0,2.0)",
+    "component": {
+      "projectKey": "PRHF",
+      "displayName": null,
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": "$major.$minor.$service-$fix"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      }
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
+  },
+  {
+    "componentName": "TEST_PER_RANGE_HOTFIX_FORMAT",
+    "versionRange": "[2.0,)",
+    "component": {
+      "projectKey": "PRHF",
+      "displayName": null,
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": "$major.$minor.$service-$fix-$build"
+      },
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      }
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- v3's schema-v2 import was discarding per-range `jira.componentVersionFormat.hotfixVersionFormat` DSL overrides — only the per-component scalar was written. The DB-backed resolver then surfaced the same hotfixVersionFormat for every version of a component, regardless of any per-range `componentVersion(R) { jira { hotfixVersionFormat = … } }` blocks. v2.0.87 prod (= `f1-gateway` baseline) propagates the per-range value correctly through the upstream Groovy library; v3 candidate was diverging.
- Fix is additive (mirrors how `releaseVersionFormat`/`buildVersionFormat`/etc. are stored): adds a per-range `component_configurations.jira_hotfix_version_format` column; keeps the per-component `components.jira_hotfix_version_format` as the inheritance fallback (Defaults / top-level DSL). Resolver reads per-range first, falls back to per-component, then to empty string.
- V4 editor CRUD per-range write extension is intentionally out of scope — DSL import is the only producer in production today. `JiraAspectResponse.hotfixVersionFormat` is exposed read-only; `JiraAspectRequest` is unchanged.

## Commit shape (strict TDD)

1. `test(v4): pin per-range hotfixVersionFormat override regression (RED)` — new `TEST_PER_RANGE_HOTFIX_FORMAT` fixture + failing UT against the DB-backed profile; captured failure JSON in the commit body shows the bug. Boundary test not in this commit (per the TDD-discipline note about boundary-pin separation).
2. `fix(v4): preserve per-range hotfixVersionFormat through schema-v2 import + resolver` — schema column + entity + accessors + mapper + import + V4 read-only DTO + supporting test-data updates (MetricsTest count 56→57; expected-data JSON adds 2 entries for the new fixture; MigrationIntegrationTest RANGE_PRESENCE invariant extended to cover the new column).
3. `test(v4): boundary pin — out-of-range version falls back to base hotfixVersionFormat` — companion UT for the inheritance-fallback path, confirms the per-component base is preserved for versions outside any override range.

## Schema migration

`V1__schema.sql` is edited in-place (no new V<n> file) per the pre-prod fresh-DB-on-deploy convention. One new column added to `component_configurations`; the existing all-typed-cols-NULL CHECK on MARKER/RANGE_PRESENCE rows is extended to cover it. The DB CHECK constraint allowlist for SCALAR_OVERRIDE uses `NOT IN (<markers>)`, so no allowlist change is needed.

## Test plan

- [x] `:components-registry-service-server:test` (single-worker run; full suite — parallel runs hit Spring `DefaultCacheAwareContextLoaderDelegate` init errors due to resource exhaustion on the local stand, not code-related).
- [x] `:components-registry-service-light-client:test`.
- [x] Targeted tests confirmed GREEN: `testPerRangeHotfixVersionFormatOverridesBase_dbMode`, `testVersionOutsidePerRangeHotfixOverrideFallsBackToBase_dbMode`, `MigrationIntegrationTest`.
- [x] Sonnet code-review subagent (high effort) on the 3-commit diff — flagged one critical (`MigrationIntegrationTest` RANGE_PRESENCE invariant missing the new column) which is now addressed in commit 2, plus 2 documentation polish items in `JiraAspectResponse` KDoc and the fixture comment. No call-site for the new column was missed compared to the `jiraReleaseVersionFormat` sibling pattern; the deliberate V4 CRUD scope-omission has explanatory inline comments at the `applyBaseConfigurationCreate` and `applyBaseConfigurationPatch` call sites.
- [x] Forbidden-token grep against diff + commit messages — clean.
- [ ] CI compat-test job (post-merge): the 11 active diff records on build 2.0.84-3681 should resolve after a fresh stand rebuild against this branch.

## Why two columns, not one

The schema design distinguishes "Defaults / top-level inherited value" (per-component column on `components`) from "DSL-declared per-range override" (per-range column on `component_configurations`). The resolver layering preserves the current V4 UI semantics for the per-component hotfix-format edit while letting DSL imports carry per-range overrides through to the wire DTO.

Closes the v3 compat-job regression captured by build 2.0.84-3681 (manual curl against `f1-gateway` prod and `f1-gateway-test` candidate stands confirmed the divergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)