### PR TITLE
chore(build): adopt octopus-quality / octopus-base 2.3.5 (SpotBugs stays disabled)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       java-version: '21'
       flow-type: hybrid
@@ -14,13 +14,13 @@ jobs:
     secrets: inherit
 
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
     with:
       java-version: '21'
     secrets: inherit
 
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
     with:
       java-version: '21'
       enable-codeql: true
@@ -35,6 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.4
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
     with:
       java-version: '21'
       enable-codeql: true

--- a/build.gradle
+++ b/build.gradle
@@ -176,16 +176,15 @@ configure(subprojects) {
     }
 
     afterEvaluate {
-        // SpotBugs disabled for this project. The octopus-quality convention plugin enables it,
-        // but bytecode-flow analysis produced a 95% false-positive rate on Kotlin lateinit / DSL
-        // getter / test code in build 2.0.84-3436 (1 real bug out of 21 HIGH-priority findings,
-        // resolved in PR #218). The remaining toolchain — Checkstyle + PMD (Java, blocking),
-        // detekt + ktlint (Kotlin, blocking), CodeNarc (Groovy, report-only) — already covers
-        // each language with native rule sets. Keeping SpotBugs would require ongoing exclude-filter
-        // maintenance for marginal signal. See AGENTS.md Quality Gates section.
+        // SpotBugs stays disabled. octopus-quality 2.3.5 already gates SpotBugs to Java-without-
+        // Kotlin modules, but CRS's Java/Groovy modules (component-resolver-*, *-light-client) still
+        // yield low-value noise — EI_EXPOSE_REP on the escrow model/config POJOs plus findings on
+        // Groovy-generated classes (22 in component-resolver-api alone) — exactly the exclude-filter
+        // maintenance we opted out of (1 real bug / 21 HIGH in build 2.0.84-3436, PR #218).
+        // Checkstyle + PMD (Java, blocking), detekt + ktlint (Kotlin, blocking) and CodeNarc (Groovy)
+        // already cover each language. See AGENTS.md Quality Gates section.
         //
-        // We disable the *tasks* rather than apply-false the plugin: the SpotBugs plugin is owned
-        // by octopus-quality (shared convention), so opting out happens at the consumer side here.
+        // Disable the *tasks* (not apply-false): the SpotBugs plugin is owned by octopus-quality.
         if (pluginManager.hasPlugin('com.github.spotbugs')) {
             tasks.matching { it.name.startsWith('spotbugs') }.configureEach { enabled = false }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
         id 'org.jetbrains.kotlin.plugin.jpa'            version settings['kotlin.version']
         id 'io.gitlab.arturbosch.detekt'                version settings['detekt.version']
         id 'org.jlleitschuh.gradle.ktlint'              version settings['ktlint-gradle.version']
-        id 'org.octopusden.octopus-quality'             version '2.3.4'
+        id 'org.octopusden.octopus-quality'             version '2.3.5'
         id 'com.bmuschko.docker-java-application'       version settings['gradle-docker-plugin.version']
         id 'com.github.johnrengelman.shadow'            version '8.1.1'
         id 'org.octopusden.octopus.oc-template'         version settings['octopus-oc-template.version']


### PR DESCRIPTION
## What

Adopt **octopus-base / octopus-quality 2.3.5** ([octopus-base#142](https://github.com/octopusden/octopus-base/pull/142)), which gates SpotBugs to **Java-without-Kotlin** modules and pins a Java-25-capable engine.

CRS **keeps its blanket SpotBugs disable** — unlike the (Kotlin-only) management portal, CRS has Java/Groovy modules where SpotBugs still produces low-value noise.

## Why the disable stays

With the disable removed, `qualityStatic` fails: SpotBugs runs on the non-Kotlin modules and `component-resolver-api:spotbugsMain` reports **22 findings** (`java { failOnViolation = true }` blocks the build):
- 12× `EI_EXPOSE_REP`/`EI_EXPOSE_REP2` on the escrow model/config POJOs
- 4× `EQ_UNUSUAL` (incl. Groovy-generated closures), plus `SE_NO_SERIALVERSIONID` / `CT_CONSTRUCTOR_THROW` / `CN_IDIOM_NO_SUPER_CALL`

This is exactly the *"ongoing exclude-filter maintenance for marginal signal"* tradeoff already documented (PR #218). 2.3.5's gating removes the *Kotlin*-module noise, but CRS's *Java/Groovy* modules keep it — so the consumer-side disable is still load-bearing.

## Change

- `settings.gradle`: `octopus-quality` 2.3.4 → **2.3.5**
- workflows: octopus-base reusable refs `@v2.3.4` → **`@v2.3.5`** (7 refs / 4 files)
- `build.gradle`: refreshed the SpotBugs-disable comment for the 2.3.5 gating — **disable logic unchanged**

## Verification

`./gradlew qualityStatic` → **BUILD SUCCESSFUL**; SpotBugs tasks **SKIPPED** on the three Java-without-Kotlin modules (`component-resolver-api/core`, `…-light-client`), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)