### PR TITLE
feat(components): extended-search list filters on GET /components

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -146,6 +146,14 @@ class ComponentControllerV4(
         @RequestParam(required = false) buildSystem: List<String>?,
         @RequestParam(required = false) labels: List<String>?,
         @RequestParam(required = false) canBeParent: Boolean?,
+        @RequestParam(required = false) clientCode: String?,
+        @RequestParam(required = false) solution: Boolean?,
+        @RequestParam(required = false) jiraProjectKey: String?,
+        @RequestParam(required = false) jiraTechnical: Boolean?,
+        @RequestParam(required = false) vcsPath: String?,
+        @RequestParam(required = false) productionBranch: String?,
+        @RequestParam(required = false) parentComponentName: String?,
+        @RequestParam(required = false) groupKey: String?,
         pageable: Pageable,
     ): Page<ComponentSummaryResponse> {
         // Each multi-value list filter parameter (system, owner, buildSystem,
@@ -163,6 +171,14 @@ class ComponentControllerV4(
                 buildSystem = normalizeCsvParam(buildSystem),
                 labels = normalizeCsvParam(labels),
                 canBeParent = canBeParent,
+                clientCode = clientCode,
+                solution = solution,
+                jiraProjectKey = jiraProjectKey,
+                jiraTechnical = jiraTechnical,
+                vcsPath = vcsPath,
+                productionBranch = productionBranch,
+                parentComponentName = parentComponentName,
+                groupKey = groupKey,
             )
         return componentManagementService.listComponents(filter, pageable)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentFilter.kt
@@ -56,4 +56,23 @@ data class ComponentFilter(
      * "no extra filter applied". Scalar column, so no JOIN / distinct needed.
      */
     val canBeParent: Boolean? = null,
+    // ── Extended-search single-value filters (Portal "extended search" mode) ──
+    /** Case-insensitive LIKE on `components.client_code`. */
+    val clientCode: String? = null,
+    /** Exact match on `components.solution`. `solution=false` matches only rows
+     *  explicitly set false — rows where `solution IS NULL` (never set) are excluded. */
+    val solution: Boolean? = null,
+    /** Case-insensitive LIKE on the BASE configuration row's `jira_project_key`. */
+    val jiraProjectKey: String? = null,
+    /** Exact match on the BASE configuration row's `jira_technical`. As with
+     *  `solution`, `jiraTechnical=false` excludes rows where the value IS NULL. */
+    val jiraTechnical: Boolean? = null,
+    /** Case-insensitive LIKE on a BASE-row VCS entry's `vcs_path`. */
+    val vcsPath: String? = null,
+    /** Case-insensitive LIKE on a BASE-row VCS entry's `branch` (production branch). */
+    val productionBranch: String? = null,
+    /** Exact match on the parent component's `component_key`. */
+    val parentComponentName: String? = null,
+    /** Case-insensitive LIKE on the owning group's `group_key`. */
+    val groupKey: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1723,6 +1723,98 @@ class ComponentManagementServiceImpl(
                     },
                 )
         }
+        // ── Extended-search filters (single-value; null/blank → no filter) ──
+        // Scalar columns on `components` — no JOIN, no distinct.
+        filter.clientCode?.takeIf { it.isNotBlank() }?.let { v ->
+            val pattern = "%${v.trim().lowercase()}%"
+            spec = spec.and(Specification { root, _, cb -> cb.like(cb.lower(root.get("clientCode")), pattern) })
+        }
+        filter.solution?.let { v ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<Boolean>("solution"), v) })
+        }
+        // ManyToOne joins — a component has at most one parent / one group, so no
+        // row multiplication and no distinct needed.
+        filter.parentComponentName?.takeIf { it.isNotBlank() }?.let { v ->
+            spec =
+                spec.and(
+                    Specification { root, _, cb ->
+                        val parent = root.join<ComponentEntity, ComponentEntity>("parentComponent")
+                        cb.equal(parent.get<String>("componentKey"), v.trim())
+                    },
+                )
+        }
+        filter.groupKey?.takeIf { it.isNotBlank() }?.let { v ->
+            val pattern = "%${v.trim().lowercase()}%"
+            spec =
+                spec.and(
+                    Specification { root, _, cb ->
+                        val group = root.join<ComponentEntity, ComponentGroupEntity>("componentGroup")
+                        cb.like(cb.lower(group.get("groupKey")), pattern)
+                    },
+                )
+        }
+        // BASE configuration-row filters — one OneToMany JOIN through
+        // `configurations` (rowType=BASE), distinct(true) to dedupe (mirrors the
+        // buildSystem filter above).
+        filter.jiraProjectKey?.takeIf { it.isNotBlank() }?.let { v ->
+            val pattern = "%${v.trim().lowercase()}%"
+            spec =
+                spec.and(
+                    Specification { root, query, cb ->
+                        val cfg = root.join<ComponentEntity, ComponentConfigurationEntity>("configurations")
+                        query?.distinct(true)
+                        cb.and(
+                            cb.equal(cfg.get<String>("rowType"), "BASE"),
+                            cb.like(cb.lower(cfg.get("jiraProjectKey")), pattern),
+                        )
+                    },
+                )
+        }
+        filter.jiraTechnical?.let { v ->
+            spec =
+                spec.and(
+                    Specification { root, query, cb ->
+                        val cfg = root.join<ComponentEntity, ComponentConfigurationEntity>("configurations")
+                        query?.distinct(true)
+                        cb.and(
+                            cb.equal(cfg.get<String>("rowType"), "BASE"),
+                            cb.equal(cfg.get<Boolean>("jiraTechnical"), v),
+                        )
+                    },
+                )
+        }
+        // BASE-row VCS-entry filters — two-level JOIN (configurations(BASE) →
+        // vcsEntries), distinct(true) to dedupe multi-entry components.
+        filter.vcsPath?.takeIf { it.isNotBlank() }?.let { v ->
+            val pattern = "%${v.trim().lowercase()}%"
+            spec =
+                spec.and(
+                    Specification { root, query, cb ->
+                        val cfg = root.join<ComponentEntity, ComponentConfigurationEntity>("configurations")
+                        val vcs = cfg.join<ComponentConfigurationEntity, VcsSettingsEntryEntity>("vcsEntries")
+                        query?.distinct(true)
+                        cb.and(
+                            cb.equal(cfg.get<String>("rowType"), "BASE"),
+                            cb.like(cb.lower(vcs.get("vcsPath")), pattern),
+                        )
+                    },
+                )
+        }
+        filter.productionBranch?.takeIf { it.isNotBlank() }?.let { v ->
+            val pattern = "%${v.trim().lowercase()}%"
+            spec =
+                spec.and(
+                    Specification { root, query, cb ->
+                        val cfg = root.join<ComponentEntity, ComponentConfigurationEntity>("configurations")
+                        val vcs = cfg.join<ComponentConfigurationEntity, VcsSettingsEntryEntity>("vcsEntries")
+                        query?.distinct(true)
+                        cb.and(
+                            cb.equal(cfg.get<String>("rowType"), "BASE"),
+                            cb.like(cb.lower(vcs.get("branch")), pattern),
+                        )
+                    },
+                )
+        }
         return spec
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
@@ -1,0 +1,242 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * CRS-PR2 — extended-search list filters: clientCode, solution, jiraProjectKey,
+ * jiraTechnical, vcsPath, productionBranch, parentComponentName, groupKey.
+ *
+ * Focused integration test on the H2 `ft-db` profile (does NOT extend the global
+ * Groovy fixtures). Also pins the load-bearing pagination concern for the
+ * VCS two-level JOIN: a component with multiple BASE VCS entries must be counted
+ * ONCE under a `?vcsPath=` filter (distinct), not once per entry.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+class ListComponentsExtendedFiltersTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(ListComponentsExtendedFiltersTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun uniqueName(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    /** POST a component from a raw JSON body; returns its id. Expects 201. */
+    private fun create(bodyJson: String): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(bodyJson),
+                ).andExpect(status().isCreated)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun names(vararg params: Pair<String, String>): Set<String> {
+        var request = get("/rest/api/4/components").with(viewerJwt()).param("size", "300")
+        for ((k, v) in params) request = request.param(k, v)
+        val body = mvc.perform(request).andExpect(status().isOk).andReturn().response.contentAsString
+        return objectMapper.readTree(body)["content"].map { it["name"].asText() }.toSet()
+    }
+
+    private fun page(vararg params: Pair<String, String>): com.fasterxml.jackson.databind.JsonNode {
+        // size=1 so the totalElements assertion genuinely exercises the COUNT
+        // query (where a missing distinct would inflate the count).
+        var request = get("/rest/api/4/components").with(viewerJwt()).param("size", "1")
+        for ((k, v) in params) request = request.param(k, v)
+        val body = mvc.perform(request).andExpect(status().isOk).andReturn().response.contentAsString
+        return objectMapper.readTree(body)
+    }
+
+    private fun baseBody(
+        name: String,
+        extraTop: String = "",
+        build: String = """"build":{"buildSystem":"MAVEN"}""",
+    ): String =
+        """{"name":"$name","displayName":"$name"$extraTop,""" +
+            """"group":{"groupKey":"org.example.test","isFake":false},""" +
+            """"baseConfiguration":{$build}}"""
+
+    @Test
+    @DisplayName("?clientCode= does a case-insensitive partial match")
+    fun clientCodeFilter() {
+        val match = uniqueName("ext_cc_match")
+        val other = uniqueName("ext_cc_other")
+        create(baseBody(match, ""","clientCode":"ACME-PORTAL""""))
+        create(baseBody(other, ""","clientCode":"OTHER""""))
+        val n = names("clientCode" to "acme")
+        assert(n.contains(match)) { "expected $match in $n" }
+        assert(!n.contains(other)) { "did not expect $other in $n" }
+    }
+
+    @Test
+    @DisplayName("?solution=true returns only solution components")
+    fun solutionFilter() {
+        val sol = uniqueName("ext_sol_true")
+        val notSol = uniqueName("ext_sol_false")
+        create(baseBody(sol, ""","solution":true"""))
+        create(baseBody(notSol, ""","solution":false"""))
+        val n = names("solution" to "true")
+        assert(n.contains(sol)) { "expected $sol in $n" }
+        assert(!n.contains(notSol)) { "did not expect $notSol in $n" }
+    }
+
+    @Test
+    @DisplayName("?jiraProjectKey= matches on the BASE row's jira project key")
+    fun jiraProjectKeyFilter() {
+        val match = uniqueName("ext_jpk_match")
+        val other = uniqueName("ext_jpk_other")
+        create(baseBody(match, build = """"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"ZZJIRA"}"""))
+        create(baseBody(other, build = """"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"AAOTHER"}"""))
+        val n = names("jiraProjectKey" to "zzjira")
+        assert(n.contains(match)) { "expected $match in $n" }
+        assert(!n.contains(other)) { "did not expect $other in $n" }
+    }
+
+    @Test
+    @DisplayName("?jiraTechnical=true returns only components whose BASE jira is technical")
+    fun jiraTechnicalFilter() {
+        val tech = uniqueName("ext_jt_true")
+        val notTech = uniqueName("ext_jt_false")
+        create(baseBody(tech, build = """"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"JTT","technical":true}"""))
+        create(baseBody(notTech, build = """"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"JTF","technical":false}"""))
+        val n = names("jiraTechnical" to "true")
+        assert(n.contains(tech)) { "expected $tech in $n" }
+        assert(!n.contains(notTech)) { "did not expect $notTech in $n" }
+    }
+
+    @Test
+    @DisplayName("?parentComponentName= returns children of that parent (parent must be canBeParent)")
+    fun parentComponentNameFilter() {
+        val parent = uniqueName("ext_p_parent")
+        create(baseBody(parent, ""","canBeParent":true"""))
+        val child = uniqueName("ext_p_child")
+        create(baseBody(child, ""","parentComponentName":"$parent""""))
+        val standalone = uniqueName("ext_p_standalone")
+        create(baseBody(standalone))
+        val n = names("parentComponentName" to parent)
+        assert(n.contains(child)) { "expected $child in $n" }
+        assert(!n.contains(standalone)) { "did not expect $standalone in $n" }
+    }
+
+    @Test
+    @DisplayName("?groupKey= matches the owning group key")
+    fun groupKeyFilter() {
+        val unique = uniqueName("grp")
+        val inGroup = uniqueName("ext_g_in")
+        create(
+            """{"name":"$inGroup","displayName":"$inGroup",""" +
+                """"group":{"groupKey":"org.example.$unique","isFake":false},""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+        )
+        val other = uniqueName("ext_g_other")
+        create(baseBody(other))
+        val n = names("groupKey" to unique)
+        assert(n.contains(inGroup)) { "expected $inGroup in $n" }
+        assert(!n.contains(other)) { "did not expect $other in $n" }
+    }
+
+    @Test
+    @DisplayName("?vcsPath= matches a BASE VCS entry; a multi-entry component is counted ONCE (distinct)")
+    fun vcsPathFilterAndPaginationDistinct() {
+        val multi = uniqueName("ext_vcs_multi")
+        // Two VCS entries on the BASE row, both matching the filter token.
+        create(
+            baseBody(
+                multi,
+                build = """"build":{"buildSystem":"MAVEN"},"vcsEntries":[""" +
+                    """{"name":"main","vcsPath":"octo/ext-multi-a"},""" +
+                    """{"name":"alt","vcsPath":"octo/ext-multi-b"}]""",
+            ),
+        )
+        val other = uniqueName("ext_vcs_other")
+        create(baseBody(other, build = """"build":{"buildSystem":"MAVEN"},"vcsEntries":[{"name":"main","vcsPath":"octo/unrelated"}]"""))
+
+        val n = names("vcsPath" to "ext-multi")
+        assert(n.contains(multi)) { "expected $multi in $n" }
+        assert(!n.contains(other)) { "did not expect $other in $n" }
+
+        // Pagination/distinct: the multi-entry component must contribute exactly
+        // one row to totalElements (a missing distinct would inflate it to 2).
+        val json = page("vcsPath" to "ext-multi")
+        assert(json["totalElements"].asLong() == 1L) {
+            "expected totalElements=1 for the multi-VCS-entry match; got ${json["totalElements"]}"
+        }
+        assert(json["content"].count { it["name"].asText() == multi } == 1) {
+            "expected exactly one content row for $multi"
+        }
+    }
+
+    @Test
+    @DisplayName("?productionBranch= matches a BASE VCS entry's branch")
+    fun productionBranchFilter() {
+        val match = uniqueName("ext_br_match")
+        create(
+            baseBody(
+                match,
+                build = """"build":{"buildSystem":"MAVEN"},"vcsEntries":[{"name":"main","vcsPath":"octo/br","branch":"release/2025"}]""",
+            ),
+        )
+        val other = uniqueName("ext_br_other")
+        create(
+            baseBody(
+                other,
+                build = """"build":{"buildSystem":"MAVEN"},"vcsEntries":[{"name":"main","vcsPath":"octo/br2","branch":"master"}]""",
+            ),
+        )
+        val n = names("productionBranch" to "release")
+        assert(n.contains(match)) { "expected $match in $n" }
+        assert(!n.contains(other)) { "did not expect $other in $n" }
+    }
+
+    @Test
+    @DisplayName("blank extended filter value is treated as no filter")
+    fun blankIsNoFilter() {
+        val seed = uniqueName("ext_blank_seed")
+        create(baseBody(seed))
+        val without = names()
+        val withBlank = names("clientCode" to "")
+        assert(without == withBlank) { "blank clientCode should match no-filter; without=$without blank=$withBlank" }
+    }
+}

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -8,7 +8,9 @@
 ## 1. Component Management
 
 ### 1.1 List Components
-- **Input**: Optional filters — `productType`, `archived`, `search` (name/displayName), `owner` (exact match on `componentOwner`, `SYS-035`). `system` is currently rejected with 400 (see ADR/TDD on JPA Criteria + `text[]` limitations); `clientCode` is reserved for future.
+- **Input**: Optional filters, ANDed when combined.
+  - **Main:** `search` (case-insensitive LIKE on name/displayName), `system` (multi-value, OR), `owner` (multi-value, OR on `componentOwner`, `SYS-035`), `buildSystem` (multi-value, OR on the BASE row), `labels` (multi-value, AND), `archived`, `productType`.
+  - **Extended** (single-value; back the Portal "extended search" mode): `clientCode` (LIKE), `solution`, `jiraProjectKey` (LIKE on the BASE row), `jiraTechnical`, `vcsPath` (LIKE on a BASE VCS entry), `productionBranch` (LIKE on a BASE VCS entry's `branch`), `parentComponentName` (exact, the parent's component key), `groupKey` (LIKE on the owning group), `canBeParent`. The BASE-row and VCS-entry joins use `distinct` so a multi-entry component is counted once.
 - **Output**: Paginated list of components with summary info
 - **Sorting**: By name (default), system, productType, updatedAt
 - **Pagination**: Page number + page size (default 20, max 100)


### PR DESCRIPTION
## Summary
Adds 8 single-value list filters on `GET /rest/api/4/components`, backing the Portal **extended search** mode. **Stacked on #304** (`can-be-parent-group-derivation`) — it shares `ComponentFilter` / `buildSpecification`; review/merge after #304.

## Filters
| Param | Match | Mechanism |
|---|---|---|
| `clientCode` | LIKE | scalar |
| `solution` | exact | scalar boolean |
| `jiraProjectKey` | LIKE | BASE config-row join |
| `jiraTechnical` | exact | BASE config-row join |
| `vcsPath` | LIKE | BASE VCS-entry join (2-level) |
| `productionBranch` | LIKE (on a BASE VCS entry's `branch`) | BASE VCS-entry join |
| `parentComponentName` | exact (parent's component key) | self-join |
| `groupKey` | LIKE | group join |

(`canBeParent` lands in #304; `productType`/`repositoryType` intentionally excluded per the requirements.)

## Correctness notes
- The OneToMany joins (configurations, vcsEntries) use `query.distinct(true)`. `ListComponentsExtendedFiltersTest` creates a component with **two** matching BASE VCS entries and asserts `totalElements == 1` with `size=1` — pinning that the COUNT query is de-duplicated (not inflated).
- Boolean filters match the explicit value only; `solution=false`/`jiraTechnical=false` exclude `NULL`/unset rows (documented on the DTO).
- Blank text values are treated as no-filter.

## Verification
`./gradlew :components-registry-service-server:build` green (full server suite + detekt/ktlint). New `ListComponentsExtendedFiltersTest` covers each filter + the pagination/distinct case. Independent subagent review passed. Docs (`functional-spec.md`) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)