### PR TITLE
feat(v4): render component as Groovy-style code (full + resolved)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -22,7 +22,11 @@ import org.octopusden.octopus.escrow.RepositoryType
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -34,7 +38,10 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.nio.charset.StandardCharsets
 import java.util.UUID
+
+private const val TEXT_PLAIN_UTF8 = "text/plain;charset=UTF-8"
 
 /**
  * `@PreAuthorize` is applied method-by-method rather than at class level because
@@ -266,6 +273,36 @@ class ComponentControllerV4(
             }
         }
         return componentManagementService.getComponentByName(idOrName)
+    }
+
+    /**
+     * Render the component as a Groovy-style "as-code" definition (text/plain).
+     * Without `version` → the FULL view (all version ranges); with `version` →
+     * the view RESOLVED/merged for that concrete version. The component is
+     * resolved by UUID or name, identical to [getComponent].
+     */
+    @GetMapping("/{idOrName}/as-code", produces = [TEXT_PLAIN_UTF8])
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getComponentAsCode(
+        @PathVariable idOrName: String,
+        @RequestParam(required = false) version: String?,
+    ): ResponseEntity<String> {
+        val rendered =
+            if (version.isNullOrBlank()) {
+                componentManagementService.renderComponentAsCode(idOrName)
+            } else {
+                componentManagementService.renderResolvedComponentAsCode(idOrName, version)
+            }
+        val disposition =
+            ContentDisposition
+                .inline()
+                .filename("${rendered.componentKey}.groovy", StandardCharsets.UTF_8)
+                .build()
+        return ResponseEntity
+            .ok()
+            .contentType(MediaType.parseMediaType(TEXT_PLAIN_UTF8))
+            .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
+            .body(rendered.body)
     }
 
     // Field-level gating: a plain edit passes on EDIT_COMPONENTS alone, but switching

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentManagementService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentManagementService.kt
@@ -49,4 +49,27 @@ interface ComponentManagementService {
     )
 
     fun listFieldOverrides(componentId: UUID): List<FieldOverrideResponse>
+
+    /**
+     * Render the component (resolved by UUID or name) as a Groovy-style "as-code"
+     * definition with ALL version ranges. Carries the canonical component key so
+     * the controller can build the download filename without a second lookup.
+     */
+    fun renderComponentAsCode(idOrName: String): RenderedComponentCode
+
+    /**
+     * Render the component flattened/merged for a single concrete [version].
+     * Throws `NotFoundException` when the component has no resolvable
+     * configuration for the version (e.g. no BASE row, or unparseable version).
+     */
+    fun renderResolvedComponentAsCode(
+        idOrName: String,
+        version: String,
+    ): RenderedComponentCode
 }
+
+/** A rendered as-code document plus the canonical component key (for the filename). */
+data class RenderedComponentCode(
+    val componentKey: String,
+    val body: String,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -65,7 +65,9 @@ import org.octopusden.octopus.components.registry.server.repository.ToolReposito
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
 import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.components.registry.server.service.RenderedComponentCode
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
+import org.octopusden.octopus.components.registry.server.util.ComponentCodeRenderer
 import org.octopusden.octopus.escrow.config.ConfigHelper
 import org.octopusden.releng.versions.VersionRangeFactory
 import org.springframework.context.ApplicationEventPublisher
@@ -106,6 +108,7 @@ class ComponentManagementServiceImpl(
     private val teamcityProperties: TeamcityProperties,
     private val versionRangeFactory: VersionRangeFactory,
     private val environment: Environment,
+    private val componentCodeRenderer: ComponentCodeRenderer,
 ) : ComponentManagementService {
     // ConfigHelper is constructed lazily because it touches the Spring
     // Environment on first access; mirrors the pattern used by
@@ -291,6 +294,28 @@ class ComponentManagementServiceImpl(
             componentRepository.findByComponentKey(name)
                 ?: throw NotFoundException("Component with name '$name' not found")
         ).toDetailResponse(teamcityProperties.baseUrl)
+
+    // The renderer walks LAZY child collections, so it must run inside this
+    // readOnly transaction (the Hibernate session that loaded the entity).
+    @Transactional(readOnly = true)
+    override fun renderComponentAsCode(idOrName: String): RenderedComponentCode {
+        val entity = findByIdOrName(idOrName)
+        return RenderedComponentCode(entity.componentKey, componentCodeRenderer.renderFull(entity))
+    }
+
+    @Transactional(readOnly = true)
+    override fun renderResolvedComponentAsCode(
+        idOrName: String,
+        version: String,
+    ): RenderedComponentCode {
+        val entity = findByIdOrName(idOrName)
+        val body =
+            componentCodeRenderer.renderResolved(entity, version)
+                ?: throw NotFoundException(
+                    "No configuration resolves for component '${entity.componentKey}' at version '$version'",
+                )
+        return RenderedComponentCode(entity.componentKey, body)
+    }
 
     // ============================================================
     // Update
@@ -1406,6 +1431,22 @@ class ComponentManagementServiceImpl(
         componentRepository.findById(id).orElseThrow {
             NotFoundException("Component with id '$id' not found")
         }
+
+    /**
+     * Resolve a component by UUID-or-name, mirroring `ComponentControllerV4.getComponent`:
+     * try the UUID path when the token parses as one, fall back to a name lookup
+     * (a name that happens to parse as a UUID but has no id match still resolves
+     * by name). Infra errors from `findById` propagate; only a missing row falls
+     * through. Throws `NotFoundException` when neither matches.
+     */
+    private fun findByIdOrName(idOrName: String): ComponentEntity {
+        val asUuid = runCatching { UUID.fromString(idOrName) }.getOrNull()
+        if (asUuid != null) {
+            componentRepository.findById(asUuid).orElse(null)?.let { return it }
+        }
+        return componentRepository.findByComponentKey(idOrName)
+            ?: throw NotFoundException("Component '$idOrName' not found")
+    }
 
     /**
      * Parse `range` via the shared `VersionRangeFactory`; throws

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
@@ -1,0 +1,704 @@
+package org.octopusden.octopus.components.registry.server.util
+
+import org.octopusden.octopus.components.registry.server.entity.ComponentBuildToolBeanEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionDockerImageEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionFileUrlArtifactEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionPackageEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.mapper.ComponentConfigurationView
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.mapper.extractScalarValue
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionRangeFactory
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+/**
+ * Renders a [ComponentEntity] as a human-readable, Groovy-style "as-code"
+ * definition — the reverse of the legacy Groovy import (which no longer exists
+ * in the code). Pure [StringBuilder]; **no GroovyShell / old escrow libraries**.
+ *
+ * Two modes:
+ *
+ *  - [renderFull] — the whole component WITH all version ranges: a top-level
+ *    block built from the BASE row + per-component fields, followed by one
+ *    `"<range>" { … }` block per distinct override range (delta-style — only the
+ *    fields that the range overrides). Mirrors how the data is stored and how
+ *    the DSL was authored.
+ *
+ *  - [renderResolved] — the component flattened/merged for ONE concrete version:
+ *    a single block, no range sub-blocks. The merge reuses the exact same
+ *    primitives the resolver uses ([ComponentConfigurationView.applyScalarOverride]
+ *    for scalars, marker-pick for child collections), so the values match what
+ *    the v2 version-resolution endpoints return — with one deliberate exception:
+ *    distribution `$version` substitution (a runtime concern) is NOT applied, so
+ *    the resolved view shows the same distribution patterns as the full view.
+ *
+ * Visual format (old Groovy look):
+ * ```
+ * bcomponent {
+ *     componentOwner = "user1"
+ *     vcsSettings {
+ *         vcsUrl = "ssh://git@github/bcomponent.git"
+ *         repositoryType = GIT
+ *     }
+ *     build {
+ *         buildSystem = MAVEN
+ *         javaVersion = "1.8"
+ *     }
+ *     jira {
+ *         projectKey = "BS"
+ *         majorVersionFormat = '$major'
+ *     }
+ *     "[1.5,)" {
+ *         jira {
+ *             releaseVersionFormat = '$major.$minor'
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * Enum-valued fields (`buildSystem`, `repositoryType`, `generation`) and booleans
+ * render as bare words; strings are quoted; strings containing `$` use single
+ * quotes so the literal `$placeholder` is preserved (matching the old format).
+ */
+@Component
+@Suppress("TooManyFunctions")
+class ComponentCodeRenderer(
+    private val versionRangeFactory: VersionRangeFactory,
+    private val numericVersionFactory: NumericVersionFactory,
+) {
+    /** FULL view: base block + one `"<range>" { … }` block per distinct override range. */
+    fun renderFull(component: ComponentEntity): String {
+        val configs =
+            component.configurations.sortedWith(
+                compareBy(
+                    { it.rowType != ROW_BASE },
+                    { it.createdAt ?: Instant.MIN },
+                    { it.id?.toString() ?: "" },
+                ),
+            )
+        val base = configs.firstOrNull { it.rowType == ROW_BASE }
+        val overrides = configs.filter { it.rowType != ROW_BASE }
+
+        val cb = CodeBuilder()
+        cb.open(blockHeader(component.componentKey))
+        if (base == null) {
+            cb.close()
+            return cb.toString()
+        }
+
+        // Per schema-spec.md §3.4 (MIG-029): a synthetic base whose component also
+        // has overrides is just a placeholder anchor — its row-level aspects are
+        // not a meaningful default view, so suppress them at top level. The
+        // per-component fields (identity / people / docs / …) still render once.
+        val renderRowAspects = !(base.isSyntheticBase && overrides.isNotEmpty())
+        val view = if (renderRowAspects) ComponentConfigurationView.from(base) else ComponentConfigurationView()
+        writeComponentBody(
+            cb = cb,
+            component = component,
+            scalars = view,
+            vcsEntries = if (renderRowAspects) base.vcsEntries.toList() else emptyList(),
+            mavenArtifacts = if (renderRowAspects) base.mavenArtifacts.toList() else emptyList(),
+            fileUrlArtifacts = if (renderRowAspects) base.fileUrlArtifacts.toList() else emptyList(),
+            dockerImages = if (renderRowAspects) base.dockerImages.toList() else emptyList(),
+            packages = if (renderRowAspects) base.packages.toList() else emptyList(),
+            requiredTools = if (renderRowAspects) base.requiredToolJunctions.map { it.toolName } else emptyList(),
+            buildToolBeans = if (renderRowAspects) base.buildToolBeans.toList() else emptyList(),
+        )
+
+        // Distinct override ranges in deterministic (DSL declaration) order.
+        overrides
+            .map { it.versionRange }
+            .distinct()
+            .forEach { range -> writeRangeBlock(cb, range, overrides.filter { it.versionRange == range }) }
+
+        cb.close()
+        return cb.toString()
+    }
+
+    /**
+     * RESOLVED view for [version]. Returns `null` when the component has no BASE
+     * row or [version] is unparseable (the caller maps that to a 404), matching
+     * `EntityMappers.toResolvedEscrowModuleConfig`.
+     */
+    @Suppress("ReturnCount")
+    fun renderResolved(
+        component: ComponentEntity,
+        version: String,
+    ): String? {
+        val configs = component.configurations.toList()
+        val base = configs.firstOrNull { it.rowType == ROW_BASE } ?: return null
+        val numericVersion =
+            try {
+                numericVersionFactory.create(version)
+            } catch (_: Exception) {
+                return null
+            }
+        val matching =
+            configs.filter { it.rowType == ROW_SCALAR_OVERRIDE || it.rowType == ROW_MARKER }
+                .filter { override ->
+                    try {
+                        versionRangeFactory.create(override.versionRange).containsVersion(numericVersion)
+                    } catch (_: Exception) {
+                        false
+                    }
+                }
+        val scalarOverrides = matching.filter { it.rowType == ROW_SCALAR_OVERRIDE }
+        val markerOverrides = matching.filter { it.rowType == ROW_MARKER }
+
+        val view = ComponentConfigurationView.from(base)
+        scalarOverrides.forEach { view.applyScalarOverride(it) }
+
+        val vcs =
+            pickMarkerChildren(MarkerAttributes.VCS_SETTINGS, markerOverrides, base.vcsEntries.toList()) { it.vcsEntries.toList() }
+        val maven =
+            pickMarkerChildren(MarkerAttributes.DISTRIBUTION_MAVEN, markerOverrides, base.mavenArtifacts.toList()) {
+                it.mavenArtifacts.toList()
+            }
+        val fileUrl =
+            pickMarkerChildren(MarkerAttributes.DISTRIBUTION_FILE_URL, markerOverrides, base.fileUrlArtifacts.toList()) {
+                it.fileUrlArtifacts.toList()
+            }
+        val docker =
+            pickMarkerChildren(MarkerAttributes.DISTRIBUTION_DOCKER, markerOverrides, base.dockerImages.toList()) {
+                it.dockerImages.toList()
+            }
+        val pkgs =
+            pickMarkerChildren(MarkerAttributes.DISTRIBUTION_PACKAGES, markerOverrides, base.packages.toList()) { it.packages.toList() }
+        val tools =
+            pickMarkerChildren(MarkerAttributes.BUILD_REQUIRED_TOOLS, markerOverrides, base.requiredToolJunctions.toList()) {
+                it.requiredToolJunctions.toList()
+            }.map { it.toolName }
+        val beans =
+            pickMarkerChildren(MarkerAttributes.BUILD_TOOLS, markerOverrides, base.buildToolBeans.toList()) { it.buildToolBeans.toList() }
+
+        val cb = CodeBuilder()
+        cb.open(blockHeader(component.componentKey))
+        writeComponentBody(
+            cb = cb,
+            component = component,
+            scalars = view,
+            vcsEntries = vcs,
+            mavenArtifacts = maven,
+            fileUrlArtifacts = fileUrl,
+            dockerImages = docker,
+            packages = pkgs,
+            requiredTools = tools,
+            buildToolBeans = beans,
+        )
+        cb.close()
+        return cb.toString()
+    }
+
+    // ============================================================
+    // Component body (shared by full base block and resolved block)
+    // ============================================================
+
+    @Suppress("LongParameterList", "CyclomaticComplexMethod", "LongMethod")
+    private fun writeComponentBody(
+        cb: CodeBuilder,
+        component: ComponentEntity,
+        scalars: ComponentConfigurationView,
+        vcsEntries: List<VcsSettingsEntryEntity>,
+        mavenArtifacts: List<DistributionMavenArtifactEntity>,
+        fileUrlArtifacts: List<DistributionFileUrlArtifactEntity>,
+        dockerImages: List<DistributionDockerImageEntity>,
+        packages: List<DistributionPackageEntity>,
+        requiredTools: List<String>,
+        buildToolBeans: List<ComponentBuildToolBeanEntity>,
+    ) {
+        // Identity
+        cb.str("displayName", component.displayName)
+        cb.str("componentOwner", component.componentOwner)
+        cb.str("system", component.systemCode)
+        cb.str("productType", component.productType)
+        cb.str("clientCode", component.clientCode)
+        cb.bool("solution", component.solution)
+        cb.bool("archived", component.archived.takeIf { it })
+        cb.bool("canBeParent", component.canBeParent.takeIf { it })
+        cb.bool("releasesInDefaultBranch", component.releasesInDefaultBranch)
+        cb.str("copyright", component.copyright)
+        cb.str("parentComponent", component.parentComponent?.componentKey)
+        cb.strList("releaseManager", component.releaseManagerUsernames())
+        cb.strList("securityChampion", component.securityChampionUsernames())
+        cb.strList("labels", component.labelJunctions.map { it.labelCode })
+
+        writeVcs(cb, vcsEntries, component.vcsExternalRegistry)
+        writeBuild(cb, scalars, requiredTools, buildToolBeans)
+        writeArtifactIds(cb, component)
+        writeJira(cb, scalars, component)
+        writeDistribution(cb, component, mavenArtifacts, fileUrlArtifacts, dockerImages, packages)
+        writeEscrow(cb, scalars)
+        writeDocs(cb, component)
+        cb.strList("teamcityProjects", component.teamcityProjects.sortedBy { it.sortOrder }.map { it.projectId })
+    }
+
+    private fun writeVcs(
+        cb: CodeBuilder,
+        entries: List<VcsSettingsEntryEntity>,
+        externalRegistry: String?,
+    ) {
+        if (entries.isEmpty() && externalRegistry == null) return
+        cb.open("vcsSettings")
+        cb.str("externalRegistry", externalRegistry)
+        val sorted = entries.sortedBy { it.sortOrder }
+        if (sorted.size <= 1) {
+            sorted.firstOrNull()?.let { writeVcsRootFields(cb, it) }
+        } else {
+            // Multiple named roots → one named sub-block each (name is always quoted).
+            sorted.forEach { root ->
+                cb.open(doubleQuoted(root.name))
+                writeVcsRootFields(cb, root)
+                cb.close()
+            }
+        }
+        cb.close()
+    }
+
+    private fun writeVcsRootFields(
+        cb: CodeBuilder,
+        root: VcsSettingsEntryEntity,
+    ) {
+        cb.str("vcsUrl", root.vcsPath)
+        cb.bare("repositoryType", root.repositoryType)
+        cb.str("branch", root.branch)
+        cb.str("tag", root.tag)
+        cb.str("hotfixBranch", root.hotfixBranch)
+    }
+
+    private fun writeBuild(
+        cb: CodeBuilder,
+        s: ComponentConfigurationView,
+        requiredTools: List<String>,
+        buildToolBeans: List<ComponentBuildToolBeanEntity>,
+    ) {
+        val hasContent =
+            listOf(
+                s.buildSystem, s.buildSystemVersion, s.javaVersion, s.mavenVersion, s.gradleVersion,
+                s.buildFilePath, s.projectVersion, s.systemProperties, s.buildTasks,
+            ).any { it != null } || s.deprecated != null || s.requiredProject != null ||
+                requiredTools.isNotEmpty() || buildToolBeans.isNotEmpty()
+        if (!hasContent) return
+        cb.open("build")
+        cb.bare("buildSystem", s.buildSystem)
+        cb.str("buildSystemVersion", s.buildSystemVersion)
+        cb.str("javaVersion", s.javaVersion)
+        cb.str("mavenVersion", s.mavenVersion)
+        cb.str("gradleVersion", s.gradleVersion)
+        cb.str("buildFilePath", s.buildFilePath)
+        cb.bool("deprecated", s.deprecated)
+        cb.bool("requiredProject", s.requiredProject)
+        cb.str("projectVersion", s.projectVersion)
+        cb.str("systemProperties", s.systemProperties)
+        cb.str("buildTasks", s.buildTasks)
+        cb.strList("requiredTools", requiredTools)
+        writeBuildToolBeans(cb, buildToolBeans)
+        cb.close()
+    }
+
+    private fun writeBuildToolBeans(
+        cb: CodeBuilder,
+        beans: List<ComponentBuildToolBeanEntity>,
+    ) {
+        if (beans.isEmpty()) return
+        cb.open("buildTools")
+        beans.sortedBy { it.sortOrder }.forEach { bean ->
+            cb.open("tool")
+            cb.str("beanType", bean.beanType)
+            cb.str("toolType", bean.toolType)
+            cb.str("settingsProperty", bean.settingsProperty)
+            cb.str("versionPattern", bean.versionPattern)
+            cb.str("edition", bean.edition)
+            cb.close()
+        }
+        cb.close()
+    }
+
+    private fun writeArtifactIds(
+        cb: CodeBuilder,
+        component: ComponentEntity,
+    ) {
+        val artifactIds = component.artifactIds
+        if (artifactIds.isEmpty()) return
+        cb.open("artifactIds")
+        artifactIds.forEach { a ->
+            cb.open("artifact")
+            cb.str("groupPattern", a.groupPattern)
+            cb.str("artifactPattern", a.artifactPattern)
+            cb.close()
+        }
+        cb.close()
+    }
+
+    private fun writeJira(
+        cb: CodeBuilder,
+        s: ComponentConfigurationView,
+        component: ComponentEntity,
+    ) {
+        // hotfixVersionFormat has a per-component fallback layer. Mirror the resolver
+        // (`EntityMappers.buildJiraComponent`): once a per-range SCALAR_OVERRIDE has set it
+        // (`jiraHotfixVersionFormatOverridden`), the merged value wins as-is — including a
+        // null-clear; otherwise fall back to the per-component base value.
+        val effectiveHotfix =
+            if (s.jiraHotfixVersionFormatOverridden) {
+                s.jiraHotfixVersionFormat
+            } else {
+                s.jiraHotfixVersionFormat ?: component.jiraHotfixVersionFormat
+            }
+        val hasContent =
+            listOf(
+                s.jiraProjectKey, s.jiraMajorVersionFormat, s.jiraReleaseVersionFormat, s.jiraBuildVersionFormat,
+                s.jiraLineVersionFormat, s.jiraVersionPrefix, s.jiraVersionFormat, effectiveHotfix,
+                component.jiraDisplayName,
+            ).any { it != null } || s.jiraTechnical != null
+        if (!hasContent) return
+        cb.open("jira")
+        cb.str("projectKey", s.jiraProjectKey)
+        cb.str("displayName", component.jiraDisplayName)
+        cb.bool("technical", s.jiraTechnical)
+        cb.str("majorVersionFormat", s.jiraMajorVersionFormat)
+        cb.str("releaseVersionFormat", s.jiraReleaseVersionFormat)
+        cb.str("buildVersionFormat", s.jiraBuildVersionFormat)
+        cb.str("lineVersionFormat", s.jiraLineVersionFormat)
+        cb.str("versionPrefix", s.jiraVersionPrefix)
+        cb.str("versionFormat", s.jiraVersionFormat)
+        cb.str("hotfixVersionFormat", effectiveHotfix)
+        cb.close()
+    }
+
+    @Suppress("LongParameterList")
+    private fun writeDistribution(
+        cb: CodeBuilder,
+        component: ComponentEntity,
+        mavenArtifacts: List<DistributionMavenArtifactEntity>,
+        fileUrlArtifacts: List<DistributionFileUrlArtifactEntity>,
+        dockerImages: List<DistributionDockerImageEntity>,
+        packages: List<DistributionPackageEntity>,
+    ) {
+        val securityGroups = component.securityGroups
+        val hasContent =
+            component.distributionExplicit != null || component.distributionExternal != null ||
+                mavenArtifacts.isNotEmpty() || fileUrlArtifacts.isNotEmpty() || dockerImages.isNotEmpty() ||
+                packages.isNotEmpty() || securityGroups.isNotEmpty()
+        if (!hasContent) return
+        cb.open("distribution")
+        cb.bool("explicit", component.distributionExplicit)
+        cb.bool("external", component.distributionExternal)
+        mavenArtifacts.sortedBy { it.sortOrder }.forEach { m ->
+            cb.open("maven")
+            cb.str("groupPattern", m.groupPattern)
+            cb.str("artifactPattern", m.artifactPattern)
+            cb.str("extension", m.extension)
+            cb.str("classifier", m.classifier)
+            cb.close()
+        }
+        fileUrlArtifacts.sortedBy { it.sortOrder }.forEach { f ->
+            cb.open("fileUrl")
+            cb.str("url", f.url)
+            cb.str("artifactId", f.artifactId)
+            cb.str("classifier", f.classifier)
+            cb.close()
+        }
+        dockerImages.sortedBy { it.sortOrder }.forEach { d ->
+            cb.open("docker")
+            cb.str("imageName", d.imageName)
+            cb.str("flavor", d.flavor)
+            cb.close()
+        }
+        packages.sortedBy { it.sortOrder }.forEach { p ->
+            cb.open("package")
+            cb.bare("type", p.packageType)
+            cb.str("name", p.packageName)
+            cb.close()
+        }
+        if (securityGroups.isNotEmpty()) {
+            cb.open("securityGroups")
+            securityGroups.forEach { g -> cb.str(g.groupType, g.groupName) }
+            cb.close()
+        }
+        cb.close()
+    }
+
+    private fun writeEscrow(
+        cb: CodeBuilder,
+        s: ComponentConfigurationView,
+    ) {
+        val hasContent =
+            listOf(
+                s.escrowBuildTask, s.escrowProvidedDependencies, s.escrowGeneration, s.escrowDiskSpace,
+                s.escrowAdditionalSources, s.escrowGradleIncludeConfigurations, s.escrowGradleExcludeConfigurations,
+            ).any { it != null } || s.escrowReusable != null || s.escrowGradleIncludeTestConfigurations != null
+        if (!hasContent) return
+        cb.open("escrow")
+        cb.str("buildTask", s.escrowBuildTask)
+        cb.str("providedDependencies", s.escrowProvidedDependencies)
+        cb.bool("reusable", s.escrowReusable)
+        cb.bare("generation", s.escrowGeneration)
+        cb.str("diskSpace", s.escrowDiskSpace)
+        cb.str("additionalSources", s.escrowAdditionalSources)
+        cb.str("gradleIncludeConfigurations", s.escrowGradleIncludeConfigurations)
+        cb.str("gradleExcludeConfigurations", s.escrowGradleExcludeConfigurations)
+        cb.bool("gradleIncludeTestConfigurations", s.escrowGradleIncludeTestConfigurations)
+        cb.close()
+    }
+
+    private fun writeDocs(
+        cb: CodeBuilder,
+        component: ComponentEntity,
+    ) {
+        val docs = component.docLinks.sortedBy { it.sortOrder }
+        if (docs.isEmpty()) return
+        cb.open("docs")
+        docs.forEach { d ->
+            cb.open("doc")
+            cb.str("component", d.docComponentKey)
+            cb.str("majorVersion", d.majorVersion)
+            cb.close()
+        }
+        cb.close()
+    }
+
+    // ============================================================
+    // Per-range override block (FULL only)
+    // ============================================================
+
+    private fun writeRangeBlock(
+        cb: CodeBuilder,
+        range: String,
+        rows: List<ComponentConfigurationEntity>,
+    ) {
+        val scalarOverrides = rows.filter { it.rowType == ROW_SCALAR_OVERRIDE }
+        // Only render markers the editor model knows about. Import-internal markers
+        // (e.g. MarkerAttributes.GROUP_ARTIFACT_PATTERN, deliberately not in `ALL`)
+        // carry no renderable block — including them would emit an empty range block.
+        val markers = rows.filter { it.rowType == ROW_MARKER && it.overriddenAttribute in MarkerAttributes.ALL }
+        // RANGE_PRESENCE-only (or import-marker-only) ranges contribute nothing → skip (no empty block).
+        if (scalarOverrides.isEmpty() && markers.isEmpty()) return
+
+        cb.open(doubleQuoted(range))
+        writeAspectOverrides(cb, "build", scalarOverrides, markers)
+        writeAspectOverrides(cb, "jira", scalarOverrides, emptyList())
+        writeAspectOverrides(cb, "escrow", scalarOverrides, emptyList())
+        writeMarkerVcs(cb, markers)
+        writeMarkerDistribution(cb, markers)
+        cb.close()
+    }
+
+    private fun writeAspectOverrides(
+        cb: CodeBuilder,
+        aspect: String,
+        scalarOverrides: List<ComponentConfigurationEntity>,
+        markers: List<ComponentConfigurationEntity>,
+    ) {
+        val prefix = "$aspect."
+        val scalars = scalarOverrides.filter { (it.overriddenAttribute ?: "").startsWith(prefix) }
+            .sortedBy { it.overriddenAttribute }
+        val toolMarker = markers.firstOrNull { it.overriddenAttribute == MarkerAttributes.BUILD_REQUIRED_TOOLS }
+        val beanMarker = markers.firstOrNull { it.overriddenAttribute == MarkerAttributes.BUILD_TOOLS }
+        val hasBuildMarkers = aspect == "build" && (toolMarker != null || beanMarker != null)
+        if (scalars.isEmpty() && !hasBuildMarkers) return
+
+        cb.open(aspect)
+        scalars.forEach { row -> writeScalarOverrideLine(cb, row) }
+        if (aspect == "build") {
+            toolMarker?.let { cb.strList("requiredTools", it.requiredToolJunctions.map { j -> j.toolName }) }
+            beanMarker?.let { writeBuildToolBeans(cb, it.buildToolBeans.toList()) }
+        }
+        cb.close()
+    }
+
+    /** A single SCALAR_OVERRIDE row → `field = value` (or `field = null` for a null-clear). */
+    private fun writeScalarOverrideLine(
+        cb: CodeBuilder,
+        row: ComponentConfigurationEntity,
+    ) {
+        val path = row.overriddenAttribute ?: return
+        val field = path.substringAfter('.')
+        when (path) {
+            // Bare enum tokens
+            "build.buildSystem", "escrow.generation" -> cb.bareRaw(field, row.extractScalarValue()?.toString())
+            // Booleans
+            "build.deprecated", "build.requiredProject", "escrow.reusable",
+            "escrow.gradleIncludeTestConfigurations", "jira.technical",
+            -> cb.boolRaw(field, row.extractScalarValue() as? Boolean)
+            // Everything else is a string-valued scalar
+            else -> cb.strRaw(field, row.extractScalarValue()?.toString())
+        }
+    }
+
+    private fun writeMarkerVcs(
+        cb: CodeBuilder,
+        markers: List<ComponentConfigurationEntity>,
+    ) {
+        val vcs = markers.firstOrNull { it.overriddenAttribute == MarkerAttributes.VCS_SETTINGS } ?: return
+        // externalRegistry is per-component (not per-range), so range vcs blocks carry only roots.
+        writeVcs(cb, vcs.vcsEntries.toList(), externalRegistry = null)
+    }
+
+    private fun writeMarkerDistribution(
+        cb: CodeBuilder,
+        markers: List<ComponentConfigurationEntity>,
+    ) {
+        val maven = markers.firstOrNull { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN }
+        val fileUrl = markers.firstOrNull { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_FILE_URL }
+        val docker = markers.firstOrNull { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_DOCKER }
+        val pkgs = markers.firstOrNull { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_PACKAGES }
+        if (maven == null && fileUrl == null && docker == null && pkgs == null) return
+        cb.open("distribution")
+        maven?.mavenArtifacts?.sortedBy { it.sortOrder }?.forEach { m ->
+            cb.open("maven")
+            cb.str("groupPattern", m.groupPattern)
+            cb.str("artifactPattern", m.artifactPattern)
+            cb.str("extension", m.extension)
+            cb.str("classifier", m.classifier)
+            cb.close()
+        }
+        fileUrl?.fileUrlArtifacts?.sortedBy { it.sortOrder }?.forEach { f ->
+            cb.open("fileUrl")
+            cb.str("url", f.url)
+            cb.str("artifactId", f.artifactId)
+            cb.str("classifier", f.classifier)
+            cb.close()
+        }
+        docker?.dockerImages?.sortedBy { it.sortOrder }?.forEach { d ->
+            cb.open("docker")
+            cb.str("imageName", d.imageName)
+            cb.str("flavor", d.flavor)
+            cb.close()
+        }
+        pkgs?.packages?.sortedBy { it.sortOrder }?.forEach { p ->
+            cb.open("package")
+            cb.bare("type", p.packageType)
+            cb.str("name", p.packageName)
+            cb.close()
+        }
+        cb.close()
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private fun <T> pickMarkerChildren(
+        attribute: String,
+        markerOverrides: List<ComponentConfigurationEntity>,
+        baseChildren: List<T>,
+        childExtractor: (ComponentConfigurationEntity) -> List<T>,
+    ): List<T> {
+        val marker = markerOverrides.firstOrNull { it.overriddenAttribute == attribute }
+        return if (marker != null) childExtractor(marker) else baseChildren
+    }
+
+    /** Block header token: bare identifier when valid, quoted otherwise. */
+    private fun blockHeader(name: String): String =
+        if (name.matches(IDENTIFIER_RE)) name else doubleQuoted(name)
+
+    private companion object {
+        const val ROW_BASE = "BASE"
+        const val ROW_SCALAR_OVERRIDE = "SCALAR_OVERRIDE"
+        const val ROW_MARKER = "MARKER"
+        val IDENTIFIER_RE = Regex("^[A-Za-z_][A-Za-z0-9_]*$")
+    }
+}
+
+/**
+ * Indentation-aware Groovy emitter. `open`/`close` manage brace blocks; the
+ * typed `str` / `bool` / `bare` / `strList` helpers skip null/empty values so no
+ * empty assignment or block is ever emitted. The `*Raw` variants always emit
+ * (used for per-range overrides where a null value is a meaningful null-clear).
+ */
+internal class CodeBuilder {
+    private val sb = StringBuilder()
+    private var indent = 0
+
+    fun open(header: String) {
+        raw("$header {")
+        indent++
+    }
+
+    fun close() {
+        indent--
+        raw("}")
+    }
+
+    /** String value — emitted only when non-null. */
+    fun str(name: String, value: String?) {
+        if (value != null) raw("$name = ${groovyString(value)}")
+    }
+
+    /** String value, always emitted (null → `null`). For per-range null-clear overrides. */
+    fun strRaw(name: String, value: String?) {
+        raw("$name = ${value?.let { groovyString(it) } ?: "null"}")
+    }
+
+    fun bool(name: String, value: Boolean?) {
+        if (value != null) raw("$name = $value")
+    }
+
+    fun boolRaw(name: String, value: Boolean?) {
+        raw("$name = ${value ?: "null"}")
+    }
+
+    /** Bare (enum) token — emitted only when non-null/blank. */
+    fun bare(name: String, value: String?) {
+        if (!value.isNullOrBlank()) raw("$name = $value")
+    }
+
+    fun bareRaw(name: String, value: String?) {
+        raw("$name = ${value ?: "null"}")
+    }
+
+    /** List of strings — emitted only when non-empty. */
+    fun strList(name: String, values: List<String>) {
+        if (values.isNotEmpty()) raw("$name = ${groovyList(values)}")
+    }
+
+    private fun raw(text: String) {
+        repeat(indent) { sb.append("    ") }
+        sb.append(text).append('\n')
+    }
+
+    override fun toString(): String = sb.toString()
+}
+
+/** Quote a string Groovy-style; values containing `$` use single quotes so the literal is preserved. */
+internal fun groovyString(s: String): String = if (s.contains('$')) singleQuoted(s) else doubleQuoted(s)
+
+internal fun doubleQuoted(s: String): String =
+    buildString {
+        append('"')
+        s.forEach { c ->
+            when (c) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(c)
+            }
+        }
+        append('"')
+    }
+
+internal fun singleQuoted(s: String): String =
+    buildString {
+        append('\'')
+        s.forEach { c ->
+            when (c) {
+                '\\' -> append("\\\\")
+                '\'' -> append("\\'")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(c)
+            }
+        }
+        append('\'')
+    }
+
+internal fun groovyList(values: List<String>): String =
+    values.joinToString(prefix = "[", postfix = "]") { groovyString(it) }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerAsCodeV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerAsCodeV4Test.kt
@@ -1,0 +1,129 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
+import org.octopusden.octopus.components.registry.server.service.RenderedComponentCode
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * GET /rest/api/4/components/{idOrName}/as-code — the Groovy "as-code" view.
+ * The rendering itself is covered by `ComponentCodeRendererTest`; here we pin
+ * the HTTP contract: media type, the version-driven FULL↔RESOLVED routing, the
+ * `Content-Disposition` filename (canonical key even when called by UUID), and
+ * the 404 propagation.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+class ComponentControllerAsCodeV4Test {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockBean
+    private lateinit var componentManagementService: ComponentManagementService
+
+    init {
+        val testResourcesPath =
+            Paths.get(ComponentControllerAsCodeV4Test::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("FULL: text/plain body + Content-Disposition filename from canonical key")
+    fun fullView() {
+        `when`(componentManagementService.renderComponentAsCode("bcomponent"))
+            .thenReturn(RenderedComponentCode("bcomponent", "bcomponent {\n}\n"))
+
+        mvc
+            .perform(get("/rest/api/4/components/bcomponent/as-code").with(editorJwt()))
+            .andExpect(status().isOk)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+            .andExpect(content().string(containsString("bcomponent {")))
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, containsString("bcomponent.groovy")))
+
+        verify(componentManagementService, never()).renderResolvedComponentAsCode("bcomponent", "")
+    }
+
+    @Test
+    @DisplayName("RESOLVED: ?version routes to the resolved renderer")
+    fun resolvedView() {
+        `when`(componentManagementService.renderResolvedComponentAsCode("bcomponent", "2.0"))
+            .thenReturn(RenderedComponentCode("bcomponent", "bcomponent {\n    // resolved 2.0\n}\n"))
+
+        mvc
+            .perform(get("/rest/api/4/components/bcomponent/as-code?version=2.0").with(editorJwt()))
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("resolved 2.0")))
+
+        verify(componentManagementService).renderResolvedComponentAsCode("bcomponent", "2.0")
+        verify(componentManagementService, never()).renderComponentAsCode("bcomponent")
+    }
+
+    @Test
+    @DisplayName("Filename uses canonical key even when the path is a UUID")
+    fun filenameFromCanonicalKey() {
+        val uuid = UUID.randomUUID()
+        `when`(componentManagementService.renderComponentAsCode(uuid.toString()))
+            .thenReturn(RenderedComponentCode("real-key", "real-key {\n}\n"))
+
+        mvc
+            .perform(get("/rest/api/4/components/$uuid/as-code").with(editorJwt()))
+            .andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, containsString("real-key.groovy")))
+    }
+
+    @Test
+    @DisplayName("Unknown component → 404")
+    fun unknownComponent404() {
+        `when`(componentManagementService.renderComponentAsCode("ghost"))
+            .thenThrow(NotFoundException("Component 'ghost' not found"))
+
+        mvc
+            .perform(get("/rest/api/4/components/ghost/as-code").with(editorJwt()))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    @DisplayName("Version that resolves to nothing → 404")
+    fun versionNotResolvable404() {
+        `when`(componentManagementService.renderResolvedComponentAsCode("bcomponent", "99.0"))
+            .thenThrow(NotFoundException("No configuration resolves for component 'bcomponent' at version '99.0'"))
+
+        mvc
+            .perform(get("/rest/api/4/components/bcomponent/as-code?version=99.0").with(editorJwt()))
+            .andExpect(status().isNotFound)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
@@ -30,6 +30,7 @@ import org.octopusden.octopus.components.registry.server.repository.SystemReposi
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.components.registry.server.util.ComponentCodeRenderer
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
 import org.octopusden.releng.versions.NumericVersionFactory
 import org.octopusden.releng.versions.VersionNames
@@ -92,6 +93,11 @@ class MIG047FieldOverrideWriteGuardTest {
                 teamcityProperties = mock(TeamcityProperties::class.java),
                 versionRangeFactory = VersionRangeFactory(versionNames),
                 environment = mock(org.springframework.core.env.Environment::class.java),
+                componentCodeRenderer =
+                    ComponentCodeRenderer(
+                        VersionRangeFactory(versionNames),
+                        NumericVersionFactory(versionNames),
+                    ),
             )
 
         component = ComponentEntity(id = componentId, componentKey = "alpha-fixture")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
@@ -1,0 +1,425 @@
+package org.octopusden.octopus.components.registry.server.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.entity.ComponentBuildToolBeanEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentRequiredToolEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionDockerImageEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+import java.util.UUID
+
+/**
+ * Golden / structural tests for [ComponentCodeRenderer]. The full minimal case is
+ * asserted as an exact string (locks indentation + format); the richer scenarios
+ * assert on the salient lines/blocks so they stay robust against unrelated field
+ * additions.
+ */
+class ComponentCodeRendererTest {
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val renderer =
+        ComponentCodeRenderer(
+            VersionRangeFactory(versionNames),
+            NumericVersionFactory(versionNames),
+        )
+
+    // ----------------------------------------------------------------------
+    // Fixtures
+    // ----------------------------------------------------------------------
+
+    private fun component(key: String = "bcomponent"): ComponentEntity =
+        ComponentEntity(id = UUID.randomUUID(), componentKey = key)
+
+    private fun base(
+        c: ComponentEntity,
+        synthetic: Boolean = false,
+        block: ComponentConfigurationEntity.() -> Unit = {},
+    ): ComponentConfigurationEntity {
+        val row =
+            ComponentConfigurationEntity(
+                id = UUID.randomUUID(),
+                component = c,
+                versionRange = "(,0),[0,)",
+                overriddenAttribute = null,
+                rowType = "BASE",
+                isSyntheticBase = synthetic,
+            ).apply(block)
+        c.configurations.add(row)
+        return row
+    }
+
+    private fun scalarOverride(
+        c: ComponentEntity,
+        range: String,
+        attribute: String,
+        block: ComponentConfigurationEntity.() -> Unit,
+    ) {
+        c.configurations.add(
+            ComponentConfigurationEntity(
+                id = UUID.randomUUID(),
+                component = c,
+                versionRange = range,
+                overriddenAttribute = attribute,
+                rowType = "SCALAR_OVERRIDE",
+            ).apply(block),
+        )
+    }
+
+    private fun marker(
+        c: ComponentEntity,
+        range: String,
+        attribute: String,
+        block: ComponentConfigurationEntity.() -> Unit,
+    ): ComponentConfigurationEntity {
+        val row =
+            ComponentConfigurationEntity(
+                id = UUID.randomUUID(),
+                component = c,
+                versionRange = range,
+                overriddenAttribute = attribute,
+                rowType = "MARKER",
+            ).apply(block)
+        c.configurations.add(row)
+        return row
+    }
+
+    @Suppress("LongParameterList")
+    private fun vcs(
+        cfg: ComponentConfigurationEntity,
+        name: String,
+        path: String,
+        branch: String? = null,
+        repo: String? = null,
+        order: Int = 0,
+    ) = VcsSettingsEntryEntity(
+        componentConfiguration = cfg,
+        name = name,
+        vcsPath = path,
+        branch = branch,
+        repositoryType = repo,
+        sortOrder = order,
+    )
+
+    private fun docker(
+        cfg: ComponentConfigurationEntity,
+        image: String,
+        flavor: String? = null,
+        order: Int = 0,
+    ) = DistributionDockerImageEntity(
+        componentConfiguration = cfg,
+        imageName = image,
+        flavor = flavor,
+        sortOrder = order,
+    )
+
+    // ----------------------------------------------------------------------
+    // FULL — exact golden for the minimal shape
+    // ----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("FULL: minimal component renders exact Groovy shape (indentation, quote styles)")
+    fun fullMinimalExact() {
+        val c = component("bcomponent").also { it.componentOwner = "user1" }
+        base(c) {
+            buildSystem = "MAVEN"
+            jiraProjectKey = "BS"
+            jiraMajorVersionFormat = "\$major"
+        }
+
+        val expected =
+            """
+            bcomponent {
+                componentOwner = "user1"
+                build {
+                    buildSystem = MAVEN
+                }
+                jira {
+                    projectKey = "BS"
+                    majorVersionFormat = '${'$'}major'
+                }
+            }
+            """.trimIndent() + "\n"
+
+        assertEquals(expected, renderer.renderFull(c))
+    }
+
+    @Test
+    @DisplayName("FULL: no-override component is a single block with no range sub-blocks")
+    fun fullNoOverrideSingleBlock() {
+        val c = component().also { it.componentOwner = "u" }
+        base(c) { buildSystem = "GRADLE" }
+        val out = renderer.renderFull(c)
+        assertFalse(out.contains("\"(,") || out.contains("\"[")) // no range header
+    }
+
+    // ----------------------------------------------------------------------
+    // FULL — per-range override block (delta-style)
+    // ----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("FULL: scalar override becomes a \"<range>\" block carrying only the overridden field")
+    fun fullScalarOverrideRangeBlock() {
+        val c = component()
+        base(c) { jiraReleaseVersionFormat = "\$major" }
+        scalarOverride(c, "[1.5,)", "jira.releaseVersionFormat") { jiraReleaseVersionFormat = "\$major.\$minor" }
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("\"[1.5,)\" {"), out)
+        assertTrue(out.contains("releaseVersionFormat = '\$major.\$minor'"), out)
+    }
+
+    @Test
+    @DisplayName("FULL: null-clear scalar override renders `field = null` (presence, not value)")
+    fun fullNullClearRendersNull() {
+        val c = component()
+        base(c) { buildFilePath = "build.gradle" }
+        // import-only null-clear: SCALAR_OVERRIDE row exists, typed column is null
+        scalarOverride(c, "[2,3)", "build.buildFilePath") { buildFilePath = null }
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("\"[2,3)\" {"), out)
+        assertTrue(out.contains("buildFilePath = null"), out)
+    }
+
+    @Test
+    @DisplayName("FULL: import-internal marker-only range (group-artifact-pattern) does not emit an empty block")
+    fun fullImportMarkerOnlyRangeSkipped() {
+        val c = component()
+        base(c) { buildSystem = "MAVEN" }
+        // MIG-047: group-artifact-pattern is an import-internal MARKER not in MarkerAttributes.ALL.
+        marker(c, "[5,)", MarkerAttributes.GROUP_ARTIFACT_PATTERN) {}
+        val out = renderer.renderFull(c)
+        assertFalse(out.contains("\"[5,)\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: RANGE_PRESENCE-only range does not emit an empty block")
+    fun fullRangePresenceSkipped() {
+        val c = component()
+        base(c) { buildSystem = "MAVEN" }
+        c.configurations.add(
+            ComponentConfigurationEntity(
+                id = UUID.randomUUID(),
+                component = c,
+                versionRange = "[9,10)",
+                overriddenAttribute = null,
+                rowType = "RANGE_PRESENCE",
+            ),
+        )
+        val out = renderer.renderFull(c)
+        assertFalse(out.contains("\"[9,10)\""), out)
+    }
+
+    // ----------------------------------------------------------------------
+    // FULL — child collections (vcs, distribution, build markers)
+    // ----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("FULL: multiple VCS roots render as named sub-blocks")
+    fun fullMultiVcs() {
+        val c = component()
+        val b = base(c) { buildSystem = "MAVEN" }
+        b.vcsEntries.add(vcs(b, name = "core", path = "org/core", repo = "GIT", order = 0))
+        b.vcsEntries.add(vcs(b, name = "ui", path = "org/ui", repo = "GIT", order = 1))
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("vcsSettings {"), out)
+        assertTrue(out.contains("\"core\" {"), out)
+        assertTrue(out.contains("\"ui\" {"), out)
+        assertTrue(out.contains("vcsUrl = \"org/core\""), out)
+        assertTrue(out.contains("repositoryType = GIT"), out)
+    }
+
+    @Test
+    @DisplayName("FULL: single unnamed VCS root renders flat (no named sub-block)")
+    fun fullSingleVcsFlat() {
+        val c = component()
+        val b = base(c) { buildSystem = "MAVEN" }
+        b.vcsEntries.add(vcs(b, name = "main", path = "ssh://git/x.git", branch = "master"))
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("vcsSettings {"), out)
+        assertFalse(out.contains("\"main\" {"), out)
+        assertTrue(out.contains("vcsUrl = \"ssh://git/x.git\""), out)
+        assertTrue(out.contains("branch = \"master\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: build markers (requiredTools + buildTools beans) render inside build block")
+    fun fullBuildMarkers() {
+        val c = component()
+        val b = base(c) { buildSystem = "MAVEN" }
+        b.requiredToolJunctions.add(ComponentRequiredToolEntity(componentConfigurationId = b.id!!, toolName = "BuildEnv"))
+        b.buildToolBeans.add(
+            ComponentBuildToolBeanEntity(
+                id = UUID.randomUUID(),
+                componentConfiguration = b,
+                beanType = "oracleDatabase",
+                toolType = "ORACLE",
+                versionPattern = "[12,)",
+                edition = "ENTERPRISE",
+                sortOrder = 0,
+            ),
+        )
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("requiredTools = [\"BuildEnv\"]"), out)
+        assertTrue(out.contains("buildTools {"), out)
+        assertTrue(out.contains("beanType = \"oracleDatabase\""), out)
+        assertTrue(out.contains("edition = \"ENTERPRISE\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: distribution docker child renders inside distribution block")
+    fun fullDistributionDocker() {
+        val c = component()
+        val b = base(c) { buildSystem = "MAVEN" }
+        b.dockerImages.add(docker(b, image = "acme/svc", flavor = "slim"))
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("distribution {"), out)
+        assertTrue(out.contains("docker {"), out)
+        assertTrue(out.contains("imageName = \"acme/svc\""), out)
+        assertTrue(out.contains("flavor = \"slim\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: per-range vcs.settings marker renders a vcsSettings block in the range")
+    fun fullRangeVcsMarker() {
+        val c = component()
+        base(c) { buildSystem = "MAVEN" }
+        val m = marker(c, "[2,)", MarkerAttributes.VCS_SETTINGS) {}
+        m.vcsEntries.add(vcs(m, name = "main", path = "org/v2", branch = "v2"))
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("\"[2,)\" {"), out)
+        assertTrue(out.contains("vcsUrl = \"org/v2\""), out)
+    }
+
+    // ----------------------------------------------------------------------
+    // FULL — people, escaping, key quoting, synthetic base
+    // ----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("FULL: multi-value people render as list literals")
+    fun fullMultiValuePeople() {
+        val c = component()
+        c.replaceReleaseManagerUsernames(listOf("alice", "bob"))
+        c.replaceSecurityChampionUsernames(listOf("carol"))
+        base(c) { buildSystem = "MAVEN" }
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("releaseManager = [\"alice\", \"bob\"]"), out)
+        assertTrue(out.contains("securityChampion = [\"carol\"]"), out)
+    }
+
+    @Test
+    @DisplayName("FULL: strings escape quotes/backslashes; \$ values use single quotes")
+    fun fullEscaping() {
+        val c = component().also { it.displayName = "a\"b\\c" }
+        base(c) {
+            buildSystem = "MAVEN"
+            jiraVersionFormat = "\$prefix-\$base"
+        }
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("displayName = \"a\\\"b\\\\c\""), out)
+        assertTrue(out.contains("versionFormat = '\$prefix-\$base'"), out)
+    }
+
+    @Test
+    @DisplayName("FULL: component key with special chars is quoted in the block header")
+    fun fullKeyQuoting() {
+        val c = component("buildsystem-model")
+        base(c) { buildSystem = "MAVEN" }
+        assertTrue(renderer.renderFull(c).startsWith("\"buildsystem-model\" {"))
+    }
+
+    @Test
+    @DisplayName("FULL: synthetic base with overrides suppresses base row aspects but keeps range blocks")
+    fun fullSyntheticBaseSuppression() {
+        val c = component()
+        base(c, synthetic = true) { buildSystem = "MAVEN" }
+        scalarOverride(c, "[1,2)", "jira.projectKey") { jiraProjectKey = "AAA" }
+
+        val out = renderer.renderFull(c)
+        assertFalse(out.contains("buildSystem"), "synthetic base row aspects must be suppressed:\n$out")
+        assertTrue(out.contains("\"[1,2)\" {"), out)
+        assertTrue(out.contains("projectKey = \"AAA\""), out)
+    }
+
+    // ----------------------------------------------------------------------
+    // RESOLVED
+    // ----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("RESOLVED: scalar override merges in for an in-range version; base value otherwise")
+    fun resolvedScalarMerge() {
+        val c = component()
+        base(c) { javaVersion = "1.8" }
+        scalarOverride(c, "[1.5,)", "build.javaVersion") { javaVersion = "11" }
+
+        val inRange = renderer.renderResolved(c, "2.0")!!
+        val outOfRange = renderer.renderResolved(c, "1.0")!!
+        assertTrue(inRange.contains("javaVersion = \"11\""), inRange)
+        assertTrue(outOfRange.contains("javaVersion = \"1.8\""), outOfRange)
+        // No range sub-blocks in a resolved view.
+        assertFalse(inRange.contains("\"[1.5,)\""), inRange)
+    }
+
+    @Test
+    @DisplayName("RESOLVED: marker override replaces the base child collection for an in-range version")
+    fun resolvedMarkerReplace() {
+        val c = component()
+        val b = base(c) { buildSystem = "MAVEN" }
+        b.dockerImages.add(docker(b, image = "base/img"))
+        val m = marker(c, "[2,)", MarkerAttributes.DISTRIBUTION_DOCKER) {}
+        m.dockerImages.add(docker(m, image = "v2/img"))
+
+        val resolved = renderer.renderResolved(c, "2.5")!!
+        assertTrue(resolved.contains("imageName = \"v2/img\""), resolved)
+        assertFalse(resolved.contains("base/img"), resolved)
+    }
+
+    @Test
+    @DisplayName("RESOLVED: null-clear of jira.hotfixVersionFormat suppresses the per-component fallback")
+    fun resolvedHotfixNullClear() {
+        val c = component().also { it.jiraHotfixVersionFormat = "hf/\$major" }
+        base(c) { jiraProjectKey = "X" }
+        // import-only null-clear: per-range SCALAR_OVERRIDE row exists with a NULL typed column
+        scalarOverride(c, "[2,)", "jira.hotfixVersionFormat") { jiraHotfixVersionFormat = null }
+
+        val inRange = renderer.renderResolved(c, "2.5")!!
+        assertFalse(inRange.contains("hotfixVersionFormat"), inRange)
+        assertFalse(inRange.contains("hf/\$major"), inRange)
+
+        // Out of the override range → per-component fallback still applies.
+        val outOfRange = renderer.renderResolved(c, "1.0")!!
+        assertTrue(outOfRange.contains("hotfixVersionFormat = 'hf/\$major'"), outOfRange)
+    }
+
+    @Test
+    @DisplayName("RESOLVED: null when no BASE row")
+    fun resolvedNullWhenNoBase() {
+        val noBase = component()
+        marker(noBase, "[1,)", MarkerAttributes.VCS_SETTINGS) {}
+        assertNull(renderer.renderResolved(noBase, "1.0"))
+    }
+
+    @Test
+    @DisplayName("RESOLVED: out-of-range version still renders the base view (resolver fallback semantics)")
+    fun resolvedFallsBackToBase() {
+        val c = component().also { base(it) { buildSystem = "MAVEN" } }
+        scalarOverride(c, "[1.5,)", "build.javaVersion") { javaVersion = "11" }
+        val out = renderer.renderResolved(c, "1.0")!!
+        assertTrue(out.contains("buildSystem = MAVEN"), out)
+        assertFalse(out.contains("javaVersion = \"11\""), out)
+    }
+}

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -77,6 +77,29 @@ Base URLs for links are configurable per deployment via `registry_config` (same 
 - **Hard delete**: Admin-only, removes component and all related data (with CASCADE)
 - **Audit**: DELETE event logged
 
+### 1.6 View as Code
+
+- **Endpoint**: `GET /rest/api/4/components/{idOrName}/as-code` — auth `ACCESS_COMPONENTS`
+- **Output**: `text/plain;charset=UTF-8` — a human-readable, **Groovy-style** rendering of the
+  component definition (the reverse of the legacy Groovy import). `Content-Disposition: inline;
+  filename="{componentKey}.groovy"`.
+- **Two modes**:
+  - **FULL** (no `version` param): the whole component **with all version ranges**, delta-style —
+    a top-level block with the per-component fields + BASE-row aspects, followed by one
+    `"<range>" { … }` block per distinct override range carrying only the fields that range
+    overrides (a per-range `field = null` line denotes an explicit null-clear).
+  - **RESOLVED** (`?version=<v>`): the component flattened/merged for one concrete version — a
+    single block, no range sub-blocks. The scalar + child-collection merge reuses the same
+    primitives as version resolution, so values match the v2 version-resolution endpoints. (One
+    deliberate difference: distribution `$version` substitution — a runtime concern — is not
+    applied, so distribution patterns show the same templates as the FULL view.)
+- **404** when the component is unknown, or (RESOLVED) when no configuration resolves for the
+  version (no BASE row / unparseable version). A version that simply matches no override range
+  still renders the BASE view (resolver fallback semantics).
+- **Read-only**: the rendering is a projection; it is not parsed back (no GroovyShell / legacy
+  escrow libraries are involved — it is a plain string builder). Surfaced in the Portal as the
+  read-only **"As Code"** tab on the component page (syntax-highlighted, with Full/Resolved toggle).
+
 ## 2. Version Range Management
 
 Version overrides are **per-field**, not per-component-version. Each field in each parameter group (build, VCS, jira, distribution, escrow) can have its own independent set of version ranges.

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -378,7 +378,7 @@ Effectively-dead endpoints (≤2 calls in 2 production days) are dropped or stub
 
 All other v1-v3 endpoints preserve byte-for-byte response shape for unchanged components, validated against the prod-aligned fixture suite.
 
-### 5.2 As-code rendering (`GET /api/4/components/{idOrName}/as-code`)
+### 5.2 As-code rendering (`GET /rest/api/4/components/{idOrName}/as-code`)
 
 A read-only **Groovy-style** projection of a component (the reverse of the §6 import; a plain
 string builder — no GroovyShell). `ComponentCodeRenderer` walks the entity:

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -378,6 +378,20 @@ Effectively-dead endpoints (≤2 calls in 2 production days) are dropped or stub
 
 All other v1-v3 endpoints preserve byte-for-byte response shape for unchanged components, validated against the prod-aligned fixture suite.
 
+### 5.2 As-code rendering (`GET /api/4/components/{idOrName}/as-code`)
+
+A read-only **Groovy-style** projection of a component (the reverse of the §6 import; a plain
+string builder — no GroovyShell). `ComponentCodeRenderer` walks the entity:
+
+| Mode | Source | Shape |
+|---|---|---|
+| **FULL** (no `version`) | `ComponentEntity` + its `configurations` rows | Delta-style: top-level block (per-component fields + BASE-row aspects) + one `"<range>" { … }` block per distinct override range. Reuses the §3 row taxonomy — SCALAR_OVERRIDE rows become `field = value` (or `field = null` for the import-only null-clear, §3.2), MARKER rows become the replaced child block. RANGE_PRESENCE-only ranges (§3.4) and the synthetic-base row aspects (§3.4, when overrides exist) are suppressed. |
+| **RESOLVED** (`?version=X`) | merged single view | Reuses the §3.5 resolve primitives (`ComponentConfigurationView.applyScalarOverride` for scalars, marker-pick for child collections) — values match the v2 version-resolution endpoints. Single block, no range sub-blocks. **Difference vs the v2 resolver:** distribution `$version` substitution (§6.8, a runtime concern) is intentionally not applied, so distribution patterns render as the stored templates — consistent with the FULL view. |
+
+Null-clear (§3.2) is preserved in FULL: a SCALAR_OVERRIDE row is rendered by *presence* of the
+row (keyed on `overridden_attribute`), not by value, so a NULL typed column emits `field = null`.
+Renderer/HTTP contract is covered by `ComponentCodeRendererTest` and `ComponentControllerAsCodeV4Test`.
+
 ## 6. Migration approach
 
 `POST /admin/migrate` is rewritten to populate the new schema from DSL. Async-job semantics (MIG-027/028) are unchanged.


### PR DESCRIPTION
## What

Adds a read-only "as-code" view of a component: `GET /rest/api/4/components/{idOrName}/as-code` returning a **text/plain, Groovy-style** component definition.

- **FULL** (no `version`) — the whole component **with all version ranges**, delta-style: a top-level block (per-component fields + BASE-row aspects) + one `"<range>" { … }` block per distinct override range.
- **RESOLVED** (`?version=X`) — the component flattened/merged for one concrete version (single block, no range sub-blocks).

`Content-Disposition: inline; filename="{componentKey}.groovy"`. Auth: `ACCESS_COMPONENTS`.

## How

`ComponentCodeRenderer` is a plain `StringBuilder` — **no GroovyShell / legacy escrow libs**. FULL walks the entity + `component_configurations` rows (reusing the row taxonomy + null-clear contract from `ConfigurationRowAccessors`/`EntityMappers`). RESOLVED reuses the resolver's own merge primitives (`ComponentConfigurationView` + scalar-override + marker-pick), so scalar/child values match the v2 version-resolution endpoints.

**Deliberate difference from v2 resolution:** distribution `$version` substitution (a runtime concern) is **not** applied, so the resolved view shows the same definition patterns as the full view — appropriate for a code view. Documented in code + `docs/registry/`.

Edge cases handled: null-clear scalar overrides render `field = null` (presence-driven); RANGE_PRESENCE and import-internal (`group-artifact-pattern`) marker rows are skipped (no empty blocks); synthetic-base aspect suppression; multi-VCS named sub-blocks; all distribution + build markers; `jira.hotfixVersionFormat` null-clear honored in RESOLVED.

## Tests / docs

- `ComponentCodeRendererTest` — exact golden for the minimal shape + edge cases (null-clear, build/distribution markers, multi-VCS, synthetic base, escaping, resolved merge/fallback).
- `ComponentControllerAsCodeV4Test` — HTTP contract (media type, version routing, filename from canonical key, 404s).
- `docs/registry/functional-spec.md` §1.6, `schema-spec.md` §5.2.

Full server test suite + JaCoCo coverage gate green locally; `qualityStatic` green.

## Follow-up

Portal "As Code" tab (syntax-highlighted, Full/Resolved toggle) consumes this endpoint — separate PR against the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)