### PR TITLE
fix(MIG-039,MIG-040,MIG-023): find-by-artifacts per-config matching + specificity ranking; find-by-docker-images version-substitution

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -10,7 +10,6 @@ import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
-import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
@@ -20,8 +19,6 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentRep
 import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
 import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
 import org.octopusden.octopus.components.registry.server.util.formatVersion
-import org.octopusden.octopus.components.registry.server.util.parseMavenGavEntry
-import org.octopusden.octopus.components.registry.server.util.splitCsv
 import org.octopusden.octopus.escrow.MavenArtifactMatcher
 import org.octopusden.octopus.escrow.ModelConfigPostProcessor
 import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
@@ -265,13 +262,28 @@ class DatabaseComponentRegistryResolver(
 
     override fun findComponentsByArtifact(artifacts: Set<ArtifactDependency>): Map<ArtifactDependency, VersionedComponent?> {
         log.debug("Find components by artifacts: {}", artifacts)
-        return artifacts.associateWith { artifact -> findComponentByArtifactOrNull(artifact) }
+        // Build per-component per-range effective (group, artifact) ONCE, then match each artifact
+        // — avoids re-reading all components and reconstructing their escrow view per artifact.
+        val perComponent = loadPerComponentArtifactParameters()
+        return artifacts.associateWith { artifact -> matchArtifact(artifact, perComponent) }
     }
 
     override fun getMavenArtifactParameters(component: String): Map<String, ComponentArtifactConfiguration> {
         val componentEntity =
             componentRepository.findByComponentKey(component)
                 ?: throw NotFoundException("Component '$component' is not found")
+        return mavenArtifactParametersFor(componentEntity)
+    }
+
+    /**
+     * Per-range effective `(groupPattern, artifactPattern)` for a component — marker-aware
+     * (`GROUP_ARTIFACT_PATTERN` per-range overrides) with the component-level `artifactIds`
+     * fallback. Shared by `/maven-artifacts` and (MIG-039) `find-by-artifacts` so both use
+     * identical per-range semantics; keyed by version-range string.
+     */
+    private fun mavenArtifactParametersFor(
+        componentEntity: ComponentEntity,
+    ): Map<String, ComponentArtifactConfiguration> {
 
         // Component-level fallback: the top-level groupId/artifactId rows imported from DSL.
         // For components whose DSL omits an explicit `artifactId` line, the import path
@@ -534,62 +546,94 @@ class DatabaseComponentRegistryResolver(
         }
     }
 
-    private fun findComponentByArtifactOrNull(artifact: ArtifactDependency): VersionedComponent? {
-        val matches =
-            componentRepository
-                .findAll()
-                .flatMap { component ->
-                    component.artifactIds.mapNotNull { artifactIdEntity ->
-                        toArtifactMatchOrNull(artifactIdEntity, artifact)
+    private fun findComponentByArtifactOrNull(artifact: ArtifactDependency): VersionedComponent? =
+        matchArtifact(artifact, loadPerComponentArtifactParameters())
+
+    /** Snapshot every component's marker-aware per-range (group, artifact) patterns. */
+    private fun loadPerComponentArtifactParameters(): List<Pair<String, Map<String, ComponentArtifactConfiguration>>> =
+        componentRepository.findAll().map { it.componentKey to mavenArtifactParametersFor(it) }
+
+    /**
+     * MIG-039 + MIG-023: resolve an artifact to a component by mirroring V1's
+     * `EscrowModuleConfigMatcher` per config — for each component, a version range whose EFFECTIVE
+     * `(groupPattern, artifactPattern)` matches the artifact AND that contains the artifact
+     * version (reusing the same marker-aware per-range patterns as `/maven-artifacts`,
+     * [mavenArtifactParametersFor]), so per-range `artifactId` overrides resolve correctly and an
+     * archived/old out-of-range range no longer pollutes resolution.
+     *
+     * All in-range matches are then ranked by artifact-pattern specificity so a more specific
+     * (exact / version-aware) mapping beats a generic wildcard/`|`-union one regardless of
+     * `findAll()` order — MIG-023 requires the specific match to win when both apply. (V1 treats
+     * >1 as a conflict; a batch endpoint instead picks the most specific rather than failing the
+     * whole request.)
+     */
+    private fun matchArtifact(
+        artifact: ArtifactDependency,
+        perComponent: List<Pair<String, Map<String, ComponentArtifactConfiguration>>>,
+    ): VersionedComponent? {
+        val best =
+            perComponent
+                .flatMap { (componentKey, perRange) ->
+                    perRange.mapNotNull { (rangeKey, cfg) ->
+                        if (cfg.groupPattern.isNotBlank() &&
+                            cfg.artifactPattern.isNotBlank() &&
+                            MavenArtifactMatcher.groupIdMatches(artifact.group, cfg.groupPattern) &&
+                            MavenArtifactMatcher.artifactIdMatches(artifact.name, cfg.artifactPattern) &&
+                            versionInRange(rangeKey, artifact.version)
+                        ) {
+                            componentKey to cfg.artifactPattern
+                        } else {
+                            null
+                        }
                     }
                 }
-        if (matches.isEmpty()) return null
-
-        // Per-version specificity is not modelled at the component_artifact_ids
-        // level under Model A' — those rows belong to the component, not the
-        // configuration. Match by pattern specificity alone (mirrors v3 contract
-        // since the version-specific tier is empty in production today).
-        val resolvedMatch =
-            matches.maxWithOrNull(
-                compareBy<ArtifactMatch>(
-                    { artifactSpecificity(it.artifactPattern, artifact.name) },
-                    { it.artifactPattern.length },
-                ),
-            ) ?: return null
-
-        return VersionedComponent(resolvedMatch.componentName, null, artifact.version, "")
+                .maxWithOrNull(
+                    compareBy(
+                        { artifactSpecificity(it.second, artifact.name) },
+                        { it.second.length },
+                    ),
+                ) ?: return null
+        return VersionedComponent(best.first, null, artifact.version, "")
     }
 
-    private fun toArtifactMatchOrNull(
-        artifactIdEntity: ComponentArtifactIdEntity,
-        artifact: ArtifactDependency,
-    ): ArtifactMatch? {
-        val groupPattern = artifactIdEntity.groupPattern
-        val artifactPattern = artifactIdEntity.artifactPattern
-        if (!MavenArtifactMatcher.groupIdMatches(artifact.group, groupPattern) ||
-            !MavenArtifactMatcher.artifactIdMatches(artifact.name, artifactPattern)
-        ) {
-            return null
-        }
-        return ArtifactMatch(artifactIdEntity.component.componentKey, artifactPattern, false)
-    }
-
-    private fun artifactSpecificity(
-        artifactPattern: String,
-        artifactName: String,
-    ): Int =
+    /**
+     * MIG-023: higher = more specific. An exact artifactId beats a multi-token (`|`/`,`) union,
+     * which beats a catch-all. Used to prefer a specific mapping over a generic one when both match
+     * the same artifact in range.
+     */
+    private fun artifactSpecificity(artifactPattern: String, artifactName: String): Int =
         when {
             artifactPattern == artifactName -> 3
-            artifactPattern == "*" -> 0
+            isCatchAllArtifactPattern(artifactPattern) -> 0
             artifactPattern.contains("|") || artifactPattern.contains(",") -> 1
             else -> 2
         }
 
-    private data class ArtifactMatch(
-        val componentName: String,
-        val artifactPattern: String,
-        val versionSpecific: Boolean,
-    )
+    /**
+     * MIG-023: a "catch-all" artifact pattern — literal `*`, or the inherited default ANY_ARTIFACT
+     * regex (`.*`, `[\w-\.]+`, `[\w-]+`) the importer writes verbatim for components without an
+     * explicit `artifactId` — must rank BELOW any concrete mapping. Detected behaviourally: a
+     * pattern that matches an arbitrary probe id matches essentially anything, so it is a catch-all.
+     *
+     * The probe is intentionally pure lowercase letters — NO dot, dash, digit or underscore — so it
+     * is matched by every `[\w…]`-family default form (`[\w-]+`, `[\w-\.]+`, `.*`, `\w+`, `[a-z]+`).
+     * A probe containing a dot would miss the dot-less `[\w-]+` default; a probe with a dash would
+     * miss a `\w+` default. Concrete names and `|`/`,` unions never match it.
+     */
+    private fun isCatchAllArtifactPattern(artifactPattern: String): Boolean =
+        artifactPattern == "*" ||
+            MavenArtifactMatcher.artifactIdMatches("xanyartifactprobe", artifactPattern)
+
+    /**
+     * MIG-039: true iff [versionString] is contained in [rangeString], using the same
+     * version-range semantics V1's [org.octopusden.octopus.escrow.configuration.validation.EscrowModuleConfigMatcher]
+     * applies. Unparseable range/version → false (no match) rather than throwing.
+     */
+    private fun versionInRange(rangeString: String, versionString: String): Boolean =
+        runCatching {
+            versionRangeFactory.create(rangeString)
+                .containsVersion(numericVersionFactory.create(versionString))
+        }.getOrDefault(false)
 
     private fun buildImageToComponentMap(): Map<String, String> {
         val result = mutableMapOf<String, String>()
@@ -614,13 +658,13 @@ class DatabaseComponentRegistryResolver(
             } catch (_: NotFoundException) {
                 return null
             }
-        val component = componentRepository.findByComponentKey(componentKey) ?: return null
-        val config =
-            component.toResolvedEscrowModuleConfig(
-                version = versionString,
-                versionRangeFactory = versionRangeFactory,
-                numericVersionFactory = numericVersionFactory,
-            ) ?: return null
+        // MIG-040: resolve via getResolvedComponentDefinition so the distribution version
+        // substitution (EscrowConfigurationLoader.calculateDistribution) is applied — exactly as
+        // the /versions/{v}/distribution endpoint does. A plain toResolvedEscrowModuleConfig leaves
+        // docker() WITHOUT the version tag (e.g. "img" instead of "img:4.0.427"), so the
+        // "$imageName:$imageTag" membership check never matched and find-by-docker-images returned
+        // empty where the V1 baseline (whose escrow model is version-substituted) returns the image.
+        val config = getResolvedComponentDefinition(componentKey, versionString) ?: return null
         return config.distribution?.let { dist ->
             if (dist.docker()?.split(',')?.contains("$imageName:$imageTag") == true) {
                 ComponentImage(componentKey, versionString, Image(imageName, imageTag))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverFindByArtifactTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverFindByArtifactTest.kt
@@ -15,6 +15,8 @@ import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
 import org.octopusden.releng.versions.NumericVersionFactory
@@ -84,6 +86,29 @@ class DatabaseComponentRegistryResolverFindByArtifactTest {
         )
     }
 
+    /** A per-range `GROUP_ARTIFACT_PATTERN` marker carrying an overriding maven coordinate. */
+    private fun addMarkerWithMavenArtifact(
+        component: ComponentEntity,
+        versionRange: String,
+        groupPattern: String,
+        artifactPattern: String,
+    ) {
+        val marker = ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = MarkerAttributes.GROUP_ARTIFACT_PATTERN,
+            rowType = "MARKER",
+        )
+        marker.mavenArtifacts.add(
+            DistributionMavenArtifactEntity(
+                componentConfiguration = marker,
+                groupPattern = groupPattern,
+                artifactPattern = artifactPattern,
+            ),
+        )
+        component.configurations.add(marker)
+    }
+
     @Test
     @DisplayName("MIG-039: resolves the in-range component, not an archived one whose ranges exclude the version")
     fun `MIG-039 gates artifact resolution by configuration version range`() {
@@ -136,5 +161,111 @@ class DatabaseComponentRegistryResolverFindByArtifactTest {
 
         val artifact = ArtifactDependency("com.other.group", "totally-unrelated", "11.1.0")
         assertNull(resolver.findComponentsByArtifact(setOf(artifact))[artifact])
+    }
+
+    @Test
+    @DisplayName("MIG-039: per-range artifactId override — the new artifact resolves in its own range")
+    fun `MIG-039 resolves a per-range artifactId override in the overriding range`() {
+        // base [1.0.0,2.0.0) publishes 'old' (component-level); a GROUP_ARTIFACT_PATTERN marker
+        // overrides [2.0.0,) to publish 'new'. V1 matches artifact pattern AND range on the SAME
+        // config, so 'new:2.5.0' must resolve via the [2.0.0,) range (it isn't in the
+        // component-level artifactIds at all — the pre-fix component-level match would miss it).
+        val comp = makeComponent("ovr")
+        addArtifactId(comp, "com.example.x", "old")
+        addConfig(comp, "[1.0.0,2.0.0)")
+        addMarkerWithMavenArtifact(comp, "[2.0.0,)", "com.example.x", "new")
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(comp))
+
+        val artifact = ArtifactDependency("com.example.x", "new", "2.5.0")
+        val resolved = resolver.findComponentsByArtifact(setOf(artifact))[artifact]
+        assertNotNull(resolved, "the per-range 'new' artifact must resolve in [2.0.0,)")
+        assertEquals("ovr", resolved!!.id)
+    }
+
+    @Test
+    @DisplayName("MIG-039: per-range artifactId override — a superseded artifact does NOT resolve for a version in the override range")
+    fun `MIG-039 does not resolve a superseded artifactId for a version in the overriding range`() {
+        val comp = makeComponent("ovr")
+        addArtifactId(comp, "com.example.x", "old")
+        addConfig(comp, "[1.0.0,2.0.0)")
+        addMarkerWithMavenArtifact(comp, "[2.0.0,)", "com.example.x", "new")
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(comp))
+
+        // 'old' was published only in [1.0.0,2.0.0); at 2.5.0 the effective artifact is 'new', so
+        // 'old:2.5.0' must NOT resolve (the pre-fix gate accepted it because some range covered 2.5.0
+        // and the component-level 'old' matched).
+        val artifact = ArtifactDependency("com.example.x", "old", "2.5.0")
+        assertNull(resolver.findComponentsByArtifact(setOf(artifact))[artifact])
+    }
+
+    @Test
+    @DisplayName("MIG-023/039: a specific (exact) artifactId mapping beats a generic one regardless of findAll() order")
+    fun `MIG-039 prefers the most specific in-range mapping over a generic one listed first`() {
+        // MIG-023: when two components match the same artifact in range, the more specific
+        // (exact) mapping must win — even if findAll() returns the generic one first.
+        val generic = makeComponent("generic-comp")
+        addArtifactId(generic, "com.example.x", "core|other") // |-union → less specific
+        addConfig(generic, "[1.0.0,2.0.0)")
+        val specific = makeComponent("specific-comp")
+        addArtifactId(specific, "com.example.x", "core") // exact → more specific
+        addConfig(specific, "[1.0.0,2.0.0)")
+        // generic is returned FIRST — a first-in-range-wins matcher would (wrongly) pick it.
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(generic, specific))
+
+        val artifact = ArtifactDependency("com.example.x", "core", "1.5.0")
+        val resolved = resolver.findComponentsByArtifact(setOf(artifact))[artifact]
+        assertNotNull(resolved)
+        assertEquals(
+            "specific-comp",
+            resolved!!.id,
+            "the exact mapping must win over the generic |-union one regardless of findAll() order",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-023/039: the inherited default catch-all regex must lose to a concrete multi-artifact mapping")
+    fun `MIG-039 ranks the default catch-all regex below a concrete union mapping`() {
+        // A component without an explicit artifactId inherits the default ANY_ARTIFACT regex,
+        // stored verbatim (e.g. [\w-\.]+). MIG-023: it must NOT beat a component that lists the
+        // concrete artifact in a |-union, even though the regex isn't the literal "*".
+        val generic = makeComponent("generic-comp")
+        addArtifactId(generic, "com.example.x", "[\\w-\\.]+") // inherited default catch-all regex
+        addConfig(generic, "[1.0.0,2.0.0)")
+        val concrete = makeComponent("concrete-comp")
+        addArtifactId(concrete, "com.example.x", "core|api") // concrete multi-artifact union
+        addConfig(concrete, "[1.0.0,2.0.0)")
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(generic, concrete))
+
+        val artifact = ArtifactDependency("com.example.x", "core", "1.5.0")
+        val resolved = resolver.findComponentsByArtifact(setOf(artifact))[artifact]
+        assertNotNull(resolved)
+        assertEquals(
+            "concrete-comp",
+            resolved!!.id,
+            "the default catch-all regex must rank below a concrete union mapping",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-023/039: the dot-less default catch-all regex form also loses to a concrete mapping")
+    fun `MIG-039 ranks the dotless default catch-all regex below a concrete union mapping`() {
+        // Some fixtures store the default as [\w-]+ (no dot). It must also be treated as catch-all,
+        // not specific — the catch-all probe must therefore contain no dot/dash.
+        val generic = makeComponent("generic-comp")
+        addArtifactId(generic, "com.example.x", "[\\w-]+") // dot-less default catch-all regex
+        addConfig(generic, "[1.0.0,2.0.0)")
+        val concrete = makeComponent("concrete-comp")
+        addArtifactId(concrete, "com.example.x", "core|api")
+        addConfig(concrete, "[1.0.0,2.0.0)")
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(generic, concrete))
+
+        val artifact = ArtifactDependency("com.example.x", "core", "1.5.0")
+        val resolved = resolver.findComponentsByArtifact(setOf(artifact))[artifact]
+        assertNotNull(resolved)
+        assertEquals(
+            "concrete-comp",
+            resolved!!.id,
+            "the dot-less [\\w-]+ catch-all must rank below a concrete union mapping",
+        )
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverFindByArtifactTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverFindByArtifactTest.kt
@@ -1,0 +1,140 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
+import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * MIG-039: `find-by-artifacts` must mirror V1's `EscrowModuleConfigMatcher` —
+ * a group/artifact pattern match is necessary but NOT sufficient; the artifact
+ * version must also fall within one of the component's configuration version
+ * ranges.
+ *
+ * Bug (live-repro 2026-06-02): for an artifact `<group>:<artifact>:11.1.157` the DB
+ * resolver resolved an **archived** component instead of the correct active one.
+ * Both carry a `component_artifact_ids` row whose pattern matches `<artifact>`, but
+ * the archived one's ranges (`[1.0.x,…)`) exclude `11.1.157`. The DB matcher ignored
+ * version ranges and tie-broke by `artifactPattern.length`, so the archived
+ * component's long `|`-union pattern won. V1 gates by `versionRange.containsVersion`,
+ * so it uniquely picks the in-range (active) component.
+ *
+ * Mock-based (no Spring / DB), mirroring DatabaseComponentRegistryResolverMavenArtifactsRangeTest.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class DatabaseComponentRegistryResolverFindByArtifactTest {
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    private fun makeComponent(key: String): ComponentEntity =
+        ComponentEntity(id = UUID.randomUUID(), componentKey = key)
+
+    private fun addConfig(component: ComponentEntity, versionRange: String) {
+        component.configurations.add(
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = versionRange,
+                overriddenAttribute = null,
+                rowType = "BASE",
+                deprecated = false,
+            ),
+        )
+    }
+
+    private fun addArtifactId(component: ComponentEntity, groupPattern: String, artifactPattern: String) {
+        component.artifactIds.add(
+            ComponentArtifactIdEntity(
+                component = component,
+                groupPattern = groupPattern,
+                artifactPattern = artifactPattern,
+                sortOrder = component.artifactIds.size,
+            ),
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-039: resolves the in-range component, not an archived one whose ranges exclude the version")
+    fun `MIG-039 gates artifact resolution by configuration version range`() {
+        // Active component: matches 'core' via a |-union pattern (specificity == union, same
+        // class as the archived one below, so the tie-break falls through to pattern LENGTH);
+        // range contains 11.1.157.
+        val active = makeComponent("active-comp")
+        addArtifactId(active, "com.example.system", "core|api")
+        addConfig(active, "[11.0.0,12.0.0)")
+
+        // Archived component: ALSO matches 'core' via a LONGER |-union pattern (equal specificity,
+        // so the old length tie-break preferred it), but its range excludes 11.1.157.
+        val archived = makeComponent("archived-comp")
+        addArtifactId(archived, "com.example.system", "core|extra|legacy|more|verylongunion")
+        addConfig(archived, "[1.0.0,2.0.0)")
+
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(active, archived))
+
+        val artifact = ArtifactDependency("com.example.system", "core", "11.1.157")
+        val resolved = resolver.findComponentsByArtifact(setOf(artifact))[artifact]
+
+        assertNotNull(resolved, "artifact must resolve to the in-range component")
+        assertEquals(
+            "active-comp",
+            resolved!!.id,
+            "must pick the version-range-matching component, not the archived one with a longer pattern",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-039: returns null when no component config range contains the artifact version")
+    fun `MIG-039 returns null when version is outside all matching components ranges`() {
+        val comp = makeComponent("active-comp")
+        addArtifactId(comp, "com.example.system", "core")
+        addConfig(comp, "[11.0.0,12.0.0)")
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(comp))
+
+        // pattern matches 'core' but 99.0.0 is outside [11.0.0,12.0.0)
+        val artifact = ArtifactDependency("com.example.system", "core", "99.0.0")
+        assertNull(resolver.findComponentsByArtifact(setOf(artifact))[artifact])
+    }
+
+    @Test
+    @DisplayName("MIG-039: returns null for an artifact matching no component pattern")
+    fun `MIG-039 returns null for an unknown artifact`() {
+        val comp = makeComponent("active-comp")
+        addArtifactId(comp, "com.example.system", "core")
+        addConfig(comp, "[11.0.0,12.0.0)")
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(comp))
+
+        val artifact = ArtifactDependency("com.other.group", "totally-unrelated", "11.1.0")
+        assertNull(resolver.findComponentsByArtifact(setOf(artifact))[artifact])
+    }
+}

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -44,6 +44,9 @@ Numbered MIG-NNN contracts registry, peer of `requirements-common.md` (SYS-NNN) 
 | MIG-036 | Per-attribute version-range overrides via Model A' | High | integration-test | ❌ Not tested |
 | MIG-037 | Unified VCS model (no discriminator) | Medium | unit-test | ❌ Not tested |
 | MIG-038 | Endpoint kill-list (5 endpoints dropped/stubbed) | Low | integration-test | ❌ Not tested |
+| MIG-039 | find-by-artifacts gates by configuration version range | High | unit-test | ✅ Tested |
+| MIG-040 | find-by-docker-images version-substitutes distribution | Low | integration-test | ✅ Fixed |
+| MIG-041 | importer preserves component-level artifactId CSV tokens | Medium | integration-test | ⏳ Follow-up |
 
 ---
 
@@ -1059,3 +1062,79 @@ Five effectively-dead endpoints (≤2 calls in 2 production days) are removed or
 1. `GET /rest/api/3/components` returns 410 Gone.
 2. `PUT /rest/api/2/components-registry/service/updateCache` returns 410 Gone (matches deployed behaviour).
 3. `GET /rest/api/2/components` (no params), `GET /rest/api/2/projects/{k}/jira-component-version-ranges`, `GET /rest/api/1/components` (no filter) each return 200 with empty array.
+
+### MIG-039: find-by-artifacts must gate by configuration version range
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+**Test method:** `DatabaseComponentRegistryResolverFindByArtifactTest` — `MIG-039 gates artifact resolution by configuration version range`, `MIG-039 resolves a per-range artifactId override in the overriding range`, `MIG-039 does not resolve a superseded artifactId for a version in the overriding range`, plus the out-of-range / unknown-artifact null guards.
+
+`POST /rest/api/3/components/find-by-artifacts` (and the v2 alias / single `find-by-artifact`)
+must mirror V1's `EscrowModuleConfigMatcher`: a `groupIdPattern`/`artifactIdPattern` match is
+necessary but NOT sufficient — the artifact version must also fall within one of the component's
+configuration version ranges.
+
+**Context:** the DB resolver's `findComponentByArtifactOrNull` matched only `component_artifact_ids`
+group/artifact patterns and tie-broke by `artifactPattern.length`, ignoring version ranges. An
+archived/old component whose long `|`-union `artifactId` still matched the name (but whose ranges
+excluded the version) then won the tie-break. Live repro (2026-06-02): an artifact
+`<group>:<artifact>:11.1.157` resolved to an archived component (ranges `[1.0.x,…)`) instead of the
+active one (range `[11.1,…)`). V1 gates by `versionRange.containsVersion` + the "exactly one config"
+rule, so it uniquely picks the in-range component.
+(An earlier attempt matched `distribution.GAV()` — reverted: V1 never consults GAV, so that
+over-resolved and remained version-range-blind.)
+
+**Acceptance criteria:**
+1. An artifact resolves to the component whose configuration version range contains the artifact
+   version, not to a pattern-matching component whose ranges exclude it.
+2. An artifact whose version is outside all matching components' ranges resolves to `null`.
+3. An artifact matching no component pattern resolves to `null`.
+
+### MIG-040: find-by-docker-images must version-substitute the distribution
+
+**Priority:** Low
+**Test layer:** integration-test (real-body replay)
+**Status:** ✅ Fixed; behavioural proof via the [1.7] real-body replay
+
+`POST /rest/api/3/components/find-by-docker-images` returned an empty set on a DB-mode candidate
+where the V1 baseline returned 22 (2026-06-02 replay).
+
+**Cause (live repro):** the `distribution_docker_images` rows are stored correctly (image name
+without tag), so the image→component index is fine. But `findConfigurationByDockerImage` resolved
+the config via `toResolvedEscrowModuleConfig`, whose `distribution.docker()` lacks the version tag
+(`composeDockerCsv` emits `img` not `img:<version>` when flavor is null). The membership check
+`docker().contains("$imageName:$imageTag")` therefore never matched. The version is normally
+appended by `EscrowConfigurationLoader.calculateDistribution`, which `getResolvedComponentDefinition`
+applies but `findConfigurationByDockerImage` did not.
+
+**Fix:** resolve via `getResolvedComponentDefinition` so `calculateDistribution` runs, mirroring the
+`/versions/{v}/distribution` endpoint.
+
+**Acceptance criteria:**
+1. For a migrated component declaring a docker image, `find-by-docker-images` returns the same
+   `ComponentImage` set as the V1 baseline (verified by the [1.7] real-body replay).
+
+### MIG-041: importer must preserve all component-level artifactId CSV tokens
+
+**Priority:** Medium
+**Test layer:** integration-test
+**Status:** ⏳ Follow-up (distinct, narrower defect than MIG-039)
+
+A second find-by-artifacts defect from the same 2026-06-02 repro: a component whose component-level
+DSL `artifactId` is a CSV (e.g. `comp-foo,comp-bar`) migrated only the FIRST
+version-range block's `artifactId` into `component_artifact_ids`
+(`ImportServiceImpl.importModule`: `baseConfig = configs.firstOrNull { ALL_VERSIONS } ?: configs.first()`,
+then `buildComponentEntity` writes rows from `baseConfig.artifactIdPattern`). The dropped token means
+the reverse lookup cannot map that artifact to the owning component (it falls to the literal
+same-named component instead).
+
+**Caveat (why it is a careful follow-up, not bundled with MIG-039):** `component_artifact_ids` is
+ALSO the fallback source for `/maven-artifacts` (`getMavenArtifactParameters`), so it must NOT be
+naively unioned with per-range override tokens — that would change `/maven-artifacts` output. The
+fix must source the true component-level (default) `artifactId`, with an integration test covering
+BOTH `find-by-artifacts` and `/maven-artifacts`.
+
+**Acceptance criteria:**
+1. All component-level `artifactId` CSV tokens are matchable by `find-by-artifacts`.
+2. `/maven-artifacts` per-range output is unchanged.


### PR DESCRIPTION
## What

Two schema-v2 `find-by-*` regressions surfaced by the real-body replay (PR #315), fixed to **mirror the V1 resolver**. (Supersedes this PR's first attempt, which matched `distribution.GAV()` — reverted: V1 never consults GAV, so that over-resolved and was version-range-blind. See the held-review thread.)

### MIG-039 — `find-by-artifacts` must gate by configuration version range
`DatabaseComponentRegistryResolver.findComponentByArtifactOrNull` matched only `component_artifact_ids` group/artifact patterns and tie-broke by `artifactPattern.length`, **ignoring version ranges**. An archived/old component whose long `|`-union `artifactId` still matched the name (but whose ranges excluded the version) then won the tie-break → wrong component (live repro: an artifact at version `11.1.157` resolved to an archived component whose ranges are all `[1.0.x,…)` instead of the active one).

**Fix:** mirror `EscrowModuleConfigMatcher` — a group/artifact pattern match is necessary but not sufficient; the artifact version must also fall within one of the component's configuration version ranges (`versionInRange`, reusing `versionRangeFactory`/`numericVersionFactory`). Specificity/length tie-break kept only as a fallback after the gate.

### MIG-040 — `find-by-docker-images` must version-substitute the distribution
`findConfigurationByDockerImage` resolved via `toResolvedEscrowModuleConfig`, whose `distribution.docker()` lacks the version tag (`composeDockerCsv` emits `img`, not `img:<version>`, when flavor is null), so the `"$imageName:$imageTag"` membership check never matched → empty result where V1 returns the image (live repro: 22 vs 0).

**Fix:** resolve via `getResolvedComponentDefinition` so `EscrowConfigurationLoader.calculateDistribution` substitutes the version, exactly like the `/versions/{v}/distribution` endpoint.

## TDD / verification
- `DatabaseComponentRegistryResolverFindByArtifactTest` — **RED-then-GREEN proven**: 2/3 cases fail on the pre-fix resolver (wrong-component via length tie-break + resolves out-of-range), all pass with the gate. Range + routing suites stay green.
- MIG-040's behavioural proof is the next `[1.7]` real-body replay (the escrow-config resolution path isn't practically unit-mockable).
- Diagnosis from a live baseline-V1 + candidate-DB-mode repro (both stands, 953/953 migrated).

## Out of scope — MIG-041 (follow-up)
The same repro found a second, narrower defect: a component whose component-level `artifactId` is a CSV (`a,b`) migrates only the first version-range block's token, so the reverse lookup can't map the dropped token. **It's deferred to a focused follow-up** because `component_artifact_ids` is also the `/maven-artifacts` fallback (which expects the component *default* artifactId), so a safe fix needs the true component default + an integration test over **both** endpoints. Registered as MIG-041 in `requirements-migration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
