### PR TITLE
fix(v4): reject containment between field-override ranges (disjoint-only)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1427,10 +1427,12 @@ class ComponentManagementServiceImpl(
         }
     }
 
-    // ─── Field-override range validation (partial-overlap, matches Portal) ───────
+    // ─── Field-override range validation (disjoint-only, matches Portal) ─────────
     //
-    // The Portal applies the same partial-overlap and semantic-equality rules
-    // client-side via `versionRange.ts` (`rangesOverlap`). Keeping the two
+    // The Portal applies the same disjoint-only rule client-side via
+    // `versionRange.ts` (`rangesOverlap` / `classifyRangeConflict`): two
+    // overrides on one attribute conflict if they intersect at all — partial
+    // overlap, strict containment, or semantic equality. Keeping the two
     // implementations in sync is the explicit goal — a client-side `false`
     // should not surprise the user with a server 400 and vice versa.
     //
@@ -1504,25 +1506,31 @@ class ComponentManagementServiceImpl(
      *    Existing composite rows (legacy DSL import) are untouched — the
      *    sibling walk below uses `isIntersect` on them but treats them as
      *    opaque when measuring containment.
-     * 3. Partial overlap with sibling overrides on the same attribute is
-     *    rejected per schema-spec §3.5.
+     * 3. Any intersection with a sibling override on the same attribute is
+     *    rejected — field-override ranges must be DISJOINT. Partial overlap
+     *    AND strict containment are both conflicts: a version inside the
+     *    intersection would match both overrides, so the resolved value would
+     *    be ambiguous. (This is stricter than the original schema-spec §3.5,
+     *    which allowed strict containment; see also Portal #67.)
      * 4. Semantic equality (each contains the other after Maven-comparator
-     *    normalisation) is rejected as a duplicate, even when the raw strings
-     *    differ by whitespace or trailing zeros (`[1.0, 2.0)` vs `[1.0,2.0)`
-     *    or `[1,2)` vs `[1.0,2.0)`). The DB UNIQUE constraint catches only
-     *    exact-string duplicates.
-     * 5. Strict containment is allowed (per schema-spec §3.5).
+     *    normalisation) is also a conflict but is reported with a distinct
+     *    "duplicate" message, even when the raw strings differ by whitespace
+     *    or trailing zeros (`[1.0, 2.0)` vs `[1.0,2.0)` or `[1,2)` vs
+     *    `[1.0,2.0)`). The DB UNIQUE constraint catches only exact-string
+     *    duplicates.
      *
      * D5 (closed-range only) is NOT enforced here — the Portal blocks
      * open-upward input client-side; server-side D5 is tracked as a follow-up
      * because several existing API tests seed throwaway components with
      * `[X,)` overrides and would break under a strict server rejection.
      *
-     * When the SIBLING row carries a legacy composite range, intersection is
-     * still detected via [VersionRange.isIntersect], but containment is
-     * undecidable; the validator defers (allows) and trusts the DB UNIQUE
-     * constraint for exact-string duplicates. A future releng-versions
-     * `containsRange` API will let us tighten this back up.
+     * Intersection is detected via [VersionRange.isIntersect], which handles
+     * legacy composite SIBLING rows correctly. Because the disjoint-only rule
+     * rejects on ANY intersection, we no longer need to classify partial vs
+     * containment for composite siblings — so a simple new range intersecting
+     * a composite sibling is now rejected too (closing the former composite-
+     * vs-simple gap). Composite NEW ranges are still rejected up front
+     * (point 2); users compose multiple single-segment overrides instead.
      */
     private fun validateFieldOverrideRange(
         range: String,
@@ -1548,25 +1556,21 @@ class ComponentManagementServiceImpl(
                 continue
             }
             if (!newRangeObj.isIntersect(existingRangeObj)) continue
-            // Intersect. Three sub-cases under schema-spec §3.5:
-            //   - each contains the other → semantically EQUAL → reject as
-            //     a duplicate (the DB UNIQUE on the raw versionRange string
-            //     catches exact textual equality, but `[1.0,2.0)` vs
-            //     `[1.0, 2.0)` or `[1,2)` vs `[1.0,2.0)` slip past it).
-            //   - exactly one contains the other → strict containment → allow.
-            //   - neither contains → partial overlap → reject.
+            // They intersect → conflict. Field-override ranges on one attribute
+            // must be DISJOINT, so partial overlap, strict containment, AND
+            // semantic equality are all rejected (a version in the intersection
+            // would match both overrides — ambiguous). We only distinguish the
+            // semantic-equal case for a clearer "duplicate" message. If the
+            // SIBLING is a legacy composite (`parsedExisting` null) we cannot
+            // classify it precisely, but `isIntersect` returning true is already
+            // sufficient grounds to reject.
             //
             // `parsedNew` is non-null (composites are rejected up-front above).
-            // If the SIBLING row is a legacy composite (`parsedExisting` null),
-            // we cannot decide strict containment with the simple-segment
-            // heuristic, so we DEFER and trust the DB UNIQUE for exact-string
-            // duplicates. A future releng-versions `containsRange` API will
-            // let us tighten this back up.
             val parsedExisting = parseSimpleSegment(row.versionRange)
-            if (parsedExisting == null) continue
-            val aContainsB = simpleContains(parsedNew, parsedExisting)
-            val bContainsA = simpleContains(parsedExisting, parsedNew)
-            if (aContainsB && bContainsA) {
+            if (parsedExisting != null &&
+                simpleContains(parsedNew, parsedExisting) &&
+                simpleContains(parsedExisting, parsedNew)
+            ) {
                 throw IllegalArgumentException(
                     "Range '$range' is semantically equal to existing " +
                         "override range '${row.versionRange}' on attribute " +
@@ -1574,12 +1578,16 @@ class ComponentManagementServiceImpl(
                         "override per attribute (schema-spec §3.5 / UNIQUE).",
                 )
             }
-            if (aContainsB || bContainsA) continue
+            // Reached for partial overlap, strict containment, and (composite
+            // sibling) intersections — for composite siblings the semantic-equal
+            // message above is unreachable (parsedExisting is null), and this
+            // generic reject is the correct outcome anyway.
             throw IllegalArgumentException(
-                "Range '$range' partially overlaps with existing override range " +
-                    "'${row.versionRange}' on attribute '$attribute'. Equal " +
-                    "ranges are blocked by the unique index; strict containment " +
-                    "is allowed; partial overlap is rejected per schema-spec §3.5.",
+                "Range '$range' overlaps existing override range " +
+                    "'${row.versionRange}' on attribute '$attribute'. " +
+                    "Field-override ranges on one attribute must be disjoint — " +
+                    "partial overlap and strict containment are both rejected " +
+                    "(a version in the intersection would match both overrides).",
             )
         }
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
@@ -449,13 +449,16 @@ class V4WriteValidationTest {
     }
 
     // -------------------------------------------------------------------
-    // Partial-overlap rejection (R3 / schema-spec §3.5).
+    // Overlap rejection — disjoint-only rule (R3 / schema-spec §3.5).
     //
-    // Mirrors the Portal-side preview from
-    // octopusden/octopus-components-management-portal#65: a new field-override
-    // range that partially overlaps a sibling on the same attribute is
-    // rejected with 400. Strict containment and disjoint ranges remain
-    // allowed; equal ranges are still caught by the DB UNIQUE constraint.
+    // Mirrors the Portal-side preview
+    // (octopusden/octopus-components-management-portal#67): field-overrides on
+    // the same attribute must be DISJOINT. A new range that intersects a
+    // sibling in any way — partial overlap, strict containment, or semantic
+    // equality — is rejected with 400. Only a disjoint range is accepted.
+    // (This is stricter than the original schema-spec §3.5, which allowed
+    // strict containment; a version inside the inner range would match both
+    // overrides, so the resolved value would be ambiguous.)
     // -------------------------------------------------------------------
 
     private fun seedComponentForOverlap(suffix: String): String {
@@ -492,18 +495,35 @@ class V4WriteValidationTest {
     }
 
     @Test
-    @DisplayName("R3: POST /field-overrides accepts a range strictly contained inside a sibling (schema-spec §3.5)")
-    fun fieldOverride_allows_strictContainment() {
+    @DisplayName("R3: POST /field-overrides rejects a range strictly contained inside a sibling (disjoint-only)")
+    fun fieldOverride_rejects_strictContainment_innerInsideExisting() {
         val id = seedComponentForOverlap("contained-${uniqueSuffix()}")
         postFieldOverride(
             id,
             """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0,5.0)","value":"11"}""",
         ).andExpect(status().isCreated)
-        // [2.0,3.0) is fully inside [1.0,5.0) → strict containment, accepted.
+        // [2.0,3.0) is fully inside [1.0,5.0) → a version like 2.5 matches both
+        // overrides → ambiguous → reject.
         postFieldOverride(
             id,
             """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"17"}""",
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("R3: POST /field-overrides rejects a range that strictly contains a sibling (disjoint-only)")
+    fun fieldOverride_rejects_strictContainment_newContainsExisting() {
+        val id = seedComponentForOverlap("contains-${uniqueSuffix()}")
+        // Reported case: existing [1.0,2.0], new [0,3.0] which fully contains
+        // it — version 1.5 matches both → must be rejected, not accepted.
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0,2.0]","value":"17"}""",
         ).andExpect(status().isCreated)
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[0,3.0]","value":"18"}""",
+        ).andExpect(status().isBadRequest)
     }
 
     @Test
@@ -517,6 +537,25 @@ class V4WriteValidationTest {
         postFieldOverride(
             id,
             """{"overriddenAttribute":"build.javaVersion","versionRange":"[5.0,6.0)","value":"17"}""",
+        ).andExpect(status().isCreated)
+    }
+
+    @Test
+    @DisplayName("R3: POST /field-overrides accepts adjacent half-open ranges sharing a boundary point")
+    fun fieldOverride_allows_adjacentHalfOpenRanges() {
+        // Boundary regression guard: isIntersect is now the sole gate for the
+        // disjoint-only rule. 2.0 is excluded from [1.0,2.0) and included in
+        // [2.0,3.0) — no version falls in both, so this MUST stay accepted.
+        // If a releng upgrade ever made touching-exclusive bounds "intersect",
+        // contiguous half-open coverage would break and this test would catch it.
+        val id = seedComponentForOverlap("adjacent-${uniqueSuffix()}")
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0,2.0)","value":"11"}""",
+        ).andExpect(status().isCreated)
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"17"}""",
         ).andExpect(status().isCreated)
     }
 
@@ -604,6 +643,33 @@ class V4WriteValidationTest {
                     .with(adminJwt())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"versionRange":"[1.0, 2.0)"}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("R3: PATCH /field-overrides/{id} rejects a range update that contains a sibling")
+    fun fieldOverride_patch_rejects_strictContainment() {
+        val id = seedComponentForOverlap("patch-contain-${uniqueSuffix()}")
+        // Sibling A — stays put, narrow.
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"11"}""",
+        ).andExpect(status().isCreated)
+        // Sibling B — disjoint at create time.
+        val bCreate =
+            postFieldOverride(
+                id,
+                """{"overriddenAttribute":"build.javaVersion","versionRange":"[8.0,9.0)","value":"17"}""",
+            ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val bId = objectMapper.readTree(bCreate)["id"].asText()
+        // PATCH B to [1.0,5.0) which fully contains A's [2.0,3.0) → reject.
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id/field-overrides/$bId")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"versionRange":"[1.0,5.0)"}"""),
             ).andExpect(status().isBadRequest)
     }
 

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -105,7 +105,7 @@ For request `(component, version V)`:
 1. Load base row + all matching override rows: `WHERE component_id = X AND (row_type = 'BASE' OR range_contains(version_range, V))`. RANGE_PRESENCE rows are loaded but discarded before scalar/marker overlay.
 2. Start with base row scalar values; for each scalar override row matching V, set its single non-NULL column on the merged result.
 3. For child collections, pick the most-specific marker override row whose `version_range` contains V; if found, its children REPLACE base children (full replacement). If no marker matches, use base children.
-4. Transitional constraint: version_range of override rows within one component MUST NOT partially overlap (equal ranges are blocked by UNIQUE; strict containment and disjoint allowed; partial overlap rejected at write-time). Under this constraint, at most one override per attribute matches V — no runtime tiebreaker needed.
+4. Constraint: version_range of override rows within one component MUST be pairwise **disjoint** per attribute. Any intersection — partial overlap, strict containment, or equality — is rejected at write-time by the service validator (`validateFieldOverrideRange`); the DB UNIQUE on `(component_id, version_range, overridden_attribute)` additionally blocks only *exact-text* duplicates, while *semantic*-equal ranges differing by whitespace or trailing zeros (`[1.0, 2.0)` / `[1,2)` vs `[1.0,2.0)`) are caught by the validator. This guarantees at most one override per attribute matches V, so no runtime tiebreaker is needed. (Stricter than the earlier transitional rule, which allowed strict containment — but that left a version inside the inner range matching *two* overrides, which contradicts the "at most one matches V" guarantee. Enforced client-side in Portal #67 and server-side in `validateFieldOverrideRange`.)
 5. For the legacy variants-Map endpoints, skip emitting the base row entry if `is_synthetic_base = true` (this is the MIG-029 fix). For single-version resolve (hot path), synthetic base is always used as fallback.
 
 ## 4. Table specifications
@@ -482,7 +482,7 @@ DSL strings containing `${version}`, `${env.X}`, `${major}`, etc. are stored **v
 - Base row: at least one typed column may be filled; child rows allowed.
 - Scalar override row: `overridden_attribute` is a known `aspect.field`; exactly one matching typed column non-NULL; no child rows.
 - Marker override row: `overridden_attribute` ∈ marker set; all typed scalar columns NULL (DB CHECK also enforces this); child rows attached.
-- Version_range overlap (transitional): override rows within one component must not partially overlap (equal ranges blocked by UNIQUE; strict containment and disjoint allowed).
+- Version_range overlap: override rows within one component must be pairwise disjoint per attribute — any intersection (partial overlap, strict containment, or equality) is rejected at write-time by the service validator; the DB UNIQUE additionally blocks only exact-text duplicates (semantic-equal ranges are caught by the validator).
 
 DB-level CHECK constraints defend against migration / bulk-load bypassing the service layer (one CHECK per marker name).
 


### PR DESCRIPTION
## Bug

`validateFieldOverrideRange` rejected only **partial overlap** and **exact/semantic duplicates** between two overrides on the same attribute; **strict containment was allowed**. So `build.javaVersion` could hold both:

```
[1.0,2.0] → 17
[0,3.0]   → 18
```

Version `1.5` matches **both** overrides → the resolved value is ambiguous. Reported from the Portal UI.

This was also internally inconsistent with schema-spec §3.5, which allowed containment yet claimed "at most one override per attribute matches V" — containment lets a version match two.

## Fix — disjoint-only

Field-override ranges on one attribute must be **disjoint**. Once `isIntersect` is true it's a conflict (partial overlap, strict containment, and equality all rejected); the semantic-equal case keeps its distinct "duplicate" message.

- Removed the `if (aContainsB || bContainsA) continue` that allowed containment.
- **Composite-sibling gap closed for free:** since rejection now triggers on intersection alone, the containment decision for legacy composite siblings is no longer needed — `isIntersect` (which handles composites correctly) suffices — so a simple new range intersecting a composite sibling is now rejected too (previously deferred/allowed). Composite *new* ranges are still rejected up front.
- `schema-spec.md §3.5` updated to "pairwise disjoint per attribute" (removes the self-contradiction noted above).

Mirrors the Portal client-side change (octopus-components-management-portal#67), so a client `false` and a server 400 now agree.

## Tests (`V4WriteValidationTest`)
- Flipped `allows_strictContainment` → `rejects_strictContainment_innerInsideExisting`.
- Added `rejects_strictContainment_newContainsExisting` (the reported `[1.0,2.0]` + `[0,3.0]` case) and `patch_rejects_strictContainment`.
- Added `allows_adjacentHalfOpenRanges` — boundary guard: `[1.0,2.0)` + `[2.0,3.0)` must stay **allowed** (touching-exclusive ≠ intersecting), since `isIntersect` is now the sole gate.
- Disjoint, semantic-equal, and PATCH self-reassign tests unchanged.

`./gradlew :components-registry-service-server:test --tests V4WriteValidationTest` → **BUILD SUCCESSFUL**. Sonnet review: no P0; P1 (the boundary test) and a doc nit addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)