### PR TITLE
feat(crs): git-only no-DB boot mode (no Postgres for git-mode compat)

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -819,16 +819,18 @@ object id17CompatLocalStandManual : BuildType({
 })
 
 // Git-mode sibling of id17. Boots the SAME baseline + candidate JARs, but runs
-// the candidate WITHOUT DB migration (CANDIDATE_MODE=git → --auto-migrate=false
-// --default-source=git): every v1/v2/v3 response is served by the Git resolver,
-// the same code path as the 2.0.87 baseline. This asserts the deploy-without-
-// migration NO-OP invariant — deploying v3 and not migrating must be byte-
-// identical to the old version for v1/v2/v3. It uses the (empty) git-mode
+// the candidate WITHOUT a database (CANDIDATE_MODE=git → the `no-db` profile +
+// --auto-migrate=false --default-source=git): the JDBC/JPA/Flyway auto-configs are
+// excluded so the candidate needs no Postgres, and every v1/v2/v3 response is served
+// by the Git resolver — the same code path as the 2.0.87 baseline. This asserts the
+// deploy-without-migration NO-OP invariant — deploying v3 and not migrating must be
+// byte-identical to the old version for v1/v2/v3. It uses the (empty) git-mode
 // known-deltas file, so any active diff is a real regression of that invariant.
 //
-// Differs from id17 ONLY by: id/name, the /tmp/crs-id18-* work namespace, and
-// `export CANDIDATE_MODE=git` before the wrapper. Runs on a separate agent from
-// id17, so the shared default ports (4567/4568) + local Postgres don't collide.
+// Differs from id17 by: id/name, the /tmp/crs-id18-* work namespace, and
+// `export CANDIDATE_MODE=git` before the wrapper (which selects the no-db,
+// no-Postgres candidate). Runs on a separate agent from id17 so the shared
+// default ports (4567/4568) don't collide.
 object id18CompatLocalStandGitModeAuto : BuildType({
     id("18CompatLocalStandGitModeAuto")
     name = "[1.8] Compat — Local Stand (no DB migration, git-mode) [AUTO]"
@@ -898,9 +900,9 @@ object id18CompatLocalStandGitModeAuto : BuildType({
             name = "Run local-stand compat (git-mode)"
             id = "run_compat"
             // Same wrapper as id17, namespaced under /tmp/crs-id18-%teamcity.build.id%
-            // and with CANDIDATE_MODE=git exported so the candidate boots with no
-            // migration (default-source=git). Runs on a separate agent from id17,
-            // so the shared default ports + local Postgres don't collide.
+            // and with CANDIDATE_MODE=git exported so the candidate boots with the no-db
+            // profile (no database, no migration, default-source=git; issue #310).
+            // Runs on a separate agent from id17 so the shared default ports don't collide.
             scriptContent = """
                 set -euo pipefail
                 WORK_DIR="/tmp/crs-id18-%teamcity.build.id%"
@@ -965,11 +967,13 @@ object id18CompatLocalStandGitModeAuto : BuildType({
                 export COMPAT_VERSIONS_FILE="${'$'}VERSIONS_FILE_PATH"
                 export COMPAT_FULL="%COMPAT_FULL%"
                 export COMPAT_PARALLELISM="%COMPAT_PARALLELISM%"
-                export POSTGRES_IMAGE="%DOCKER_REGISTRY_INTERNAL%/postgres:16"
+                # git-mode (no-db, issue #310) does NOT start Postgres, so no POSTGRES_IMAGE
+                # pull is needed. RESET_DB=1 only drives teamcity-run.sh's pre-run teardown
+                # of any stale Postgres left by a prior db-mode run on this (persistent) agent.
                 export RESET_DB=1
                 export COMPONENTS_REGISTRY_SERVICE_VERSION="%COMPAT_BASELINE_VERSION%"
                 export BUILD_VERSION="%COMPAT_CANDIDATE_VERSION%"
-                # No-migration / git-routing mode — the only behavioural delta vs id17.
+                # No-migration / no-DB git-routing mode — the only behavioural delta vs id17.
                 export CANDIDATE_MODE=git
                 bash scripts/local-stands/teamcity-run.sh
             """.trimIndent()
@@ -977,8 +981,8 @@ object id18CompatLocalStandGitModeAuto : BuildType({
     }
 
     failureConditions {
-        // Git-mode skips auto-migrate, so the candidate comes up faster than id17;
-        // keep the same generous cap for cold pulls + postgres + two stand boots.
+        // Git-mode skips auto-migrate AND Postgres, so the candidate comes up faster
+        // than id17; keep a generous cap for cold image pulls + two stand boots.
         executionTimeoutMin = 120
     }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,8 @@ All four `COMPAT_*` values are confidential per the open-source rule — they li
 
 **One-shot bootstrap** (first time on a clean host, or after `stop-all.sh`): `postgres-up.sh` → `baseline.sh` (one-time `bootJar`, ~2 min) → `candidate.sh` → then `verify.sh` for subsequent iterations. Baseline is `origin/main` (or whatever fat JAR is in `_wt/local-baseline/components-registry-service-server/build/libs/`); `baseline.sh` rebuilds the JAR automatically when any `*.kt`/`*.java`/`*.gradle` in the baseline worktree is newer.
 
+**Git-mode (no-db) stands need no Postgres** (issue #310 / SYS-047): `candidate.sh --mode=vcs` and the TeamCity git-mode stand (`id18`, `CANDIDATE_MODE=git`) boot the candidate with the `no-db` profile, which excludes the JDBC/JPA/Flyway auto-configs — the candidate runs with no database. Skip `postgres-up.sh` for these; only db-mode (`--mode=db` / `id17`) requires Postgres.
+
 **Reading `build/reports/compat/summary.md`:**
 - `Total recorded / Suppressed / Active` counts at the top — exit code is `0` iff active == 0.
 - Diffs are grouped under `### STATUS_CODE_DIFF`, `### STRUCTURAL_DIFF`, `### VALUE_DIFF` headings (plus `### TIMESTAMP_DRIFT` etc. when present).

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ComponentsRegistryProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ComponentsRegistryProperties.kt
@@ -28,7 +28,16 @@ class ComponentsRegistryProperties(
     // every component to the git resolver.
     @field:Pattern(regexp = "git|db", message = "default-source must be exactly 'git' or 'db'")
     val defaultSource: String = "git",
+    // SYS-047: when false (set by the `no-db` profile), every DB-coupled bean is
+    // gated out via @ConditionalOnDatabaseEnabled and the JDBC/JPA/Flyway
+    // auto-configs are excluded, so the service boots with no database and serves
+    // v1/v2/v3 purely from the Git resolver. Default true → unchanged db-mode.
+    val database: DatabaseSettings = DatabaseSettings(),
 ) {
+    data class DatabaseSettings(
+        val enabled: Boolean = true,
+    )
+
     data class VcsSettings(
         val enabled: Boolean = true,
         val root: String?,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ConditionalOnDatabaseEnabled.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ConditionalOnDatabaseEnabled.kt
@@ -1,0 +1,26 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * SYS-047: marks a bean as part of the database layer. Such beans are present in
+ * the default (db) mode and dropped from the context when the `no-db` profile
+ * sets `components-registry.database.enabled=false` (see application-no-db.yml).
+ *
+ * `matchIfMissing = true` is the contract that keeps db-mode (id17) untouched:
+ * with the flag unset, every annotated bean loads exactly as before.
+ *
+ * Put this on any bean that transitively requires a [javax.sql.DataSource] —
+ * i.e. injects a Spring Data JPA repository, a `TransactionTemplate`, an
+ * `EntityManager`, or another bean so annotated. The no-db context-load test
+ * (`NoDbModeContextTest`) is the completeness backstop: if a DB bean is left
+ * un-annotated, the no-db context fails to start and the test goes red.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ConditionalOnProperty(
+    name = ["components-registry.database.enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+annotation class ConditionalOnDatabaseEnabled

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/MigrationExecutorConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/MigrationExecutorConfig.kt
@@ -20,7 +20,13 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
  * MigrateEndpointTest) without tripping Spring Boot's bean-definition-override
  * guard. With the test bean registered first via @TestConfiguration / @Import,
  * Spring sees the slot already filled and skips this method.
+ *
+ * `@ConditionalOnDatabaseEnabled` (class level, so the test-override path via
+ * `@ConditionalOnMissingBean` still works in db-mode): the only consumers of this
+ * executor are the DB-only migration / history / TC-sync job services, all of which
+ * are gated off in no-db mode — so there is no point creating the thread pool there.
  */
+@ConditionalOnDatabaseEnabled
 @Configuration
 open class MigrationExecutorConfig {
     @Bean("migrationExecutor")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.dto.v4.HistoryMigrationJobResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationConflictResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.MigrationJobResponse
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+@ConditionalOnDatabaseEnabled
 @RestController
 @RequestMapping("rest/api/4/admin")
 @PreAuthorize("@permissionEvaluator.canImport()")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogResponse
 import org.octopusden.octopus.components.registry.server.service.AuditService
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.Instant
 
+@ConditionalOnDatabaseEnabled
 @RestController
 @RequestMapping("rest/api/4/audit")
 @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_AUDIT')")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.components.registry.server.controller
 
 import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentDetailResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
@@ -43,6 +44,7 @@ import java.util.UUID
  * read gate, which is the opposite of what "class-level default" suggests. Every
  * endpoint now declares the full set of permissions it requires.
  */
+@ConditionalOnDatabaseEnabled
 @RestController
 @RequestMapping("rest/api/4/components")
 @Suppress("TooManyFunctions")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceController.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceController.kt
@@ -20,7 +20,10 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("rest/api/2/components-registry/service")
 class ComponentsRegistryServiceController(
     private val componentsRegistryService: ComponentsRegistryService,
-    private val importService: ImportService,
+    // Nullable: ImportService is part of the database layer (@ConditionalOnDatabaseEnabled)
+    // and is therefore absent in no-db mode. Spring treats a Kotlin-nullable constructor
+    // parameter as an optional dependency, injecting null when no bean exists.
+    private val importService: ImportService?,
     private val migrationLifecycleGate: MigrationLifecycleGate,
 ) {
     // Per-pod mutual exclusion for the Git re-read: updateConfigCache() ->
@@ -69,11 +72,15 @@ class ComponentsRegistryServiceController(
                 .body<Any>(ErrorResponse("A cache refresh is already in progress; retry updateCache after it completes"))
         }
         try {
-            val status = importService.getMigrationStatus()
+            // DB-mode only: getMigrationStatus() reads countBySource("db"). In no-db
+            // mode ImportService is absent (importService == null) — there is no
+            // migration that can be "fully done", so always fall through to the Git
+            // re-read and return HTTP 200, exactly like the pre-v3 endpoint.
+            val status = importService?.getMigrationStatus()
             // status.total = git-resolver component count (0 if it errored/empty);
             // status.git = total - countBySource("db"). Retire only on a confirmed
             // fully-migrated state; otherwise attempt the refresh.
-            val fullyMigrated = status.total > 0 && status.git == 0L
+            val fullyMigrated = status != null && status.total > 0 && status.git == 0L
             if (!fullyMigrated) {
                 return ResponseEntity.ok<Any>(componentsRegistryService.updateConfigCache())
             }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ConfigControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ConfigControllerV4.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.RegistryConfigEntity
 import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
 import org.springframework.http.ResponseEntity
@@ -16,6 +17,7 @@ import java.time.Instant
  * via `@JdbcTypeCode(SqlTypes.JSON)`. Hibernate handles JSON marshalling on
  * read and write — the controller just passes the map through.
  */
+@ConditionalOnDatabaseEnabled
 @RestController
 @RequestMapping("rest/api/4")
 class ConfigControllerV4(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.event
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
 import org.octopusden.octopus.components.registry.server.util.AuditDiff
@@ -7,6 +8,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
+@ConditionalOnDatabaseEnabled
 @Component
 class AuditEventListener(
     private val auditLogRepository: AuditLogRepository,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/listener/FieldConfigSeeder.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/listener/FieldConfigSeeder.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.listener
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.RegistryConfigEntity
 import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
 import org.octopusden.octopus.escrow.config.ConfigHelper
@@ -44,6 +45,7 @@ import java.time.Instant
  * `{"<section>": {"<field>": {"defaultValue": ...}}}` — i.e.
  * `{"component": {"groupId": {"defaultValue": "<prefix>"}}}`.
  */
+@ConditionalOnDatabaseEnabled
 @Component
 class FieldConfigSeeder(
     private val registryConfigRepository: RegistryConfigRepository,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogResponse
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
+@ConditionalOnDatabaseEnabled
 @Service
 @Transactional(readOnly = true)
 class AuditServiceImpl(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.OptimisticLockException
 import jakarta.persistence.criteria.JoinType
 import org.octopusden.octopus.components.registry.core.exceptions.ComponentNameConflictException
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.dto.v4.BaseConfigurationRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.BuildToolBeanRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
@@ -84,6 +85,7 @@ import java.util.UUID
  * configuration lives on `component_configurations` rows — base + scalar/marker
  * overrides — and is edited via the field-override sub-resource.
  */
+@ConditionalOnDatabaseEnabled
 @Service
 @Transactional
 @Suppress("TooManyFunctions", "LongParameterList", "LargeClass")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -8,6 +8,7 @@ import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
@@ -22,6 +23,7 @@ import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 import java.util.EnumMap
 
+@ConditionalOnDatabaseEnabled
 @Service
 @Primary
 @Suppress("TooManyFunctions")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
@@ -1,12 +1,14 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
 import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.ComponentSourceEntity
 import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.springframework.stereotype.Service
 import java.time.Instant
 
+@ConditionalOnDatabaseEnabled
 @Service
 class ComponentSourceRegistryImpl(
     private val componentSourceRepository: ComponentSourceRepository,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentsRegistryServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentsRegistryServiceImpl.kt
@@ -20,8 +20,11 @@ class ComponentsRegistryServiceImpl(
     private val componentRegistryResolver: ComponentRegistryResolver,
     private val serviceStatus: ServiceStatus,
     private val properties: ComponentsRegistryProperties,
-    private val importService: ImportService,
-    private val componentSourceRepository: ComponentSourceRepository,
+    // Nullable: both are part of the database layer (@ConditionalOnDatabaseEnabled /
+    // JPA) and absent in no-db mode. Spring injects null for a Kotlin-nullable
+    // constructor parameter when no candidate bean exists; in db-mode both are wired.
+    private val importService: ImportService?,
+    private val componentSourceRepository: ComponentSourceRepository?,
 ) : ComponentsRegistryService {
     override fun updateConfigCache(): Long {
         log.info("Start update of Component Registry")
@@ -41,7 +44,8 @@ class ComponentsRegistryServiceImpl(
             serviceMode = serviceStatus.serviceMode,
             versionControlRevision = serviceStatus.versionControlRevision,
             defaultSource = properties.defaultSource,
-            dbComponentCount = componentSourceRepository.countBySource("db"),
+            // null-safe: no ComponentSourceRepository in no-db mode → no DB-sourced components.
+            dbComponentCount = componentSourceRepository?.countBySource("db") ?: 0L,
         )
 
     @PostConstruct
@@ -50,7 +54,13 @@ class ComponentsRegistryServiceImpl(
         updateConfigCache()
         if (properties.autoMigrate) {
             log.info("Auto-migrate enabled, migrating all components to database...")
-            val result = importService.migrate()
+            // auto-migrate is a DB-mode-only operation, so ImportService is always present
+            // here; the no-db profile forces auto-migrate=false, so this branch is unreachable
+            // when the DB layer is absent.
+            val result =
+                checkNotNull(importService) {
+                    "auto-migrate requires the database layer (ImportService bean); it must not be enabled in no-db mode"
+                }.migrate()
             log.info(
                 "Auto-migrate complete: ${result.components.migrated} migrated, " +
                     "${result.components.skipped} skipped, ${result.components.failed} failed",

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -9,6 +9,7 @@ import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
@@ -56,6 +57,7 @@ import java.util.EnumMap
  * Synthetic-base handling lives in the mapper (MIG-029 fix); the resolver does
  * not special-case it here.
  */
+@ConditionalOnDatabaseEnabled
 @Suppress("TooManyFunctions")
 @Service("databaseComponentRegistryResolver")
 @Transactional(readOnly = true)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional
  * un-configured field, so this service can land without a config-data
  * migration.
  */
+@ConditionalOnDatabaseEnabled
 @Service
 @Transactional(readOnly = true)
 class FieldConfigService(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryCommitWriter.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
@@ -16,6 +17,7 @@ import java.time.Instant
  * commit's rows are durable before the next commit is processed, which is
  * the v1 trade-off we accepted in lieu of full resume support.
  */
+@ConditionalOnDatabaseEnabled
 @Component
 class GitHistoryCommitWriter(
     private val auditLogRepository: AuditLogRepository,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -10,6 +10,7 @@ import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 import org.eclipse.jgit.treewalk.CanonicalTreeParser
 import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.dto.v4.HistoryImportResult
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
@@ -52,6 +53,7 @@ private const val SHORT_SHA_LENGTH = 7
  */
 private val HEARTBEAT_INTERVAL: java.time.Duration = java.time.Duration.ofMinutes(5)
 
+@ConditionalOnDatabaseEnabled
 @Service
 class GitHistoryImportServiceImpl(
     private val componentsRegistryProperties: ComponentsRegistryProperties,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStateEntity
 import org.octopusden.octopus.components.registry.server.entity.GitHistoryImportStatus
 import org.octopusden.octopus.components.registry.server.repository.GitHistoryImportStateRepository
@@ -34,6 +35,7 @@ import java.time.Instant
  * [current] synthesizes a state from it so the SPA can render the right action
  * (Retry on COMPLETED/FAILED, Force-reset on stale IN_PROGRESS).
  */
+@ConditionalOnDatabaseEnabled
 @Service
 class HistoryMigrationJobServiceImpl(
     private val gitHistoryImportService: GitHistoryImportService,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -11,6 +11,7 @@ import org.octopusden.octopus.components.registry.api.beans.PTDDbProductToolBean
 import org.octopusden.octopus.components.registry.api.beans.PTDProductToolBean
 import org.octopusden.octopus.components.registry.api.beans.PTKProductToolBean
 import org.octopusden.octopus.components.registry.api.build.tools.BuildTool
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentBuildToolBeanEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
@@ -81,6 +82,7 @@ import java.time.Instant
  *  §6.7  Tools and required tools: junction rows.
  *  §6.8  `${version}` placeholders stored verbatim.
  */
+@ConditionalOnDatabaseEnabled
 @Service
 @Suppress("CyclomaticComplexMethod", "TooGenericExceptionCaught")
 class ImportServiceImpl(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.service.AsyncJobLifecycle
 import org.octopusden.octopus.components.registry.server.service.FullMigrationResult
 import org.octopusden.octopus.components.registry.server.service.ImportService
@@ -40,6 +41,7 @@ import java.time.Instant
  *    it queues the second submit, so without the gate both `startAsync` calls
  *    would return 202 and the SPA would render two RUNNING jobs.
  */
+@ConditionalOnDatabaseEnabled
 @Service
 class MigrationJobServiceImpl(
     private val importService: ImportService,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.components.registry.server.teamcity
 
 import mu.KotlinLogging
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Component
  * logged-and-swallowed so a transient TC outage / live migration does not
  * crash the bean and prevent next week's run.
  */
+@ConditionalOnDatabaseEnabled
 @Component
 @EnableScheduling
 @ConditionalOnProperty(prefix = "teamcity.sync", name = ["enabled"], havingValue = "true")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.components.registry.server.teamcity
 
 import mu.KotlinLogging
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentTeamcityProjectEntity
 import org.octopusden.octopus.components.registry.server.event.AuditEvent
@@ -63,6 +64,7 @@ import java.util.UUID
  * scheduler. Per-write JPA failures inside the transaction template cause the
  * whole transaction to roll back, leaving DB state untouched.
  */
+@ConditionalOnDatabaseEnabled
 @Service
 class TeamcitySyncService(
     private val componentRepository: ComponentRepository,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.teamcity.impl
 
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.service.AsyncJobLifecycle
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
@@ -24,6 +25,7 @@ import java.time.Instant
  * surface — those exist on history because of its DB-backed
  * `git_history_import_state` row; TC has nothing equivalent to clear.
  */
+@ConditionalOnDatabaseEnabled
 @Service
 class TeamcitySyncJobServiceImpl(
     private val teamcitySyncService: TeamcitySyncService,

--- a/components-registry-service-server/src/main/resources/application-no-db.yml
+++ b/components-registry-service-server/src/main/resources/application-no-db.yml
@@ -1,0 +1,45 @@
+# SYS-047: no-DB boot mode. Activate this profile (alongside the usual
+# dev / dev-vcs-local / local set) to run the service with NO database at all:
+# every v1/v2/v3 request is served by the Git resolver — the same code path as
+# the pre-v3 (2.0.87) baseline. Used by the git-mode compat local stand (id18),
+# which no longer needs Postgres.
+#
+# This profile is the single switch. It does two things:
+#  1. Excludes the JDBC/JPA/Flyway auto-configurations so Spring never opens a
+#     Hikari pool or runs Flyway (spring.autoconfigure.exclude is read from the
+#     Environment before AutoConfigurationImportSelector runs, so a profile YAML
+#     is an effective place to set it).
+#  2. Sets components-registry.database.enabled=false, which makes every
+#     DB-coupled bean (@ConditionalOnDatabaseEnabled) drop out of the context.
+#
+# db-mode (id17) never activates this profile and never sets the flag, so it is
+# completely unchanged (every gated bean is matchIfMissing=true).
+#
+# Note: this profile does NOT disable Spring Cloud Config itself — that is a
+# bootstrap-context concern. Activate `no-db` alongside a profile that turns Cloud
+# Config off at bootstrap (the `dev` suite does, same as db-mode id17); tests use
+# `bootstrap-no-db.yml`. Running `no-db` with neither would hit the Config Server
+# bootstrap retry loop.
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+  flyway:
+    enabled: false
+
+components-registry:
+  database:
+    enabled: false
+  auto-migrate: false
+  default-source: git
+
+# Defensive: the DB-backed TeamCity sync scheduler is also gated by
+# @ConditionalOnDatabaseEnabled, but keep sync disabled here so a stray
+# teamcity.sync.enabled=true from service-config cannot try to wire it.
+teamcity:
+  sync:
+    enabled: false

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/NoDbModeContextTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/NoDbModeContextTest.kt
@@ -1,0 +1,137 @@
+package org.octopusden.octopus.components.registry.server
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.octopusden.octopus.components.registry.server.controller.ComponentControllerV4
+import org.octopusden.octopus.components.registry.server.controller.ComponentsRegistryServiceController
+import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
+import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
+import org.octopusden.octopus.components.registry.server.service.ComponentsRegistryService
+import org.octopusden.octopus.components.registry.server.service.ImportService
+import org.octopusden.octopus.components.registry.server.service.impl.ComponentRegistryResolverImpl
+import org.octopusden.octopus.components.registry.server.service.impl.ComponentRoutingResolver
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
+import org.octopusden.octopus.components.registry.test.BaseComponentsRegistryServiceTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import javax.sql.DataSource
+
+/**
+ * SYS-047: proves the service boots with NO database when the `no-db` profile is
+ * active (`components-registry.database.enabled=false` + JDBC/JPA/Flyway
+ * auto-configs excluded), serving v1/v2/v3 purely from the Git resolver.
+ *
+ * This is the completeness backstop for the @ConditionalOnDatabaseEnabled gating:
+ * if any DB-coupled bean is left un-annotated it would demand a (now-absent)
+ * repository/DataSource and this context would fail to start.
+ *
+ * webEnvironment = MOCK (not NONE): NONE gives a non-servlet context, under which
+ * the servlet SecurityFilterChain bean cannot wire — a failure unrelated to the
+ * database that would make the test prove the wrong thing. MOCK supplies a mock
+ * servlet context so security wires exactly as in production; all assertions are
+ * plain bean lookups + a direct service call (no MockMvc needed).
+ *
+ * `common` supplies the Git/FS boot config (vcs.enabled=false, groovy-path, …);
+ * `no-db` is the mode under test. The `test` profile (Testcontainers Postgres) is
+ * deliberately NOT activated. Assertions check wiring only — not fixture data —
+ * so the test is not coupled to the shared DSL fixture content.
+ */
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    classes = [ComponentRegistryServiceApplication::class],
+    properties = ["auth-server.disabled=true"],
+)
+@ActiveProfiles("common", "no-db")
+class NoDbModeContextTest {
+    companion object {
+        // Reuse only the shared boot data dir helper (sets
+        // COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR, which application-common.yml's
+        // work-dir/groovy-path placeholders need) WITHOUT extending the global
+        // fixture base — this class asserts wiring only, so it stays decoupled from
+        // the shared TestComponents/Defaults assertion surface. The companion
+        // initializer runs at class-load, before Spring builds the context.
+        init {
+            BaseComponentsRegistryServiceTest.configureSpringAppTestDataDir()
+        }
+    }
+
+    @Autowired
+    private lateinit var ctx: ApplicationContext
+
+    @Autowired
+    private lateinit var registryService: ComponentsRegistryService
+
+    @Test
+    @DisplayName("SYS-047: no DataSource / Flyway-JPA stack is wired in no-db mode")
+    fun `SYS-047 no DataSource bean exists in no-db mode`() {
+        Assertions.assertTrue(
+            ctx.getBeanNamesForType(DataSource::class.java).isEmpty(),
+            "no-db mode must boot without a DataSource bean, found: " +
+                ctx.getBeanNamesForType(DataSource::class.java).joinToString(),
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-047: Git resolver is the sole ComponentRegistryResolver (routing resolver dropped)")
+    fun `SYS-047 git resolver is the sole resolver in no-db mode`() {
+        Assertions.assertTrue(
+            ctx.getBeanNamesForType(ComponentRoutingResolver::class.java).isEmpty(),
+            "ComponentRoutingResolver (git+db) must be absent in no-db mode",
+        )
+        val resolvers = ctx.getBeanNamesForType(ComponentRegistryResolver::class.java)
+        Assertions.assertEquals(
+            1,
+            resolvers.size,
+            "exactly one ComponentRegistryResolver expected, found: ${resolvers.joinToString()}",
+        )
+        Assertions.assertTrue(
+            ctx.getBean(ComponentRegistryResolver::class.java) is ComponentRegistryResolverImpl,
+            "the sole resolver must be the pure-Git ComponentRegistryResolverImpl",
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-047: DB-only beans (v4 CRUD, TeamCity sync) are absent; git read controller stays")
+    fun `SYS-047 db-only beans absent and git read path present in no-db mode`() {
+        Assertions.assertTrue(
+            ctx.getBeanNamesForType(ComponentControllerV4::class.java).isEmpty(),
+            "v4 CRUD controller must be absent in no-db mode",
+        )
+        Assertions.assertTrue(
+            ctx.getBeanNamesForType(TeamcitySyncService::class.java).isEmpty(),
+            "DB-backed TeamcitySyncService must be absent in no-db mode",
+        )
+        Assertions.assertTrue(
+            ctx.getBeanNamesForType(ImportService::class.java).isEmpty(),
+            "DB-only ImportService must be absent in no-db mode " +
+                "(so the controller's nullable importService is injected null)",
+        )
+        Assertions.assertTrue(
+            ctx.getBeanNamesForType(ComponentManagementService::class.java).isEmpty(),
+            "DB-only ComponentManagementService must be absent in no-db mode",
+        )
+        Assertions.assertEquals(
+            1,
+            ctx.getBeanNamesForType(ComponentsRegistryServiceController::class.java).size,
+            "the v1/v2/v3 service controller (status/ping/updateCache) must stay wired",
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-047: /service/status reports git routing and zero db components without a DB")
+    fun `SYS-047 status reports defaultSource git and zero db components in no-db mode`() {
+        val status = registryService.getComponentsRegistryStatus()
+        Assertions.assertEquals("git", status.defaultSource, "no-db mode routes every component via Git")
+        Assertions.assertEquals(
+            0L,
+            status.dbComponentCount,
+            "dbComponentCount must be 0 (null-safe) when no ComponentSourceRepository is wired",
+        )
+    }
+}

--- a/components-registry-service-server/src/test/resources/bootstrap-no-db.yml
+++ b/components-registry-service-server/src/test/resources/bootstrap-no-db.yml
@@ -1,0 +1,10 @@
+# Loaded by the Spring Cloud bootstrap context when the `no-db` profile is active
+# (mirrors bootstrap-test.yml). Without it, NoDbModeContextTest boots with
+# common+no-db but no bootstrap override, so ConfigServicePropertySourceLocator
+# tries to reach a Config Server and retries with exponential backoff — hanging
+# the test. The real no-db candidate (local stand / id18) activates `dev`, whose
+# suite already keeps Cloud Config off, so this is a test-only concern.
+spring:
+  cloud:
+    config:
+      enabled: false

--- a/docs/registry/adr/007-dual-read-migration.md
+++ b/docs/registry/adr/007-dual-read-migration.md
@@ -177,6 +177,38 @@ Git repository is preserved read-only until all components are validated in DB +
 - Set target date for Phase 4 to prevent indefinite dual-running
 - `component_source` can be dropped after Phase 5
 
+## No-Database Boot Mode (git-only, issue #310, SYS-047)
+
+The dual-read model above assumes a database is present: every read passes through
+`ComponentRoutingResolver`, which consults the `component_source` table. For the
+**git-mode compat stand** (id18) and any "deploy v3 but do not migrate" scenario the
+DB is never read — yet the service still booted a full JPA + Flyway + Hikari stack
+just to satisfy the routing wiring.
+
+The `no-db` Spring profile (`application-no-db.yml`) removes that cost. It excludes
+the JDBC / JPA / Flyway auto-configurations and sets
+`components-registry.database.enabled=false`, which drops every DB-coupled bean via
+the `@ConditionalOnDatabaseEnabled` meta-annotation — including
+`ComponentRoutingResolver` itself. With the `@Primary` routing resolver gone, the
+pure-Git `ComponentRegistryResolverImpl` (which already implements the whole
+`ComponentRegistryResolver` interface) becomes the **sole** resolver, so v1/v2/v3 are
+served exactly as on the pre-v3 (2.0.87) baseline — with no database at all.
+
+This is opt-in and orthogonal to the per-component routing above: db-mode never
+activates the profile and never sets the flag (`matchIfMissing = true`), so it is
+unchanged. v4 CRUD / admin / audit and all migration machinery are DB-only and are
+absent in no-db mode — acceptable because the sole purpose of this mode is serving
+v1/v2/v3 from Git.
+
+**Coverage note:** because `ComponentRoutingResolver` is now absent in no-db, the
+git-mode compat stand (id18) exercises `ComponentRegistryResolverImpl` directly — it
+no longer covers `ComponentRoutingResolver`'s git branch and aggregate-merge code
+(which, with an empty `component_source`, reduced to git-only anyway). That routing
+code stays covered by db-mode (id17). This is a deliberate, accepted coverage shift,
+not a regression of the no-op invariant.
+
+See requirement **SYS-047** and `NoDbModeContextTest`.
+
 ## References
 - Strangler Fig pattern: https://martinfowler.com/bliki/StranglerFigApplication.html
 - `ComponentRegistryResolver` interface: `components-registry-service-server/.../service/ComponentRegistryResolver.kt`

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -55,6 +55,7 @@
 | SYS-044 | releaseManager / securityChampion are ordered multi-value (`string[]`) in v4 with keep-first dedupe; legacy v1/v2/v3 keep the comma-joined `String`; componentOwner stays single-value and is removed from the global component-defaults surface | High | unit + integration-test | ✅ Tested |
 | SYS-045 | GET /components?distributionExplicit= / ?distributionExternal= activate the two scalar distribution boolean filters (mirror `solution`; `=false` excludes NULL rows) | Medium | integration-test | ✅ Tested |
 | SYS-046 | clientCode / jiraProjectKey / parentComponentName / groupKey become multi-value exact-IN filters (CSV / repeatable); 4 companion in-use meta endpoints (/meta/client-codes, /meta/jira-project-keys, /meta/parent-component-names, /meta/group-keys) | High | integration-test | ✅ Tested |
+| SYS-047 | git-only no-DB boot mode: the `no-db` profile excludes the JDBC/JPA/Flyway auto-configs and gates every DB-coupled bean off (`@ConditionalOnDatabaseEnabled`), so the service boots with no database and serves v1/v2/v3 from the Git resolver — the compat git-mode stand (id18) needs no Postgres | High | unit / context-load test | ✅ Tested |
 
 ---
 
@@ -1525,3 +1526,62 @@ Mirrors SYS-040 (labels) / SYS-042 (system): a filter change plus a companion in
 **Out of scope:**
 - Converting the remaining extended scalars (`vcsPath`, `productionBranch`) to multi-value — they stay single-value `LIKE` (free-text search, not dropdown-backed).
 - URL/bookmark state for the filters (Portal holds filter state in React, not query params).
+
+### SYS-047: git-only no-DB boot mode
+
+**Priority:** High
+**Test layer:** unit / context-load test
+**Status:** ✅ Tested
+
+**Motivation:**
+The `[1.8]` git-mode compat stand (id18) runs the candidate with
+`auto-migrate=false` + `default-source=git`, serving every v1/v2/v3 request from
+the Git resolver. Before this change the candidate still booted a full JPA +
+Flyway + Hikari stack against Postgres purely because the active profile supplied a
+datasource — the DB was never read for serving. The stand therefore had to start
+Postgres for nothing (follow-up from #308 / #309, issue #310).
+
+**Description:**
+- New `no-db` Spring profile (`application-no-db.yml`) — the single switch. It (a)
+  sets `spring.autoconfigure.exclude` for `DataSourceAutoConfiguration`,
+  `DataSourceTransactionManagerAutoConfiguration`, `HibernateJpaAutoConfiguration`,
+  `JpaRepositoriesAutoConfiguration`, `FlywayAutoConfiguration`, and (b) sets
+  `components-registry.database.enabled=false` (plus `auto-migrate=false`,
+  `default-source=git`, `teamcity.sync.enabled=false`).
+- New `components-registry.database.enabled` flag (default `true`) and the
+  `@ConditionalOnDatabaseEnabled` meta-annotation
+  (`@ConditionalOnProperty(..., matchIfMissing = true)`) gate every DB-coupled bean:
+  the DB resolver, `ComponentSourceRegistry`, the `@Primary` routing resolver, the
+  import / component-management / audit / field-config / git-history / migration /
+  TeamCity-sync services, the TeamCity scheduler, the migration executor, the audit +
+  field-config listeners, and the v4 CRUD / admin / audit / config controllers. With
+  the flag unset, db-mode (id17) is unchanged.
+- The pure-Git `ComponentRegistryResolverImpl` already implements the full
+  `ComponentRegistryResolver` interface; when the `@Primary` routing resolver drops
+  out it becomes the **sole** resolver, so every v1/v2/v3 consumer binds to it — the
+  same code path as the 2.0.87 baseline.
+- The two git-path beans that inject DB deps (`ComponentsRegistryServiceImpl`,
+  `ComponentsRegistryServiceController`) take them as Kotlin-nullable (optional)
+  dependencies: status `dbComponentCount` is null-safe (0), and `updateCache` keeps
+  its per-pod refresh lock in **both** modes but skips the DB-only migration-status
+  / 410-retirement gate when no `ImportService` is wired.
+- Local stand: `teamcity-run.sh` / `candidate.sh` run git-mode with the `no-db`
+  profile and do NOT start Postgres (id18 drops the `POSTGRES_IMAGE` pull); db-mode
+  (id17) is untouched.
+
+**Acceptance criteria:**
+1. With the `no-db` profile active the context starts with **no `DataSource` bean**
+   and no Hikari/Flyway — no database is required.
+2. The `@Primary` `ComponentRoutingResolver` and all DB-coupled beans (v4 CRUD,
+   TeamCity sync, …) are absent; the sole `ComponentRegistryResolver` is the
+   pure-Git `ComponentRegistryResolverImpl`.
+3. `GET /rest/api/2/components-registry/service/status` reports `defaultSource=git`
+   and `dbComponentCount=0`.
+4. db-mode (no `no-db` profile) is unchanged — every gated bean is `matchIfMissing=true`.
+
+**Test method:** `NoDbModeContextTest` — four methods, each carrying `SYS-047` in
+its name + a `@DisplayName("SYS-047: …")` (test-to-requirement traceability):
+`SYS-047 no DataSource bean exists in no-db mode`,
+`SYS-047 git resolver is the sole resolver in no-db mode`,
+`SYS-047 db-only beans absent and git read path present in no-db mode`,
+`SYS-047 status reports defaultSource git and zero db components in no-db mode`.

--- a/scripts/local-stands/README.md
+++ b/scripts/local-stands/README.md
@@ -10,7 +10,7 @@ test against them — bypassing the TeamCity build + OKD deploy cycle.
 | Port | `4567` | `4568` |
 | Runtime | fat JAR (`java -jar`, built once via `bootJar`) | Gradle `bootRun` (incremental iteration) |
 | Mode | VCS (Git-DSL) | DB (Postgres + auto-migrate from VCS at startup; `default-source=db` so `DatabaseComponentRegistryResolver` serves the migrated components) |
-| Profiles | `dev,dev-vcs-local,local` | `dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local` (default — `candidate.sh --mode=db`); fallback `dev,dev-vcs-local,dev-db-automigrate,local` (`--mode=vcs`, for V1-vs-V1 parity-debug) |
+| Profiles | `dev,dev-vcs-local,local` | `dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local` (default — `candidate.sh --mode=db`); no-db `dev,dev-vcs-local,no-db,local` (`--mode=vcs` — no database, issue #310) |
 | Cloud Config | disabled (yamls mounted from local `service-config` clone) | not used (`dev` profile) |
 
 Both stands point at the same local Git-DSL clone (no remote git fetch) so the
@@ -149,10 +149,12 @@ serves component reads:
 | Mode | When | Profile added | Effect |
 |---|---|---|---|
 | `--mode=db` (**default**) | Validating cluster-fix PRs (#208/#209/#211/#212 family); measuring real schema-v2-vs-V1 deltas | `dev-db-only` — sets `components-registry.default-source=db` | `ComponentRoutingResolver` picks `DatabaseComponentRegistryResolver` for unmigrated components (post-automigrate everything is migrated, so DB serves all). |
-| `--mode=vcs` | V1-vs-V1 parity-debug only (e.g., comparing two test-builds of the V1 in-memory resolver) | (none added — falls back to global `default-source=git`) | V1 `EscrowConfigurationLoader` serves; schema-v2 code path is dormant. |
+| `--mode=vcs` | The deploy-without-migration no-op check (id18) and V1-vs-V1 parity-debug | `no-db` instead of `dev-db-automigrate` — excludes the JDBC/JPA/Flyway auto-configs and sets `default-source=git` (issue #310) | V1 `EscrowConfigurationLoader` serves; the candidate boots with **no database at all** (no Hikari/Flyway), so **no Postgres is needed**. |
 
 `verify.sh --restart` invokes `candidate.sh` without args → mode `db` by default.
-Use `--mode=vcs` only when you need to reproduce the V1-only behaviour.
+Use `--mode=vcs` for the no-migration / V1-only behaviour; it needs no Postgres
+(`postgres-up.sh` is for db-mode only). The TeamCity git-mode stand (`id18`,
+`CANDIDATE_MODE=git`) likewise starts no Postgres.
 
 ## Polluted-run guard
 

--- a/scripts/local-stands/candidate.sh
+++ b/scripts/local-stands/candidate.sh
@@ -15,12 +15,14 @@
 #                  has a `component_sources` row with source='db', so the fallback governs
 #                  unmigrated components only. This is the mode in which the four cluster-
 #                  fix PRs (#208/#209/#211/#212) are actually exercised.
-#   --mode=vcs           — components-registry.default-source=git (the global default);
-#                  V1 in-memory EscrowConfigurationLoader serves. Use for V1-vs-V1 parity-
-#                  debugging only.
+#   --mode=vcs           — no-db profile (issue #310): the JDBC/JPA/Flyway auto-configs
+#                  are excluded so the candidate boots with NO database;
+#                  components-registry.default-source=git, the V1 in-memory
+#                  EscrowConfigurationLoader serves. No Postgres required. Use for the
+#                  deploy-without-migration no-op check and V1-vs-V1 parity-debugging.
 #
-# Requires Postgres running (see postgres-up.sh).
-# Triggers full DSL→DB migration at startup (~30-60 sec on first run).
+# db-mode requires Postgres running (see postgres-up.sh) and triggers a full DSL→DB
+# migration at startup (~30-60 sec on first run); vcs/no-db mode needs neither.
 # Unlike baseline.sh, this script does NOT explicitly disable Spring Cloud Config — the
 # dev profile suite doesn't request cloud-config, so it's implicitly off.
 set -euo pipefail
@@ -61,15 +63,29 @@ ADDITIONAL_LOCATION="file:$CANDIDATE_WORKTREE/components-registry-service-server
 ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
 
 WORK_DIR="${WORK_DIR:-/tmp/crs-candidate-work}"
+NODB_OVERRIDE_ARGS=""
 if [ "$MODE" = "db" ]; then
   PROFILES="dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local"
 else
-  PROFILES="dev,dev-vcs-local,dev-db-automigrate,local"
+  # vcs (no-db) mode: the `no-db` profile excludes the JDBC/JPA/Flyway auto-configs
+  # so the candidate boots with no database at all (issue #310); no Postgres needed.
+  PROFILES="dev,dev-vcs-local,no-db,local"
+  # Force all three no-db knobs at the CLI (highest precedence) so a stray override
+  # in service-config (loaded via additional-location, which outranks the bundled
+  # no-db profile YAML) cannot re-enable the DB beans / migration / db routing while
+  # JPA autoconfig stays excluded — mirrors teamcity-run.sh's git-mode args exactly.
+  NODB_OVERRIDE_ARGS=" --components-registry.database.enabled=false"
+  NODB_OVERRIDE_ARGS="$NODB_OVERRIDE_ARGS --components-registry.auto-migrate=false"
+  NODB_OVERRIDE_ARGS="$NODB_OVERRIDE_ARGS --components-registry.default-source=git"
 fi
 cd "$CANDIDATE_WORKTREE"
 echo ">>> candidate: $CANDIDATE_WORKTREE @ $(git rev-parse --short HEAD)"
 echo ">>> mode: $MODE   profiles: $PROFILES"
-echo ">>> port: $CANDIDATE_PORT,  VCS root: $LOCAL_VCS_ROOT  (work-dir: $WORK_DIR),  DB: localhost:${CRS_DB_PORT:-5432}"
+if [ "$MODE" = "db" ]; then
+  echo ">>> port: $CANDIDATE_PORT,  VCS root: $LOCAL_VCS_ROOT  (work-dir: $WORK_DIR),  DB: localhost:${CRS_DB_PORT:-5432}"
+else
+  echo ">>> port: $CANDIDATE_PORT,  VCS root: $LOCAL_VCS_ROOT  (work-dir: $WORK_DIR),  DB: none (no-db mode)"
+fi
 echo ">>> config: $SERVICE_CONFIG_DIR (overlaid on dev/)"
 exec ./gradlew :components-registry-service-server:bootRun --no-daemon --console=plain \
   --args="--server.port=$CANDIDATE_PORT \
@@ -78,4 +94,4 @@ exec ./gradlew :components-registry-service-server:bootRun --no-daemon --console
           --components-registry.vcs.root=file://$LOCAL_VCS_ROOT \
           --components-registry.work-dir=$WORK_DIR \
           --components-registry.groovy-path=$WORK_DIR/src/main/resources \
-          --auth-server.disabled=true"
+          --auth-server.disabled=true$NODB_OVERRIDE_ARGS"

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -109,12 +109,13 @@ CANDIDATE_LOG="${CANDIDATE_LOG:-/tmp/crs-candidate-tc.log}"
 #   db  (default) — dev-db-automigrate + dev-db-only: DSL→DB migration at
 #                   startup, default-source=db. Compat asserts the schema-v2
 #                   DB resolver reproduces the v1/v2/v3 contract (id17 / [1.7]).
-#   git           — dev-db-automigrate only (DB present + Flyway schema so the
-#                   JAR boots), plus CLI --auto-migrate=false --default-source=git.
-#                   NO migration runs, component_source stays empty, every
-#                   component is served from the Git resolver — the same code
-#                   path as the 2.0.87 baseline. Compat asserts that deploying
-#                   v3 WITHOUT migrating is a no-op for v1/v2/v3 (id18 / [1.8]).
+#   git           — no-db profile (issue #310): the JDBC/JPA/Flyway auto-configs
+#                   are excluded so the candidate boots with NO database at all,
+#                   plus CLI --auto-migrate=false --default-source=git. NO
+#                   migration runs and every component is served from the Git
+#                   resolver — the same code path as the 2.0.87 baseline. Compat
+#                   asserts that deploying v3 WITHOUT migrating is a no-op for
+#                   v1/v2/v3 (id18 / [1.8]). Postgres is never started in git-mode.
 CANDIDATE_MODE="${CANDIDATE_MODE:-db}"
 case "$CANDIDATE_MODE" in
   db|git) ;;
@@ -183,7 +184,15 @@ if [ "$RESET_DB" = "1" ]; then
     fi
   fi
 fi
-"$SCRIPT_DIR/postgres-up.sh"
+if [ "$CANDIDATE_MODE" = "git" ]; then
+  # no-db git mode (issue #310): any stale Postgres from a prior db-mode run on a
+  # persistent agent was torn down above (RESET_DB); do NOT start a new one. The
+  # candidate boots with the `no-db` profile, which excludes the JDBC/JPA/Flyway
+  # auto-configs, so it needs no database at all — that absence is the point of id18.
+  echo "    git-mode (no-db): Postgres not started — candidate boots with no database"
+else
+  "$SCRIPT_DIR/postgres-up.sh"
+fi
 
 # ---------- Stage 2/4: baseline JAR ----------
 echo ">>> Stage 2/4: baseline JAR (V1 mode)"
@@ -241,22 +250,32 @@ CANDIDATE_WORK_DIR="${CANDIDATE_WORK_DIR:-/tmp/crs-candidate-tc-work}"
 # Candidate's profile suite. Common base:
 #   dev                  — base dev overlay
 #   dev-vcs-local        — file:// VCS access (no remote bitbucket pull)
+#   local                — local stand identity marker
+# db-mode (id17) adds:
 #   dev-db-automigrate   — datasource + Flyway schema (the JAR needs a live DB to
 #                          boot); in db-mode it ALSO runs the DSL→DB migration
-#   local                — local stand identity marker
-# db-mode adds:
 #   dev-db-only          — components-registry.default-source=db (schema-v2 code
 #                          path active for unmigrated-component fallback)
-# git-mode instead forces no-migration + git routing via the CLI overrides below
-# (top of Spring's property-source order, so they also beat service-config).
+# git-mode (id18, issue #310) adds:
+#   no-db                — excludes the JDBC/JPA/Flyway auto-configs so the JAR
+#                          boots with NO database; the CLI overrides below also
+#                          force no-migration + git routing (top of Spring's
+#                          property-source order, so they beat service-config).
 CANDIDATE_ADDITIONAL="file:$CANDIDATE_WORKTREE/components-registry-service-server/dev/"
 CANDIDATE_ADDITIONAL="$CANDIDATE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
 CANDIDATE_AUTOMIGRATE_ARG=""
 CANDIDATE_DEFAULTSOURCE_ARG=""
+CANDIDATE_DATABASE_ARG=""
 if [ "$CANDIDATE_MODE" = "git" ]; then
-  CANDIDATE_PROFILES="dev,dev-vcs-local,dev-db-automigrate,local"
+  CANDIDATE_PROFILES="dev,dev-vcs-local,no-db,local"
   CANDIDATE_AUTOMIGRATE_ARG="--components-registry.auto-migrate=false"
   CANDIDATE_DEFAULTSOURCE_ARG="--components-registry.default-source=git"
+  # Reinforce the no-db flag at the CLI (highest precedence) so a stray
+  # components-registry.database.enabled=true in service-config (loaded via
+  # additional-location, which outranks the bundled no-db profile YAML) cannot
+  # silently re-enable the DB beans. The autoconfigure-exclude still comes from
+  # the no-db profile; the Hikari/Flyway candidate.log guard below is the backstop.
+  CANDIDATE_DATABASE_ARG="--components-registry.database.enabled=false"
 else
   CANDIDATE_PROFILES="dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local"
 fi
@@ -275,13 +294,14 @@ nohup "$JAVA_BIN" -jar "$CANDIDATE_JAR" \
   --auth-server.disabled=true \
   $CANDIDATE_AUTOMIGRATE_ARG \
   $CANDIDATE_DEFAULTSOURCE_ARG \
+  $CANDIDATE_DATABASE_ARG \
   >"$CANDIDATE_LOG" 2>&1 &
 CANDIDATE_PID=$!
 echo "    candidate started (PID=$CANDIDATE_PID, log=$CANDIDATE_LOG)"
 
 CANDIDATE_HEALTH_TIMEOUT_ITERS="${CANDIDATE_HEALTH_TIMEOUT_ITERS:-120}"
 # Auto-migrate import takes ~30-60s, plus startup ~20s, plus headroom for slow agents.
-echo -n "    waiting for candidate health on :$CANDIDATE_PORT (up to $((CANDIDATE_HEALTH_TIMEOUT_ITERS * 4 / 60)) min — includes auto-migrate)"
+echo -n "    waiting for candidate health on :$CANDIDATE_PORT (up to $((CANDIDATE_HEALTH_TIMEOUT_ITERS * 4 / 60)) min — db-mode also runs auto-migrate)"
 for i in $(seq 1 "$CANDIDATE_HEALTH_TIMEOUT_ITERS"); do
   if curl -fsS --max-time 2 "http://localhost:$CANDIDATE_PORT/actuator/health" >/dev/null 2>&1; then
     echo
@@ -335,6 +355,24 @@ elif [ "$CANDIDATE_DEFAULT_SOURCE" != "$CANDIDATE_MODE" ]; then
   exit 2
 else
   echo "    candidate routing: defaultSource=$CANDIDATE_DEFAULT_SOURCE ✓ (mode=$CANDIDATE_MODE)"
+fi
+
+# no-db guard (issue #310): git-mode MUST boot with NO database. The defaultSource
+# check above is necessary but NOT sufficient — default-source=git is forced via the
+# CLI, so it would still read 'git' even if a service-config override or a profile-
+# precedence regression let the JDBC/JPA/Flyway stack back in. The unambiguous signal
+# is the candidate's own log: a Hikari pool start or a Flyway run means a database was
+# wired. Assert their ABSENCE so id18 can never silently pass while running against a
+# DB — this is the acceptance evidence for the issue.
+if [ "$CANDIDATE_MODE" = "git" ]; then
+  if grep -Eq "HikariPool|HikariDataSource|Flyway Community|Migrating schema|DataSourceAutoConfiguration matched" "$CANDIDATE_LOG"; then
+    echo "ERROR: git-mode candidate started a database stack — Hikari/Flyway found in $CANDIDATE_LOG."
+    echo "       no-db mode must exclude DataSource/JPA/Flyway. Check that the 'no-db' profile is active"
+    echo "       and that no service-config override re-enabled spring.autoconfigure.exclude / database.enabled."
+    grep -En "HikariPool|HikariDataSource|Flyway Community|Migrating schema" "$CANDIDATE_LOG" | head -n 5 || true
+    exit 2
+  fi
+  echo "    no-db guard: no Hikari/Flyway in candidate.log ✓ (candidate booted with no database)"
 fi
 
 # ---------- Stage 4/4: compat ----------


### PR DESCRIPTION
## What & why

Closes #310 (follow-up from #308 / #309).

The `[1.8]` git-mode compat stand (`id18`) runs the candidate with `auto-migrate=false` + `default-source=git`, so every v1/v2/v3 response is served by the Git resolver and **no migration runs**. But the candidate still booted a full **JPA + Flyway + Hikari** stack against Postgres purely because the active profile supplied a datasource — the DB was never read for serving. So `id18` started Postgres for nothing.

This adds a **no-DB boot mode** so the service runs with **no database at all** when git-only, serving v1/v2/v3 from the Git resolver — exactly the pre-v3 (2.0.87) code path. `id18` no longer needs Postgres. **db-mode (`id17`) is unchanged.**

## How

**One switch — the `no-db` Spring profile** (`application-no-db.yml`):
- sets `spring.autoconfigure.exclude` for `DataSourceAutoConfiguration`, `DataSourceTransactionManagerAutoConfiguration`, `HibernateJpaAutoConfiguration`, `JpaRepositoriesAutoConfiguration`, `FlywayAutoConfiguration`;
- sets `components-registry.database.enabled=false` (+ `auto-migrate=false`, `default-source=git`, `teamcity.sync.enabled=false`).

**Bean gating** — a new `components-registry.database.enabled` flag (default `true`) and the `@ConditionalOnDatabaseEnabled` meta-annotation (`@ConditionalOnProperty(..., matchIfMissing = true)`) drop every DB-coupled bean in no-db mode: the DB resolver, `ComponentSourceRegistry`, the `@Primary` `ComponentRoutingResolver`, the import / component-management / audit / field-config / git-history / migration / TeamCity-sync services, the TeamCity scheduler, the migration executor, the audit + field-config listeners, and the v4 CRUD/admin/audit/config controllers. With the flag unset, db-mode is bit-for-bit unchanged.

**The seam:** the pure-Git `ComponentRegistryResolverImpl` already implements the whole `ComponentRegistryResolver` interface; when the `@Primary` routing resolver drops out it becomes the **sole** resolver, so every v1/v2/v3 consumer binds to it transparently.

**Two git-path beans** (`ComponentsRegistryServiceImpl`, `ComponentsRegistryServiceController`) take their DB deps as Kotlin-nullable (optional) dependencies: status `dbComponentCount` is null-safe (0), and `updateCache` keeps its per-pod refresh lock in **both** modes while skipping only the DB-only migration-status / 410-retirement gate when no `ImportService` is wired.

**Local stand / TeamCity:**
- `teamcity-run.sh` + `candidate.sh` run git-mode on the `no-db` profile and do **not** start Postgres (the stale-Postgres teardown is kept). Git-mode also forces `--components-registry.database.enabled=false` via CLI and **asserts `candidate.log` contains no Hikari/Flyway** — fail-fast so the stand can never silently pass while actually running against a DB.
- `.teamcity` `id18` drops the `POSTGRES_IMAGE` pull. `id17` (db-mode) untouched.

## Tests

`NoDbModeContextTest` (**SYS-045**) — a focused `@SpringBootTest` on the `no-db` profile asserting: no `DataSource` bean, the Git resolver is the sole `ComponentRegistryResolver`, v4 CRUD / TeamCity-sync / `ImportService` / `ComponentManagementService` beans are absent, the v1/v2/v3 service controller stays wired, and `/service/status` reports `defaultSource=git`, `dbComponentCount=0`. Demonstrated RED (context fails on missing repos) → GREEN.

## Verification

- `./gradlew build` (local, excluding the docker-image / OKD-deploy / automation-FT CI-only tasks) — **green**, including ktlint/detekt, all module tests, the fat-jar integration tests, and `NoDbModeContextTest`.
- Reviewed by two independent agents (correctness + adversarial on the infra); no P1/P2 correctness defects; their P2/P3 items are folded in (CLI-flag + `candidate.log` no-DB guard; coverage-shift note; cosmetics).
- **Compat gate (operator / TeamCity, not run here):** trigger `id18` from this branch and confirm — `candidate.log` shows no Hikari/Flyway, Postgres never starts, compat `summary.md` = **0 active diffs**, and `id17` (db-mode) stays green.

## Docs

`requirements-common.md` SYS-045; ADR-007 no-DB section (incl. the deliberate id18 coverage shift — the routing resolver's git path stays covered by id17); operator notes in `scripts/local-stands/README.md` + `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
