### PR TITLE
feat(security): add ADMIN_DATA permission, mapped to ROLE_ADMIN

### DIFF
--- a/components-registry-automation/data/components-registry-service.yaml
+++ b/components-registry-automation/data/components-registry-service.yaml
@@ -57,6 +57,7 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      - ADMIN_DATA
 
 logging:
   level:

--- a/components-registry-service-client/src/test/resources/application-common.yml
+++ b/components-registry-service-client/src/test/resources/application-common.yml
@@ -55,3 +55,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      - ADMIN_DATA

--- a/components-registry-service-client/src/test/resources/application-v3.yml
+++ b/components-registry-service-client/src/test/resources/application-v3.yml
@@ -53,3 +53,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      - ADMIN_DATA

--- a/components-registry-service-light-client/src/test/resources/application-common.yml
+++ b/components-registry-service-light-client/src/test/resources/application-common.yml
@@ -52,3 +52,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      - ADMIN_DATA

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/PermissionEvaluator.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/PermissionEvaluator.kt
@@ -28,6 +28,14 @@ class PermissionEvaluator(
 
     fun canImport(): Boolean = hasPermission(IMPORT_DATA)
 
+    /**
+     * Admin-tier data administration — gates power-user / escape-hatch editing
+     * surfaces (e.g. the Portal Field-Overrides tab's add/edit/delete actions,
+     * incl. marker editing). Distinct from IMPORT_DATA (bulk import). Mapped to
+     * ROLE_ADMIN in octopus-security.roles.
+     */
+    fun canAdminData(): Boolean = hasPermission(ADMIN_DATA)
+
     companion object {
         const val ACCESS_COMPONENTS = "ACCESS_COMPONENTS"
         const val EDIT_COMPONENTS = "EDIT_COMPONENTS"
@@ -36,5 +44,6 @@ class PermissionEvaluator(
         const val DELETE_COMPONENTS = "DELETE_COMPONENTS"
         const val IMPORT_DATA = "IMPORT_DATA"
         const val ACCESS_AUDIT = "ACCESS_AUDIT"
+        const val ADMIN_DATA = "ADMIN_DATA"
     }
 }

--- a/components-registry-service-server/src/main/resources/application-dev.yml
+++ b/components-registry-service-server/src/main/resources/application-dev.yml
@@ -14,3 +14,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      - ADMIN_DATA

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -98,3 +98,5 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      # Admin-tier data administration (e.g. Portal Field-Overrides edit surface).
+      - ADMIN_DATA

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/UserInfoConverterIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/UserInfoConverterIntegrationTest.kt
@@ -92,6 +92,9 @@ class UserInfoConverterIntegrationTest {
             .andExpect(jsonPath("$.username").value("alice"))
             .andExpect(jsonPath("$.roles[0].name").value("ROLE_ADMIN"))
             .andExpect(jsonPath("$.roles[0].permissions", org.hamcrest.Matchers.hasItem("ACCESS_COMPONENTS")))
+            // ADMIN_DATA gates the admin-only data-administration surface
+            // (e.g. the Portal Field-Overrides edit tab). Admins must carry it.
+            .andExpect(jsonPath("$.roles[0].permissions", org.hamcrest.Matchers.hasItem("ADMIN_DATA")))
     }
 
     @Test

--- a/components-registry-service-server/src/test/resources/application-common.yml
+++ b/components-registry-service-server/src/test/resources/application-common.yml
@@ -65,3 +65,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      - ADMIN_DATA

--- a/docs/registry/adr/004-auth-keycloak.md
+++ b/docs/registry/adr/004-auth-keycloak.md
@@ -177,7 +177,7 @@ class ComponentCrudController(private val service: ComponentManagementService) {
 
 ### Roles & Permissions
 
-Permissions (7):
+Permissions (8):
 
 | Permission | Endpoint / Operation |
 |---|---|
@@ -188,6 +188,7 @@ Permissions (7):
 | `DELETE_COMPONENTS` | `DELETE /{id}` — hard delete, ADMIN-only |
 | `IMPORT_DATA` | `POST /rest/api/4/admin/**`, `PUT /rest/api/4/admin/config/**` (migrate/import/global-config writes) |
 | `ACCESS_AUDIT` | `GET /rest/api/4/audit/**` |
+| `ADMIN_DATA` | admin-tier data administration — gates the Portal Field-Overrides edit surface (add/edit/delete, incl. marker editing). `ROLE_ADMIN` only. Currently enforced client-side in the Portal; the permission is surfaced via `/auth/me` |
 
 Role map (`octopus-security.roles` in `components-registry-service.yml`):
 
@@ -222,6 +223,7 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
+      - ADMIN_DATA
 ```
 
 Notes on the model:

--- a/docs/registry/deployment/keycloak-setup.md
+++ b/docs/registry/deployment/keycloak-setup.md
@@ -32,7 +32,7 @@ out of the box:
 |---|---|---|
 | `ROLE_COMPONENTS_REGISTRY_VIEWER` | `ACCESS_COMPONENTS`, `ACCESS_AUDIT` | `COMPONENTS_REGISTRY_VIEWER` |
 | `ROLE_COMPONENTS_REGISTRY_EDITOR` | `+ EDIT_COMPONENTS` | `COMPONENTS_REGISTRY_EDITOR` |
-| `ROLE_ADMIN` | all permissions including `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA` | usually a platform-wide `ADMIN` realm-role you already have |
+| `ROLE_ADMIN` | all permissions including `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA`, `ADMIN_DATA` | usually a platform-wide `ADMIN` realm-role you already have |
 | `ROLE_ANONYMOUS` | `ACCESS_COMPONENTS` (public read on v4 GETs) | implicit Spring authority — no Keycloak action needed |
 
 Authority naming convention: `UserInfoGrantedAuthoritiesConverter` (from
@@ -147,6 +147,16 @@ In the impersonated session, open the portal and check:
   `octopus-security.roles` map in your config server overlay
   accordingly (see [ADR-004](../adr/004-auth-keycloak.md) for the
   pattern).
+- **Config-overlay lists REPLACE, they do not append.** Production reads
+  `octopus-security.roles` from the `service-config` overlay
+  (`<env>/service-config: components-registry-service.yml`), which Spring
+  merges over the bundled `application.yml`. YAML *list* properties are
+  replaced wholesale, so an overlay that redefines `ROLE_ADMIN` shadows the
+  bundled permission list entirely. **When a new permission is added (e.g.
+  `ADMIN_DATA`), it must be added to `ROLE_ADMIN` in every overlay too** —
+  otherwise admins keep `ROLE_ADMIN` but silently lose the new capability
+  (here: the Portal Field-Overrides edit surface). Verify post-deploy via an
+  admin's `/auth/me` or the startup role-→-permission log.
 - **Diagnosing a 403 when you expect 200.** Enable
   `logging.level.org.octopusden.cloud.commons.security: TRACE` in
   the CRS config. The startup log prints the resolved role-→-permission

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -211,7 +211,7 @@ All admin endpoints below live under `POST /rest/api/4/admin/**` and require `IM
 
 The canonical role/permission matrix, filter-chain rules, and Keycloak role naming convention live in [ADR-004 — Authentication & Authorization via Keycloak](adr/004-auth-keycloak.md). That document is the source of truth; this section only sketches the shape so a reader of the functional spec has enough context without jumping.
 
-- **Permissions** (7): `ACCESS_COMPONENTS`, `EDIT_COMPONENTS`, `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA`, `ACCESS_AUDIT`.
+- **Permissions** (8): `ACCESS_COMPONENTS`, `EDIT_COMPONENTS`, `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA`, `ACCESS_AUDIT`, `ADMIN_DATA` (admin-tier data administration — gates the Portal Field-Overrides edit surface; `ROLE_ADMIN` only).
 - **Roles** (4): `ROLE_ANONYMOUS` → public reads only; `ROLE_COMPONENTS_REGISTRY_VIEWER`; `ROLE_COMPONENTS_REGISTRY_EDITOR`; `ROLE_ADMIN` (super-admin, reuses the existing Keycloak `ADMIN` realm-role). No separate `COMPONENTS_REGISTRY_ADMIN` — we piggyback on the platform admin role.
 - **v1/v2/v3 reads**: public (Phase 1 backward compat).
 - **v4 GET `/components/**` and `/config/**`**: public via `ROLE_ANONYMOUS` → `ACCESS_COMPONENTS`. All other v4 endpoints (writes, admin, audit) require authentication + the permission named in ADR-004.


### PR DESCRIPTION
## What

Adds an admin-tier **`ADMIN_DATA`** permission to gate power-user / escape-hatch editing surfaces — specifically the Portal **Field-Overrides** tab (add/edit/delete, incl. marker editing). Distinct from `IMPORT_DATA` (bulk import).

- `PermissionEvaluator`: `const ADMIN_DATA` + `canAdminData()` helper (mirrors `canImport()` etc.).
- `octopus-security.roles`: `ADMIN_DATA` added to `ROLE_ADMIN` in **all** role-config files — server `application.yml` / `application-dev.yml`, the **OKD deploy config** (`components-registry-automation/data/components-registry-service.yaml`, injected as `application-test` into the running pod), and the server/client/light-client test resources.

## Why no Keycloak change

Role→permission mapping is **CRS config** (`octopus-security.roles`), not Keycloak. Keycloak only assigns *roles* (realm-role `ADMIN` → `ROLE_ADMIN`); CRS resolves roles→permissions and `/auth/me` returns them. So anyone already holding the `ADMIN` realm-role automatically gains `ADMIN_DATA` once this deploys — no IdP/DevOps coordination needed.

## Safety

Granting `ADMIN_DATA` to `ROLE_ADMIN` is **inert** on its own — no `@PreAuthorize` keys off it yet (the gate is currently the Portal UI). It changes zero server behavior; it just makes the permission available. Added only to `ROLE_ADMIN` (not VIEWER/EDITOR/ANONYMOUS).

**Deploy ordering:** this should deploy **before** the paired Portal change (octopus-components-management-portal#NN), so admins carry `ADMIN_DATA` before the UI starts gating on it.

## Verification
- TDD: `UserInfoConverterIntegrationTest` now asserts an admin's `/auth/me` permissions include `ADMIN_DATA`. `./gradlew :components-registry-service-server:test --tests UserInfoConverterIntegrationTest` → BUILD SUCCESSFUL.
- Sonnet review: the P1 (4 role-config files initially missed, incl. the OKD deploy config) is fixed in this revision; all 7 now carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)