### PR TITLE
feat(compat): replay real captured POST bodies in [1.7]/[1.8]

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -734,7 +734,7 @@ object id17CompatLocalStandManual : BuildType({
                 export COMPAT_VERSIONS_FILE="${'$'}VERSIONS_FILE_PATH"
                 export COMPAT_FULL="%COMPAT_FULL%"
                 export COMPAT_PARALLELISM="%COMPAT_PARALLELISM%"
-                # Real captured POST/PUT bodies (post-bodies.ndjson) replayed by
+                # Real captured POST bodies (post-bodies.ndjson) replayed by
                 # RealBodyReplayCompatTest. Fail-FAST on a missing sidecar (Stage-2
                 # review): the trace repo's master carries latest-bodies.ndjson, so
                 # an absent file means the CrsCompatTrace checkout is broken. Fail-soft
@@ -985,7 +985,7 @@ object id18CompatLocalStandGitModeAuto : BuildType({
                 export COMPAT_VERSIONS_FILE="${'$'}VERSIONS_FILE_PATH"
                 export COMPAT_FULL="%COMPAT_FULL%"
                 export COMPAT_PARALLELISM="%COMPAT_PARALLELISM%"
-                # Real captured POST/PUT bodies (post-bodies.ndjson) replayed by
+                # Real captured POST bodies (post-bodies.ndjson) replayed by
                 # RealBodyReplayCompatTest. Fail-FAST on a missing sidecar (Stage-2
                 # review): the trace repo's master carries latest-bodies.ndjson, so
                 # an absent file means the CrsCompatTrace checkout is broken. Fail-soft

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -398,6 +398,10 @@ object id16CompatTraceReplayManual : BuildType({
         // dated subdir. Operator can override at run time (e.g. to a specific
         // snapshot for reproducibility).
         text("COMPAT_TRACE_FILE_RELATIVE", "latest-top.txt", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        // Real-body sidecar (post-bodies.ndjson) replayed by RealBodyReplayCompatTest.
+        // Also a symlink in the trace repo; override for a pinned snapshot. If the
+        // resolved file is absent the test SKIPs (assumeTrue), so this never fails id16.
+        text("COMPAT_BODIES_FILE_RELATIVE", "latest-bodies.ndjson", allowEmpty = false, display = ParameterDisplay.PROMPT)
         param("ARTIFACT_PATH", """
             components-registry-compat-test/build/reports/compat/** => reports/compat
             components-registry-compat-test/build/test-results/**/*.xml => test-results/compat
@@ -410,13 +414,14 @@ object id16CompatTraceReplayManual : BuildType({
         // "Unknown command-line option '--tests'"). Inline the filter into
         // GRADLE_TASK between the test and reporter task refs so the option
         // attaches to the correct task; do NOT move it back into the extras.
-        param("GRADLE_TASK", ":components-registry-compat-test:test --tests *TraceReplayCompatTest* :components-registry-compat-test:compatibilityReporter")
+        param("GRADLE_TASK", ":components-registry-compat-test:test --tests *TraceReplayCompatTest* --tests *RealBodyReplayCompatTest* :components-registry-compat-test:compatibilityReporter")
         param("GRADLE_EXTRA_PARAMETERS", """
             -Pcompat.baseline.url=%COMPAT_BASELINE_URL%
             -Pcompat.candidate.url=%COMPAT_CANDIDATE_URL%
             -Pcompat.rms.url=%COMPAT_RMS_URL%
             -Pcompat.allow-non-db-candidate=%COMPAT_ALLOW_NON_DB_CANDIDATE%
             -Pcompat.trace.file=%teamcity.build.checkoutDir%/trace-data/%COMPAT_TRACE_FILE_RELATIVE%
+            -Pcompat.bodies.file=%teamcity.build.checkoutDir%/trace-data/%COMPAT_BODIES_FILE_RELATIVE%
             -Pcompat.parallelism=10
         """.trimIndent())
     }
@@ -729,6 +734,19 @@ object id17CompatLocalStandManual : BuildType({
                 export COMPAT_VERSIONS_FILE="${'$'}VERSIONS_FILE_PATH"
                 export COMPAT_FULL="%COMPAT_FULL%"
                 export COMPAT_PARALLELISM="%COMPAT_PARALLELISM%"
+                # Real captured POST/PUT bodies (post-bodies.ndjson) replayed by
+                # RealBodyReplayCompatTest. Fail-FAST on a missing sidecar (Stage-2
+                # review): the trace repo's master carries latest-bodies.ndjson, so
+                # an absent file means the CrsCompatTrace checkout is broken. Fail-soft
+                # would silently SKIP the real-body replay and a green build would be
+                # indistinguishable from one that actually replayed the real bodies.
+                BODIES_FILE_PATH="${'$'}TRACE_DATA_DIR/latest-bodies.ndjson"
+                if [ ! -f "${'$'}BODIES_FILE_PATH" ]; then
+                    echo "ERROR: real-body sidecar ${'$'}BODIES_FILE_PATH does not exist (CrsCompatTrace checkout failed or post-bodies.ndjson missing)" >&2
+                    exit 2
+                fi
+                export COMPAT_BODIES_FILE="${'$'}BODIES_FILE_PATH"
+                echo "Bodies file:     ${'$'}BODIES_FILE_PATH"
                 # Route the postgres pull through the artifactory mirror so
                 # id17 doesn't hit Docker Hub's anonymous-pull rate limit
                 # (#3636 failed mid-Stage-1 with `toomanyrequests`). The
@@ -967,6 +985,19 @@ object id18CompatLocalStandGitModeAuto : BuildType({
                 export COMPAT_VERSIONS_FILE="${'$'}VERSIONS_FILE_PATH"
                 export COMPAT_FULL="%COMPAT_FULL%"
                 export COMPAT_PARALLELISM="%COMPAT_PARALLELISM%"
+                # Real captured POST/PUT bodies (post-bodies.ndjson) replayed by
+                # RealBodyReplayCompatTest. Fail-FAST on a missing sidecar (Stage-2
+                # review): the trace repo's master carries latest-bodies.ndjson, so
+                # an absent file means the CrsCompatTrace checkout is broken. Fail-soft
+                # would silently SKIP the real-body replay and a green build would be
+                # indistinguishable from one that actually replayed the real bodies.
+                BODIES_FILE_PATH="${'$'}TRACE_DATA_DIR/latest-bodies.ndjson"
+                if [ ! -f "${'$'}BODIES_FILE_PATH" ]; then
+                    echo "ERROR: real-body sidecar ${'$'}BODIES_FILE_PATH does not exist (CrsCompatTrace checkout failed or post-bodies.ndjson missing)" >&2
+                    exit 2
+                fi
+                export COMPAT_BODIES_FILE="${'$'}BODIES_FILE_PATH"
+                echo "Bodies file:     ${'$'}BODIES_FILE_PATH"
                 # git-mode (no-db, issue #310) does NOT start Postgres, so no POSTGRES_IMAGE
                 # pull is needed. RESET_DB=1 only drives teamcity-run.sh's pre-run teardown
                 # of any stale Postgres left by a prior db-mode run on this (persistent) agent.

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -157,6 +157,7 @@ test {
      'compat.max-components',
      'compat.smoke-components',
      'compat.trace.file',
+     'compat.bodies.file',
      'compat.verbose',
      'compat.allow-non-db-candidate',
      'compat.candidate.mode',

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RealBodyReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RealBodyReplayCompatTest.kt
@@ -1,0 +1,296 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Replay of REAL captured POST/PUT request bodies.
+ *
+ * Where [TraceReplayCompatTest] replays the deduplicated `(method, path)` trace
+ * and SYNTHESISES bodies (`BodyFixtures`), this test replays the actual bodies
+ * captured from prod by the server's request-body logging filter and dumped to
+ * the `post-bodies.ndjson` sidecar in the CrsCompatTrace repo. Each line is one
+ * distinct `{count, method, path, body}` record; the real `body` is POSTed
+ * verbatim to both stands and the responses are diffed via the shared
+ * [Comparators.compareRaw] pipeline (same `RawArraySorters` / `GavCsvComparator`
+ * classification as every other compat test).
+ *
+ * Value over synthetic replay: `find-by-artifacts` and `detailed-versions` are
+ * body-driven; a synthetic 1-element body exercises a trivial lookup, whereas
+ * the real bodies are the actual multi-artifact / multi-version batches clients
+ * send — so this is where schema-v2 resolution divergences actually surface.
+ *
+ * Activation: set `compat.bodies.file` / `COMPAT_BODIES_FILE` to the NDJSON
+ * path AND both compat URLs. Skipped via `Assumptions.assumeTrue` otherwise, so
+ * the rest of the suite (and branches without the bodies sidecar) are
+ * unaffected. Lightweight (~hundreds of requests), so it runs inline in the
+ * [1.7]/[1.8] local-stand builds, not just the manual id16.
+ *
+ * Endpoint-key methodology (path-only key, query as data) is identical to
+ * [TraceReplayCompatTest] — see its KDoc; this test reuses
+ * [TraceReplayCompatTest.parsePathAndQuery].
+ */
+class RealBodyReplayCompatTest : CompatibilityTestBase() {
+    internal data class BodyEntry(
+        val count: Long,
+        val method: String,
+        val path: String,
+        val body: JsonNode,
+    )
+
+    /**
+     * Diagnostic / operational endpoints NOT in the strict v1/v2/v3 compat
+     * contract. The bodies sidecar should not contain these (the extractor drops
+     * the bodyless `updateCache` PUTs), but filter defensively for parity with
+     * [TraceReplayCompatTest.excludedPaths]. Exact match against the path before
+     * any `?` query string.
+     */
+    private val excludedPaths =
+        setOf(
+            "/rest/api/2/components-registry/service/status",
+            "/rest/api/2/components-registry/service/ping",
+            "/rest/api/2/components-registry/service/updateCache",
+        )
+
+    private fun isDiagnostic(path: String): Boolean =
+        path.substringBefore('?') in excludedPaths
+
+    @Test
+    fun `replay real captured request bodies`() {
+        val bodiesFilePath =
+            System.getProperty("compat.bodies.file")
+                ?: System.getenv("COMPAT_BODIES_FILE")
+        assumeTrue(
+            !bodiesFilePath.isNullOrBlank(),
+            "compat.bodies.file / COMPAT_BODIES_FILE not set — RealBodyReplayCompatTest skipped " +
+                "(point it at post-bodies.ndjson to activate).",
+        )
+        val file = File(bodiesFilePath!!)
+        assumeTrue(file.exists() && file.canRead(), "bodies file not readable: $bodiesFilePath")
+
+        val mapper = jacksonObjectMapper()
+        val (entries, droppedDiagnostic, malformed) =
+            file.useLines { lines ->
+                var dropped = 0
+                var bad = 0
+                val parsed =
+                    lines
+                        .map { it.trim() }
+                        .filter { it.isNotEmpty() && !it.startsWith("#") }
+                        .mapNotNull { line ->
+                            val e = parseBodyLine(line, mapper)
+                            if (e == null) bad++
+                            e
+                        }
+                        .filter { e ->
+                            if (isDiagnostic(e.path)) { dropped++; false } else true
+                        }
+                        .filter { it.method == "POST" } // only POST carries a JSON body in this corpus
+                        .toList()
+                Triple(parsed, dropped, bad)
+            }
+
+        // Vacuous-pass guard: a present-but-unparseable or all-diagnostic file
+        // would otherwise replay zero requests and report 0 diffs as GREEN. Skip
+        // (not pass) so the operator sees the corpus never reached the stands.
+        assumeTrue(
+            entries.isNotEmpty(),
+            "no replayable POST bodies parsed from $bodiesFilePath " +
+                "(malformed=$malformed, dropped-diagnostic=$droppedDiagnostic) — " +
+                "verify the NDJSON sidecar is the {count,method,path,body} format from enrich-trace.py.",
+        )
+
+        // Distinct stands required (Stage-2 review): identical baseline/candidate
+        // URLs make every pair byte-identical → 0 diffs → vacuous GREEN on the
+        // highest-signal test. Fail-HARD (not assumeTrue-skip) so a copy-paste
+        // misconfiguration of COMPAT_*_URL is loud rather than silently clean.
+        check(config.baselineUrl != config.candidateUrl) {
+            "real-body replay: COMPAT_BASELINE_URL and COMPAT_CANDIDATE_URL are identical " +
+                "(${config.baselineUrl}) — the run would be vacuously green. Point them at the two " +
+                "different stands."
+        }
+
+        // Fail-hard on baseline transport failure (status==0 = IOException in
+        // RawHttp). A wrong/unreachable COMPAT_BASELINE_URL makes BOTH stands miss
+        // symmetrically → every diff suppressed → vacuous green. Same guard as
+        // TraceReplayCompatTest.loadBodyFixtures.
+        val probe = baselineRaw.get("rest/api/2/components")
+        check(probe.status != 0) {
+            "real-body replay: GET ${baselineRaw.baseUrl}/rest/api/2/components returned status=0 " +
+                "(transport failure). Check COMPAT_BASELINE_URL is reachable from this agent — a " +
+                "vacuous-green replay would otherwise look identical to a clean one. Underlying " +
+                "error: ${probe.headers["X-Compat-Transport-Error"] ?: "<not captured>"}"
+        }
+
+        log.info(
+            "real-body replay: ${entries.size} distinct POST bodies from $bodiesFilePath " +
+                "(parallelism=${config.parallelism}, dropped $droppedDiagnostic diagnostic, " +
+                "$malformed malformed lines)",
+        )
+
+        val verbose =
+            (System.getProperty("compat.verbose") ?: System.getenv("COMPAT_VERBOSE"))
+                ?.equals("true", ignoreCase = true) == true
+
+        val pool = Executors.newFixedThreadPool(config.parallelism)
+        val ts = java.time.Instant.now().toString()
+        val processed = AtomicInteger(0)
+        val withDiffs = AtomicInteger(0)
+        val weightByBucket = ConcurrentHashMap<Pair<String, DiffClassifier>, Long>()
+        val hungEntries = java.util.concurrent.ConcurrentLinkedQueue<BodyEntry>()
+        val futureToEntry = java.util.concurrent.ConcurrentHashMap<java.util.concurrent.Future<*>, BodyEntry>()
+
+        try {
+            val futures =
+                entries.map { entry ->
+                    pool.submit {
+                        val diffsBefore = DiffCollector.count()
+                        val (baseline, candidate) =
+                            try {
+                                postJsonPair(entry.path, entry.body)
+                            } catch (e: Exception) {
+                                log.warn("transport failed for ${entry.method} ${entry.path}: ${e.message}")
+                                return@submit
+                            }
+                        val (pathOnly, parsedQuery) = TraceReplayCompatTest.parsePathAndQuery(entry.path)
+                        val endpoint = "${entry.method} $pathOnly"
+                        val queryParams = parsedQuery + ("_weight" to entry.count.toString())
+                        // Symmetric-failure blind spot (same as TraceReplayCompatTest): if BOTH
+                        // stands return identical 4xx/5xx with identical bodies (e.g. a body
+                        // referencing a since-deleted component), compareRaw records no diff and
+                        // the tuple looks clean. Real prod bodies make this rarer than synthetic
+                        // ones, but it remains a known gap — see TraceReplayCompatTest's
+                        // BOTH_STANDS_ERRORED follow-up sketch.
+                        val cats =
+                            Comparators.compareRaw(
+                                endpoint = endpoint,
+                                pathParams = emptyMap(),
+                                baseline = baseline,
+                                candidate = candidate,
+                                queryParams = queryParams,
+                            )
+                        cats.distinct().forEach { cat ->
+                            weightByBucket.merge(endpoint to cat, entry.count) { a, b -> a + b }
+                        }
+                        val diffsAfter = DiffCollector.count()
+                        val newDiffs = diffsAfter - diffsBefore
+                        // Record every replayed body in the execution log so the run is
+                        // PROVABLE: the reporter's proof-of-execution guard counts these, and a
+                        // silently-skipped replay (missing sidecar) cannot masquerade as a clean
+                        // run that actually exercised the real bodies.
+                        logExecution(
+                            endpoint = endpoint,
+                            pathParams = emptyMap(),
+                            queryParams = queryParams,
+                            baseline = baseline,
+                            candidate = candidate,
+                            layer = "raw-body",
+                            diffsBefore = diffsBefore,
+                            diffsAfter = diffsAfter,
+                        )
+                        if (verbose) {
+                            // SECURITY: body preview includes real group/artifact/version
+                            // triples — gradle stdout is operator-confidential, do not paste
+                            // into the public repo (feedback_redacted_identifiers).
+                            log.info(
+                                "← ${entry.method} ${entry.path} " +
+                                    "b=${baseline.status}/${baseline.bodyBytes.size}B " +
+                                    "c=${candidate.status}/${candidate.bodyBytes.size}B " +
+                                    "diffs=$newDiffs cats=${cats.distinct()}",
+                            )
+                        }
+                        val n = processed.incrementAndGet()
+                        if (newDiffs > 0) withDiffs.incrementAndGet()
+                        if (n % 100 == 0) {
+                            log.info("real-body replay progress: $n / ${entries.size} (${withDiffs.get()} with diffs)")
+                        }
+                    }.also { f -> futureToEntry[f] = entry }
+                }
+            futures.forEach { f ->
+                val entry = futureToEntry[f]
+                try {
+                    f.get(90, TimeUnit.SECONDS)
+                } catch (e: java.util.concurrent.TimeoutException) {
+                    log.warn("HUNG (>90s, cancelling): ${entry?.method} ${entry?.path}")
+                    if (entry != null) hungEntries.add(entry)
+                    f.cancel(true)
+                } catch (e: java.util.concurrent.CancellationException) {
+                    // already cancelled
+                } catch (e: Exception) {
+                    log.warn("future failed for ${entry?.path ?: "?"}: ${e.message}")
+                }
+            }
+        } finally {
+            pool.shutdown()
+            pool.awaitTermination(30, TimeUnit.SECONDS)
+        }
+
+        val topN = weightByBucket.entries.sortedByDescending { it.value }.take(20)
+        val totalReplayed = entries.size
+        val totalWithDiffs = withDiffs.get()
+        log.info(
+            "real-body replay done: $totalReplayed bodies replayed, $totalWithDiffs produced " +
+                "at least one diff, ${weightByBucket.size} unique (endpoint, category) buckets, " +
+                "${hungEntries.size} hung",
+        )
+        if (topN.isNotEmpty()) {
+            log.info("=== top-20 frequency-weighted buckets (real bodies) ===")
+            topN.forEach { (key, weight) ->
+                val (ep, cat) = key
+                log.info("  weight=$weight  category=$cat  $ep")
+            }
+        }
+
+        val reportDir = File("build/reports/compat").also { it.mkdirs() }
+        val payload =
+            mapOf(
+                "generatedAt" to ts,
+                "totals" to mapOf(
+                    "bodiesReplayed" to totalReplayed,
+                    "bodiesWithDiffs" to totalWithDiffs,
+                    "bodiesWithoutDiffs" to (totalReplayed - totalWithDiffs),
+                    "droppedDiagnostic" to droppedDiagnostic,
+                    "malformedLines" to malformed,
+                    "hung" to hungEntries.size,
+                ),
+                "topWeightedBuckets" to topN.map { (key, weight) ->
+                    val (ep, cat) = key
+                    mapOf("endpoint" to ep, "category" to cat.name, "weight" to weight)
+                },
+            )
+        File(reportDir, "real-body-replay-summary.json")
+            .writeText(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload))
+    }
+
+    companion object {
+        /**
+         * Parse one `post-bodies.ndjson` line into a [BodyEntry]. Returns null on
+         * malformed input (not JSON, missing/blank method or path, path not
+         * starting with `/`, or absent `body`). `count` defaults to 1 when
+         * absent or non-numeric. `body` is kept as a [JsonNode] and POSTed
+         * verbatim, so an empty array/object body (a real edge case clients send)
+         * is preserved, not rejected.
+         */
+        internal fun parseBodyLine(line: String, mapper: com.fasterxml.jackson.databind.ObjectMapper): BodyEntry? {
+            val node =
+                runCatching { mapper.readTree(line) }.getOrNull()
+                    ?: return null
+            if (!node.isObject) return null
+            val method = node.path("method").asText("").trim().uppercase()
+            if (method.isEmpty()) return null
+            val path = node.path("path").asText("").trim()
+            if (path.isEmpty() || !path.startsWith('/')) return null
+            val body = node.get("body")
+            if (body == null || body.isNull) return null
+            val count = node.path("count").asLong(1L).coerceAtLeast(0L)
+            return BodyEntry(count, method, path, body)
+        }
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RealBodyReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RealBodyReplayCompatTest.kt
@@ -11,7 +11,11 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * Replay of REAL captured POST/PUT request bodies.
+ * Replay of REAL captured POST request bodies.
+ *
+ * (PUT-with-body is parsed by [parseBodyLine] but NOT replayed — the captured
+ * corpus is POST-only; the only prod PUT, `updateCache`, carries no body and is
+ * dropped by the extractor. The replay loop filters to POST below.)
  *
  * Where [TraceReplayCompatTest] replays the deduplicated `(method, path)` trace
  * and SYNTHESISES bodies (`BodyFixtures`), this test replays the actual bodies
@@ -73,7 +77,18 @@ class RealBodyReplayCompatTest : CompatibilityTestBase() {
                 "(point it at post-bodies.ndjson to activate).",
         )
         val file = File(bodiesFilePath!!)
-        assumeTrue(file.exists() && file.canRead(), "bodies file not readable: $bodiesFilePath")
+        // From here the test is CONFIGURED (the path is set), so every downstream
+        // failure is HARD (`check`), not an `assumeTrue` skip. The TeamCity layer
+        // only fail-fasts on file EXISTENCE; a present-but-empty/corrupt sidecar
+        // must still fail the build here rather than silently skip and leave the
+        // auto [1.7]/[1.8] chain green with zero real-body coverage (the rest of
+        // the suite keeps the run's execution count non-zero, so the reporter's
+        // zero-execution guard would not notice). This in-JVM parse is the
+        // authoritative parseability gate.
+        check(file.exists() && file.canRead()) {
+            "compat.bodies.file=$bodiesFilePath is set but the file is not readable — a configured " +
+                "real-body replay must fail, not skip. Check the CrsCompatTrace checkout / the path."
+        }
 
         val mapper = jacksonObjectMapper()
         val (entries, droppedDiagnostic, malformed) =
@@ -97,15 +112,18 @@ class RealBodyReplayCompatTest : CompatibilityTestBase() {
                 Triple(parsed, dropped, bad)
             }
 
-        // Vacuous-pass guard: a present-but-unparseable or all-diagnostic file
-        // would otherwise replay zero requests and report 0 diffs as GREEN. Skip
-        // (not pass) so the operator sees the corpus never reached the stands.
-        assumeTrue(
-            entries.isNotEmpty(),
-            "no replayable POST bodies parsed from $bodiesFilePath " +
-                "(malformed=$malformed, dropped-diagnostic=$droppedDiagnostic) — " +
-                "verify the NDJSON sidecar is the {count,method,path,body} format from enrich-trace.py.",
-        )
+        // Vacuous-pass guard (reviewer P1): a present-but-empty/corrupt sidecar
+        // parses to zero entries. Fail HARD — NOT an assumeTrue skip — because the
+        // other compat tests keep the run's execution count non-zero, so the
+        // reporter's zero-execution guard would NOT notice that the real-body
+        // replay never ran, leaving the auto chain green with the new coverage
+        // absent. assumeTrue-skip is reserved above for the not-configured case.
+        check(entries.isNotEmpty()) {
+            "compat.bodies.file=$bodiesFilePath is configured but yielded zero replayable POST " +
+                "bodies (malformed=$malformed, dropped-diagnostic=$droppedDiagnostic). An empty or " +
+                "corrupt sidecar must fail the build, not skip. Verify the NDJSON is the " +
+                "{count,method,path,body} format from enrich-trace.py."
+        }
 
         // Distinct stands required (Stage-2 review): identical baseline/candidate
         // URLs make every pair byte-identical → 0 diffs → vacuous GREEN on the
@@ -213,6 +231,13 @@ class RealBodyReplayCompatTest : CompatibilityTestBase() {
                         }
                     }.also { f -> futureToEntry[f] = entry }
                 }
+            // NOTE (Copilot review): this walks futures in submission order, so the
+            // 90s budget is wall-clock from each get(), not from submission — a
+            // pathological all-hung run can approach O(N*90s). For this corpus
+            // (~hundreds of bodies, far smaller than the 40k trace) it is not a
+            // problem in practice; this deliberately mirrors TraceReplayCompatTest.
+            // A shared future fix (ExecutorCompletionService / per-submission
+            // deadline) would tighten both tests together — tracked there.
             futures.forEach { f ->
                 val entry = futureToEntry[f]
                 try {

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RealBodyReplayParseTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RealBodyReplayParseTest.kt
@@ -1,0 +1,86 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-unit coverage for [RealBodyReplayCompatTest.parseBodyLine] — the
+ * `post-bodies.ndjson` line parser. No HTTP / Spring scaffolding, so it runs in
+ * the URL-free `:unitTest` task on every PR (`@Tag("unit")`).
+ */
+@Tag("unit")
+class RealBodyReplayParseTest {
+    private val mapper = jacksonObjectMapper()
+
+    private fun parse(line: String) = RealBodyReplayCompatTest.parseBodyLine(line, mapper)
+
+    @Test
+    fun `parses a find-by-artifacts array body`() {
+        val line =
+            """{"count":12,"method":"POST","path":"/rest/api/3/components/find-by-artifacts","body":[{"group":"g","name":"n","version":"1.2.3"}]}"""
+        val e = parse(line)!!
+        assertEquals(12L, e.count)
+        assertEquals("POST", e.method)
+        assertEquals("/rest/api/3/components/find-by-artifacts", e.path)
+        assertTrue(e.body.isArray, "body should be a JSON array")
+        assertEquals(1, e.body.size())
+    }
+
+    @Test
+    fun `parses a detailed-versions object body`() {
+        val line =
+            """{"count":3,"method":"POST","path":"/rest/api/2/components/x/detailed-versions","body":{"versions":["1.0","1.1"]}}"""
+        val e = parse(line)!!
+        assertTrue(e.body.isObject, "body should be a JSON object")
+        assertEquals(2, e.body.path("versions").size())
+    }
+
+    @Test
+    fun `keeps a real empty-array body (clients send it)`() {
+        val line = """{"count":60,"method":"POST","path":"/rest/api/3/components/find-by-artifacts","body":[]}"""
+        val e = parse(line)!!
+        assertTrue(e.body.isArray)
+        assertEquals(0, e.body.size())
+    }
+
+    @Test
+    fun `defaults count to 1 when absent`() {
+        val line = """{"method":"POST","path":"/rest/api/3/components/find-by-artifacts","body":[]}"""
+        assertEquals(1L, parse(line)!!.count)
+    }
+
+    @Test
+    fun `lowercases-then-uppercases method`() {
+        val line = """{"method":"post","path":"/rest/api/3/components/find-by-artifacts","body":[]}"""
+        assertEquals("POST", parse(line)!!.method)
+    }
+
+    @Test
+    fun `rejects malformed json`() = assertNull(parse("""{"method":"POST", not json"""))
+
+    @Test
+    fun `rejects a bare-array (non-object) line`() = assertNull(parse("""[1,2,3]"""))
+
+    @Test
+    fun `rejects missing method`() =
+        assertNull(parse("""{"path":"/rest/api/3/components/find-by-artifacts","body":[]}"""))
+
+    @Test
+    fun `rejects missing path`() = assertNull(parse("""{"method":"POST","body":[]}"""))
+
+    @Test
+    fun `rejects path not starting with slash`() =
+        assertNull(parse("""{"method":"POST","path":"rest/api/3/x","body":[]}"""))
+
+    @Test
+    fun `rejects missing body`() =
+        assertNull(parse("""{"method":"POST","path":"/rest/api/3/components/find-by-artifacts"}"""))
+
+    @Test
+    fun `rejects explicit null body`() =
+        assertNull(parse("""{"method":"POST","path":"/rest/api/3/components/find-by-artifacts","body":null}"""))
+}


### PR DESCRIPTION
## What

Replays the **real captured prod POST bodies** (`crs-compat-trace/post-bodies.ndjson`) against the baseline + candidate stands, wiring it into the `[1.7]` (id17, db-mode) and `[1.8]` (id18, git-mode) local-stand builds and the manual `[1.6]` (id16).

Until now `TraceReplayCompatTest` synthesised POST bodies (`BodyFixtures`), so the body-driven endpoints (`find-by-artifacts`, `detailed-versions`) only exercised a trivial 1-element lookup. The real bodies are the actual multi-artifact / multi-version batches clients send — that is where schema-v2 resolution divergences actually surface.

## Changes

- **`RealBodyReplayCompatTest`** (HTTP-tagged via `CompatibilityTestBase`): reads `compat.bodies.file` / `COMPAT_BODIES_FILE`, parses `{count,method,path,body}` NDJSON, POSTs each real body to both stands, diffs via the shared `Comparators.compareRaw` pipeline. Reuses `TraceReplayCompatTest.parsePathAndQuery`. Diffs flow into the same `DiffCollector` → `compatibilityReporter` gate as every other compat test.
- **`RealBodyReplayParseTest`** (`@Tag("unit")`): 12 parser cases, runs in `:unitTest` on every PR.
- **`build.gradle`**: forward the `compat.bodies.file` system property.
- **`.teamcity/settings.kts`**: id17/id18 `export COMPAT_BODIES_FILE=…/trace-data/latest-bodies.ndjson` (**fail-hard** if the sidecar is missing); id16 gains a `COMPAT_BODIES_FILE_RELATIVE` prompt and runs the new test alongside trace replay.

## Guards against vacuous-green (Stage-2 review)

- **Provable execution**: every replayed body is logged via `ExecutionLogger`, so the reporter's proof-of-execution guard counts them and a silently-skipped replay cannot masquerade as a clean run.
- **Fail-hard sidecar** in id17/id18: a missing `latest-bodies.ndjson` (broken checkout) fails the build instead of silently skipping.
- **Distinct-URL guard**: identical baseline/candidate URLs fail-hard (would otherwise be byte-identical → vacuous green).
- **Baseline transport fail-hard** (`status==0`) and **empty-corpus `assumeTrue`** skip.

## Validation

- `:components-registry-compat-test:unitTest` — 12/12 `RealBodyReplayParseTest` green.
- `:components-registry-compat-test:build` — compiles + publication-valid; URL-gated `test` self-skips without stands.
- Two-stage review: Sonnet (correctness) + Opus (adversarial). All FIX findings applied. `RawHttp.postJson` confirmed to serialise a `JsonNode` without double-encoding; `COMPAT_BODIES_FILE` confirmed to reach the test JVM via the build.gradle env→sysprop pass-through.
- Live stand smoke happens on the first `[1.7]` run (booting two stands locally is out of band).

## Intended behaviour

Enabling real bodies in the **auto** `[1.7]`/`[1.8]` chain means a fresh prod-body divergence not in `known-deltas` will **RED** the build — that is the signal we want; triage as a regression or add a reviewed known-delta. id18 uses the empty `known-deltas-git.json`, so any git-mode body diff REDs by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
