### PR TITLE
refactor(crs): decouple aggregator grouping from flat parentComponent (R1)

### DIFF
--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -223,11 +223,21 @@ class EscrowConfigurationLoader {
                 validationConfig
         )
 
+        // TRUE-aggregator membership (a component that owns a `components{}` block) —
+        // the authoritative source for ComponentGroup membership, distinct from the
+        // flat `parentComponent` reference. Captured from the Groovy ConfigObject tree...
+        fullConfig.aggregatorSubComponents.putAll(extractAggregatorMembership(rootObject))
         dslComponents.forEach { component ->
             LOG.debug("processing dsl $component")
             validator.validateEscrow(component, fullConfig)
             mergeGroovyAndDslComponent(component, fullConfig)
             component.subComponents.forEach { name, subComponent -> mergeGroovyAndDslSubComponent(subComponent, fullConfig) }
+            // ...and from the Kotlin-DSL Components (which expose subComponents directly).
+            if (component.subComponents != null && !component.subComponents.isEmpty()) {
+                fullConfig.aggregatorSubComponents
+                        .computeIfAbsent(component.name, { new HashSet<String>() })
+                        .addAll(component.subComponents.keySet())
+            }
         }
 
         if (!ignoreUnknownAttributes) {
@@ -313,6 +323,30 @@ class EscrowConfigurationLoader {
             }
         }
         componentList
+    }
+
+    /**
+     * TRUE-aggregator membership from the Groovy DSL: a component is an aggregator iff
+     * it owns a {@code components { ... }} block; the keys of that block are its
+     * sub-components. Returns aggregator key -> sub-component keys. This is the
+     * authoritative grouping signal — a flat {@code parentComponent} reference does
+     * NOT make a component an aggregator and never appears here as a key.
+     */
+    private static Map<String, Set<String>> extractAggregatorMembership(ConfigObject rootObject) {
+        Map<String, Set<String>> result = new HashMap<>()
+        getComponentList(rootObject).each { String componentName ->
+            def componentObject = rootObject.get(componentName)
+            if (componentObject instanceof ConfigObject && ((ConfigObject) componentObject).containsKey("components")) {
+                def componentsObject = ((ConfigObject) componentObject).get("components")
+                if (componentsObject instanceof ConfigObject) {
+                    Set<String> subs = new HashSet<>(getComponentList((ConfigObject) componentsObject))
+                    if (!subs.isEmpty()) {
+                        result.put(componentName, subs)
+                    }
+                }
+            }
+        }
+        return result
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)

--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/model/EscrowConfiguration.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/model/EscrowConfiguration.groovy
@@ -6,6 +6,17 @@ class EscrowConfiguration {
 
     Map<String, EscrowModule> escrowModules = new HashMap<>()
 
+    /**
+     * Aggregator membership derived from DSL {@code components { ... }} blocks:
+     * aggregator component key -> set of its sub-component keys. A TRUE aggregator
+     * is a component that owns a {@code components{}} block; this map is the
+     * authoritative source for ComponentGroup membership (NOT the flat
+     * {@code parentComponent} field, which is a separate reference). Components not
+     * present as a key here are not aggregators; sub-components appear only in the
+     * value sets. Populated by the loader; empty when no aggregators are defined.
+     */
+    Map<String, Set<String>> aggregatorSubComponents = new HashMap<>()
+
     EscrowModule defaultConfiguration
 
     VersionNames versionNames

--- a/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/EscrowConfigurationLoaderTest.groovy
+++ b/component-resolver-core/src/test/groovy/org/octopusden/octopus/escrow/resolvers/EscrowConfigurationLoaderTest.groovy
@@ -557,6 +557,31 @@ class EscrowConfigurationLoaderTest extends GroovyTestCase {
                 copyright: "companyName1",
         )
         assert expectedModuleConfig == modelConfiguration
+
+        // R1 — aggregator membership captured from the Groovy `components {}` block.
+        // `bcomponent` owns the block, so it is the (only) aggregator and its members
+        // are exactly the four sub-components. A component that does NOT own a
+        // `components {}` block (including the sub-components themselves) never appears
+        // as a key. This map is the authoritative ComponentGroup source the importer
+        // reads — NOT the flat `parentComponent` field.
+        assert (configuration.aggregatorSubComponents.keySet() == ([TEST_MODULE] as Set))
+        assert (configuration.aggregatorSubComponents[TEST_MODULE] ==
+                (["buildsystem-model", "buildsystem-mojo", "notJiraComponent", "sub-component-with-defaults"] as Set))
+        assert !configuration.aggregatorSubComponents.containsKey("buildsystem-model")
+    }
+
+    @Test
+    void testFlatParentComponentIsNotAggregator() {
+        EscrowConfiguration configuration = loadConfiguration("flatParentComponent.groovy")
+        assert 2 == configuration.escrowModules.size()
+        // `childcomp` references `parentcomp` via the flat `parentComponent` field, but
+        // NEITHER owns a `components { }` block — so neither is an aggregator. A flat
+        // parentComponent reference must NOT create aggregator/group membership (R1):
+        // extractAggregatorMembership reads only `components { }`, never `parentComponent`.
+        assert configuration.aggregatorSubComponents.isEmpty()
+        // The flat reference is still resolved — it's a separate concept the importer
+        // keeps as the parentComponent FK; it just doesn't form a group.
+        assert "parentcomp" == configuration.escrowModules["childcomp"].moduleConfigurations[0].parentComponent
     }
 
     private static EscrowModuleConfig getAndAssertConfiguration(EscrowConfiguration configuration, String moduleName) {

--- a/component-resolver-core/src/test/resources/flatParentComponent.groovy
+++ b/component-resolver-core/src/test/resources/flatParentComponent.groovy
@@ -1,0 +1,90 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.MERCURIAL
+
+// Two flat (top-level) components where `childcomp` references `parentcomp` via the
+// flat `parentComponent` field. NEITHER owns a `components { }` block, so neither is
+// an aggregator — a flat `parentComponent` reference must NOT create aggregator/group
+// membership (R1). Used by EscrowConfigurationLoaderTest to prove that
+// `aggregatorSubComponents` is derived only from `components { }`, never from
+// `parentComponent`.
+
+Defaults {
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    copyright = 'companyName1'
+
+    jira {
+        majorVersionFormat = '$major.$minor'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+}
+
+Tools {
+    BuildEnv {
+        escrowEnvironmentVariable = "BUILD_ENV"
+        targetLocation = "tools/BUILD_ENV"
+        sourceLocation = "env.BUILD_ENV"
+        installScript = "script"
+    }
+}
+
+parentcomp {
+    componentOwner = "user"
+    releaseManager = "user"
+    securityChampion = "user"
+    system = "CLASSIC"
+    componentDisplayName = "Parent Component Official Name"
+    "[1.0,)" {
+        vcsUrl = "ssh://hg@mercurial/parentcomp"
+        buildSystem = MAVEN
+        repositoryType = MERCURIAL
+        groupId = "org.octopusden.octopus.parentcomp"
+        artifactId = "parentcomp"
+        tag = '$module.$version'
+        branch = "default"
+        build {
+            requiredTools = "BuildEnv"
+        }
+        distribution {
+            explicit = true
+            external = true
+            GAV = "org.octopusden.octopus.parentcomp:parentcomp:jar"
+        }
+        jira {
+            projectKey = "PARENTCOMP"
+        }
+    }
+}
+
+childcomp {
+    parentComponent = "parentcomp"
+    componentOwner = "user"
+    releaseManager = "user"
+    securityChampion = "user"
+    system = "CLASSIC"
+    componentDisplayName = "Child Component Official Name"
+    "[1.0,)" {
+        vcsUrl = "ssh://hg@mercurial/childcomp"
+        buildSystem = MAVEN
+        repositoryType = MERCURIAL
+        groupId = "org.octopusden.octopus.childcomp"
+        artifactId = "childcomp"
+        tag = '$module.$version'
+        branch = "default"
+        build {
+            requiredTools = "BuildEnv"
+        }
+        distribution {
+            explicit = true
+            external = true
+            GAV = "org.octopusden.octopus.childcomp:childcomp:jar"
+        }
+        jira {
+            projectKey = "CHILDCOMP"
+        }
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
@@ -9,17 +9,18 @@ package org.octopusden.octopus.components.registry.server.dto.v4
  * `baseConfiguration`; override rows are added afterwards via the
  * field-override API.
  *
- * **Strict contract (UI-swift-sloth)** — `ComponentManagementService`
- * rejects payloads with **400 Bad Request** when:
- *  - `group` is null, or `group.groupKey` is blank;
- *  - `baseConfiguration` is null, or `baseConfiguration.build` is null,
- *    or `baseConfiguration.build.buildSystem` is null/blank.
- *
- * In other words: although these fields are declared nullable at the
- * Kotlin / Jackson layer for backward-compatible deserialisation, every
- * created component MUST carry a group and a base build system. The
- * Portal's Create Component dialog enforces both at the UX layer; the
+ * **Strict contract** — `ComponentManagementService` rejects a payload with
+ * **400 Bad Request** when `baseConfiguration` is null, or
+ * `baseConfiguration.build` is null, or `baseConfiguration.build.buildSystem` is
+ * null/blank. Although declared nullable for backward-compatible
+ * deserialisation, every created component MUST carry a base build system; the
  * server is the source of truth.
+ *
+ * **`group` is NOT required and is NOT assigned via the API** (R1
+ * aggregator/parentComponent decouple): a ComponentGroup is DSL aggregator
+ * membership (a `components { }` owner + its sub-components), established only by
+ * the migration/import path. A provided `group` here is accepted but IGNORED —
+ * an API-created component is standalone (`componentGroup = null`).
  */
 data class ComponentCreateRequest(
     val name: String,
@@ -35,10 +36,12 @@ data class ComponentCreateRequest(
     val clientCode: String? = null,
     val solution: Boolean? = null,
     val parentComponentName: String? = null,
-    // Whether this component may be referenced as a parent by others. Normally
-    // seeded by import; accepted here so an admin can create an aggregator up
-    // front. A component with `canBeParent = true` may not also set
-    // `parentComponentName` (a parent cannot have a parent) — service rejects it.
+    // Whether this component may be referenced as a parent by others (parent-picker
+    // eligibility). Normally seeded by import; accepted here so an admin can mark a
+    // component can-be-parent. NOTE: this is NOT the same as an aggregator (a
+    // `components { }` owner that forms a group — see `group`); the two are
+    // independent. A component with `canBeParent = true` may not also set
+    // `parentComponentName` (single-level: a parent cannot have a parent) — rejected.
     val canBeParent: Boolean = false,
     val archived: Boolean = false,
     // Ordered multi-value (first = primary); canonicalized server-side
@@ -53,6 +56,8 @@ data class ComponentCreateRequest(
     val vcsExternalRegistry: String? = null,
     val distributionExplicit: Boolean? = null,
     val distributionExternal: Boolean? = null,
+    // Accepted for backward compatibility but IGNORED: group membership is
+    // migration-owned (DSL `components { }` aggregators), never assigned via the API.
     val group: ComponentGroupRequest? = null,
     val docs: List<DocLinkRequest> = emptyList(),
     val artifactIds: List<ArtifactIdRequest> = emptyList(),

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -9,17 +9,13 @@ package org.octopusden.octopus.components.registry.server.dto.v4
  * rules — null aspect fields preserve, present child lists replace. Override
  * rows are managed via the field-override API, not from here.
  *
- * **Strict contract (UI-swift-sloth)** — `ComponentManagementService`
- * rejects PATCH payloads with **400 Bad Request** when:
- *  - `clearGroup == true` — every component must belong to a group, so
- *    clearing the group via PATCH is no longer expressible. The frontend's
- *    `buildUpdateRequest` always emits `clearGroup: false`.
- *  - `group` is non-null with a blank `group.groupKey` — same blank-key
- *    invariant as create.
- *
- * `group == null` continues to mean "don't touch" (Jackson cannot
- * distinguish field-absent from explicit-null without a presence-preserving
- * DTO, and every untouched-group PATCH today carries `group == null`).
+ * **`group` is migration-owned and is NEVER modified via PATCH** (R1
+ * aggregator/parentComponent decouple): a ComponentGroup is DSL aggregator
+ * membership, established only by the migration/import path. On PATCH the group is
+ * left untouched regardless of input — a provided `group` is accepted but IGNORED,
+ * and `clearGroup` (true or false) is an accepted no-op. Both are kept on the wire
+ * for backward compatibility (the frontend's `buildUpdateRequest` still emits
+ * `clearGroup: false`).
  */
 data class ComponentUpdateRequest(
     val version: Long,
@@ -53,6 +49,8 @@ data class ComponentUpdateRequest(
     val vcsExternalRegistry: String? = null,
     val distributionExplicit: Boolean? = null,
     val distributionExternal: Boolean? = null,
+    // Both accepted for backward compatibility but IGNORED (no-op): group membership
+    // is migration-owned and never modified via the API (see class KDoc).
     val group: ComponentGroupRequest? = null,
     val clearGroup: Boolean = false,
     // Explicit "remove the parent" signal. `parentComponentName == null` means

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
@@ -92,12 +92,14 @@ class ComponentEntity(
     @JoinColumn(name = "component_group_id")
     var componentGroup: ComponentGroupEntity? = null,
 
-    // True when this component is referenced as a `parentComponent` by at least
-    // one other component (i.e., it is an aggregator parent). Seeded by the
-    // Groovy import (sets true for DSL-referenced parents, never false) and
-    // editable via the v4 API. A component with `canBeParent = true` may not
-    // itself have a `parentComponent` (enforced in the service layer) — a
-    // parent cannot have a parent.
+    // True when this component is referenced as a `parentComponent` by at least one
+    // other component — i.e. it is eligible to be picked as a parent. This is the flat
+    // peer-reference relationship and is INDEPENDENT of aggregator status: an
+    // aggregator owns a `components { }` block and forms a ComponentGroup
+    // (`componentGroup` above), a separate concept. Seeded by the Groovy import (sets
+    // true for DSL-referenced parents, never false) and editable via the v4 API. A
+    // component with `canBeParent = true` may not itself have a `parentComponent`
+    // (enforced in the service layer) — single-level: a parent cannot have a parent.
     @Column(name = "can_be_parent", nullable = false)
     var canBeParent: Boolean = false,
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentRepository.kt
@@ -61,4 +61,11 @@ interface ComponentRepository :
             "FROM ComponentEntity c WHERE c.parentComponent.id = :parentId",
     )
     fun existsByParentComponentId(parentId: UUID): Boolean
+
+    /**
+     * All components whose `componentGroup` is [groupId]. Used by migration cleanup
+     * (§6.3) to unlink the members of a group that is no longer a true aggregator
+     * before deleting the now-orphaned `component_groups` row.
+     */
+    fun findByComponentGroupId(groupId: UUID): List<ComponentEntity>
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -8,7 +8,6 @@ import org.octopusden.octopus.components.registry.server.dto.v4.BuildToolBeanReq
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentDetailResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
-import org.octopusden.octopus.components.registry.server.dto.v4.ComponentGroupRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentSummaryResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.DockerImageRequest
@@ -54,7 +53,6 @@ import org.octopusden.octopus.components.registry.server.mapper.toFieldOverrideR
 import org.octopusden.octopus.components.registry.server.mapper.toSummaryResponse
 import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
-import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
@@ -91,7 +89,6 @@ import java.util.UUID
 class ComponentManagementServiceImpl(
     private val componentRepository: ComponentRepository,
     private val configurationRepository: ComponentConfigurationRepository,
-    private val componentGroupRepository: ComponentGroupRepository,
     private val componentLabelRepository: ComponentLabelRepository,
     private val componentRequiredToolRepository: ComponentRequiredToolRepository,
     private val componentBuildToolBeanRepository: ComponentBuildToolBeanRepository,
@@ -125,27 +122,16 @@ class ComponentManagementServiceImpl(
             "Component with name '$normalizedKey' already exists"
         }
         // Strict contract (UI-swift-sloth): a component cannot legitimately exist
-        // without an owning group or without a build system on its BASE
-        // configuration row. The Portal's Create dialog enforces both fields at
-        // the UX layer; the server is the source of truth and rejects payloads
-        // missing either field with 400. The frontend gates the Submit button
-        // on these constraints, so reaching this branch implies a misbehaving
-        // client (or a direct API caller skipping validation).
-        requireNotNull(request.group) {
-            "group is required: every component must belong to a group (groupKey is mandatory)"
-        }
-        // Trim first so leading/trailing whitespace doesn't survive into the
-        // `component_groups.group_key` UNIQUE index — a key like
-        // `"org.example.test "` and `"org.example.test"` would otherwise be
-        // two distinct group rows and silently fragment aggregator queries.
-        // Leniency for clients (we trim instead of rejecting), strict
-        // canonicalisation on storage.
-        val normalizedGroupKey = request.group.groupKey.trim()
-        require(normalizedGroupKey.isNotBlank()) {
-            "group.groupKey must not be blank"
-        }
-        validateGroupKeyPrefix(normalizedGroupKey)
-        val normalizedGroupRequest = request.group.copy(groupKey = normalizedGroupKey)
+        // without a build system on its BASE configuration row. The Portal's Create
+        // dialog enforces it at the UX layer; the server is the source of truth and
+        // rejects a payload missing it with 400.
+        //
+        // R1 (aggregator/parentComponent decouple): `group` is NO LONGER required and
+        // is NOT assigned on the API path. A ComponentGroup represents DSL aggregator
+        // membership (a `components { }` owner + its sub-components) and is established
+        // ONLY by the migration/import path. An API-created component is therefore
+        // standalone → `componentGroup = null`; any `request.group` is accepted but
+        // ignored (creating a component via the API does not make it an aggregator).
         val baseConfigRequest =
             requireNotNull(request.baseConfiguration) {
                 "baseConfiguration is required: provide baseConfiguration.build.buildSystem on create"
@@ -203,8 +189,6 @@ class ComponentManagementServiceImpl(
                     ?: throw NotFoundException("Parent component '$parentKey' not found")
             }
 
-        val group = upsertGroup(normalizedGroupRequest)
-
         // Parent invariants (create = everything is new): a chosen parent must be
         // marked can-be-parent, and a component that itself can be a parent may
         // not have a parent (a parent cannot have a parent).
@@ -227,7 +211,8 @@ class ComponentManagementServiceImpl(
                 archived = request.archived,
                 solution = request.solution,
                 parentComponent = parent,
-                componentGroup = group,
+                // R1: group = migration-derived aggregator membership only; never assigned via API.
+                componentGroup = null,
                 canBeParent = request.canBeParent,
                 copyright = request.copyright,
                 releasesInDefaultBranch = request.releasesInDefaultBranch,
@@ -238,15 +223,6 @@ class ComponentManagementServiceImpl(
                 distributionExternal = request.distributionExternal,
                 systemCode = canonicalSystem,
             )
-
-        // Group follows the parent/aggregator relationship (schema-v2), mirroring
-        // the update path: a child joins its parent's group and an aggregator
-        // (canBeParent) gets its own-key group — both override the requested group;
-        // a standalone keeps the (legacy) requested group set above. Without this an
-        // API-created aggregator would retain request.group and its children would
-        // inherit that key instead of the aggregator's own componentKey. (A full
-        // standalone -> null group awaits the deferred create-flow rework.)
-        entity.componentGroup = deriveComponentGroup(entity)
 
         // Per-component child collections (cascade = ALL on these — flushed with the parent)
         // Ordered multi-value people — the accessor canonicalizes (trim → drop
@@ -328,40 +304,18 @@ class ComponentManagementServiceImpl(
                 "Optimistic locking conflict: expected version ${request.version} but found ${entity.version}",
             )
         }
-        // Strict contract (UI-swift-sloth): clearing the group via PATCH is no
-        // longer expressible — a component cannot legitimately exist without
-        // an owning group. The frontend's buildUpdateRequest always emits
-        // `clearGroup: false` (the wire schema requires the field be present),
-        // and only `clearGroup: true` is rejected. `group == null` continues
-        // to mean "don't touch" — Jackson cannot distinguish field-absent from
-        // explicit-null without a presence-preserving DTO, and every
-        // untouched-group PATCH today carries `group == null`. If clients
-        // later need to disambiguate, switch the DTO to a presence-preserving
-        // shape (JsonNullable / sentinel wrapper) — out of scope here.
-        require(!request.clearGroup) {
-            "clearGroup: true is no longer allowed — every component must belong to a group"
-        }
+        // R1 (aggregator/parentComponent decouple): a ComponentGroup is migration-derived
+        // aggregator membership (a `components { }` owner + its sub-components), NOT an
+        // API-editable field. On PATCH it is never touched — `request.group` is accepted
+        // but ignored, and `clearGroup` is an accepted no-op (both kept on the wire for
+        // backward compatibility). A `group == null` PATCH always meant "don't touch";
+        // now a non-null one means the same.
+        //
         // `clearParent` (remove the parent) and `parentComponentName` (set a parent)
         // are mutually exclusive — accepting both would silently drop one.
         require(!(request.clearParent && request.parentComponentName != null)) {
             "parentComponentName: clearParent and parentComponentName are mutually exclusive"
         }
-        // Mirror the create-side validation on the PATCH path. Same
-        // trim-then-validate-then-canonicalise pipeline so a PATCH that
-        // sets `groupKey = "org.example.test "` rounds to the canonical
-        // form before it reaches `upsertGroup`. The trimmed value is also
-        // what's used for prefix validation and persistence, so the rest
-        // of the method must read from `normalizedGroupRequest` rather
-        // than `request.group`.
-        val normalizedGroupRequest =
-            request.group?.let { req ->
-                val trimmed = req.groupKey.trim()
-                require(trimmed.isNotBlank()) {
-                    "group.groupKey must not be blank"
-                }
-                validateGroupKeyPrefix(trimmed)
-                req.copy(groupKey = trimmed)
-            }
 
         val oldKey = entity.componentKey
         val normalizedNewKey = request.name?.trim()
@@ -485,34 +439,15 @@ class ComponentManagementServiceImpl(
                     ?: throw NotFoundException("Parent component '$parentKey' not found")
         }
 
-        // Group: `clearGroup: true` was rejected at the top of this method
-        // (strict contract — every component must belong to a group), so the
-        // only reachable shapes here are "no change" (request.group == null)
-        // or "replace with a new/upserted group" (request.group != null).
-        // The normalised (trimmed + prefix-validated) form is used so the
-        // upserted row is byte-stable across whitespace-y inputs.
-        // canBeParent invariants + derived group (schema-v2: group membership
-        // follows the parent/aggregator relationship). Rederive whenever the parent
-        // OR the canBeParent flag actually changes:
-        //  - a child joins its parent's group;
-        //  - a component promoted to canBeParent gets its OWN-key group, so its
-        //    children inherit the aggregator key rather than whatever legacy group
-        //    it happened to carry (the bug this fixes);
-        //  - validateParentInvariants runs first, so a grandfathered
-        //    parent-of-parent row is only re-derived on a genuine parent change
-        //    (e.g. clearParent remediation), never corrupted by a no-op.
-        // A pure no-op (neither parent nor canBeParent changed) preserves the
-        // existing group and still honours a legacy request.group if present.
+        // Parent / canBeParent invariants (single-level — matches the DSL validator):
+        // a chosen parent must be can-be-parent; a can-be-parent component may not
+        // itself have a parent; a parent still referenced by children may not be
+        // demoted. Group membership is NOT re-derived here — it is migration-owned
+        // aggregator membership and the API leaves it untouched (see the group note at
+        // the top of this method).
         val parentChanged = entity.parentComponent?.componentKey != oldParentKey
         val canBeParentChanged = entity.canBeParent != oldCanBeParent
         validateParentInvariants(entity, parentChanged, canBeParentChanged)
-        if (parentChanged || canBeParentChanged) {
-            // Derived group wins over any (legacy) request.group on a relationship change.
-            entity.componentGroup = deriveComponentGroup(entity)
-        } else {
-            // No relationship change: honor an explicit (legacy) request.group if present.
-            normalizedGroupRequest?.let { entity.componentGroup = upsertGroup(it) }
-        }
 
         // Per-component child REPLACE — present collection wipes and refills
         request.artifactIds?.let {
@@ -970,9 +905,8 @@ class ComponentManagementServiceImpl(
 
     /**
      * Validate `value` against the env-config allowlist
-     * `components-registry.supportedSystems` (primary path — mirrors the
-     * analogous `validateGroupKeyPrefix` gate against `supportedGroupIds`
-     * for `groupKey`) AND return the canonical form. A secondary path
+     * `components-registry.supportedSystems` (primary path) AND return the
+     * canonical form. A secondary path
      * also accepts any code that's already in the master `systems`
      * table — this matches the import-side seeding model in
      * `ImportServiceImpl.seedSystems`, which auto-creates `SystemEntity`
@@ -989,10 +923,9 @@ class ComponentManagementServiceImpl(
      * (exact match against a configured / known value).
      *
      * **Returns the canonical form, NOT the caller's input.** Case
-     * matching against the config path is case-insensitive (mirrors
-     * `validateGroupKeyPrefix`'s leniency — env config typically uses
-     * upper-case codes `NONE,CLASSIC,ALFA` but a caller posting
-     * `Classic` should not be rejected for stylistic difference), but
+     * matching against the config path is case-insensitive (env config
+     * typically uses upper-case codes `NONE,CLASSIC,ALFA` but a caller
+     * posting `Classic` should not be rejected for stylistic difference), but
      * the form persisted to `components.system_code` is the config's
      * canonical casing — NOT the caller's input. This prevents a v4
      * write of `system: "Classic"` from creating a duplicate master
@@ -1073,50 +1006,6 @@ class ComponentManagementServiceImpl(
     private fun bumpParentVersion(component: ComponentEntity) {
         component.updatedAt = Instant.now()
         componentRepository.saveAndFlush(component)
-    }
-
-    private fun upsertGroup(request: ComponentGroupRequest): ComponentGroupEntity =
-        componentGroupRepository.findByGroupKey(request.groupKey)
-            ?: componentGroupRepository.save(
-                ComponentGroupEntity(
-                    groupKey = request.groupKey,
-                    isFake = request.isFake,
-                ),
-            )
-
-    /**
-     * Derive a component's aggregator group from its parent relationship
-     * (schema-v2: group membership follows structure, not a user-entered Maven
-     * groupId):
-     *   - child (has a parent): the parent's group; if the parent has none yet,
-     *     upsert one keyed by the parent's componentKey and assign it to the parent;
-     *   - aggregator (canBeParent, no parent): its own group keyed by componentKey;
-     *   - standalone (no parent, not canBeParent): PRESERVE the existing group.
-     * Callers invoke this on create and whenever the parent OR canBeParent flag
-     * changes, so a no-op update leaves the existing group untouched. The
-     * aggregator branch re-keys to the own component key even if a legacy group
-     * was carried, which is how a promoted/created aggregator stops leaking its
-     * old group key to its children.
-     */
-    private fun deriveComponentGroup(entity: ComponentEntity): ComponentGroupEntity? {
-        val parent = entity.parentComponent
-        return when {
-            parent != null ->
-                parent.componentGroup ?: run {
-                    val derived = upsertGroup(ComponentGroupRequest(groupKey = parent.componentKey, isFake = false))
-                    parent.componentGroup = derived
-                    componentRepository.save(parent)
-                    derived
-                }
-            entity.canBeParent ->
-                entity.componentGroup?.takeIf { it.groupKey == entity.componentKey }
-                    ?: upsertGroup(ComponentGroupRequest(groupKey = entity.componentKey, isFake = false))
-            // Standalone: PRESERVE the existing group rather than null it. Every
-            // component must belong to a group (create-side strict contract), so a
-            // bare `clearParent` on a plain child must not strip its group. Full
-            // standalone→no-group awaits the create-contract relaxation follow-up.
-            else -> entity.componentGroup
-        }
     }
 
     /**
@@ -1528,60 +1417,6 @@ class ComponentManagementServiceImpl(
         require(value.isNotBlank()) { "productType must not be blank" }
         require(value in PRODUCT_TYPE_NAMES) {
             "Invalid productType: '$value'. Allowed: $PRODUCT_TYPE_NAMES"
-        }
-    }
-
-    /**
-     * Reject group keys whose prefix is not in
-     * `components-registry.supportedGroupIds`. The frontend already gates
-     * the Submit button on the same check (via
-     * `GET /rest/api/2/common/supported-groups`), but the server is the
-     * source of truth: a CLI / automation client that bypasses the UI
-     * cannot land a component on a disallowed prefix.
-     *
-     * Allowed iff `groupKey == prefix` OR `groupKey.startsWith(prefix + ".")`,
-     * **compared case-insensitively** (both sides lowercased before the
-     * compare). The trailing-dot boundary is critical: without it,
-     * allowed=`org.example` would let `org.exampleextra.foo` slip through.
-     * Mirrors the frontend's `useSupportedGroups` check exactly —
-     * `CreateComponentDialog.tsx` and `GeneralTab.tsx` both lowercase
-     * `groupId` and each `prefix` before `v === lp || v.startsWith(lp + '.')`.
-     * Without case-insensitive comparison on the CRS side, the portal
-     * passes its pre-check on `ORG.EXAMPLE.foo` and the server then
-     * returns 400 — confusing UX.
-     *
-     * Case is preserved on storage: the caller passes the user-typed
-     * value (trimmed) and persistence happens with that value, NOT the
-     * lowercased form. Lowercasing is a validation-time comparison only.
-     *
-     * Known trade-off: because `upsertGroup` does a case-sensitive
-     * `findByGroupKey`, a user can land `org.example.foo` AND
-     * `ORG.EXAMPLE.foo` as two distinct `component_groups` rows that
-     * both validate against the same prefix. If a future requirement
-     * surfaces (e.g. "same logical groupKey must dedupe regardless of
-     * case"), the fix is either (a) a case-insensitive lookup in
-     * `upsertGroup`, or (b) a DB-level `UNIQUE LOWER(group_key)`
-     * constraint. Out of scope here — the spec keeps user-typed case.
-     *
-     * The error message names the allowed prefixes verbatim so non-UI
-     * clients see actionable feedback (the frontend can also surface the
-     * server message when its own pre-check disagrees with the server).
-     *
-     * Assumes `value` is already trimmed by the caller (see CREATE/PATCH
-     * blocks). An empty `supportedGroupIds` list rejects everything —
-     * misconfigured envs produce a clear 400 rather than silently
-     * accepting any prefix.
-     */
-    private fun validateGroupKeyPrefix(value: String) {
-        val allowed = configHelper.supportedGroupIds().toList()
-        val lowerValue = value.lowercase()
-        val matches =
-            allowed.any { prefix ->
-                val lowerPrefix = prefix.lowercase()
-                lowerValue == lowerPrefix || lowerValue.startsWith("$lowerPrefix.")
-            }
-        require(matches) {
-            "group.groupKey '$value' is not in the configured supportedGroupIds. Allowed: $allowed"
         }
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -172,21 +172,18 @@ class ImportServiceImpl(
                     )
                 }
 
-                // schema-spec §4.3: when this name is referenced as parentComponent by some
-                // other DSL entry AND its first config classifies as a FAKE aggregator, it is
-                // group-only — no ComponentEntity row. Still upsert the ComponentGroupEntity
-                // and link any children that already exist in DB; otherwise an operator-driven
-                // single-component migration of the aggregator key would leave the group
-                // uncreated while marking source = "db".
+                // R1 §4.3/§6.3 — group membership is driven by the DSL `components { }`
+                // aggregator membership (fullConfig.aggregatorSubComponents), NOT the flat
+                // parentComponent field. `name` is an aggregator iff it owns a components{} block.
                 val firstCfgForCheck = module.moduleConfigurations.firstOrNull()
-                val childrenReferencingThis: Map<String, String> =
-                    fullConfig.escrowModules.mapNotNull { (otherKey, otherModule) ->
-                        val parentRef = otherModule.moduleConfigurations.firstOrNull()?.parentComponent
-                        if (otherKey != name && parentRef == name) otherKey to name else null
-                    }.toMap()
-                if (firstCfgForCheck != null && childrenReferencingThis.isNotEmpty() && isFakeAggregator(firstCfgForCheck)) {
+                val subComponentsOfThis: Set<String> = fullConfig.aggregatorSubComponents[name] ?: emptySet()
+                val isAggregator = subComponentsOfThis.isNotEmpty()
+
+                // (a) FAKE aggregator (owns components{} AND stub) → group-only, no ComponentEntity row.
+                if (isAggregator && firstCfgForCheck != null && isFakeAggregator(firstCfgForCheck)) {
                     sourceRegistry.setComponentSource(name, "db")
-                    val fakePass3Failures = linkAggregatorGroups(fullConfig.escrowModules, childrenReferencingThis)
+                    val fakePass3Failures =
+                        linkAggregatorGroups(fullConfig.escrowModules, mapOf(name to subComponentsOfThis))
                     if (fakePass3Failures.isNotEmpty()) {
                         val msg = fakePass3Failures.joinToString(" | ") { "${it.first}=${it.second}" }
                         return MigrationResult(
@@ -207,16 +204,24 @@ class ImportServiceImpl(
                 importModule(name, module.moduleConfigurations)
                 sourceRegistry.setComponentSource(name, "db")
 
-                // §6.3 Pass 3 for the single-component path: if the component
-                // declares a parentComponent, link it to (or create) the
-                // parent's aggregator group. The batch path handles this
-                // across the full DSL; here we only have the one component,
-                // so reverse-map just its parent.
-                val firstConfig = module.moduleConfigurations.firstOrNull()
+                // §6.3 single-path grouping, keyed off `components { }` membership:
+                //   (b) REAL aggregator (owns components{}, not fake) → create its group,
+                //       self-link, and link any children already in DB;
+                //   (c) sub-component of some aggregator → link it to that aggregator's group.
+                val pass3Input: Map<String, Set<String>> =
+                    if (isAggregator) {
+                        mapOf(name to subComponentsOfThis)
+                    } else {
+                        // case (c): `name` is a sub-component of one or more aggregators →
+                        // link it to each owning aggregator's group.
+                        fullConfig.aggregatorSubComponents.filter { (_, subKeys) -> name in subKeys }
+                    }
                 val pass3Failures: List<Pair<String, String>> =
-                    firstConfig?.parentComponent?.takeIf { it.isNotBlank() }?.let { parentKey ->
-                        linkAggregatorGroups(fullConfig.escrowModules, mapOf(name to parentKey))
-                    } ?: emptyList()
+                    if (pass3Input.isNotEmpty()) {
+                        linkAggregatorGroups(fullConfig.escrowModules, pass3Input)
+                    } else {
+                        emptyList()
+                    }
                 if (pass3Failures.isNotEmpty()) {
                     val msg = pass3Failures.joinToString(" | ") { "${it.first}=${it.second}" }
                     return MigrationResult(
@@ -311,17 +316,20 @@ class ImportServiceImpl(
                     }
                 }.toMap()
 
-            // schema-spec §4.3: FAKE aggregators are group-only — no ComponentEntity row. Detect
-            // which keys in `allModules` are referenced as parentComponent AND classify as FAKE,
-            // and skip them in Pass 1. Pass 3 still creates their ComponentGroupEntity.
+            // schema-spec §4.3: FAKE aggregators are group-only — no ComponentEntity row. R1:
+            // an aggregator is a component that OWNS a `components { }` block (a key in
+            // `aggregatorSubComponents`), NOT merely a flat-`parentComponent` target. Among
+            // aggregators, the FAKE ones (stub VCS / artifactId) are skipped in Pass 1; Pass 3
+            // still creates their ComponentGroupEntity.
             val fakeAggregatorKeys: Set<String> =
-                pendingParentByKey.values.toSet().filter { parentKey ->
+                fullConfig.aggregatorSubComponents.keys.filter { parentKey ->
                     val firstConfig = allModules[parentKey]?.moduleConfigurations?.firstOrNull()
                     firstConfig != null && isFakeAggregator(firstConfig)
                 }.toSet()
             LOG.info(
-                "§6 DSL derivation: {} ms ({} parent refs, {} FAKE aggregators)",
-                (System.nanoTime() - deriveStart) / 1_000_000, pendingParentByKey.size, fakeAggregatorKeys.size,
+                "§6 DSL derivation: {} ms ({} parent refs, {} aggregators, {} FAKE)",
+                (System.nanoTime() - deriveStart) / 1_000_000, pendingParentByKey.size,
+                fullConfig.aggregatorSubComponents.size, fakeAggregatorKeys.size,
             )
 
             var total = 0
@@ -498,10 +506,12 @@ class ImportServiceImpl(
                         )
                         continue
                     }
-                    // Seed canBeParent on the referenced parent: a component that is
-                    // referenced as a parent IS an aggregator. Idempotent — set true
-                    // once, never false. FAKE aggregators have no ComponentEntity row
-                    // (findByComponentKey returns null above), so they're excluded.
+                    // Seed canBeParent on the referenced parent: any component referenced
+                    // as a `parentComponent` becomes can-be-parent (eligible in the parent
+                    // picker). This is INDEPENDENT of aggregator status — an aggregator owns
+                    // a `components { }` block (§6.3 / aggregatorSubComponents), a separate
+                    // concept. Idempotent — set true once, never false. FAKE aggregators have
+                    // no ComponentEntity row (findByComponentKey returns null above), excluded.
                     if (!parent.canBeParent) {
                         parent.canBeParent = true
                         componentRepository.save(parent)
@@ -516,15 +526,21 @@ class ImportServiceImpl(
 
             LOG.info("§6.2 Pass 2 complete: {} ms ({} parent refs)", (System.nanoTime() - pass2Start) / 1_000_000, pendingParentByKey.size)
 
-            // §6.3 Pass 3: upsert component_groups rows and link component_group_id FKs.
-            // Runs after Pass 2 so all ComponentEntity rows are present and parentComponent FKs are resolved.
-            LOG.info("§6.3 Pass 3: linking aggregator groups for {} parent references", pendingParentByKey.size)
+            // §6.3 Pass 3: upsert component_groups rows and link component_group_id FKs from the
+            // DSL `components { }` aggregator membership (R1 — NOT the flat parentComponent graph).
+            // Runs after Pass 2 so all ComponentEntity rows are present.
+            LOG.info("§6.3 Pass 3: linking {} aggregator group(s)", fullConfig.aggregatorSubComponents.size)
             val pass3Start = System.nanoTime()
-            val pass3Failures = linkAggregatorGroups(allModules, pendingParentByKey)
+            val pass3Failures = linkAggregatorGroups(allModules, fullConfig.aggregatorSubComponents)
             LOG.info(
                 "§6.3 Pass 3 complete: {} ms ({} failures)",
                 (System.nanoTime() - pass3Start) / 1_000_000, pass3Failures.size,
             )
+            // §6.3 cleanup (re-run safety): the OLD logic grouped by flat parentComponent and could
+            // have created groups for non-aggregators (a plain parentComponent target with no
+            // components{} block). Remove any group whose key is
+            // not a current true aggregator — unlink its members and delete the orphaned row.
+            cleanupStaleGroups(fullConfig.aggregatorSubComponents.keys)
             for ((parentKey, errorMessage) in pass3Failures) {
                 failed++
                 results.add(
@@ -987,41 +1003,16 @@ class ImportServiceImpl(
     // =========================================================================
 
     /**
-     * Import a single DSL module (top-level component + its sub-components if
-     * it is an aggregator).
+     * Import a single DSL module: create its `components` row plus the
+     * `component_configurations` rows (BASE + per-version + markers). Sets only
+     * scalar / per-component fields on the entity.
      *
-     * §6.3: aggregator detection — if any config in [configs] has sub-components
-     * (detected by `EscrowModule.moduleConfigurations` containing configs with
-     * identical jira/build but different artifactIds, which is the DSL pattern),
-     * then classify as aggregator. However, sub-components are returned as
-     * separate top-level EscrowModule entries by the loader, so at this level
-     * we only handle the top-level module. The loader already flattened the
-     * sub-component tree. We detect aggregator by checking if an EscrowModule
-     * in the config map appears to be a "parent" (has sub-components registered
-     * under the same group pattern) — but the loader doesn't expose that
-     * information directly.
-     *
-     * Since the loader flattens sub-components into peer-level EscrowModules,
-     * the `componentGroup` linkage must be done via `parentComponent` field:
-     * sub-components reference their parent via `parentComponent`.
-     *
-     * Simplified aggregator detection: an EscrowModule is an aggregator (and
-     * thus should have a ComponentGroupEntity) when there exists at least one
-     * other module in the full config whose configs reference this module's name
-     * as `parentComponent` OR when the first config has `isFakeAggregator` = true
-     * with a known aggregator VCS URL pattern.
-     *
-     * For the migration pipeline, we handle group creation in Pass 2 (after all
-     * components exist) based on parentComponent linkages. A simpler approach
-     * used here: check if the DSL for this module has a `components {}` block
-     * by detecting `sub-components` in the full configuration.
-     *
-     * The loader returns all sub-components as top-level EscrowModules (peers).
-     * The `parentComponent` field on a sub-component's config points to the
-     * parent. So we DON'T need to detect aggregators at importModule time;
-     * we just save each module as a standalone ComponentEntity and wire
-     * parentComponent in Pass 2. ComponentGroupEntity is created as a follow-on
-     * step based on parentComponent graph.
+     * Relationships are resolved in LATER passes, not here:
+     *  - `parent_component_id` FK and `can_be_parent` seeding → Pass 2 (§6.2),
+     *    from the flat `parentComponent` field;
+     *  - `component_group_id` (aggregator membership) → Pass 3 (§6.3), keyed off
+     *    the DSL `components { }` block (EscrowConfiguration.aggregatorSubComponents),
+     *    NEVER the flat `parentComponent` field.
      */
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun importModule(
@@ -2080,35 +2071,35 @@ class ImportServiceImpl(
     /**
      * Pass 3 (§6.3): create `component_groups` rows and set `component_group_id` FKs.
      *
-     * Strategy: build a reverse map parentKey → [childKeys] from [pendingParentByKey], then
-     * for each aggregator parent:
-     *  1. Classify REAL vs FAKE via [isFakeAggregator] against the parent's first DSL config.
-     *  2. Upsert a [ComponentGroupEntity] (idempotent — re-runs skip existing rows).
-     *  3. Set `componentGroup` on every child component — and update it when the existing
-     *     link points at a *different* group (DSL parent changed since the last migration).
-     *  4. For a REAL aggregator: same self-link update rule.
+     * Input is [aggregatorSubComponents] (aggregatorKey → its sub-component keys), derived by
+     * the loader from DSL `components { }` blocks — NOT the flat `parentComponent` field. For
+     * each aggregator key:
+     *  1. Classify REAL vs FAKE via [isFakeAggregator] against the aggregator's first DSL config.
+     *  2. Upsert a [ComponentGroupEntity] keyed by the aggregator key (idempotent — re-runs skip
+     *     existing rows).
+     *  3. Set `componentGroup` on every sub-component — and update it when the existing link
+     *     points at a *different* group (DSL membership changed since the last migration).
+     *  4. For a REAL aggregator (non-fake): self-link the aggregator to its own group too.
      *
-     * @return per-parent failures: list of `(parentKey, errorMessage)`. Empty list on full
-     *         success. Callers should fold these into their own result aggregation so a
+     * @return per-aggregator failures: list of `(aggregatorKey, errorMessage)`. Empty list on
+     *         full success. Callers should fold these into their own result aggregation so a
      *         partial Pass 3 failure does not silently look like a fully-successful migration.
      */
     private fun linkAggregatorGroups(
         allModules: Map<String, EscrowModule>,
-        pendingParentByKey: Map<String, String>,
+        aggregatorSubComponents: Map<String, Set<String>>,
     ): List<Pair<String, String>> {
-        // Reverse the child→parent map to parent→[children]
-        val childrenByParent = mutableMapOf<String, MutableList<String>>()
-        for ((childKey, parentKey) in pendingParentByKey) {
-            childrenByParent.getOrPut(parentKey) { mutableListOf() }.add(childKey)
-        }
-
+        // R1: group membership is driven by the DSL `components { }` block
+        // (aggregatorKey → its sub-component keys), NOT the flat `parentComponent`
+        // field. `aggregatorSubComponents` is already parent→children, so no
+        // reversal is needed.
+        //
         // Aggregate per-parent failures and log a single summary at the end
         // instead of letting individual WARN lines hide a systemic issue. A
         // migration step is a one-shot batch — silent partial-success is the
-        // wrong default. Callers that need stricter behaviour can inspect the
-        // summary log or wire this list into BatchMigrationResult later.
+        // wrong default.
         val failures = mutableListOf<Pair<String, String>>()
-        for ((parentKey, childKeys) in childrenByParent) {
+        for ((parentKey, childKeys) in aggregatorSubComponents) {
             try {
                 val parentModule = allModules[parentKey]
                 if (parentModule == null) {
@@ -2170,14 +2161,53 @@ class ImportServiceImpl(
         return failures
     }
 
-    /** Upsert a [ComponentGroupEntity] by [groupKey]. Idempotent. */
+    /**
+     * Upsert a [ComponentGroupEntity] by [groupKey]. Idempotent. On a re-run the
+     * `isFake` flag is refreshed when the DSL classification flips (REAL↔FAKE), so the
+     * stored flag never goes stale. (NB: a REAL→FAKE flip also leaves the aggregator's
+     * old ComponentEntity row behind; that row-level transition is out of scope here.)
+     */
     private fun upsertComponentGroup(
         groupKey: String,
         isFake: Boolean,
     ): ComponentGroupEntity {
         val existing = componentGroupRepository.findByGroupKey(groupKey)
-        if (existing != null) return existing
+        if (existing != null) {
+            if (existing.isFake != isFake) {
+                existing.isFake = isFake
+                return componentGroupRepository.save(existing)
+            }
+            return existing
+        }
         return componentGroupRepository.save(ComponentGroupEntity(groupKey = groupKey, isFake = isFake))
+    }
+
+    /**
+     * Re-run cleanup (R1): the previous logic created a ComponentGroup for every flat
+     * `parentComponent` target, including non-aggregators (a plain parentComponent target that
+     * owns no `components { }` block). Group membership
+     * is now driven solely by `components { }` aggregators, so any EXISTING group whose key is
+     * NOT a current true aggregator ([validAggregatorKeys]) is stale: unlink its members
+     * (`componentGroup = null`) and delete the orphaned `component_groups` row. Real-aggregator
+     * groups are preserved. Operates on existing DB rows, so it runs correctly even when Pass 1
+     * skipped already-present components.
+     */
+    private fun cleanupStaleGroups(validAggregatorKeys: Set<String>) {
+        val stale = componentGroupRepository.findAll().filter { it.groupKey !in validAggregatorKeys }
+        if (stale.isEmpty()) return
+        for (group in stale) {
+            val members = group.id?.let { componentRepository.findByComponentGroupId(it) } ?: emptyList()
+            for (member in members) {
+                member.componentGroup = null
+                componentRepository.save(member)
+            }
+            componentGroupRepository.delete(group)
+            LOG.info(
+                "§6.3 cleanup: removed stale (non-aggregator) group '{}' — unlinked {} member(s)",
+                group.groupKey, members.size,
+            )
+        }
+        LOG.info("§6.3 cleanup: removed {} stale group(s)", stale.size)
     }
 
     // =========================================================================

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentCanBeParentTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentCanBeParentTest.kt
@@ -25,14 +25,19 @@ import java.nio.file.Paths
 import java.util.UUID
 
 /**
- * CRS-PR1 — `canBeParent` attribute end-to-end:
+ * `canBeParent` attribute end-to-end:
  *  - round-trips on create / detail / summary;
  *  - drives the `?canBeParent=true` list filter (parent picker);
  *  - enforces the parent invariants (chosen parent must be canBeParent; a
  *    canBeParent component may not have a parent; can't disable canBeParent
  *    while children reference it);
- *  - update derives the component group from the parent when the parent
- *    actually changes, and `clearParent` removes it.
+ *  - `clearParent` removes the parent.
+ *
+ * Group membership is NOT derived from the parent/canBeParent relationship on
+ * the API path (R1 decouple): a ComponentGroup is migration-owned aggregator
+ * membership (a DSL `components { }` owner + its sub-components), so an
+ * API-created/edited component carries a null group regardless of its parent or
+ * canBeParent flag.
  *
  * Focused integration test on the H2 `ft-db` profile — does NOT extend the
  * global Groovy fixtures (each case seeds its own uniquely-named components).
@@ -64,7 +69,11 @@ class ComponentCanBeParentTest {
 
     private fun uniqueName(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
 
-    /** POST a component; returns its id. Expects 201. */
+    /**
+     * POST a component; returns its id. Expects 201. The body still carries a `group`
+     * (backward-compat wire shape), but the API accepts-and-IGNORES it (R1: group is
+     * migration-owned), so every component created here ends up with a null group.
+     */
     private fun createComponent(
         name: String,
         canBeParent: Boolean = false,
@@ -195,12 +204,12 @@ class ComponentCanBeParentTest {
     }
 
     // -----------------------------------------------------------------------
-    // Update-side derivation + invariants
+    // Update-side invariants
     // -----------------------------------------------------------------------
 
     @Test
-    @DisplayName("update: setting a parent derives the component into the parent's group")
-    fun update_setParent_derivesGroup() {
+    @DisplayName("update: setting a parent does NOT assign a group (R1: group is migration-owned, not parent-derived)")
+    fun update_setParent_doesNotDeriveGroup() {
         val parent = createComponent(uniqueName("cbp_d_parent"), canBeParent = true)
         val parentName = getJson(parent)["name"].asText()
         val child = createComponent(uniqueName("cbp_d_child"))
@@ -212,12 +221,11 @@ class ComponentCanBeParentTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"version":${version(child)},"parentComponentName":"$parentName"}"""),
             ).andExpect(status().isOk)
-
-        val childGroup = getJson(child)["group"]["groupKey"].asText()
-        val parentGroup = getJson(parent)["group"]["groupKey"].asText()
-        assert(childGroup == parentGroup) {
-            "expected child to join the parent's group; child=$childGroup parent=$parentGroup"
-        }
+            .andExpect(jsonPath("$.parentComponentName").value(parentName))
+            // The flat parentComponent reference does NOT make the child a group
+            // member — group membership comes only from DSL `components { }`
+            // aggregators via migration. The child's group stays null.
+            .andExpect(jsonPath("$.group").isEmpty)
     }
 
     @Test
@@ -237,7 +245,7 @@ class ComponentCanBeParentTest {
     }
 
     @Test
-    @DisplayName("update: clearParent removes the parent but PRESERVES the existing group")
+    @DisplayName("update: clearParent removes the parent (group is unaffected — it was never parent-derived)")
     fun update_clearParent_removesParent() {
         val parent = createComponent(uniqueName("cbp_c_parent"), canBeParent = true)
         val parentName = getJson(parent)["name"].asText()
@@ -251,12 +259,9 @@ class ComponentCanBeParentTest {
                     .content("""{"version":${version(child)},"clearParent":true}"""),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.parentComponentName").doesNotExist())
-            // Clearing the parent must not STRIP the group (every component must
-            // belong to a group). The child joined the parent's group on create
-            // (schema-v2 derivation), so after clearParent it retains that derived
-            // group — the parent's own key — rather than the originally-requested
-            // org.example.test.
-            .andExpect(jsonPath("$.group.groupKey").value(parentName))
+            // R1: the child never had a parent-derived group (the API doesn't
+            // assign groups), so clearing the parent leaves the group null.
+            .andExpect(jsonPath("$.group").isEmpty)
     }
 
     @Test
@@ -278,34 +283,30 @@ class ComponentCanBeParentTest {
     }
 
     // -----------------------------------------------------------------------
-    // Aggregator group keyed by own componentKey (create + promote)
+    // R1: the API never assigns a ComponentGroup (group = migration-owned
+    // aggregator membership, decoupled from canBeParent / parentComponent)
     // -----------------------------------------------------------------------
 
     @Test
-    @DisplayName("create: an aggregator (canBeParent=true) gets its OWN-key group, not the requested group")
-    fun create_aggregator_ownKeyGroup() {
+    @DisplayName("create: a canBeParent component gets NO group via the API (group is null)")
+    fun create_canBeParent_noGroupAssigned() {
         val name = uniqueName("cbp_create_agg")
         val id = createComponent(name, canBeParent = true)
-        // The create helper requests group org.example.test, but an aggregator's
-        // group is keyed by its own componentKey so children inherit the aggregator
-        // key — not the (legacy) requested groupKey.
-        assert(getJson(id)["group"]["groupKey"].asText() == name) {
-            "expected aggregator group to equal its own key '$name', got " +
-                getJson(id)["group"]["groupKey"].asText()
+        // The create helper requests a group, but the API ignores it and does NOT
+        // derive one from canBeParent — only DSL `components { }` migration creates
+        // groups. So the response carries a null group.
+        val group = getJson(id)["group"]
+        assert(group == null || group.isNull) {
+            "expected null group for an API-created canBeParent component; got $group"
         }
     }
 
     @Test
-    @DisplayName("update: promoting a plain component to canBeParent re-keys its group to its own key; a child then inherits it")
-    fun update_promoteToCanBeParent_reKeysGroup_childInherits() {
-        // Plain component created with the legacy request.group org.example.test.
+    @DisplayName("update: promoting a plain component to canBeParent does NOT assign a group")
+    fun update_promoteToCanBeParent_noGroupAssigned() {
         val aggregator = createComponent(uniqueName("cbp_promote"))
-        val aggregatorName = getJson(aggregator)["name"].asText()
-        assert(getJson(aggregator)["group"]["groupKey"].asText() == "org.example.test") {
-            "precondition: plain component should carry the requested group"
-        }
-
-        // Promote to canBeParent — the group must re-derive to the aggregator's own key.
+        // Promote to canBeParent — no group should be derived (the API never
+        // assigns aggregator membership).
         mvc
             .perform(
                 patch("/rest/api/4/components/$aggregator")
@@ -313,18 +314,6 @@ class ComponentCanBeParentTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"version":${version(aggregator)},"canBeParent":true}"""),
             ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.group.groupKey").value(aggregatorName))
-
-        // A child assigned afterwards inherits the aggregator's OWN-key group — not
-        // the legacy org.example.test it would have inherited before the fix.
-        val child = createComponent(uniqueName("cbp_promote_child"))
-        mvc
-            .perform(
-                patch("/rest/api/4/components/$child")
-                    .with(adminJwt())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"version":${version(child)},"parentComponentName":"$aggregatorName"}"""),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.group.groupKey").value(aggregatorName))
+            .andExpect(jsonPath("$.group").isEmpty)
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentGroupEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.octopusden.octopus.components.registry.server.support.viewerJwt
 import org.springframework.beans.factory.annotation.Autowired
@@ -49,6 +52,14 @@ class ListComponentsExtendedFiltersTest {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    // R1: a ComponentGroup is migration-owned, never assigned via the API, so the
+    // `?groupKey=` filter test seeds the group + link directly through the repos.
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var componentGroupRepository: ComponentGroupRepository
 
     init {
         val testResourcesPath =
@@ -165,13 +176,18 @@ class ListComponentsExtendedFiltersTest {
     fun groupKeyFilter() {
         val unique = uniqueName("grp")
         val inGroup = uniqueName("ext_g_in")
-        create(
-            """{"name":"$inGroup","displayName":"$inGroup",""" +
-                """"group":{"groupKey":"org.example.$unique","isFake":false},""" +
-                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
-        )
+        // Create via the API (valid component, null group), then attach the group
+        // directly: groups are migration-owned aggregator membership and the API
+        // never assigns one (R1). This still exercises the `?groupKey=` JOIN.
+        create(baseBody(inGroup))
         val other = uniqueName("ext_g_other")
         create(baseBody(other))
+        val group =
+            componentGroupRepository.save(ComponentGroupEntity(groupKey = "org.example.$unique", isFake = false))
+        val entity = componentRepository.findByComponentKey(inGroup)!!
+        entity.componentGroup = group
+        componentRepository.save(entity)
+
         val n = names("groupKey" to unique)
         assert(n.contains(inGroup)) { "expected $inGroup in $n" }
         assert(!n.contains(other)) { "did not expect $other in $n" }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
@@ -27,22 +27,23 @@ import java.nio.file.Paths
 import java.util.UUID
 
 /**
- * Strict-contract validation introduced by the UI-swift-sloth iteration.
+ * Strict-contract validation for the v4 component create/update API.
  *
- * The Portal's Create Component flow now requires `group` and
- * `baseConfiguration.build.buildSystem` (frontend UX). The server is the
- * source of truth: it MUST reject create payloads missing either field with
- * 400 so a misbehaving client cannot land an under-specified component.
+ * The only hard CREATE requirement is `baseConfiguration.build.buildSystem`:
+ * a component cannot exist without a build system on its BASE configuration
+ * row. The server is the source of truth and rejects a create payload missing
+ * it with 400.
  *
- * On PATCH, semantics differ:
- *  - `group: null` continues to mean "don't touch" (Jackson cannot
- *    distinguish field-absent from explicit-null without a presence-preserving
- *    DTO, and every untouched-group PATCH today carries `group == null`).
- *  - `clearGroup: true` becomes invalid because there is no path for a
- *    component to legitimately exist without a group. Service rejects with 400.
- *  - `clearGroup: false` (explicit) with no `group` key is the canonical
- *    no-op shape the Portal sends when the group field is untouched —
- *    must remain 2xx and not modify the existing group.
+ * **`group` is NOT a hard requirement and is NOT assigned via the API**
+ * (R1 aggregator/parentComponent decouple). A ComponentGroup represents DSL
+ * aggregator membership (a `components { }` owner + its sub-components) and is
+ * established only by the migration/import path. On the API:
+ *  - CREATE: a missing `group` is valid → `componentGroup = null`; a provided
+ *    `group` is accepted but IGNORED (creating via the API does not make a
+ *    component an aggregator).
+ *  - PATCH: `group` is never touched — a provided `group` is ignored, and
+ *    `clearGroup` (true or false) is an accepted no-op (both kept on the wire
+ *    for backward compatibility).
  *
  * `baseConfiguration.build.buildSystem` may be omitted from PATCH (PATCH
  * cannot blank an already-set scalar via "field absent"; the BASE row is
@@ -96,12 +97,11 @@ class StrictContractTest {
         """.trimIndent()
 
     @Test
-    @DisplayName("CREATE returns 400 when 'group' is missing")
-    fun create_rejects_missingGroup() {
-        // The @DisplayName lists 400 status; the error message naming `group`
-        // is also part of the contract (the frontend / non-UI clients rely
-        // on the field name being mentioned). Asserting both pins the
-        // contract surface.
+    @DisplayName("CREATE accepts a payload with no 'group' (group is optional; not assigned via API) → 2xx, null group")
+    fun create_accepts_missingGroup() {
+        // R1: group is migration-derived aggregator membership, not a required
+        // create field. A component created via the API with no group is a
+        // valid standalone component whose `group` is null in the response.
         val body =
             """
             {
@@ -110,8 +110,27 @@ class StrictContractTest {
             }
             """.trimIndent()
         postCreate(body)
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("group")))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.group").isEmpty)
+    }
+
+    @Test
+    @DisplayName("CREATE accepts but IGNORES a provided 'group' (API does not assign aggregator membership) → 2xx, null group")
+    fun create_ignoresProvidedGroup() {
+        // A client may still send a `group` (backward-compat wire shape); the
+        // server accepts the payload but does not persist it — group membership
+        // is owned by the migration/import path, never assigned via the API.
+        val body =
+            """
+            {
+              "name": "${unique("strict-ignored-group")}",
+              "group": {"groupKey": "org.example.ignored", "isFake": false},
+              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
+            }
+            """.trimIndent()
+        postCreate(body)
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.group").isEmpty)
     }
 
     @Test
@@ -156,22 +175,6 @@ class StrictContractTest {
     }
 
     @Test
-    @DisplayName("CREATE returns 400 when group.groupKey is blank (whitespace-only)")
-    fun create_rejects_blankGroupKey() {
-        val body =
-            """
-            {
-              "name": "${unique("strict-blank-grp")}",
-              "group": {"groupKey": "  ", "isFake": false},
-              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
-            }
-            """.trimIndent()
-        postCreate(body)
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("groupKey")))
-    }
-
-    @Test
     @DisplayName("CREATE accepts payload with required fields present (2xx)")
     fun create_accepts_fullyValidPayload() {
         val body = validCreateBody(unique("strict-valid"))
@@ -179,9 +182,12 @@ class StrictContractTest {
     }
 
     @Test
-    @DisplayName("PATCH with {clearGroup: true} returns 400")
-    fun patch_rejects_clearGroupTrue() {
-        // Seed a component with the required fields.
+    @DisplayName("PATCH with {clearGroup: true} is an accepted no-op (2xx) — group is migration-owned, never API-cleared")
+    fun patch_clearGroupTrue_isAcceptedNoOp() {
+        // R1: clearGroup is kept on the wire for backward compatibility but is a
+        // no-op on the API path — the group is migration-derived aggregator
+        // membership and is never mutated by an update. An API-created component
+        // has a null group; clearGroup:true leaves it null and returns 2xx.
         val name = unique("strict-patch-clear")
         val seedResponse =
             postCreate(validCreateBody(name)).andExpect(status().isCreated)
@@ -196,69 +202,16 @@ class StrictContractTest {
                 .with(adminJwt())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(patchBody),
-        ).andExpect(status().isBadRequest)
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.group").isEmpty)
     }
 
     @Test
-    @DisplayName("PATCH with {clearGroup: false, version: N} (no group key) is a no-op and preserves the existing group")
-    fun patch_noOp_clearGroupFalse_preservesGroup() {
-        // The Portal sends {clearGroup: false, version: N, ...} on every save where
-        // the group field was not touched (see buildUpdateRequest.ts). This shape
-        // must remain a 2xx that does NOT modify the existing group.
-        val groupKey = "org.example.preserve.${UUID.randomUUID().toString().take(6)}"
-        val name = unique("strict-patch-noop")
-        val seedResponse =
-            postCreate(validCreateBody(name, groupKey = groupKey)).andExpect(status().isCreated)
-                .andReturn().response.contentAsString
-        val seed = objectMapper.readTree(seedResponse)
-        val id = seed["id"].asText()
-        val versionLock = seed["version"].asLong()
-
-        val patchBody = """{"version": $versionLock, "clearGroup": false}"""
-        val patched =
-            mvc.perform(
-                patch("/rest/api/4/components/$id")
-                    .with(adminJwt())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(patchBody),
-            ).andExpect(status().isOk)
-                .andExpect(jsonPath("$.group.groupKey").value(groupKey))
-                .andReturn().response.contentAsString
-        // Sanity: the response still carries the original group.
-        val groupAfter = objectMapper.readTree(patched)["group"]
-        assert(groupAfter != null && groupAfter["groupKey"].asText() == groupKey) {
-            "expected group preserved with groupKey='$groupKey'; got $groupAfter"
-        }
-    }
-
-    @Test
-    @DisplayName("PATCH with {group: {groupKey: \"  \"}} returns 400 (blank groupKey rejected on update path)")
-    fun patch_rejects_blankGroupKey() {
-        // Mirrors the create-side blank-groupKey rejection: PATCH must NOT
-        // be allowed to overwrite an existing component with a whitespace
-        // groupKey via `upsertGroup` (component_groups.group_key has only
-        // NOT NULL + UNIQUE at the DB layer — no blank check there).
-        val name = unique("strict-patch-blank-grp")
-        val seedResponse =
-            postCreate(validCreateBody(name)).andExpect(status().isCreated)
-                .andReturn().response.contentAsString
-        val seed = objectMapper.readTree(seedResponse)
-        val id = seed["id"].asText()
-        val versionLock = seed["version"].asLong()
-
-        val patchBody =
-            """{"version": $versionLock, "clearGroup": false, "group": {"groupKey": "  ", "isFake": false}}"""
-        mvc.perform(
-            patch("/rest/api/4/components/$id")
-                .with(adminJwt())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(patchBody),
-        ).andExpect(status().isBadRequest)
-    }
-
-    @Test
-    @DisplayName("PATCH with new {group: {...}} updates the group (2xx)")
-    fun patch_accepts_newGroup() {
+    @DisplayName("PATCH IGNORES a provided {group: {...}} (2xx, group unchanged) — group is migration-owned, not API-editable")
+    fun patch_ignoresProvidedGroup() {
+        // A provided `group` on PATCH is accepted but not persisted. The seeded
+        // component has a null group (API create never assigns one); after a
+        // PATCH carrying a group it is still null.
         val name = unique("strict-patch-newgrp")
         val seedResponse =
             postCreate(validCreateBody(name)).andExpect(status().isCreated)
@@ -276,200 +229,7 @@ class StrictContractTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(patchBody),
         ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.group.groupKey").value(newKey))
-    }
-
-    // -------------------------------------------------------------------
-    // Prefix validation against configHelper.supportedGroupIds()
-    //
-    // Frontend already validates against `GET /rest/api/2/common/supported-groups`,
-    // but a non-UI client (CLI, automation) could submit any prefix the
-    // frontend never would. The server is the source of truth and must
-    // reject prefixes that aren't in `components-registry.supportedGroupIds`.
-    //
-    // Test config (`application-common.yml`) sets the allowed list to
-    // `org.octopusden.octopus,io.bcomponent,org.example` — so any other
-    // prefix must produce a 400. Rejection-case fixtures use
-    // `com.someoneelse.*` (RFC 2606-style placeholder, deliberately NOT
-    // in the test allowed list).
-    // -------------------------------------------------------------------
-
-    @Test
-    @DisplayName("CREATE returns 400 when groupKey is outside the configured supportedGroupIds")
-    fun create_rejects_disallowed_groupId_prefix() {
-        val body =
-            """
-            {
-              "name": "${unique("strict-bad-prefix")}",
-              "group": {"groupKey": "com.someoneelse.legacy", "isFake": false},
-              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
-            }
-            """.trimIndent()
-        postCreate(body)
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("supportedGroupIds")))
-    }
-
-    @Test
-    @DisplayName("CREATE rejects 'org.exampleextra.foo' even though 'org.example' is an allowed prefix (no fuzzy prefix matching)")
-    fun create_rejects_prefix_with_extra_letters() {
-        // Specifically guards against `startsWith(prefix)` without a `.` separator,
-        // which would let allowed=`org.example` match `org.exampleextra.foo`. The
-        // validator must require an exact match OR `prefix + "."` — the test
-        // input `org.exampleextra.foo` starts with the allowed `org.example`
-        // characters but on a non-`.` boundary, so it must be rejected.
-        val body =
-            """
-            {
-              "name": "${unique("strict-fuzzy-prefix")}",
-              "group": {"groupKey": "org.exampleextra.foo", "isFake": false},
-              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
-            }
-            """.trimIndent()
-        postCreate(body)
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("supportedGroupIds")))
-    }
-
-    @Test
-    @DisplayName("CREATE accepts a groupKey whose entire value equals one of the supported prefixes")
-    fun create_accepts_exact_prefix_match() {
-        // `groupKey == prefix` (no trailing segments) must be accepted —
-        // not just `prefix + "."` form. Mirrors the frontend's
-        // `useSupportedGroups` check: `v === lp || v.startsWith(lp + '.')`.
-        val body =
-            """
-            {
-              "name": "${unique("strict-exact-prefix")}",
-              "group": {"groupKey": "org.example", "isFake": false},
-              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
-            }
-            """.trimIndent()
-        // 201 (Created) specifically — the rest of the create-success
-        // cases in this file use `isCreated`; keep the assertion
-        // consistent so an accidental 200 regression would surface.
-        postCreate(body).andExpect(status().isCreated)
-    }
-
-    @Test
-    @DisplayName("CREATE accepts an upper-case groupKey when the allowed prefix matches case-insensitively (case is preserved on storage)")
-    fun create_accepts_uppercased_groupId_when_allowed_prefix_matches_case_insensitively() {
-        // Frontend (CreateComponentDialog.tsx / GeneralTab.tsx) lowercases
-        // both sides before comparing the user-typed groupId against the
-        // supportedGroupIds list. Without the same case-insensitive compare
-        // on the CRS side, a user who types `ORG.EXAMPLE.test` passes the
-        // portal pre-check (lowercased to `org.example.test` which matches
-        // `org.example`) and then sees a 400 from the server — confusing UX.
-        // This test pins the case-insensitive match. Additionally,
-        // case must be PRESERVED on storage: the persisted groupKey is
-        // exactly what the user typed (`ORG.EXAMPLE.test`), not the
-        // lowercased form (we don't want silent renaming).
-        val typedKey = "ORG.EXAMPLE.test.${UUID.randomUUID().toString().take(6)}"
-        val body =
-            """
-            {
-              "name": "${unique("strict-case-insensitive-create")}",
-              "group": {"groupKey": "$typedKey", "isFake": false},
-              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
-            }
-            """.trimIndent()
-        val created =
-            postCreate(body).andExpect(status().isCreated)
-                .andReturn().response.contentAsString
-        val persistedKey = objectMapper.readTree(created)["group"]["groupKey"].asText()
-        assert(persistedKey == typedKey) {
-            "expected user-typed case to be preserved on storage; typed='$typedKey', got='$persistedKey'"
-        }
-    }
-
-    @Test
-    @DisplayName("PATCH accepts an upper-case groupKey when the allowed prefix matches case-insensitively (case is preserved on storage)")
-    fun patch_accepts_uppercased_groupId_when_allowed_prefix_matches_case_insensitively() {
-        val name = unique("strict-case-insensitive-patch")
-        val seedResponse =
-            postCreate(validCreateBody(name)).andExpect(status().isCreated)
-                .andReturn().response.contentAsString
-        val seed = objectMapper.readTree(seedResponse)
-        val id = seed["id"].asText()
-        val versionLock = seed["version"].asLong()
-
-        val typedKey = "ORG.EXAMPLE.other.${UUID.randomUUID().toString().take(6)}"
-        val patchBody =
-            """{"version": $versionLock, "clearGroup": false, "group": {"groupKey": "$typedKey", "isFake": false}}"""
-        val patched =
-            mvc.perform(
-                patch("/rest/api/4/components/$id")
-                    .with(adminJwt())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(patchBody),
-            ).andExpect(status().isOk)
-                .andExpect(jsonPath("$.group.groupKey").value(typedKey))
-                .andReturn().response.contentAsString
-        val persistedKey = objectMapper.readTree(patched)["group"]["groupKey"].asText()
-        assert(persistedKey == typedKey) {
-            "expected user-typed case to be preserved on storage; typed='$typedKey', got='$persistedKey'"
-        }
-    }
-
-    @Test
-    @DisplayName("PATCH returns 400 when the new groupKey is outside supportedGroupIds")
-    fun patch_rejects_disallowed_groupId_prefix() {
-        val name = unique("strict-patch-bad-prefix")
-        val seedResponse =
-            postCreate(validCreateBody(name)).andExpect(status().isCreated)
-                .andReturn().response.contentAsString
-        val seed = objectMapper.readTree(seedResponse)
-        val id = seed["id"].asText()
-        val versionLock = seed["version"].asLong()
-
-        val patchBody =
-            """{"version": $versionLock, "clearGroup": false, "group": {"groupKey": "com.someoneelse.legacy", "isFake": false}}"""
-        mvc.perform(
-            patch("/rest/api/4/components/$id")
-                .with(adminJwt())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(patchBody),
-        )
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errorMessage", org.hamcrest.Matchers.containsString("supportedGroupIds")))
-    }
-
-    // -------------------------------------------------------------------
-    // groupKey whitespace normalisation (Copilot review)
-    //
-    // `isNotBlank()` accepts `"org.example.test "` with trailing whitespace.
-    // Without trimming on the way in, `component_groups.group_key` UNIQUE
-    // would persist a distinct row from the canonical `"org.example.test"` —
-    // the kind of duplication that breaks aggregator queries silently.
-    // The fix is to trim the incoming key and use the trimmed form for
-    // both validation and persistence. CREATE and PATCH share the
-    // semantic.
-    // -------------------------------------------------------------------
-
-    @Test
-    @DisplayName("CREATE trims whitespace around groupKey before validating and persisting")
-    fun create_normalises_groupKey_whitespace() {
-        val name = unique("strict-create-trim")
-        val body =
-            """
-            {
-              "name": "$name",
-              "group": {"groupKey": "  org.example.trim.${UUID.randomUUID().toString().take(6)}  ", "isFake": false},
-              "baseConfiguration": {"build": {"buildSystem": "MAVEN"}}
-            }
-            """.trimIndent()
-        val created =
-            postCreate(body).andExpect(status().isCreated).andReturn().response.contentAsString
-        val groupKey = objectMapper.readTree(created)["group"]["groupKey"].asText()
-        // Asserts trimming applied: the persisted key has no leading/trailing
-        // whitespace. The leading/trailing-trim cases are both covered by the
-        // single quoted-whitespace input above.
-        assert(groupKey == groupKey.trim()) {
-            "expected persisted groupKey to be trimmed; got '$groupKey'"
-        }
-        assert(groupKey.startsWith("org.example.trim.")) {
-            "expected the canonical (trimmed) prefix to survive; got '$groupKey'"
-        }
+            .andExpect(jsonPath("$.group").isEmpty)
     }
 
     // -------------------------------------------------------------------
@@ -572,35 +332,6 @@ class StrictContractTest {
         }
     }
 
-    @Test
-    @DisplayName("PATCH trims whitespace around groupKey before validating and persisting")
-    fun patch_normalises_groupKey_whitespace() {
-        val name = unique("strict-patch-trim")
-        val seedResponse =
-            postCreate(validCreateBody(name)).andExpect(status().isCreated)
-                .andReturn().response.contentAsString
-        val seed = objectMapper.readTree(seedResponse)
-        val id = seed["id"].asText()
-        val versionLock = seed["version"].asLong()
-
-        val newKey = "org.example.patchtrim.${UUID.randomUUID().toString().take(6)}"
-        val patchBody =
-            """{"version": $versionLock, "clearGroup": false, "group": {"groupKey": "  $newKey  ", "isFake": false}}"""
-        val patched =
-            mvc.perform(
-                patch("/rest/api/4/components/$id")
-                    .with(adminJwt())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(patchBody),
-            ).andExpect(status().isOk)
-                .andExpect(jsonPath("$.group.groupKey").value(newKey))
-                .andReturn().response.contentAsString
-        val persistedKey = objectMapper.readTree(patched)["group"]["groupKey"].asText()
-        assert(persistedKey == newKey) {
-            "expected PATCH to persist trimmed key '$newKey'; got '$persistedKey'"
-        }
-    }
-
     // -------------------------------------------------------------------
     // Single-value `system` field (M:N → 1:0..1 collapse).
     //
@@ -622,8 +353,7 @@ class StrictContractTest {
         // The test profile sets `components-registry.supportedSystems:
         // NONE,CLASSIC,ALFA` in `application-common.yml`. Service-layer
         // validation gates the `system` field against that env-config
-        // allowlist (mirrors the analogous `supportedGroupIds` gate for
-        // `groupKey`); the master `systems` row is auto-created by
+        // allowlist; the master `systems` row is auto-created by
         // `ensureSystemExists` so the FK from `components.system_code →
         // systems(code)` is always satisfied — no explicit per-test
         // master-table seeding required. `CLASSIC` is the one we use
@@ -746,8 +476,8 @@ class StrictContractTest {
     fun create_normalises_system_casing_to_config() {
         // The env config (`application-common.yml`) declares
         // `supportedSystems: NONE,CLASSIC,ALFA` — all upper-case. The
-        // validator is case-insensitive on the config path (mirrors
-        // validateGroupKeyPrefix's leniency), but it must persist the
+        // validator is case-insensitive on the config path (a caller posting
+        // `Classic` should not be rejected), but it must persist the
         // CANONICAL form so the master `systems` table doesn't accumulate
         // duplicate rows `("CLASSIC")` and `("Classic")` (PK is
         // case-sensitive). Without canonical storage, `?system=CLASSIC`

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
@@ -69,12 +69,14 @@ class V4WriteValidationTest {
             )
 
     /**
-     * Minimal valid create body that satisfies the UI-swift-sloth strict
-     * contract: every component must provide `group.groupKey` and
-     * `baseConfiguration.build.buildSystem`. Tests that previously seeded
-     * with `{"name": "..."}` or `{"name": "...", "baseConfiguration": {}}`
-     * now route through this helper so the field-override / PATCH cases
-     * that follow can run against a real saved component.
+     * Minimal valid create body. The only hard create requirement is
+     * `baseConfiguration.build.buildSystem`. A `group` is included for
+     * backward-compat coverage but is accepted-and-ignored by the API (R1:
+     * group is migration-owned aggregator membership, never assigned via the
+     * API). Tests that previously seeded with `{"name": "..."}` or
+     * `{"name": "...", "baseConfiguration": {}}` route through this helper so
+     * the field-override / PATCH cases that follow run against a real saved
+     * component.
      */
     private fun validSeedBody(name: String): String =
         """{"name": "$name",""" +

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentGroupEntity
 import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
@@ -19,6 +21,7 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentRep
 import org.octopusden.octopus.components.registry.server.repository.LabelRepository
 import org.octopusden.octopus.components.registry.server.repository.SystemRepository
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -69,6 +72,9 @@ class MigrationIntegrationTest {
 
     @Autowired
     private lateinit var labelRepository: LabelRepository
+
+    @Autowired
+    private lateinit var importService: ImportService
 
     init {
         val testResourcesPath =
@@ -522,6 +528,102 @@ class MigrationIntegrationTest {
             versionsApi.componentGroup!!.id,
             "versions-api.componentGroup must reference the TESTONE group",
         )
+    }
+
+    // =========================================================================
+    // R1 §6.3 cleanup-on-rerun: the OLD importer grouped by flat parentComponent
+    // and could leave a ComponentGroup for a non-aggregator (a plain parentComponent
+    // target with no components{} block).
+    // A re-migration must remove any group whose key is NOT a current true
+    // aggregator (a `components { }` owner) — unlinking its members — while
+    // PRESERVING real-aggregator groups (TESTONE / TEST_AGGREGATOR_FAKE).
+    // =========================================================================
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "MIG-R1/§6.3: re-migration deletes a stale (non-aggregator) group and unlinks its members, " +
+            "but preserves the real-aggregator groups",
+    )
+    fun migR1_rerunRemovesStaleGroupsButPreservesAggregators() {
+        // Seed a stale group whose key is NOT any DSL aggregator, plus a victim
+        // component linked to it (mimicking a leftover from the old flat-parent
+        // grouping). The victim is not in the DSL, so re-migration ignores it
+        // except for the cleanup unlink.
+        val staleKey = "org.example.STALE_FLAT_PARENT_GROUP"
+        val staleGroup = componentGroupRepository.save(ComponentGroupEntity(groupKey = staleKey, isFake = false))
+        val victim = componentRepository.save(ComponentEntity(componentKey = "stale-cleanup-victim"))
+        victim.componentGroup = staleGroup
+        componentRepository.save(victim)
+
+        // Real-aggregator groups created at startup must exist beforehand.
+        val testoneIdBefore = componentGroupRepository.findByGroupKey("TESTONE")?.id
+        val fakeIdBefore = componentGroupRepository.findByGroupKey("TEST_AGGREGATOR_FAKE")?.id
+        assertNotNull(testoneIdBefore, "precondition: TESTONE group must exist from the initial migration")
+        assertNotNull(fakeIdBefore, "precondition: TEST_AGGREGATOR_FAKE group must exist from the initial migration")
+        assertNotNull(
+            componentRepository.findByComponentKey("stale-cleanup-victim")?.componentGroup,
+            "precondition: victim must carry the stale group before re-migration (else the test is vacuous)",
+        )
+
+        // Re-run the full batch migration (idempotent) — Pass 3 + cleanup run.
+        importService.migrateAllComponents()
+
+        // The stale group is gone and its member is unlinked.
+        assertNull(
+            componentGroupRepository.findByGroupKey(staleKey),
+            "stale non-aggregator group '$staleKey' must be removed on re-migration",
+        )
+        val victimAfter = componentRepository.findByComponentKey("stale-cleanup-victim")
+        assertNotNull(victimAfter, "victim component must still exist (cleanup unlinks, does not delete members)")
+        assertNull(
+            victimAfter!!.componentGroup,
+            "victim's componentGroup must be cleared when its stale group is removed",
+        )
+
+        // Real-aggregator groups are preserved (same rows, idempotent upsert).
+        assertEquals(
+            testoneIdBefore,
+            componentGroupRepository.findByGroupKey("TESTONE")?.id,
+            "REAL aggregator group TESTONE must be preserved across re-migration",
+        )
+        assertEquals(
+            fakeIdBefore,
+            componentGroupRepository.findByGroupKey("TEST_AGGREGATOR_FAKE")?.id,
+            "FAKE aggregator group TEST_AGGREGATOR_FAKE must be preserved across re-migration",
+        )
+    }
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "MIG-R1/§6.3: re-migration refreshes a stale component_groups.is_fake flag (REAL aggregator " +
+            "wrongly stored as fake is corrected back to is_fake=false)",
+    )
+    fun migR1_rerunRefreshesStaleIsFakeFlag() {
+        // TESTONE is a REAL aggregator (real VCS + non-stub artifactId) → is_fake=false
+        // from the initial migration. Simulate a stale flag (e.g. left by an older import
+        // or a transient mis-classification) by flipping it to true in the DB, then re-run
+        // the migration: upsertComponentGroup must refresh the flag back to the DSL-correct
+        // value (false), keeping the SAME group row (not a delete+recreate).
+        val before = componentGroupRepository.findByGroupKey("TESTONE")
+        assertNotNull(before, "precondition: TESTONE group must exist from the initial migration")
+        assertFalse(before!!.isFake, "precondition: TESTONE is a REAL aggregator (is_fake=false)")
+        val groupIdBefore = before.id
+
+        before.isFake = true
+        componentGroupRepository.save(before)
+        assertTrue(
+            componentGroupRepository.findByGroupKey("TESTONE")!!.isFake,
+            "precondition: stale is_fake=true must be persisted before re-migration",
+        )
+
+        importService.migrateAllComponents()
+
+        val after = componentGroupRepository.findByGroupKey("TESTONE")
+        assertNotNull(after, "TESTONE group must still exist after re-migration")
+        assertFalse(after!!.isFake, "re-migration must refresh the stale flag back to is_fake=false")
+        assertEquals(groupIdBefore, after.id, "the group row must be refreshed in place, not recreated")
     }
 
     // =========================================================================

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
@@ -22,7 +22,6 @@ import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
-import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
@@ -80,7 +79,6 @@ class MIG047FieldOverrideWriteGuardTest {
             ComponentManagementServiceImpl(
                 componentRepository = componentRepository,
                 configurationRepository = configurationRepository,
-                componentGroupRepository = mock(ComponentGroupRepository::class.java),
                 componentLabelRepository = mock(ComponentLabelRepository::class.java),
                 componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
                 componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -553,6 +553,9 @@ class TeamcitySyncServiceTest {
         override fun existsByParentComponentId(parentId: UUID): Boolean =
             components.any { it.parentComponent?.id == parentId }
 
+        override fun findByComponentGroupId(groupId: UUID): List<ComponentEntity> =
+            components.filter { it.componentGroup?.id == groupId }
+
         override fun <S : ComponentEntity> save(entity: S): S = entity
         override fun <S : ComponentEntity> saveAll(entities: Iterable<S>): List<S> = unsupported()
         override fun <S : ComponentEntity> saveAndFlush(entity: S): S = entity

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -125,8 +125,8 @@ Identity + fields that never vary per version range.
 | `archived` | BOOLEAN | NOT NULL DEFAULT false | |
 | `solution` | BOOLEAN | nullable | |
 | `parent_component_id` | UUID | FK → components(id) | DSL `parentComponent = "X"` reference between peers |
-| `can_be_parent` | BOOLEAN | NOT NULL DEFAULT false | True when referenced as a `parentComponent` by ≥1 other component (an aggregator parent). Seeded by import (Pass 2 sets `true` for DSL-referenced parents, never `false`) and editable via v4. Service invariants: a chosen parent must be `can_be_parent`; a `can_be_parent` component may not have a parent (a parent cannot have a parent); `can_be_parent` may not be disabled while children still reference it. Grandfathered parent-of-parent rows are tolerated on no-op updates. The `?canBeParent=true` list filter backs the Portal parent picker. |
-| `component_group_id` | UUID | FK → component_groups(id) | Aggregator membership. Schema-nullable (FK), but the v4 service layer (`ComponentManagementServiceImpl.createComponent`) rejects payloads missing `group` with 400 — every newly-created component must belong to a group. PATCH semantics: `group == null` continues to mean "don't touch" (Jackson cannot distinguish absent-from-explicit-null without a presence-preserving DTO); `clearGroup: true` is rejected with 400. On UPDATE, when `parentComponentName` changes (or `clearParent` is set), the v4 service re-derives `component_group_id` from the parent relationship (child → parent's group, upserting one keyed by the parent's `component_key` if the parent had none; aggregator → its own group keyed by `component_key`; standalone → preserves its existing group, since every component must belong to a group), and preserves the existing group on a no-op so grandfathered parent-of-parent rows are never corrupted. |
+| `can_be_parent` | BOOLEAN | NOT NULL DEFAULT false | True when referenced as a `parentComponent` by ≥1 other component — i.e. eligible to be selected as a parent in the Portal picker. **NOT the same as an aggregator:** being a `parentComponent` target is a flat peer reference, whereas an aggregator owns a `components { }` block (§4.3); the two are independent. Seeded by import (Pass 2 sets `true` for DSL-referenced parents, never `false`) and editable via v4. Service invariants: a chosen parent must be `can_be_parent`; a `can_be_parent` component may not have a parent (single-level — a parent cannot have a parent, matching the DSL validator); `can_be_parent` may not be disabled while children still reference it. Grandfathered parent-of-parent rows are tolerated on no-op updates. The `?canBeParent=true` list filter backs the Portal parent picker. |
+| `component_group_id` | UUID | FK → component_groups(id) | Aggregator membership — the group of the DSL `components { }` aggregator this component belongs to (§4.3). `NULL` = standalone (not part of any aggregator). Established **only by the migration/import path** (Pass 3, §6.3); it is keyed off DSL `components { }` membership, NOT the flat `parent_component_id` / `can_be_parent` relationship — being referenced as someone's `parentComponent` does NOT create a group. The v4 service layer does **NOT** assign or derive a group: CREATE ignores any `group` in the payload (an API-created component is standalone → `component_group_id = NULL`), and PATCH never touches it — a provided `group` is accepted-and-ignored and `clearGroup` (true or false) is an accepted no-op (both kept on the wire for backward compatibility). A `group == null` PATCH always meant "don't touch"; now a non-null one means the same. |
 | `copyright` | TEXT | nullable | |
 | `releases_in_default_branch` | BOOLEAN | nullable | |
 | `jira_display_name` | VARCHAR(255) | nullable | jira.displayName — never varies per version per audit |
@@ -134,7 +134,7 @@ Identity + fields that never vary per version range.
 | `vcs_external_registry` | TEXT | nullable | vcsSettings.externalRegistry — per-component (audit assertion enforced at migration) |
 | `distribution_explicit` | BOOLEAN | nullable | |
 | `distribution_external` | BOOLEAN | nullable | |
-| `system_code` | VARCHAR(50) | nullable, FK → systems(code) | Single-value system assignment (a component belongs to at most one system). Collapsed from the M:N junction `component_systems` in the post-#299 follow-up. Schema-nullable; service-layer validates non-null values against the env-config `components-registry.supportedSystems` allowlist on CREATE/PATCH — mirrors the `validateGroupKeyPrefix` gate against `supportedGroupIds` — with a fallback path that also accepts codes already in the master `systems` table (so `ImportServiceImpl.seedSystems`-discovered codes remain editable through v4 without a config redeploy). The master row is auto-created via `ensureSystemExists` on first write so the FK is always satisfied. Filter `?system=A,B` is an `IN(...)` predicate against this column (OR-semantic across distinct components). |
+| `system_code` | VARCHAR(50) | nullable, FK → systems(code) | Single-value system assignment (a component belongs to at most one system). Collapsed from the M:N junction `component_systems` in the post-#299 follow-up. Schema-nullable; service-layer validates non-null values against the env-config `components-registry.supportedSystems` allowlist on CREATE/PATCH, with a fallback path that also accepts codes already in the master `systems` table (so `ImportServiceImpl.seedSystems`-discovered codes remain editable through v4 without a config redeploy). The master row is auto-created via `ensureSystemExists` on first write so the FK is always satisfied. Filter `?system=A,B` is an `IN(...)` predicate against this column (OR-semantic across distinct components). |
 | `version` | BIGINT | NOT NULL DEFAULT 0 | `@Version` optimistic locking |
 | `created_at` | TIMESTAMP WITH TIME ZONE | NOT NULL DEFAULT now() | |
 | `updated_at` | TIMESTAMP WITH TIME ZONE | NOT NULL DEFAULT now() | |
@@ -225,11 +225,13 @@ Semantics:
 - **REAL aggregator** (`is_fake = false`): aggregator is itself a deployable component. Has its own row in `components` whose `component_group_id` points to this group. All sub-components also link to this group.
 - **FAKE aggregator** (`is_fake = true`): grouping-only entity. **No row in `components` for the aggregator itself.** Only sub-components link to the group.
 
+**Membership source (R1 — decoupled from `parentComponent`):** group membership is derived from the DSL `components { }` block. The loader surfaces it as `EscrowConfiguration.aggregatorSubComponents` (aggregatorKey → sub-component keys), and the importer (§6.3) keys grouping off *that map*, NOT the flat `parent_component_id` / `parentComponent` field. Being referenced as another component's `parentComponent` (without itself owning a `components { }` block) does **not** make a component an aggregator and creates **no** group. Migration is the sole writer of `component_group_id`; the v4 API never creates or assigns a group (see §4.1). A re-migration is idempotent and self-correcting: §6.3 deletes any `component_groups` row whose key is no longer a current aggregator (unlinking its members first), which clears groups left behind by the earlier flat-`parentComponent` grouping logic.
+
 Detection rule at migration:
 
 ```kotlin
 fun isFakeAggregator(cfg: EscrowModuleConfig): Boolean {
-    val vcsUrl = cfg.firstVcsUrlAcrossAllForms()    // form 1, 2, or 3
+    val vcsUrl = cfg.vcsSettings?.versionControlSystemRoots?.firstOrNull()?.vcsPath
     val artifactId = cfg.artifactIdPattern ?: ""
     return vcsUrl.isNullOrBlank()
         || isFakeVcsUrl(vcsUrl)
@@ -423,7 +425,7 @@ for ((childKey, parentKey) in pendingParentByKey) {
 
 Missing parent references are tolerated (WARN log) — referenced component may be archived or in a different installation.
 
-`can_be_parent` is seeded here: any component referenced as a parent is an aggregator. A **multi-level hierarchy** (a key that is both referenced as a parent AND references a parent itself — e.g. `A → B → C`) is **tolerated** (WARN log, FK preserved — no silent data loss); the v4 API forbids only *new/changed* parent-of-parent assignments, so grandfathered rows survive and are remediated by clearing the offending parent (`clearParent`).
+`can_be_parent` is seeded here: any component referenced as a `parentComponent` becomes `can_be_parent` (eligible to be selected as a parent in the picker). This is the flat peer-reference relationship and is **independent of aggregator status** — a `parentComponent` target is not necessarily a `components { }` aggregator, and aggregator grouping (§6.3) is keyed off the `components { }` block, not this field. A **multi-level hierarchy** (a key that is both referenced as a parent AND references a parent itself — e.g. `A → B → C`) is **tolerated** (WARN log, FK preserved — no silent data loss); the v4 API forbids only *new/changed* parent-of-parent assignments, so grandfathered rows survive and are remediated by clearing the offending parent (`clearParent`).
 
 ### 6.3 Aggregator handling
 
@@ -434,6 +436,8 @@ For each top-level DSL component:
    - Create `component_groups` row.
    - REAL: also create `components` row for the aggregator itself with `component_group_id` pointing to its own group.
    - For each sub-component (`EscrowConfigurationLoader` resolves parent defaults into the sub config): create `components` row with `component_group_id` pointing to the group.
+
+Grouping is keyed off the loader's `EscrowConfiguration.aggregatorSubComponents` (aggregatorKey → sub-component keys, derived from the `components { }` block), **never** the flat `parentComponent` field (§4.3). After linking, a **re-run cleanup** deletes any pre-existing `component_groups` row whose key is no longer a current aggregator — unlinking its members (`component_group_id = NULL`) first. This makes re-migration idempotent and removes groups left behind by the earlier flat-`parentComponent`-based grouping (a non-aggregator parent — one with no `components { }` block — no longer retains a group). Cleanup runs only on a **full batch** migration (`migrateAllComponents`); a single-component migration (`migrateComponent`) links its own group but does not sweep stale groups.
 
 ### 6.4 Base row determination
 


### PR DESCRIPTION
## What & why

The UI and backend conflated two distinct concepts:

- **Aggregator** — a DSL component that **owns a nested `components { }` block** (its sub-components). This is what defines a `ComponentGroup`.
- **`parentComponent`** — a flat peer reference (and the `canBeParent` "parent picker" eligibility). Being referenced as someone's `parentComponent` does **not** make a component an aggregator.

Previously both the importer **and** the v4 API service created/derived a `ComponentGroup` for **every** flat `parentComponent` target, over-grouping plain parents. This PR decouples them: only true `components { }` aggregators form groups, and group membership is **migration-owned** (never assigned via the API).

## Changes

**Loader (`component-resolver-core`)**
- New `EscrowConfiguration.aggregatorSubComponents: Map<String, Set<String>>` (aggregatorKey → sub-component keys), populated **only** from `components { }` blocks (Groovy `ConfigObject` + Kotlin `Component.subComponents`). This is the authoritative grouping source.

**Importer (`ImportServiceImpl`)**
- `linkAggregatorGroups` re-keyed to `aggregatorSubComponents` (batch + single paths).
- Single-migrate path reworked into 3 explicit cases: FAKE aggregator (group-only, no row), REAL aggregator (self-link + children), sub-component (link to its aggregator's group).
- New `cleanupStaleGroups(...)`: re-run safety — deletes any `component_groups` row whose key is no longer a current aggregator (unlinking members first), removing groups left by the old flat-parent logic. Runs on **full batch** migration only.
- `upsertComponentGroup` now refreshes the `is_fake` flag on a REAL↔FAKE flip.
- New `ComponentRepository.findByComponentGroupId` query.
- Pass 2 (`parentComponent` FK + `canBeParent` seeding) is **kept** as-is.

**Service (`ComponentManagementServiceImpl`) — API contract change**
- A `ComponentGroup` is **migration-owned and never assigned via the API**:
  - `POST` create → `componentGroup = null`; a `group` in the payload is **accepted-and-ignored**.
  - `PATCH` update → the group is never touched; a provided `group` is ignored and `clearGroup` (true/false) is an **accepted no-op** (both kept on the wire for backward compatibility).
- Removed now-dead `deriveComponentGroup` / `upsertGroup` / `validateGroupKeyPrefix` and the unused `componentGroupRepository` injection.
- The **single-level** parent invariant is intentionally **kept** (a `canBeParent` component may not itself have a parent), matching the DSL validator.

## Compatibility notes for API consumers
- `group` is no longer required on create and is no longer rejected when missing/blank; it is silently ignored. `group`-prefix validation against `supportedGroupIds` is removed from the create/update path.
- `clearGroup: true` no longer returns 400 — it is a no-op.
- A component's `group` in v4 responses now reflects DSL aggregator membership only (null for standalone/API-created components).

## Testing
- Full `:components-registry-service-server:test` suite green; `component-resolver-core` loader test green; `qualityStatic` (detekt + ktlint) green.
- Updated/added: `StrictContractTest` (accept-and-ignore + clearGroup no-op), `ComponentCanBeParentTest` (API never assigns a group; invariants kept), `MigrationIntegrationTest` cleanup-on-rerun test, `ListComponentsExtendedFiltersTest` (group seeded via repo), loader `flatParentComponent` fixture proving a flat parent is not an aggregator.
- Docs: `docs/registry/schema-spec.md` §4.1 / §4.3 / §6.2 / §6.3 corrected.
- Reviewed by an independent subagent (APPROVE-with-nits; nits addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
