### PR TITLE
fix(crs): keep fake aggregators in the v1-v3 API, hide them from the v4 list

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
 import jakarta.persistence.OptimisticLockException
+import jakarta.persistence.criteria.JoinType
 import org.octopusden.octopus.components.registry.core.exceptions.ComponentNameConflictException
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.dto.v4.BaseConfigurationRequest
@@ -1450,6 +1451,30 @@ class ComponentManagementServiceImpl(
 
     private fun buildSpecification(filter: ComponentFilter): Specification<ComponentEntity> {
         var spec = Specification.where<ComponentEntity>(null)
+
+        // Always-on exclusion (compat parity). A FAKE aggregator (stub VCS / artifactId that
+        // only owns a `components { }` block) keeps its ComponentEntity row so the v1–v3
+        // resolver still serves it — but it must NOT appear in the v4 regular-components list
+        // (it represents a group, not a shippable component; groups get their own UI later).
+        // The importer self-links such a stub to its OWN fake group, so the marker is:
+        // componentGroup is fake AND its groupKey equals the row's own componentKey. LEFT join
+        // so ordinary group-less components and real-aggregator members are all kept; a
+        // many-to-one join does not multiply rows, so no query.distinct(true) is needed.
+        spec =
+            spec.and(
+                Specification { root, _, cb ->
+                    val grp = root.join<ComponentEntity, ComponentGroupEntity>("componentGroup", JoinType.LEFT)
+                    cb.or(
+                        cb.isNull(grp.get<Any>("id")),
+                        cb.not(
+                            cb.and(
+                                cb.isTrue(grp.get<Boolean>("isFake")),
+                                cb.equal(grp.get<String>("groupKey"), root.get<String>("componentKey")),
+                            ),
+                        ),
+                    )
+                },
+            )
 
         filter.productType?.let { pt ->
             spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("productType"), pt) })

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1465,7 +1465,7 @@ class ComponentManagementServiceImpl(
                 Specification { root, _, cb ->
                     val grp = root.join<ComponentEntity, ComponentGroupEntity>("componentGroup", JoinType.LEFT)
                     cb.or(
-                        cb.isNull(grp.get<Any>("id")),
+                        cb.isNull(grp.get<UUID>("id")),
                         cb.not(
                             cb.and(
                                 cb.isTrue(grp.get<Boolean>("isFake")),

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -175,37 +175,17 @@ class ImportServiceImpl(
                 // R1 §4.3/§6.3 — group membership is driven by the DSL `components { }`
                 // aggregator membership (fullConfig.aggregatorSubComponents), NOT the flat
                 // parentComponent field. `name` is an aggregator iff it owns a components{} block.
-                val firstCfgForCheck = module.moduleConfigurations.firstOrNull()
+                // NOTE: a FAKE aggregator STILL gets a ComponentEntity row (so the v1–v3
+                // resolver keeps serving it = compat parity with V1); it is only excluded from
+                // the v4 regular-components list (ComponentManagementServiceImpl.buildSpecification).
                 val subComponentsOfThis: Set<String> = fullConfig.aggregatorSubComponents[name] ?: emptySet()
                 val isAggregator = subComponentsOfThis.isNotEmpty()
-
-                // (a) FAKE aggregator (owns components{} AND stub) → group-only, no ComponentEntity row.
-                if (isAggregator && firstCfgForCheck != null && isFakeAggregator(firstCfgForCheck)) {
-                    sourceRegistry.setComponentSource(name, "db")
-                    val fakePass3Failures =
-                        linkAggregatorGroups(fullConfig.escrowModules, mapOf(name to subComponentsOfThis))
-                    if (fakePass3Failures.isNotEmpty()) {
-                        val msg = fakePass3Failures.joinToString(" | ") { "${it.first}=${it.second}" }
-                        return MigrationResult(
-                            componentName = name,
-                            success = false,
-                            dryRun = false,
-                            message = "§6.3 Pass 3 group-linking failed: ${msg.take(280)}",
-                        )
-                    }
-                    return MigrationResult(
-                        componentName = name,
-                        success = true,
-                        dryRun = false,
-                        message = "Skipped insert (FAKE aggregator: group-only per schema-spec §4.3); group upserted",
-                    )
-                }
 
                 importModule(name, module.moduleConfigurations)
                 sourceRegistry.setComponentSource(name, "db")
 
                 // §6.3 single-path grouping, keyed off `components { }` membership:
-                //   (b) REAL aggregator (owns components{}, not fake) → create its group,
+                //   (b) aggregator (owns components{}, fake OR real) → create its group,
                 //       self-link, and link any children already in DB;
                 //   (c) sub-component of some aggregator → link it to that aggregator's group.
                 val pass3Input: Map<String, Set<String>> =
@@ -316,11 +296,13 @@ class ImportServiceImpl(
                     }
                 }.toMap()
 
-            // schema-spec §4.3: FAKE aggregators are group-only — no ComponentEntity row. R1:
-            // an aggregator is a component that OWNS a `components { }` block (a key in
+            // R1: an aggregator is a component that OWNS a `components { }` block (a key in
             // `aggregatorSubComponents`), NOT merely a flat-`parentComponent` target. Among
-            // aggregators, the FAKE ones (stub VCS / artifactId) are skipped in Pass 1; Pass 3
-            // still creates their ComponentGroupEntity.
+            // aggregators the FAKE ones (stub VCS / artifactId) used to be group-only (no
+            // ComponentEntity row); they now get a normal row too — so the v1–v3 resolver keeps
+            // serving them (compat parity with V1) — and are excluded from the v4 list instead
+            // (ComponentManagementServiceImpl.buildSpecification). This set is kept only for the
+            // derivation-summary log below.
             val fakeAggregatorKeys: Set<String> =
                 fullConfig.aggregatorSubComponents.keys.filter { parentKey ->
                     val firstConfig = allModules[parentKey]?.moduleConfigurations?.firstOrNull()
@@ -365,8 +347,8 @@ class ImportServiceImpl(
             // flush boundary aligns with one full JDBC batch.
             //
             // The modulus below is on `total`, which is incremented
-            // unconditionally for every iteration — including skipped (FAKE
-            // aggregator, already-in-DB, no-configurations) and failed
+            // unconditionally for every iteration — including skipped
+            // (already-in-DB, no-configurations) and failed
             // entries. This is by design: the session may have grown via
             // partial cascades even on the skip paths, so the eviction
             // cadence is driven by iteration count, not persisted-row count.
@@ -378,23 +360,10 @@ class ImportServiceImpl(
                 }
                 total++
                 try {
-                    if (componentKey in fakeAggregatorKeys) {
-                        // Register FAKE aggregator as "db"-sourced even though it has no
-                        // ComponentEntity row — Pass 3 still owns its ComponentGroupEntity,
-                        // and the source flag keeps `getMigrationStatus` totals balanced
-                        // (total == db) so the orchestrator does not retry this component.
-                        stageSource(componentKey)
-                        skipped++
-                        results.add(
-                            MigrationResult(
-                                componentName = componentKey,
-                                success = true,
-                                dryRun = false,
-                                message = "Skipped (FAKE aggregator: group-only per schema-spec §4.3)",
-                            ),
-                        )
-                        continue
-                    }
+                    // NOTE: FAKE aggregators are NO LONGER skipped here. They get a normal
+                    // ComponentEntity row (inserted below) so the v1–v3 resolver keeps serving
+                    // them (compat parity with V1); Pass 3 still creates + self-links their
+                    // ComponentGroupEntity, and the v4 list excludes them via buildSpecification.
 
                     if (componentKey in existingComponentKeys) {
                         skipped++
@@ -510,8 +479,9 @@ class ImportServiceImpl(
                     // as a `parentComponent` becomes can-be-parent (eligible in the parent
                     // picker). This is INDEPENDENT of aggregator status — an aggregator owns
                     // a `components { }` block (§6.3 / aggregatorSubComponents), a separate
-                    // concept. Idempotent — set true once, never false. FAKE aggregators have
-                    // no ComponentEntity row (findByComponentKey returns null above), excluded.
+                    // concept. Idempotent — set true once, never false. A FAKE aggregator now
+                    // HAS a row, so it may be seeded can-be-parent here, but it stays excluded
+                    // from every v4 list query (buildSpecification) and so never enters the picker.
                     if (!parent.canBeParent) {
                         parent.canBeParent = true
                         componentRepository.save(parent)
@@ -2079,7 +2049,10 @@ class ImportServiceImpl(
      *     existing rows).
      *  3. Set `componentGroup` on every sub-component — and update it when the existing link
      *     points at a *different* group (DSL membership changed since the last migration).
-     *  4. For a REAL aggregator (non-fake): self-link the aggregator to its own group too.
+     *  4. Self-link the aggregator to its own group too — for BOTH real and fake aggregators.
+     *     A fake aggregator now keeps its ComponentEntity row (so v1–v3 still serves it for
+     *     compat parity); self-linking it to its own fake group is exactly the marker the v4
+     *     list uses to EXCLUDE it (group.isFake && group.groupKey == the row's componentKey).
      *
      * @return per-aggregator failures: list of `(aggregatorKey, errorMessage)`. Empty list on
      *         full success. Callers should fold these into their own result aggregation so a
@@ -2130,14 +2103,17 @@ class ImportServiceImpl(
                     }
                 }
 
-                // For a REAL aggregator, also link the parent itself to its own group
-                if (!fake) {
-                    val parent = componentRepository.findByComponentKey(parentKey)
-                    if (parent != null && parent.componentGroup?.id != group.id) {
-                        parent.componentGroup = group
-                        componentRepository.save(parent)
-                        LOG.debug("§6.3 Pass 3: linked REAL aggregator '{}' → its own group", parentKey)
-                    }
+                // Link the aggregator itself to its own group — for BOTH real and fake
+                // aggregators. A fake aggregator now has a ComponentEntity row (so the v1–v3
+                // resolver serves it = compat parity); self-linking it to its own fake group is
+                // exactly the marker the v4 list uses to EXCLUDE it (group.isFake &&
+                // group.groupKey == the row's componentKey). For a real aggregator this is its
+                // normal group membership.
+                val aggregatorRow = componentRepository.findByComponentKey(parentKey)
+                if (aggregatorRow != null && aggregatorRow.componentGroup?.id != group.id) {
+                    aggregatorRow.componentGroup = group
+                    componentRepository.save(aggregatorRow)
+                    LOG.debug("§6.3 Pass 3: linked aggregator '{}' (isFake={}) → its own group", parentKey, fake)
                 }
 
                 LOG.info(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
@@ -194,6 +194,61 @@ class ListComponentsExtendedFiltersTest {
     }
 
     @Test
+    @DisplayName(
+        "compat: a FAKE aggregator self-linked to its own fake group is hidden from the list; " +
+            "its members, ordinary components, and a REAL self-linked aggregator are not",
+    )
+    fun fakeAggregatorSelfLinkedGroupExcludedFromList() {
+        // Reproduces the compat-fix marker in isolation: the importer gives a FAKE aggregator a
+        // ComponentEntity row whose componentGroup is its OWN fake group, i.e.
+        // group.isFake == true AND group.groupKey == componentKey. buildSpecification must hide
+        // exactly that row from the v4 list — and nothing else. Seeded via the repos (groups are
+        // migration-owned; the API never assigns one — R1), so this stays a focused test that
+        // does not depend on the global Groovy fixtures.
+        val aggKey = uniqueName("fakeagg")
+        val memberKey = uniqueName("fakeagg_member")
+        val ordinary = uniqueName("fakeagg_ordinary")
+        val realAggKey = uniqueName("realagg")
+        create(baseBody(aggKey)) // the FAKE aggregator stub: componentKey == its fake group's key
+        create(baseBody(memberKey)) // a real member of that fake group
+        create(baseBody(ordinary)) // unrelated, group-less control
+        create(baseBody(realAggKey)) // a REAL aggregator self-linked to its own (non-fake) group
+
+        // Count BEFORE any group linking: all four are ordinary, listed components.
+        val totalBefore = page()["totalElements"].asLong()
+
+        // is_fake=true group keyed by the stub's OWN componentKey → the self-link exclusion marker.
+        val fakeGroup = componentGroupRepository.save(ComponentGroupEntity(groupKey = aggKey, isFake = true))
+        val stub = componentRepository.findByComponentKey(aggKey)!!
+        stub.componentGroup = fakeGroup
+        componentRepository.save(stub)
+        val member = componentRepository.findByComponentKey(memberKey)!!
+        member.componentGroup = fakeGroup
+        componentRepository.save(member)
+
+        // A REAL aggregator is ALSO self-linked (group.groupKey == componentKey) but is_fake=false,
+        // so it must NOT be excluded — proving the predicate is gated on is_fake, not the self-link.
+        val realGroup = componentGroupRepository.save(ComponentGroupEntity(groupKey = realAggKey, isFake = false))
+        val realStub = componentRepository.findByComponentKey(realAggKey)!!
+        realStub.componentGroup = realGroup
+        componentRepository.save(realStub)
+
+        val n = names()
+        assert(!n.contains(aggKey)) { "FAKE aggregator stub $aggKey must be excluded from the v4 list; got $n" }
+        assert(n.contains(memberKey)) { "member $memberKey (not the group owner) must remain in the list; got $n" }
+        assert(n.contains(ordinary)) { "ordinary group-less $ordinary must remain in the list; got $n" }
+        assert(n.contains(realAggKey)) { "REAL self-linked aggregator $realAggKey must remain (is_fake=false); got $n" }
+
+        // The COUNT query must also drop exactly the one fake-group owner: the LEFT join must
+        // not inflate totalElements, and the exclusion must apply to the count, not just the page.
+        val totalAfter = page()["totalElements"].asLong()
+        assert(totalAfter == totalBefore - 1) {
+            "v4 list count must fall by exactly 1 (only the fake aggregator owner drops out); " +
+                "before=$totalBefore after=$totalAfter"
+        }
+    }
+
+    @Test
     @DisplayName("?vcsPath= matches a BASE VCS entry; a multi-entry component is counted ONCE (distinct)")
     fun vcsPathFilterAndPaginationDistinct() {
         val multi = uniqueName("ext_vcs_multi")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentGroupEntity
@@ -21,10 +22,12 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentRep
 import org.octopusden.octopus.components.registry.server.repository.LabelRepository
 import org.octopusden.octopus.components.registry.server.repository.SystemRepository
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
 import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
@@ -75,6 +78,9 @@ class MigrationIntegrationTest {
 
     @Autowired
     private lateinit var importService: ImportService
+
+    @Autowired
+    private lateinit var componentManagementService: ComponentManagementService
 
     init {
         val testResourcesPath =
@@ -475,12 +481,24 @@ class MigrationIntegrationTest {
         assertNotNull(fakeGroup, "ComponentGroupEntity with groupKey='TEST_AGGREGATOR_FAKE' must be created by Pass 3")
         assertTrue(fakeGroup!!.isFake, "TEST_AGGREGATOR_FAKE group must have isFake=true (artifactId contains 'stub')")
 
-        // schema-spec invariant: FAKE aggregators are represented ONLY as a ComponentGroupEntity
-        // row; there must be no corresponding ComponentEntity. Guards against a regression where
-        // a FAKE aggregator slips through Pass 1 and lands as a real component row.
-        assertNull(
-            componentRepository.findByComponentKey("TEST_AGGREGATOR_FAKE"),
-            "TEST_AGGREGATOR_FAKE must NOT have a ComponentEntity row — FAKE aggregators are group-only",
+        // R1 compat parity: a FAKE aggregator now ALSO gets a ComponentEntity row (so the
+        // v1–v3 resolver keeps serving it) and is self-linked to its OWN fake group. That
+        // self-link (group.isFake && group.groupKey == componentKey) is the marker the v4 list
+        // uses to EXCLUDE it (asserted separately in mig041b). Guards the compat regression
+        // where #306 skipped the Pass-1 insert for fake aggregators and 404'd them in v3.
+        val fakeAggRow = componentRepository.findByComponentKey("TEST_AGGREGATOR_FAKE")
+        assertNotNull(
+            fakeAggRow,
+            "TEST_AGGREGATOR_FAKE MUST have a ComponentEntity row now (v1–v3 compat parity)",
+        )
+        assertNotNull(
+            fakeAggRow!!.componentGroup,
+            "TEST_AGGREGATOR_FAKE must be self-linked to its own group",
+        )
+        assertEquals(
+            fakeGroup.id,
+            fakeAggRow.componentGroup!!.id,
+            "TEST_AGGREGATOR_FAKE.componentGroup must reference its OWN fake group (self-link = v4-exclusion marker)",
         )
 
         // The member sub-component must have its component_group_id set
@@ -527,6 +545,47 @@ class MigrationIntegrationTest {
             realGroup.id,
             versionsApi.componentGroup!!.id,
             "versions-api.componentGroup must reference the TESTONE group",
+        )
+    }
+
+    @Test
+    @Transactional
+    @DisplayName(
+        "MIG-041b/compat: FAKE aggregator is fetchable by key (v1–v3 parity) but EXCLUDED from the " +
+            "v4 list; real aggregator + members + ordinary components remain in the v4 list",
+    )
+    fun mig041b_fakeAggregatorServedByResolverButHiddenFromV4List() {
+        // v1–v3 read path (DatabaseComponentRegistryResolver.getComponentById → findByComponentKey):
+        // the FAKE aggregator MUST still resolve. This is the exact #306 compat regression — the
+        // Pass-1 skip dropped its row and v3 began 404-ing it.
+        assertNotNull(
+            componentRepository.findByComponentKey("TEST_AGGREGATOR_FAKE"),
+            "TEST_AGGREGATOR_FAKE must be fetchable by key (v1–v3 compat parity)",
+        )
+
+        // v4 regular-components list: the FAKE aggregator stub must NOT appear; everything else does.
+        val listed =
+            componentManagementService
+                .listComponents(ComponentFilter(), PageRequest.of(0, 500))
+                .content
+                .map { it.name }
+                .toSet()
+
+        assertFalse(
+            "TEST_AGGREGATOR_FAKE" in listed,
+            "FAKE aggregator stub must be hidden from the v4 regular-components list",
+        )
+        assertTrue(
+            "TEST_AGGREGATOR_MEMBER" in listed,
+            "a FAKE aggregator's member is a real component — it must remain in the v4 list",
+        )
+        assertTrue(
+            "TESTONE" in listed,
+            "a REAL aggregator must remain in the v4 list (only FAKE stubs are hidden)",
+        )
+        assertTrue(
+            "versions-api" in listed,
+            "a REAL aggregator's member must remain in the v4 list",
         )
     }
 

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -223,7 +223,7 @@ Aggregator grouping. An aggregator is a DSL component with a nested `components 
 
 Semantics:
 - **REAL aggregator** (`is_fake = false`): aggregator is itself a deployable component. Has its own row in `components` whose `component_group_id` points to this group. All sub-components also link to this group.
-- **FAKE aggregator** (`is_fake = true`): grouping-only entity. **No row in `components` for the aggregator itself.** Only sub-components link to the group.
+- **FAKE aggregator** (`is_fake = true`): a grouping stub (placeholder VCS / stub artifactId) that is not independently deployable. It **still has its own row in `components`** — so the **v1–v3 read API keeps serving it** (compat parity with the pre-schema-v2 registry, which had no aggregator concept and served these as ordinary components). That row's `component_group_id` self-links to its own group (so `group_key == component_key` with `is_fake = true`); sub-components link to the same group. The fake aggregator's own row is **excluded from the v4 regular-components list** (it represents a group, not a shippable component — groups may get their own UI later); the v4 list query filters out exactly the rows that are self-linked to their own fake group, and that self-link is the marker it keys off. (Historical note: before this compat fix, a fake aggregator had **no** `components` row at all, which 404'd it on the v1–v3 path.)
 
 **Membership source (R1 — decoupled from `parentComponent`):** group membership is derived from the DSL `components { }` block. The loader surfaces it as `EscrowConfiguration.aggregatorSubComponents` (aggregatorKey → sub-component keys), and the importer (§6.3) keys grouping off *that map*, NOT the flat `parent_component_id` / `parentComponent` field. Being referenced as another component's `parentComponent` (without itself owning a `components { }` block) does **not** make a component an aggregator and creates **no** group. Migration is the sole writer of `component_group_id`; the v4 API never creates or assigns a group (see §4.1). A re-migration is idempotent and self-correcting: §6.3 deletes any `component_groups` row whose key is no longer a current aggregator (unlinking its members first), which clears groups left behind by the earlier flat-`parentComponent` grouping logic.
 
@@ -415,7 +415,10 @@ for ((childKey, parentKey) in pendingParentByKey) {
         continue
     }
     // Seed canBeParent on the referenced parent (idempotent: set true once,
-    // never false). FAKE aggregators have no ComponentEntity row, so excluded.
+    // never false). canBeParent is the flat parentComponent-target concept,
+    // independent of aggregator status (§4.3) — a fake aggregator referenced
+    // here now has a row and may become can_be_parent, yet stays hidden from
+    // every v4 list query, so it never surfaces in the parent picker.
     if (!parent.canBeParent) { parent.canBeParent = true; componentRepository.save(parent) }
     val child = componentRepository.findByComponentKey(childKey)!!
     child.parentComponentId = parent.id
@@ -433,8 +436,8 @@ For each top-level DSL component:
 1. If no nested `components { }` block → STANDALONE; create one `components` row with `component_group_id = NULL`.
 2. Else (aggregator):
    - Classify REAL vs FAKE per the detection rule (§4.3).
-   - Create `component_groups` row.
-   - REAL: also create `components` row for the aggregator itself with `component_group_id` pointing to its own group.
+   - Create `component_groups` row (`is_fake` set accordingly).
+   - Create a `components` row for the aggregator itself — **REAL and FAKE alike** — and self-link its `component_group_id` to its own group. The REAL aggregator's row is an ordinary deployable component; the FAKE aggregator's row exists purely for **v1–v3 compat parity** and is **excluded from the v4 regular-components list** (the self-link to its own fake group is the marker the list query filters on — §4.3).
    - For each sub-component (`EscrowConfigurationLoader` resolves parent defaults into the sub config): create `components` row with `component_group_id` pointing to the group.
 
 Grouping is keyed off the loader's `EscrowConfiguration.aggregatorSubComponents` (aggregatorKey → sub-component keys, derived from the `components { }` block), **never** the flat `parentComponent` field (§4.3). After linking, a **re-run cleanup** deletes any pre-existing `component_groups` row whose key is no longer a current aggregator — unlinking its members (`component_group_id = NULL`) first. This makes re-migration idempotent and removes groups left behind by the earlier flat-`parentComponent`-based grouping (a non-aggregator parent — one with no `components { }` block — no longer retains a group). Cleanup runs only on a **full batch** migration (`migrateAllComponents`); a single-component migration (`migrateComponent`) links its own group but does not sweep stale groups.


### PR DESCRIPTION
## What & why
PR #306 decoupled aggregator grouping from the flat `parentComponent` field (R1). As a side effect it re-keyed the importer's *fake-aggregator* Pass-1 skip from "flat parentComponent targets" to "`components { }`-block owners". That set is different: it includes ~14 stub components the legacy registry (and the v1-v3 API) had always served as ordinary components. With the skip, they no longer get a `components` row, so the v1-v3 read path (`findAll` / `findByComponentKey`) 404s them — which blocks the DB cutover (it shows up as the compat diff).

Per the decision: **keep these components in the v1-v3 API, but it's fine to hide them from the v4 regular-components list** (they're grouping stubs; groups may get their own UI later).

## Change
- **Importer** (`ImportServiceImpl`): no longer skips the Pass-1 insert for fake aggregators (batch + single paths). A fake aggregator gets a normal `components` row again → v1-v3 serves it. Re-runs stay idempotent (existing-key skip).
- **Self-link** (`linkAggregatorGroups`): the aggregator is now linked to its own group for **both** real and fake aggregators (was real-only). For a fake aggregator, `group.isFake && group.groupKey == componentKey` is the marker the v4 list keys off.
- **v4 list** (`ComponentManagementServiceImpl.buildSpecification`): an always-on LEFT-join predicate hides exactly those self-linked fake-group owners from the list (and the `?canBeParent=` parent picker). Group-less components and real-aggregator members are untouched.

## Tests
- `MigrationIntegrationTest`: MIG-041 flipped (fake aggregator now HAS a self-linked row); new **MIG-041b** — fetchable by key (v1-v3 parity) yet absent from the v4 list; real aggregator + members + ordinary components stay listed.
- `ListComponentsExtendedFiltersTest`: focused query test covering all four predicate cases (fake-owner excluded; fake-member, ordinary, and REAL self-linked aggregator all kept).
- Full `gradlew build` green. RED→GREEN: the guards above fail against the pre-fix code (demonstrated locally before the fix commit).

## Docs
`docs/registry/schema-spec.md` §4.3 / §6.2 / §6.3.

## Notes / minor follow-ups
- v4 `/meta/*` distinct endpoints (owners/systems) again include a fake aggregator's attribute values (restoring pre-#306 behavior); could be filtered later if it clutters dropdowns.
- A fake aggregator's sub-components regain their flat `parentComponent` FK per the DSL (matches v1); the fake aggregator may be seeded `canBeParent=true` but stays hidden from the picker via the same list exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
