### PR TITLE
fix(audit): suppress no-op rows, mark migration baseline MIGRATED, audit field-overrides

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
@@ -22,16 +22,24 @@ import java.time.Instant
 class AuditControllerV4(
     private val auditService: AuditService,
 ) {
+    /**
+     * `includeMigrated` (default `false`) controls visibility of git-history
+     * baseline rows (`action = MIGRATED`); the Portal "Show migration" toggle
+     * flips it. SYS-049.
+     */
     @GetMapping("/{entityType}/{entityId}")
     fun getEntityHistory(
         @PathVariable entityType: String,
         @PathVariable entityId: String,
+        @RequestParam(required = false, defaultValue = "false") includeMigrated: Boolean,
         pageable: Pageable,
-    ): Page<AuditLogResponse> = auditService.getEntityHistory(entityType, entityId, pageable)
+    ): Page<AuditLogResponse> = auditService.getEntityHistory(entityType, entityId, includeMigrated, pageable)
 
     /**
      * SYS-036 filter params, all independently optional. `from`/`to` are ISO-8601
      * instants forming a half-open `[from, to)` window over `audit_log.changed_at`.
+     * `includeMigrated` (default `false`) surfaces git-history baseline rows
+     * (`action = MIGRATED`), which are hidden otherwise. SYS-049.
      */
     @GetMapping("/recent")
     fun getRecentChanges(
@@ -42,6 +50,7 @@ class AuditControllerV4(
         @RequestParam(required = false) action: String?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @RequestParam(required = false, defaultValue = "false") includeMigrated: Boolean,
         pageable: Pageable,
     ): Page<AuditLogResponse> {
         val filter =
@@ -53,6 +62,7 @@ class AuditControllerV4(
                 action = action,
                 from = from,
                 to = to,
+                includeMigrated = includeMigrated,
             )
         return auditService.getRecentChanges(filter, pageable)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
@@ -11,7 +11,12 @@ import java.time.Instant
  * `from` and `to` form a half-open interval `[from, to)` over `audit_log.changed_at`.
  * Either bound is independently optional.
  *
- * Contract: `SYS-036` in `requirements-common.md`.
+ * `includeMigrated` controls visibility of git-history baseline rows
+ * (`action = MIGRATED`). It defaults to `false` so migration noise is hidden;
+ * an explicit `action = MIGRATED` filter always wins regardless of this flag
+ * (SYS-049).
+ *
+ * Contract: `SYS-036`, `SYS-049` in `requirements-common.md`.
  */
 data class AuditLogFilter(
     val entityType: String? = null,
@@ -21,4 +26,5 @@ data class AuditLogFilter(
     val action: String? = null,
     val from: Instant? = null,
     val to: Instant? = null,
+    val includeMigrated: Boolean = false,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/AuditLogEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/AuditLogEntity.kt
@@ -58,4 +58,16 @@ class AuditLogEntity(
 
     @Column(name = "source", nullable = false, length = 20)
     var source: String = "api",
-)
+) {
+    companion object {
+        /**
+         * Audit action assigned to a component's first appearance during the
+         * git-history backfill. Distinct from the runtime `CREATE` action so the
+         * audit views can hide migration noise by default (SYS-049). Other actions
+         * (CREATE/UPDATE/DELETE/RENAME) remain inline literals at their write
+         * sites — only MIGRATED needs to be shared between the writer
+         * (`GitHistoryImportServiceImpl`) and the query filter (`AuditServiceImpl`).
+         */
+        const val ACTION_MIGRATED = "MIGRATED"
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
@@ -15,6 +15,17 @@ class AuditEventListener(
 ) {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun handleAuditEvent(event: AuditEvent) {
+        val changeDiff = AuditDiff.compute(event.oldValue, event.newValue)
+
+        // Suppress no-op updates: when both snapshots are present but nothing
+        // actually changed, AuditDiff yields null. Persisting such a row clutters
+        // the audit log with meaningless "saved, changed nothing" entries (e.g. a
+        // Save click on an unmodified form). CREATE (null oldValue) and DELETE
+        // (null newValue) legitimately produce a null diff and must still be kept.
+        if (event.oldValue != null && event.newValue != null && changeDiff == null) {
+            return
+        }
+
         val auditLog =
             AuditLogEntity(
                 entityType = event.entityType,
@@ -23,7 +34,7 @@ class AuditEventListener(
                 changedBy = event.changedBy,
                 oldValue = event.oldValue,
                 newValue = event.newValue,
-                changeDiff = AuditDiff.compute(event.oldValue, event.newValue),
+                changeDiff = changeDiff,
             )
         auditLogRepository.save(auditLog)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/AuditLogRepository.kt
@@ -19,6 +19,19 @@ interface AuditLogRepository :
         pageable: Pageable,
     ): Page<AuditLogEntity>
 
+    /**
+     * Entity history with git-history baseline rows hidden — `action != :action`
+     * (where `:action` is `MIGRATED`). Backs the default (`includeMigrated=false`)
+     * path of `getEntityHistory`; the unfiltered method above serves the opt-in
+     * path. SYS-049.
+     */
+    fun findByEntityTypeAndEntityIdAndActionNot(
+        entityType: String,
+        entityId: String,
+        action: String,
+        pageable: Pageable,
+    ): Page<AuditLogEntity>
+
     fun findByChangedBy(
         changedBy: String,
         pageable: Pageable,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/AuditService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/AuditService.kt
@@ -9,6 +9,7 @@ interface AuditService {
     fun getEntityHistory(
         entityType: String,
         entityId: String,
+        includeMigrated: Boolean,
         pageable: Pageable,
     ): Page<AuditLogResponse>
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
@@ -25,11 +25,20 @@ class AuditServiceImpl(
     override fun getEntityHistory(
         entityType: String,
         entityId: String,
+        includeMigrated: Boolean,
         pageable: Pageable,
     ): Page<AuditLogResponse> =
-        auditLogRepository
-            .findByEntityTypeAndEntityId(entityType, entityId, pageable)
-            .map { it.toResponse() }
+        if (includeMigrated) {
+            auditLogRepository.findByEntityTypeAndEntityId(entityType, entityId, pageable)
+        } else {
+            // Default: hide git-history baseline noise (action = MIGRATED). SYS-049.
+            auditLogRepository.findByEntityTypeAndEntityIdAndActionNot(
+                entityType,
+                entityId,
+                AuditLogEntity.ACTION_MIGRATED,
+                pageable,
+            )
+        }.map { it.toResponse() }
 
     override fun getRecentChanges(
         filter: AuditLogFilter,
@@ -73,6 +82,18 @@ class AuditServiceImpl(
 
         filter.action?.let { action ->
             spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("action"), action) })
+        }
+
+        // Hide git-history baseline rows (action = MIGRATED) unless the caller opted
+        // in via includeMigrated, or pinned them with an explicit action filter
+        // (which the equal-predicate above already enforces). SYS-049.
+        if (!filter.includeMigrated && filter.action == null) {
+            spec =
+                spec.and(
+                    Specification { root, _, cb ->
+                        cb.notEqual(root.get<String>("action"), AuditLogEntity.ACTION_MIGRATED)
+                    },
+                )
         }
 
         filter.from?.let { from ->

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
@@ -27,18 +27,22 @@ class AuditServiceImpl(
         entityId: String,
         includeMigrated: Boolean,
         pageable: Pageable,
-    ): Page<AuditLogResponse> =
-        if (includeMigrated) {
-            auditLogRepository.findByEntityTypeAndEntityId(entityType, entityId, pageable)
+    ): Page<AuditLogResponse> {
+        // Apply the same "newest first" default as getRecentChanges when the
+        // caller supplies no explicit sort — entity history is a timeline.
+        val sorted = withDefaultSort(pageable)
+        return if (includeMigrated) {
+            auditLogRepository.findByEntityTypeAndEntityId(entityType, entityId, sorted)
         } else {
             // Default: hide git-history baseline noise (action = MIGRATED). SYS-049.
             auditLogRepository.findByEntityTypeAndEntityIdAndActionNot(
                 entityType,
                 entityId,
                 AuditLogEntity.ACTION_MIGRATED,
-                pageable,
+                sorted,
             )
         }.map { it.toResponse() }
+    }
 
     override fun getRecentChanges(
         filter: AuditLogFilter,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -662,6 +662,12 @@ class ComponentManagementServiceImpl(
             refreshConfigRequiredToolsInMemory(saved, pendingTools)
         }
         bumpParentVersion(component)
+        publishAuditEvent(
+            action = "UPDATE",
+            entityId = component.id.toString(),
+            oldValue = emptyMap(),
+            newValue = fieldOverrideAuditSnapshot(saved),
+        )
         return saved.toFieldOverrideResponse()
     }
 
@@ -682,6 +688,8 @@ class ComponentManagementServiceImpl(
             "Cannot update id $overrideId via field-override endpoint (row_type=${row.rowType})"
         }
         requireNotImportManagedMarker(row, "update")
+
+        val beforeSnapshot = fieldOverrideAuditSnapshot(row)
 
         request.versionRange?.let {
             val canonicalRange = normalizeRange(it)
@@ -714,6 +722,12 @@ class ComponentManagementServiceImpl(
             refreshConfigRequiredToolsInMemory(saved, pendingTools)
         }
         bumpParentVersion(row.component)
+        publishAuditEvent(
+            action = "UPDATE",
+            entityId = row.component.id.toString(),
+            oldValue = beforeSnapshot,
+            newValue = fieldOverrideAuditSnapshot(saved),
+        )
         return saved.toFieldOverrideResponse()
     }
 
@@ -733,8 +747,15 @@ class ComponentManagementServiceImpl(
         }
         requireNotImportManagedMarker(row, "delete")
         val owningComponent = row.component
+        val beforeSnapshot = fieldOverrideAuditSnapshot(row)
         configurationRepository.delete(row)
         bumpParentVersion(owningComponent)
+        publishAuditEvent(
+            action = "UPDATE",
+            entityId = owningComponent.id.toString(),
+            oldValue = beforeSnapshot,
+            newValue = emptyMap(),
+        )
     }
 
     /**
@@ -1938,6 +1959,25 @@ class ComponentManagementServiceImpl(
             "labels" to (overrideLabels ?: entity.labelJunctions.map { it.labelCode }.toSet()),
             "system" to entity.systemCode,
         )
+
+    /**
+     * Snapshot of a field-override row for the audit trail, keyed by the
+     * overridden attribute so the change reads as `fieldOverride[<attr>]` in the
+     * diff. Captures the version range and the resolved scalar value / marker
+     * children. Used as the old/new payload for the synthetic Component UPDATE
+     * events published on field-override writes. SYS-050.
+     */
+    private fun fieldOverrideAuditSnapshot(row: ComponentConfigurationEntity): Map<String, Any?> {
+        val resp = row.toFieldOverrideResponse()
+        return mapOf(
+            "fieldOverride[${resp.overriddenAttribute}]" to
+                mapOf(
+                    "versionRange" to resp.versionRange,
+                    "value" to resp.value,
+                    "markerChildren" to resp.markerChildren,
+                ),
+        )
+    }
 
     private fun publishAuditEvent(
         action: String,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1966,6 +1966,12 @@ class ComponentManagementServiceImpl(
      * diff. Captures the version range and the resolved scalar value / marker
      * children. Used as the old/new payload for the synthetic Component UPDATE
      * events published on field-override writes. SYS-050.
+     *
+     * Create/delete pass an empty map (not `null`) for the absent side: with an
+     * empty map `AuditDiff` computes a non-null diff that records the override as
+     * added / removed, whereas `null` would yield a null diff and lose that
+     * detail. Both sides are non-null, so the SYS-048 no-op guard still drops a
+     * genuine no-op PATCH (before == after).
      */
     private fun fieldOverrideAuditSnapshot(row: ComponentConfigurationEntity): Map<String, Any?> {
         val resp = row.toFieldOverrideResponse()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -486,7 +486,7 @@ class GitHistoryImportServiceImpl(
             newValue: Map<String, Any?>?,
         ): String? =
             when {
-                oldValue == null && newValue != null -> "CREATE"
+                oldValue == null && newValue != null -> AuditLogEntity.ACTION_MIGRATED
                 oldValue != null && newValue == null -> "DELETE"
                 oldValue != null && newValue != null && oldValue != newValue -> "UPDATE"
                 else -> null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportServiceImpl.kt
@@ -370,17 +370,6 @@ class GitHistoryImportServiceImpl(
         }
     }
 
-    private fun resolveAction(
-        oldValue: Map<String, Any?>?,
-        newValue: Map<String, Any?>?,
-    ): String? =
-        when {
-            oldValue == null && newValue != null -> "CREATE"
-            oldValue != null && newValue == null -> "DELETE"
-            oldValue != null && newValue != null && oldValue != newValue -> "UPDATE"
-            else -> null
-        }
-
     private fun firstParentChain(
         walk: RevWalk,
         targetSha: ObjectId,
@@ -485,5 +474,22 @@ class GitHistoryImportServiceImpl(
 
     companion object {
         private val log = LoggerFactory.getLogger(GitHistoryImportServiceImpl::class.java)
+
+        /**
+         * Maps a per-commit `(old, new)` snapshot pair to an audit action, or
+         * `null` when there is nothing to record. Pure and side-effect-free —
+         * lifted to the companion so the action mapping can be unit-tested
+         * without standing up the service's heavy dependency graph.
+         */
+        internal fun resolveAction(
+            oldValue: Map<String, Any?>?,
+            newValue: Map<String, Any?>?,
+        ): String? =
+            when {
+                oldValue == null && newValue != null -> "CREATE"
+                oldValue != null && newValue == null -> "DELETE"
+                oldValue != null && newValue != null && oldValue != newValue -> "UPDATE"
+                else -> null
+            }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentTeamcityProjectEntity
-import org.octopusden.octopus.components.registry.server.event.AuditEvent
 import org.octopusden.octopus.components.registry.server.mapper.composeTeamcityProjectUrl
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentTeamcityProjectRepository
@@ -51,12 +50,12 @@ import java.util.UUID
  * `sortOrder = 0` slot). Multi-project support is still future work; for
  * now sync collapses to one row to preserve v1–v3 wire compatibility.
  *
- * Idempotent: only writes when the matched project id actually changes. Audit
- * log emitted via existing [AuditEvent] flow when fields change so admins can
- * trace the source of writes. Audit field names — `teamcityProjectId` and
- * `teamcityProjectUrl` — are kept on the wire even though the underlying
- * `components` columns are gone; consumers (Portal audit timeline,
- * downstream log indexers) still key off those names.
+ * Idempotent: only writes when the matched project id actually changes. The
+ * change is traced via an INFO log line (so admins can find the source of a
+ * write) but deliberately does NOT write an `audit_log` row: TeamCity sync is
+ * an automated background reconciliation (`changedBy = system`), and one such
+ * row per re-linked component was noise in the component history (SYS-051).
+ * If per-sync auditing is ever wanted, re-publish an `AuditEvent` here.
  *
  * Error handling: a fetcher failure (TC unreachable, auth refused, malformed
  * response) propagates out of [resync] — for the admin endpoint that surfaces
@@ -70,6 +69,11 @@ class TeamcitySyncService(
     private val componentRepository: ComponentRepository,
     private val componentTeamcityProjectRepository: ComponentTeamcityProjectRepository,
     private val tcProjectFetcher: TcProjectFetcher,
+    // Retained as the audit seam even though TeamCity sync is deliberately NOT
+    // audited (SYS-051): TeamcitySyncServiceTest injects a recording publisher
+    // and asserts no AuditEvent is published, guarding against an accidental
+    // re-introduction. Re-publish here if per-sync auditing is ever wanted.
+    @Suppress("UnusedPrivateProperty")
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val currentUserResolver: CurrentUserResolver,
     private val transactionTemplate: TransactionTemplate,
@@ -318,24 +322,13 @@ class TeamcitySyncService(
             ),
         )
 
-        applicationEventPublisher.publishEvent(
-            AuditEvent(
-                entityType = "Component",
-                entityId = component.id.toString(),
-                action = "UPDATE",
-                changedBy = changedBy,
-                oldValue =
-                    mapOf(
-                        "teamcityProjectId" to oldId,
-                        "teamcityProjectUrl" to oldUrl,
-                    ),
-                newValue =
-                    mapOf(
-                        "teamcityProjectId" to newId,
-                        "teamcityProjectUrl" to newUrl,
-                    ),
-            ),
-        )
+        // SYS-051: trace the re-link in the log (NOT the audit_log). TeamCity
+        // sync is an automated reconciliation (changedBy = system); a per-link
+        // audit row was noise in the component history.
+        log.info {
+            "TeamCity sync re-linked component ${component.id}: " +
+                "'$oldId' ($oldUrl) -> '$newId' ($newUrl) (by $changedBy)"
+        }
         return true
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -88,8 +88,8 @@ class TeamcitySyncService(
      * a slow/stalled TC server cannot hold a JDBC connection or extend a
      * transaction's lifetime. Per-component writes happen inside a single
      * [TransactionTemplate.execute] block so the bulk write is still atomic
-     * (either all changes commit, or none do on JPA failure), and the audit
-     * events published BEFORE_COMMIT remain in the same tx as their row writes.
+     * (either all changes commit, or none do on JPA failure). TC sync writes no
+     * audit rows — the re-link is logged at INFO instead (SYS-051).
      */
     fun resync(): TeamcitySyncResult {
         check(teamcityProperties.baseUrl.isNotBlank()) {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncService.kt
@@ -52,10 +52,12 @@ import java.util.UUID
  *
  * Idempotent: only writes when the matched project id actually changes. The
  * change is traced via an INFO log line (so admins can find the source of a
- * write) but deliberately does NOT write an `audit_log` row: TeamCity sync is
- * an automated background reconciliation (`changedBy = system`), and one such
- * row per re-linked component was noise in the component history (SYS-051).
- * If per-sync auditing is ever wanted, re-publish an `AuditEvent` here.
+ * write) but deliberately does NOT write an `audit_log` row: TeamCity sync is an
+ * automated reconciliation, and one such row per re-linked component was noise
+ * in the component history (SYS-051). `changedBy` comes from `CurrentUserResolver`
+ * — `"system"` for the scheduled cron, or the admin's username when the resync is
+ * triggered via an authenticated request. If per-sync auditing is ever wanted,
+ * re-publish an `AuditEvent` here.
  *
  * Error handling: a fetcher failure (TC unreachable, auth refused, malformed
  * response) propagates out of [resync] — for the admin endpoint that surfaces
@@ -323,8 +325,9 @@ class TeamcitySyncService(
         )
 
         // SYS-051: trace the re-link in the log (NOT the audit_log). TeamCity
-        // sync is an automated reconciliation (changedBy = system); a per-link
-        // audit row was noise in the component history.
+        // sync is an automated reconciliation; a per-link audit row was noise in
+        // the component history. `changedBy` is the resolving user — "system" for
+        // the cron, or the admin who triggered an authenticated resync.
         log.info {
             "TeamCity sync re-linked component ${component.id}: " +
                 "'$oldId' ($oldUrl) -> '$newId' ($newUrl) (by $changedBy)"

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditLogFilterTest.kt
@@ -44,7 +44,7 @@ import java.util.UUID
  *   - `changedBy`         — username from `audit_log.changed_by`
  *   - `source`            — currently only `api` and `git-history`; other values are
  *                           reserved for future writers
- *   - `action`            — `CREATE` | `UPDATE` | `DELETE` | `RENAME` | `ARCHIVE` | …
+ *   - `action`            — `CREATE` | `UPDATE` | `DELETE` | `RENAME` | `MIGRATED` | …
  *   - `from`, `to`        — ISO-8601 instants; either or both, half-open `[from, to)`
  *
  * Test layer: integration. The `ft-db` profile gives us H2 + auto-migrate; each test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import java.nio.file.Paths
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -68,8 +71,8 @@ class AuditMigratedVisibilityTest {
         seedRow(entityId = "${tag}_migrated", action = "MIGRATED", source = "git-history")
 
         val actions = recentActionsForTag(tag)
-        assert(actions.contains("CREATE")) { "expected the CREATE row to be visible by default, got $actions" }
-        assert(!actions.contains("MIGRATED")) { "expected MIGRATED rows to be hidden by default, got $actions" }
+        assertTrue(actions.contains("CREATE"), "expected the CREATE row to be visible by default, got $actions")
+        assertFalse(actions.contains("MIGRATED"), "expected MIGRATED rows to be hidden by default, got $actions")
     }
 
     @Test
@@ -80,8 +83,8 @@ class AuditMigratedVisibilityTest {
         seedRow(entityId = "${tag}_migrated", action = "MIGRATED", source = "git-history")
 
         val actions = recentActionsForTag(tag, includeMigrated = true)
-        assert(actions.contains("CREATE")) { "expected CREATE row, got $actions" }
-        assert(actions.contains("MIGRATED")) { "expected MIGRATED row when includeMigrated=true, got $actions" }
+        assertTrue(actions.contains("CREATE"), "expected CREATE row, got $actions")
+        assertTrue(actions.contains("MIGRATED"), "expected MIGRATED row when includeMigrated=true, got $actions")
     }
 
     @Test
@@ -105,9 +108,11 @@ class AuditMigratedVisibilityTest {
                 .filter { it["entityId"].asText().startsWith(tag) }
                 .map { it["entityId"].asText() }
                 .toSet()
-        assert(migratedIds == setOf("${tag}_migrated")) {
-            "explicit action=MIGRATED must return the MIGRATED row, got $migratedIds"
-        }
+        assertEquals(
+            setOf("${tag}_migrated"),
+            migratedIds,
+            "explicit action=MIGRATED must return the MIGRATED row, got $migratedIds",
+        )
     }
 
     @Test
@@ -118,14 +123,18 @@ class AuditMigratedVisibilityTest {
         seedRow(entityId = entityId, action = "UPDATE", source = "api")
 
         val defaultActions = entityHistoryActions(entityId)
-        assert(defaultActions == setOf("UPDATE")) {
-            "entity history must hide MIGRATED by default, got $defaultActions"
-        }
+        assertEquals(
+            setOf("UPDATE"),
+            defaultActions,
+            "entity history must hide MIGRATED by default, got $defaultActions",
+        )
 
         val withMigrated = entityHistoryActions(entityId, includeMigrated = true)
-        assert(withMigrated == setOf("UPDATE", "MIGRATED")) {
-            "entity history with includeMigrated=true must include MIGRATED, got $withMigrated"
-        }
+        assertEquals(
+            setOf("UPDATE", "MIGRATED"),
+            withMigrated,
+            "entity history with includeMigrated=true must include MIGRATED, got $withMigrated",
+        )
     }
 
     private fun recentActionsForTag(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
@@ -1,0 +1,186 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Paths
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
+import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * SYS-049 — git-history baseline rows are written with the `MIGRATED` action and
+ * are hidden from the audit views by default. Both audit read endpoints accept an
+ * `includeMigrated` flag (default `false`) to opt back in, and an explicit
+ * `action=MIGRATED` filter always returns them so the Portal "Show migration"
+ * toggle can surface them on demand.
+ *
+ * Integration test (ft-db = H2 + auto-migrate). Rows are seeded directly through
+ * the repository so action/source can be pinned without running a real Git import.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+class AuditMigratedVisibilityTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var auditLogRepository: AuditLogRepository
+
+    init {
+        val testResourcesPath =
+            Paths.get(AuditMigratedVisibilityTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("SYS-049: audit/recent hides MIGRATED rows by default")
+    fun `SYS-049 recent hides MIGRATED by default`() {
+        val tag = "sys049_recent_${UUID.randomUUID().toString().take(8)}"
+        seedRow(entityId = "${tag}_create", action = "CREATE", source = "api")
+        seedRow(entityId = "${tag}_migrated", action = "MIGRATED", source = "git-history")
+
+        val actions = recentActionsForTag(tag)
+        assert(actions.contains("CREATE")) { "expected the CREATE row to be visible by default, got $actions" }
+        assert(!actions.contains("MIGRATED")) { "expected MIGRATED rows to be hidden by default, got $actions" }
+    }
+
+    @Test
+    @DisplayName("SYS-049: audit/recent?includeMigrated=true surfaces MIGRATED rows")
+    fun `SYS-049 recent includeMigrated returns MIGRATED`() {
+        val tag = "sys049_incl_${UUID.randomUUID().toString().take(8)}"
+        seedRow(entityId = "${tag}_create", action = "CREATE", source = "api")
+        seedRow(entityId = "${tag}_migrated", action = "MIGRATED", source = "git-history")
+
+        val actions = recentActionsForTag(tag, includeMigrated = true)
+        assert(actions.contains("CREATE")) { "expected CREATE row, got $actions" }
+        assert(actions.contains("MIGRATED")) { "expected MIGRATED row when includeMigrated=true, got $actions" }
+    }
+
+    @Test
+    @DisplayName("SYS-049: explicit action=MIGRATED returns MIGRATED rows even without includeMigrated")
+    fun `SYS-049 explicit action MIGRATED wins over default hide`() {
+        val tag = "sys049_explicit_${UUID.randomUUID().toString().take(8)}"
+        seedRow(entityId = "${tag}_migrated", action = "MIGRATED", source = "git-history")
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("action", "MIGRATED")
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val migratedIds =
+            objectMapper.readTree(body)["content"]
+                .filter { it["entityId"].asText().startsWith(tag) }
+                .map { it["entityId"].asText() }
+                .toSet()
+        assert(migratedIds == setOf("${tag}_migrated")) {
+            "explicit action=MIGRATED must return the MIGRATED row, got $migratedIds"
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-049: entity history hides MIGRATED by default but includeMigrated=true surfaces it")
+    fun `SYS-049 entity history honours includeMigrated`() {
+        val entityId = "sys049_entity_${UUID.randomUUID()}"
+        seedRow(entityId = entityId, action = "MIGRATED", source = "git-history")
+        seedRow(entityId = entityId, action = "UPDATE", source = "api")
+
+        val defaultActions = entityHistoryActions(entityId)
+        assert(defaultActions == setOf("UPDATE")) {
+            "entity history must hide MIGRATED by default, got $defaultActions"
+        }
+
+        val withMigrated = entityHistoryActions(entityId, includeMigrated = true)
+        assert(withMigrated == setOf("UPDATE", "MIGRATED")) {
+            "entity history with includeMigrated=true must include MIGRATED, got $withMigrated"
+        }
+    }
+
+    private fun recentActionsForTag(
+        tag: String,
+        includeMigrated: Boolean = false,
+    ): Set<String> {
+        val request =
+            get("/rest/api/4/audit/recent")
+                .with(adminJwt())
+                .param("size", "500")
+        if (includeMigrated) request.param("includeMigrated", "true")
+        val body =
+            mvc
+                .perform(request)
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["content"]
+            .filter { it["entityId"].asText().startsWith(tag) }
+            .map { it["action"].asText() }
+            .toSet()
+    }
+
+    private fun entityHistoryActions(
+        entityId: String,
+        includeMigrated: Boolean = false,
+    ): Set<String> {
+        val request =
+            get("/rest/api/4/audit/Component/$entityId")
+                .with(adminJwt())
+                .param("size", "500")
+        if (includeMigrated) request.param("includeMigrated", "true")
+        val body =
+            mvc
+                .perform(request)
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["content"]
+            .map { it["action"].asText() }
+            .toSet()
+    }
+
+    private fun seedRow(
+        entityId: String,
+        action: String,
+        source: String,
+    ): AuditLogEntity =
+        auditLogRepository.save(
+            AuditLogEntity(
+                entityType = "Component",
+                entityId = entityId,
+                action = action,
+                changedBy = "system",
+                source = source,
+            ),
+        )
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
@@ -28,9 +28,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 /**
  * SYS-049 — git-history baseline rows are written with the `MIGRATED` action and
  * are hidden from the audit views by default. Both audit read endpoints accept an
- * `includeMigrated` flag (default `false`) to opt back in, and an explicit
- * `action=MIGRATED` filter always returns them so the Portal "Show migration"
- * toggle can surface them on demand.
+ * `includeMigrated` flag (default `false`) to opt back in. `/audit/recent` also
+ * honours an explicit `action=MIGRATED` filter (it is the only endpoint with an
+ * `action` param; entity-history takes `includeMigrated` only), so the Portal
+ * "Show migration" toggle can surface them on demand.
  *
  * Integration test (ft-db = H2 + auto-migrate). Rows are seeded directly through
  * the repository so action/source can be pinned without running a real Git import.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
@@ -1,0 +1,193 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Paths
+import java.util.UUID
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * SYS-050 — creating, updating and deleting a field override (version-ranged
+ * attribute override) is a real change to the component and must leave an audit
+ * trail, just like editing a top-level attribute. Previously these write paths
+ * bumped the parent version but published no AuditEvent, so version-range edits
+ * were invisible in the component history.
+ *
+ * Integration test (ft-db = H2 + auto-migrate): drives the real V4 write paths
+ * end-to-end and reads the resulting audit rows back through the audit API.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+class FieldOverrideAuditTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(FieldOverrideAuditTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("SYS-050: create/update/delete field-override each writes a Component UPDATE audit row")
+    fun `SYS-050 field-override writes are audited as Component UPDATE`() {
+        val id = createComponent("sys050_${UUID.randomUUID().toString().take(8)}")
+
+        // Baseline: component create wrote a CREATE row, no override UPDATEs yet.
+        assert(updateRowCount(id) == 0) { "expected no UPDATE rows before any override edit, got ${historyActions(id)}" }
+
+        // CREATE override → one UPDATE audit row carrying the attribute in its diff.
+        val overrideId =
+            createFieldOverride(
+                id,
+                """{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"FileA"}""",
+            )
+        assert(updateRowCount(id) == 1) { "createFieldOverride must write 1 UPDATE row, got ${historyActions(id)}" }
+        assert(latestUpdateMentions(id, "build.buildFilePath")) {
+            "override audit diff must mention the overridden attribute"
+        }
+
+        // UPDATE override (value change) → second UPDATE audit row.
+        patchFieldOverride(id, overrideId, """{"value":"FileB"}""")
+        assert(updateRowCount(id) == 2) { "updateFieldOverride must write a 2nd UPDATE row, got ${historyActions(id)}" }
+
+        // DELETE override → third UPDATE audit row.
+        deleteFieldOverride(id, overrideId)
+        assert(updateRowCount(id) == 3) { "deleteFieldOverride must write a 3rd UPDATE row, got ${historyActions(id)}" }
+    }
+
+    @Test
+    @DisplayName("SYS-050: a no-op field-override PATCH writes no audit row (SYS-048 guard holds)")
+    fun `SYS-050 no-op override PATCH writes no audit row`() {
+        val id = createComponent("sys050noop_${UUID.randomUUID().toString().take(8)}")
+        val overrideId =
+            createFieldOverride(
+                id,
+                """{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"Same"}""",
+            )
+        val afterCreate = updateRowCount(id)
+
+        // PATCH with the same value — nothing actually changes.
+        patchFieldOverride(id, overrideId, """{"value":"Same"}""")
+
+        assert(updateRowCount(id) == afterCreate) {
+            "a no-op override PATCH must not add an audit row, got ${historyActions(id)}"
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun createComponent(name: String): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"name":"$name",""" +
+                                """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+                        ),
+                ).andExpect(status().is2xxSuccessful)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun createFieldOverride(
+        componentId: String,
+        payload: String,
+    ): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$componentId/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload),
+                ).andExpect(status().is2xxSuccessful)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun patchFieldOverride(
+        componentId: String,
+        overrideId: String,
+        payload: String,
+    ) {
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$componentId/field-overrides/$overrideId")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(status().isOk)
+    }
+
+    private fun deleteFieldOverride(
+        componentId: String,
+        overrideId: String,
+    ) {
+        mvc
+            .perform(delete("/rest/api/4/components/$componentId/field-overrides/$overrideId").with(adminJwt()))
+            .andExpect(status().is2xxSuccessful)
+    }
+
+    private fun history(componentId: String): List<JsonNode> {
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/Component/$componentId")
+                        .with(adminJwt())
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["content"].toList()
+    }
+
+    private fun historyActions(componentId: String): List<String> = history(componentId).map { it["action"].asText() }
+
+    private fun updateRowCount(componentId: String): Int = historyActions(componentId).count { it == "UPDATE" }
+
+    private fun latestUpdateMentions(
+        componentId: String,
+        needle: String,
+    ): Boolean =
+        history(componentId)
+            .filter { it["action"].asText() == "UPDATE" }
+            .any { it.toString().contains(needle) }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
@@ -188,11 +188,17 @@ class FieldOverrideAuditTest {
 
     private fun updateRowCount(componentId: String): Int = historyActions(componentId).count { it == "UPDATE" }
 
+    // True iff some UPDATE entry's structured changeDiff has a key naming the
+    // attribute (field-override diffs are keyed `fieldOverride[<attr>]`). Asserts
+    // on the structured diff rather than a brittle whole-node toString match.
     private fun anyUpdateMentions(
         componentId: String,
-        needle: String,
+        attribute: String,
     ): Boolean =
         history(componentId)
             .filter { it["action"].asText() == "UPDATE" }
-            .any { it.toString().contains(needle) }
+            .any { entry ->
+                val diff = entry.path("changeDiff")
+                diff.isObject && diff.fieldNames().asSequence().any { it.contains(attribute) }
+            }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.nio.file.Paths
 import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -65,7 +67,7 @@ class FieldOverrideAuditTest {
         val id = createComponent("sys050_${UUID.randomUUID().toString().take(8)}")
 
         // Baseline: component create wrote a CREATE row, no override UPDATEs yet.
-        assert(updateRowCount(id) == 0) { "expected no UPDATE rows before any override edit, got ${historyActions(id)}" }
+        assertEquals(0, updateRowCount(id), "expected no UPDATE rows before any override edit, got ${historyActions(id)}")
 
         // CREATE override → one UPDATE audit row carrying the attribute in its diff.
         val overrideId =
@@ -73,18 +75,19 @@ class FieldOverrideAuditTest {
                 id,
                 """{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"FileA"}""",
             )
-        assert(updateRowCount(id) == 1) { "createFieldOverride must write 1 UPDATE row, got ${historyActions(id)}" }
-        assert(latestUpdateMentions(id, "build.buildFilePath")) {
-            "override audit diff must mention the overridden attribute"
-        }
+        assertEquals(1, updateRowCount(id), "createFieldOverride must write 1 UPDATE row, got ${historyActions(id)}")
+        assertTrue(
+            latestUpdateMentions(id, "build.buildFilePath"),
+            "override audit diff must mention the overridden attribute",
+        )
 
         // UPDATE override (value change) → second UPDATE audit row.
         patchFieldOverride(id, overrideId, """{"value":"FileB"}""")
-        assert(updateRowCount(id) == 2) { "updateFieldOverride must write a 2nd UPDATE row, got ${historyActions(id)}" }
+        assertEquals(2, updateRowCount(id), "updateFieldOverride must write a 2nd UPDATE row, got ${historyActions(id)}")
 
         // DELETE override → third UPDATE audit row.
         deleteFieldOverride(id, overrideId)
-        assert(updateRowCount(id) == 3) { "deleteFieldOverride must write a 3rd UPDATE row, got ${historyActions(id)}" }
+        assertEquals(3, updateRowCount(id), "deleteFieldOverride must write a 3rd UPDATE row, got ${historyActions(id)}")
     }
 
     @Test
@@ -101,9 +104,11 @@ class FieldOverrideAuditTest {
         // PATCH with the same value — nothing actually changes.
         patchFieldOverride(id, overrideId, """{"value":"Same"}""")
 
-        assert(updateRowCount(id) == afterCreate) {
-            "a no-op override PATCH must not add an audit row, got ${historyActions(id)}"
-        }
+        assertEquals(
+            afterCreate,
+            updateRowCount(id),
+            "a no-op override PATCH must not add an audit row, got ${historyActions(id)}",
+        )
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
@@ -77,7 +77,7 @@ class FieldOverrideAuditTest {
             )
         assertEquals(1, updateRowCount(id), "createFieldOverride must write 1 UPDATE row, got ${historyActions(id)}")
         assertTrue(
-            latestUpdateMentions(id, "build.buildFilePath"),
+            anyUpdateMentions(id, "build.buildFilePath"),
             "override audit diff must mention the overridden attribute",
         )
 
@@ -188,7 +188,7 @@ class FieldOverrideAuditTest {
 
     private fun updateRowCount(componentId: String): Int = historyActions(componentId).count { it == "UPDATE" }
 
-    private fun latestUpdateMentions(
+    private fun anyUpdateMentions(
         componentId: String,
         needle: String,
     ): Boolean =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
@@ -541,8 +541,14 @@ class StrictContractTest {
                     .content(fieldConfigPayload),
             ).andExpect(status().is2xxSuccessful)
 
-        // PATCH would write ALFA if the field were not hidden.
-        val patchBody = """{"version": $versionLock, "clearGroup": false, "system": "ALFA"}"""
+        // PATCH would write ALFA if the field were not hidden. We also change a
+        // *visible* field (`displayName`) so the write is not a no-op: under
+        // SYS-048 a PATCH that persists no change writes no audit row at all, so
+        // without a real change there would be no UPDATE entry to inspect for the
+        // ghost-write. The ghost-write guard below still holds — the resulting
+        // row's `newValue.system` must read the persisted CLASSIC, never ALFA.
+        val patchBody =
+            """{"version": $versionLock, "clearGroup": false, "system": "ALFA", "displayName": "$name-edited"}"""
         mvc.perform(
             patch("/rest/api/4/components/$id")
                 .with(adminJwt())

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListenerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListenerTest.kt
@@ -109,4 +109,23 @@ class AuditEventListenerTest {
 
         verify(auditLogRepository).save(any())
     }
+
+    @Test
+    @DisplayName("SYS-048: DELETE with a null newValue is always persisted (guard only fires when both present)")
+    fun `SYS-048 DELETE with null newValue is persisted`() {
+        // The no-op guard keys on BOTH snapshots being present. A delete-style
+        // event carrying only an oldValue (e.g. the git-history DELETE shape)
+        // yields a null diff but must never be suppressed.
+        listener.handleAuditEvent(
+            AuditEvent(
+                entityType = "Component",
+                entityId = "c1",
+                action = "DELETE",
+                oldValue = mapOf("displayName" to "Widget"),
+                newValue = null,
+            ),
+        )
+
+        verify(auditLogRepository).save(any())
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListenerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListenerTest.kt
@@ -1,0 +1,112 @@
+package org.octopusden.octopus.components.registry.server.event
+
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
+import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+
+/**
+ * Bug fix: a component "save" that changes nothing used to write an empty
+ * audit row (action=UPDATE, changeDiff=null). The listener now suppresses
+ * no-op updates — a row whose `oldValue`/`newValue` are both present but
+ * carry no field-level difference is dropped — while still recording CREATE
+ * (null oldValue) and DELETE (real diff). This keeps the audit log free of
+ * meaningless "changed nothing" entries regardless of which write path
+ * published the event (component update, field-override update, TeamCity sync).
+ *
+ * Pure Mockito test — no Spring context, no DB.
+ */
+@Timeout(10, unit = TimeUnit.SECONDS)
+class AuditEventListenerTest {
+    private lateinit var auditLogRepository: AuditLogRepository
+    private lateinit var listener: AuditEventListener
+
+    @BeforeEach
+    fun setUp() {
+        auditLogRepository = mock(AuditLogRepository::class.java)
+        listener = AuditEventListener(auditLogRepository)
+    }
+
+    @Test
+    @DisplayName("SYS-048: no-op UPDATE (both snapshots present, empty diff) is NOT persisted")
+    fun `SYS-048 no-op UPDATE writes no audit row`() {
+        listener.handleAuditEvent(
+            AuditEvent(
+                entityType = "Component",
+                entityId = "c1",
+                action = "UPDATE",
+                oldValue = mapOf("displayName" to "Widget", "owner" to "alice"),
+                newValue = mapOf("displayName" to "Widget", "owner" to "alice"),
+            ),
+        )
+
+        verify(auditLogRepository, never()).save(any())
+    }
+
+    @Test
+    @DisplayName("SYS-048: real UPDATE (non-empty diff) is persisted with the computed changeDiff")
+    fun `SYS-048 real UPDATE is persisted`() {
+        listener.handleAuditEvent(
+            AuditEvent(
+                entityType = "Component",
+                entityId = "c1",
+                action = "UPDATE",
+                oldValue = mapOf("displayName" to "Widget"),
+                newValue = mapOf("displayName" to "Gadget"),
+            ),
+        )
+
+        val captor = ArgumentCaptor.forClass(AuditLogEntity::class.java)
+        verify(auditLogRepository).save(captor.capture())
+        assertEquals("UPDATE", captor.value.action)
+        assertEquals(
+            mapOf("displayName" to mapOf("old" to "Widget", "new" to "Gadget")),
+            captor.value.changeDiff,
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-048: CREATE (null oldValue) is always persisted even though the diff is null")
+    fun `SYS-048 CREATE is always persisted`() {
+        listener.handleAuditEvent(
+            AuditEvent(
+                entityType = "Component",
+                entityId = "c1",
+                action = "CREATE",
+                oldValue = null,
+                newValue = mapOf("displayName" to "Widget"),
+            ),
+        )
+
+        val captor = ArgumentCaptor.forClass(AuditLogEntity::class.java)
+        verify(auditLogRepository).save(captor.capture())
+        assertEquals("CREATE", captor.value.action)
+        assertNull(captor.value.changeDiff, "CREATE has no oldValue, so AuditDiff yields null — but the row must still be saved")
+    }
+
+    @Test
+    @DisplayName("SYS-048: DELETE (both snapshots present, real diff) is persisted")
+    fun `SYS-048 DELETE is persisted`() {
+        listener.handleAuditEvent(
+            AuditEvent(
+                entityType = "Component",
+                entityId = "c1",
+                action = "DELETE",
+                oldValue = mapOf("name" to "Widget", "archived" to false),
+                newValue = mapOf("name" to "Widget", "archived" to true),
+            ),
+        )
+
+        verify(auditLogRepository).save(any())
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportActionResolutionTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/GitHistoryImportActionResolutionTest.kt
@@ -1,0 +1,64 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+/**
+ * SYS-049: the git-history backfill records each component's first appearance
+ * with the dedicated `MIGRATED` action (not `CREATE`). These baseline rows are
+ * migration noise — one per component — and the Portal hides them by default,
+ * so they must be distinguishable from genuine `CREATE` events authored through
+ * the runtime API.
+ *
+ * Pure unit test on the lifted `resolveAction` mapping — no Spring, no DB, no Git.
+ */
+@Timeout(10, unit = TimeUnit.SECONDS)
+class GitHistoryImportActionResolutionTest {
+    @Test
+    @DisplayName("SYS-049: a component's first appearance (no previous snapshot) resolves to MIGRATED")
+    fun `SYS-049 first appearance resolves to MIGRATED`() {
+        val action =
+            GitHistoryImportServiceImpl.resolveAction(
+                oldValue = null,
+                newValue = mapOf("displayName" to "Widget"),
+            )
+        assertEquals("MIGRATED", action)
+    }
+
+    @Test
+    @DisplayName("SYS-049: a disappearance (no current snapshot) still resolves to DELETE")
+    fun `SYS-049 disappearance resolves to DELETE`() {
+        val action =
+            GitHistoryImportServiceImpl.resolveAction(
+                oldValue = mapOf("displayName" to "Widget"),
+                newValue = null,
+            )
+        assertEquals("DELETE", action)
+    }
+
+    @Test
+    @DisplayName("SYS-049: a changed snapshot still resolves to UPDATE")
+    fun `SYS-049 changed snapshot resolves to UPDATE`() {
+        val action =
+            GitHistoryImportServiceImpl.resolveAction(
+                oldValue = mapOf("displayName" to "Widget"),
+                newValue = mapOf("displayName" to "Gadget"),
+            )
+        assertEquals("UPDATE", action)
+    }
+
+    @Test
+    @DisplayName("SYS-049: an unchanged snapshot resolves to null (no row)")
+    fun `SYS-049 unchanged snapshot resolves to null`() {
+        val action =
+            GitHistoryImportServiceImpl.resolveAction(
+                oldValue = mapOf("displayName" to "Widget"),
+                newValue = mapOf("displayName" to "Widget"),
+            )
+        assertNull(action)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -72,7 +72,7 @@ class TeamcitySyncServiceTest {
     // ---------- Tests --------------------------------------------------------
 
     @Test
-    @DisplayName("happy path: writes TC row; counts updated; emits audit event")
+    @DisplayName("SYS-051 happy path: writes TC row; counts updated; NO audit event")
     fun happyPath() {
         val components = listOf(component(alice, "alpha"))
         val fetcher = stubFetcher(
@@ -103,19 +103,11 @@ class TeamcitySyncServiceTest {
         // v2: TC project written to child table, not to entity scalar fields.
         assertEquals("Alpha_Build", tcRepo.findByComponentId(alice).single().projectId)
 
-        val audit = publisher.events.filterIsInstance<AuditEvent>().single()
-        assertEquals("Component", audit.entityType)
-        assertEquals("UPDATE", audit.action)
-        assertEquals("admin", audit.changedBy)
-        assertEquals(mapOf("teamcityProjectId" to null, "teamcityProjectUrl" to null), audit.oldValue)
-        assertEquals(
-            mapOf(
-                "teamcityProjectId" to "Alpha_Build",
-                // URL is composed at write-time from base-url + projectId; pick.webUrl is only
-                // used as a guard (must start with http/https) — it does not become the stored URL.
-                "teamcityProjectUrl" to "https://teamcity.example.com/project/Alpha_Build",
-            ),
-            audit.newValue,
+        // SYS-051: TeamCity sync is an automated reconciliation (changedBy=system) and
+        // must NOT write audit rows — that noise was cluttering the component history.
+        assertTrue(
+            publisher.events.filterIsInstance<AuditEvent>().isEmpty(),
+            "TeamCity sync must not publish an AuditEvent even when it writes/updates the TC row (SYS-051)",
         )
     }
 
@@ -206,7 +198,10 @@ class TeamcitySyncServiceTest {
         assertEquals(1, result.ambiguousAutoResolved)
         // v2: TC row stores only the projectId; URL is derived at read-time via composeTeamcityProjectUrl.
         assertEquals("Project_B_Release", tcRepo.findByComponentId(alice).single().projectId)
-        assertEquals(1, publisher.events.filterIsInstance<AuditEvent>().size)
+        assertTrue(
+            publisher.events.filterIsInstance<AuditEvent>().isEmpty(),
+            "TeamCity sync must not publish an AuditEvent (SYS-051)",
+        )
     }
 
     @Test
@@ -410,7 +405,10 @@ class TeamcitySyncServiceTest {
         assertEquals(1, result.skippedNoMatch) // gamma
         assertEquals(0, result.skippedAmbiguous)
         assertTrue(result.errors.isEmpty())
-        assertEquals(1, publisher.events.filterIsInstance<AuditEvent>().size, "one audit event for alpha")
+        assertTrue(
+            publisher.events.filterIsInstance<AuditEvent>().isEmpty(),
+            "TeamCity sync must not publish an AuditEvent for any synced component (SYS-051)",
+        )
     }
 
     // -- Test doubles ---------------------------------------------------------

--- a/docs/registry/adr/005-audit-log.md
+++ b/docs/registry/adr/005-audit-log.md
@@ -92,6 +92,37 @@ CREATE TABLE audit_log (
 ### Risks
 - Missed audit entries if writes bypass service layer → enforce via architecture (no direct repository writes from controllers)
 
+## Refinements (post-acceptance)
+
+These tighten the original mechanism; the table + domain-event design is unchanged.
+
+### Action vocabulary
+`action` is `CREATE | UPDATE | DELETE | RENAME | MIGRATED`. `MIGRATED`
+(`AuditLogEntity.ACTION_MIGRATED`) is written by the git-history backfill for a
+component's **first appearance** in history, instead of `CREATE`. It marks
+migration-origin baseline rows so the audit views can hide them by default — one
+`MIGRATED` row per component is noise, not an operational event. Runtime API
+creates stay `CREATE`. (SYS-049)
+
+### Migration noise hidden by default
+Both read endpoints (`GET /audit/recent`, `GET /audit/{entityType}/{entityId}`)
+exclude `action = MIGRATED` rows unless the caller passes `includeMigrated=true`,
+or pins them with an explicit `action=MIGRATED` filter. The Portal exposes this as
+a "Show migration" toggle (default off). (SYS-049)
+
+### No-op suppression
+A write that changes nothing must not leave an audit row. `AuditEventListener`
+drops an event whose `oldValue` and `newValue` are both present but whose computed
+`change_diff` is empty. This is centralised in the listener, so it covers every
+publisher. `CREATE` (null `oldValue`) and `DELETE` legitimately have a null diff
+and are always kept. (SYS-048)
+
+### Coverage: field overrides
+Field-override (version-ranged attribute override) create/update/delete publish a
+Component `UPDATE` event keyed by the overridden attribute, so version-range edits
+appear in the component history alongside top-level attribute edits — closing the
+"all write paths go through audited service methods" risk for these paths. (SYS-050)
+
 ## References
 - [DMS Event pattern](https://github.com/octopusden/octopus-dms-service) — `server/.../event/`
 - [PostgreSQL JSONB operators](https://www.postgresql.org/docs/current/functions-json.html)

--- a/docs/registry/adr/005-audit-log.md
+++ b/docs/registry/adr/005-audit-log.md
@@ -124,6 +124,13 @@ Component `UPDATE` event keyed by the overridden attribute, so version-range edi
 appear in the component history alongside top-level attribute edits — closing the
 "all write paths go through audited service methods" risk for these paths. (SYS-050)
 
+### Not audited: TeamCity sync
+The automated TeamCity sync (`changedBy = system`) deliberately does NOT write an
+audit row — a per-component re-link row is operational noise, not a user change.
+The re-link is traced via an INFO log line instead. This is a deliberate
+exception to "all write paths are audited"; re-publish an `AuditEvent` in
+`TeamcitySyncService` if per-sync auditing is ever wanted. (SYS-051)
+
 ## References
 - [DMS Event pattern](https://github.com/octopusden/octopus-dms-service) — `server/.../event/`
 - [PostgreSQL JSONB operators](https://www.postgresql.org/docs/current/functions-json.html)

--- a/docs/registry/adr/005-audit-log.md
+++ b/docs/registry/adr/005-audit-log.md
@@ -106,9 +106,11 @@ creates stay `CREATE`. (SYS-049)
 
 ### Migration noise hidden by default
 Both read endpoints (`GET /audit/recent`, `GET /audit/{entityType}/{entityId}`)
-exclude `action = MIGRATED` rows unless the caller passes `includeMigrated=true`,
-or pins them with an explicit `action=MIGRATED` filter. The Portal exposes this as
-a "Show migration" toggle (default off). (SYS-049)
+exclude `action = MIGRATED` rows unless the caller passes `includeMigrated=true`.
+`/audit/recent` also returns them when pinned with an explicit `action=MIGRATED`
+filter — it is the only endpoint with an `action` query param; the entity-history
+endpoint takes `includeMigrated` only. The Portal exposes this as a "Show
+migration" toggle (default off). (SYS-049)
 
 ### No-op suppression
 A write that changes nothing must not leave an audit row. `AuditEventListener`

--- a/docs/registry/adr/005-audit-log.md
+++ b/docs/registry/adr/005-audit-log.md
@@ -113,8 +113,9 @@ a "Show migration" toggle (default off). (SYS-049)
 ### No-op suppression
 A write that changes nothing must not leave an audit row. `AuditEventListener`
 drops an event whose `oldValue` and `newValue` are both present but whose computed
-`change_diff` is empty. This is centralised in the listener, so it covers every
-publisher. `CREATE` (null `oldValue`) and `DELETE` legitimately have a null diff
+`change_diff` is empty — `AuditDiff.compute` returns `null` for an empty diff, and
+the guard condition is `oldValue != null && newValue != null && changeDiff == null`.
+This is centralised in the listener, so it covers every publisher. `CREATE` (null `oldValue`) and `DELETE` legitimately have a null diff
 and are always kept. (SYS-048)
 
 ### Coverage: field overrides

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -132,9 +132,11 @@ All existing search/lookup operations must return identical results from DB:
 ## 4. Audit Log
 
 ### 4.1 View Entity History
-- **Input**: Entity type (component, version, etc.) + entity ID
+- **Input**: Entity type (component, version, etc.) + entity ID; optional `includeMigrated` (default `false`)
 - **Output**: Paginated list of changes, newest first
 - **Each entry**: action, changedBy, changedAt, oldValue (JSONB), newValue (JSONB), changeDiff (JSONB)
+- **Migration baseline hidden**: `action = MIGRATED` rows (git-history first-appearance, one per component) are hidden unless `includeMigrated=true` — the Portal "Show migration" toggle (`SYS-049`).
+- **No empty rows**: a save that changes nothing writes no entry (`SYS-048`); field-override (version-range) edits are recorded as Component `UPDATE` (`SYS-050`).
 
 ### 4.2 Global Recent Changes
 - **Endpoint**: `GET /rest/api/4/audit/recent`
@@ -143,8 +145,9 @@ All existing search/lookup operations must return identical results from DB:
   - `entityId` — UUID of a specific entity (combine with `entityType` for entity-scoped history reachable via the same query as user/source filters)
   - `changedBy` — username from `audit_log.changed_by`
   - `source` — currently only `api` and `git-history` are emitted. Other values are reserved for future writers.
-  - `action` — `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `ARCHIVE`
+  - `action` — `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `MIGRATED`
   - `from`, `to` — ISO-8601 instants forming a half-open `[from, to)` window over `audit_log.changed_at`
+  - `includeMigrated` — default `false`; `MIGRATED` (migration baseline) rows are hidden unless this is `true` or an explicit `action=MIGRATED` filter is supplied (`SYS-049`)
 - **Output**: Paginated feed of audit rows newest-first (default sort `changedAt DESC`; caller-supplied `sort=` overrides)
 - **Page size**: Spring Data `Pageable`; defaults to the global `spring.data.web.pageable.default-page-size`
 
@@ -201,6 +204,7 @@ All admin endpoints below live under `POST /rest/api/4/admin/**` and require `IM
 - **Purpose**: Replay git commit history of the legacy DSL repo into `audit_log` so the UI's history view shows changes that pre-date the DB migration.
 - **Idempotency**: One-row state in `git_history_import_state` (PK `import_key`, status `IN_PROGRESS` / `COMPLETED` / `FAILED` — see `GitHistoryImportStatus`). A second call with `reset=false` against an already-completed import is a no-op; `reset=true` clears state and re-runs.
 - **Audit source marker**: rows written by this endpoint carry `audit_log.source = 'git-history'`; runtime API events carry `'api'`. See V5 schema migration.
+- **First-appearance action**: a component's first appearance is recorded with `action = MIGRATED` (not `CREATE`); subsequent historical changes stay `UPDATE`/`DELETE`. `MIGRATED` rows are hidden from the audit views by default (`SYS-049`).
 - **Output**: `HistoryImportResult` — `{ targetRef, targetSha, processedCommits, skippedNoGroovy, skippedParseError, skippedUnknownNames, auditRecords, durationMs }`.
 - **Contract**: `MIG-026` in [requirements-migration.md](requirements-migration.md).
 

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -56,6 +56,9 @@
 | SYS-045 | GET /components?distributionExplicit= / ?distributionExternal= activate the two scalar distribution boolean filters (mirror `solution`; `=false` excludes NULL rows) | Medium | integration-test | ✅ Tested |
 | SYS-046 | clientCode / jiraProjectKey / parentComponentName / groupKey become multi-value exact-IN filters (CSV / repeatable); 4 companion in-use meta endpoints (/meta/client-codes, /meta/jira-project-keys, /meta/parent-component-names, /meta/group-keys) | High | integration-test | ✅ Tested |
 | SYS-047 | git-only no-DB boot mode: the `no-db` profile excludes the JDBC/JPA/Flyway auto-configs and gates every DB-coupled bean off (`@ConditionalOnDatabaseEnabled`), so the service boots with no database and serves v1/v2/v3 from the Git resolver — the compat git-mode stand (id18) needs no Postgres | High | unit / context-load test | ✅ Tested |
+| SYS-048 | A no-op write (component or field-override save whose old/new snapshots carry no field-level diff) writes no audit row; CREATE/DELETE keep theirs | High | unit-test | ✅ Tested |
+| SYS-049 | Git-history backfill records a component's first appearance with action `MIGRATED` (not `CREATE`); both audit read endpoints hide `MIGRATED` by default, opt back in via `includeMigrated=true`, and always honour an explicit `action=MIGRATED` filter | High | unit + integration-test | ✅ Tested |
+| SYS-050 | Field-override (version-range) create/update/delete each publish a Component `UPDATE` audit event with an attribute-keyed diff | High | integration-test | ✅ Tested |
 
 ---
 
@@ -477,8 +480,9 @@ accessible via `GET /rest/api/4/admin/component-defaults`.
 **Status:** ❌ Not tested
 
 **Description:**
-When a component is updated via PATCH, a record is created in `audit_log`
-with action = `UPDATE`, old_value, new_value, and change_diff.
+When a component is updated via PATCH **with an actual change**, a record is
+created in `audit_log` with action = `UPDATE`, old_value, new_value, and
+change_diff. A no-op PATCH (nothing changed) writes no row — see SYS-048.
 
 **Preconditions:**
 - Component exists
@@ -1585,3 +1589,99 @@ its name + a `@DisplayName("SYS-047: …")` (test-to-requirement traceability):
 `SYS-047 git resolver is the sole resolver in no-db mode`,
 `SYS-047 db-only beans absent and git read path present in no-db mode`,
 `SYS-047 status reports defaultSource git and zero db components in no-db mode`.
+
+### SYS-048: no-op save writes no audit row
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Motivation:**
+Clicking Save on an unmodified edit form (and any other write path that re-saves
+without changing anything) used to append an `UPDATE` audit row whose
+`change_diff` was empty. These "saved, changed nothing" rows are noise that
+hides the real history.
+
+**Description:**
+`AuditEventListener` computes the field-level diff (`AuditDiff.compute`) and, when
+**both** `oldValue` and `newValue` are present but the diff is empty, skips
+persisting the row entirely. This is centralised in the listener, so it applies to
+every publisher: component `UPDATE`, field-override writes (SYS-050), and TeamCity
+sync. `CREATE` (null `oldValue`) and `DELETE` legitimately produce a null diff and
+are always kept.
+
+**Acceptance criteria:**
+1. An `UPDATE` event whose `oldValue` equals `newValue` (empty diff) is not persisted.
+2. A `CREATE` event (null `oldValue`) is persisted even though its diff is null.
+3. A real `UPDATE` (non-empty diff) is persisted with the computed `change_diff`.
+
+**Test method:** `AuditEventListenerTest` — `SYS-048 no-op UPDATE writes no audit row`,
+`SYS-048 real UPDATE is persisted`, `SYS-048 CREATE is always persisted`,
+`SYS-048 DELETE is persisted`.
+
+### SYS-049: git-history baseline recorded as MIGRATED and hidden by default
+
+**Priority:** High
+**Test layer:** unit + integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+The git-history backfill writes one row per component for the commit where it first
+appears. Recording these as `CREATE` floods the audit views with migration noise
+that carries no operational value and misrepresents a migration as a user action.
+
+**Description:**
+- `GitHistoryImportServiceImpl` resolves a component's first appearance
+  (`oldValue == null`) to `AuditLogEntity.ACTION_MIGRATED` (`"MIGRATED"`) instead of
+  `CREATE`. Genuine historical `UPDATE`/`DELETE` rows are unchanged. Runtime API
+  creates (via `ComponentManagementServiceImpl`) remain `CREATE`.
+- Both audit read endpoints hide `MIGRATED` rows by default. `GET /audit/recent`
+  and `GET /audit/{entityType}/{entityId}` accept `includeMigrated` (default
+  `false`); `getEntityHistory` uses a no-`MIGRATED` query on the default path and the
+  recent-filter adds a `action != MIGRATED` predicate. An explicit `action=MIGRATED`
+  filter always returns them regardless of `includeMigrated`, so the Portal
+  "Show migration" toggle can surface them on demand.
+
+**Acceptance criteria:**
+1. A first-appearance snapshot resolves to `MIGRATED`; disappearance → `DELETE`;
+   changed → `UPDATE`; unchanged → null (no row).
+2. `GET /audit/recent` and `GET /audit/Component/{id}` exclude `MIGRATED` rows by default.
+3. `includeMigrated=true` surfaces `MIGRATED` rows on both endpoints.
+4. An explicit `action=MIGRATED` filter returns `MIGRATED` rows even without `includeMigrated`.
+
+**Test method:** `GitHistoryImportActionResolutionTest` (`SYS-049 first appearance
+resolves to MIGRATED` and the DELETE/UPDATE/null cases) +
+`AuditMigratedVisibilityTest` (`SYS-049 recent hides MIGRATED by default`,
+`SYS-049 recent includeMigrated returns MIGRATED`,
+`SYS-049 explicit action MIGRATED wins over default hide`,
+`SYS-049 entity history honours includeMigrated`).
+
+### SYS-050: field-override writes are audited as Component UPDATE
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+Adding, changing or removing a version-ranged attribute override is a real change to
+the component, but the field-override write paths only bumped the parent version —
+they published no audit event, so version-range edits were invisible in the
+component history (inconsistent with top-level attribute edits, which are audited).
+
+**Description:**
+`createFieldOverride` / `updateFieldOverride` / `deleteFieldOverride` publish a
+Component `UPDATE` `AuditEvent` (`entityId` = the parent component id) with an
+old/new snapshot keyed by the overridden attribute (`fieldOverride[<attr>]`),
+carrying the version range and the resolved scalar value / marker children. A no-op
+override PATCH produces an empty diff and is dropped by the SYS-048 guard.
+
+**Acceptance criteria:**
+1. `createFieldOverride` writes one Component `UPDATE` audit row whose diff names the
+   overridden attribute.
+2. `updateFieldOverride` (real change) and `deleteFieldOverride` each write a
+   Component `UPDATE` audit row.
+3. A no-op override PATCH (unchanged value) writes no audit row.
+
+**Test method:** `FieldOverrideAuditTest` —
+`SYS-050 field-override writes are audited as Component UPDATE`,
+`SYS-050 no-op override PATCH writes no audit row`.

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -57,7 +57,7 @@
 | SYS-046 | clientCode / jiraProjectKey / parentComponentName / groupKey become multi-value exact-IN filters (CSV / repeatable); 4 companion in-use meta endpoints (/meta/client-codes, /meta/jira-project-keys, /meta/parent-component-names, /meta/group-keys) | High | integration-test | ✅ Tested |
 | SYS-047 | git-only no-DB boot mode: the `no-db` profile excludes the JDBC/JPA/Flyway auto-configs and gates every DB-coupled bean off (`@ConditionalOnDatabaseEnabled`), so the service boots with no database and serves v1/v2/v3 from the Git resolver — the compat git-mode stand (id18) needs no Postgres | High | unit / context-load test | ✅ Tested |
 | SYS-048 | A no-op write (component or field-override save whose old/new snapshots carry no field-level diff) writes no audit row; CREATE/DELETE keep theirs | High | unit-test | ✅ Tested |
-| SYS-049 | Git-history backfill records a component's first appearance with action `MIGRATED` (not `CREATE`); both audit read endpoints hide `MIGRATED` by default, opt back in via `includeMigrated=true`, and always honour an explicit `action=MIGRATED` filter | High | unit + integration-test | ✅ Tested |
+| SYS-049 | Git-history backfill records a component's first appearance with action `MIGRATED` (not `CREATE`); both audit read endpoints hide `MIGRATED` by default and opt back in via `includeMigrated=true`. `/audit/recent` additionally honours an explicit `action=MIGRATED` filter (the entity-history endpoint takes only `includeMigrated`) | High | unit + integration-test | ✅ Tested |
 | SYS-050 | Field-override (version-range) create/update/delete each publish a Component `UPDATE` audit event with an attribute-keyed diff | High | integration-test | ✅ Tested |
 | SYS-051 | TeamCity sync (automated `changedBy=system` reconciliation) does NOT write an audit row — the re-link is traced via an INFO log instead | Medium | unit-test | ✅ Tested |
 
@@ -1639,16 +1639,18 @@ that carries no operational value and misrepresents a migration as a user action
 - Both audit read endpoints hide `MIGRATED` rows by default. `GET /audit/recent`
   and `GET /audit/{entityType}/{entityId}` accept `includeMigrated` (default
   `false`); `getEntityHistory` uses a no-`MIGRATED` query on the default path and the
-  recent-filter adds a `action != MIGRATED` predicate. An explicit `action=MIGRATED`
-  filter always returns them regardless of `includeMigrated`, so the Portal
-  "Show migration" toggle can surface them on demand.
+  recent-filter adds a `action != MIGRATED` predicate. `/audit/recent` (the only
+  endpoint with an `action` query param) additionally returns `MIGRATED` rows when
+  an explicit `action=MIGRATED` filter is given, regardless of `includeMigrated`;
+  the entity-history endpoint has no `action` param, so `includeMigrated` is its
+  sole opt-in. Either way the Portal "Show migration" toggle surfaces them.
 
 **Acceptance criteria:**
 1. A first-appearance snapshot resolves to `MIGRATED`; disappearance → `DELETE`;
    changed → `UPDATE`; unchanged → null (no row).
 2. `GET /audit/recent` and `GET /audit/Component/{id}` exclude `MIGRATED` rows by default.
 3. `includeMigrated=true` surfaces `MIGRATED` rows on both endpoints.
-4. An explicit `action=MIGRATED` filter returns `MIGRATED` rows even without `includeMigrated`.
+4. On `GET /audit/recent`, an explicit `action=MIGRATED` filter returns `MIGRATED` rows even without `includeMigrated` (the entity-history endpoint has no `action` param).
 
 **Test method:** `GitHistoryImportActionResolutionTest` (`SYS-049 first appearance
 resolves to MIGRATED` and the DELETE/UPDATE/null cases) +

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -59,6 +59,7 @@
 | SYS-048 | A no-op write (component or field-override save whose old/new snapshots carry no field-level diff) writes no audit row; CREATE/DELETE keep theirs | High | unit-test | ✅ Tested |
 | SYS-049 | Git-history backfill records a component's first appearance with action `MIGRATED` (not `CREATE`); both audit read endpoints hide `MIGRATED` by default, opt back in via `includeMigrated=true`, and always honour an explicit `action=MIGRATED` filter | High | unit + integration-test | ✅ Tested |
 | SYS-050 | Field-override (version-range) create/update/delete each publish a Component `UPDATE` audit event with an attribute-keyed diff | High | integration-test | ✅ Tested |
+| SYS-051 | TeamCity sync (automated `changedBy=system` reconciliation) does NOT write an audit row — the re-link is traced via an INFO log instead | Medium | unit-test | ✅ Tested |
 
 ---
 
@@ -1685,3 +1686,35 @@ override PATCH produces an empty diff and is dropped by the SYS-048 guard.
 **Test method:** `FieldOverrideAuditTest` —
 `SYS-050 field-override writes are audited as Component UPDATE`,
 `SYS-050 no-op override PATCH writes no audit row`.
+
+### SYS-051: TeamCity sync writes no audit row
+
+**Priority:** Medium
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Motivation:**
+The TeamCity sync (`/admin/teamcity-resync` and the scheduled cron) is an
+automated reconciliation that links each component to its TeamCity project.
+Every re-link previously published a Component `UPDATE` `AuditEvent`
+(`changedBy = system`, `teamcityProjectId` / `teamcityProjectUrl`). One such row
+per re-linked component is operational noise in the component history — it is
+not a user-initiated change.
+
+**Description:**
+`TeamcitySyncService.applyMatch` no longer publishes an `AuditEvent`; instead it
+emits an INFO log line tracing the re-link (component id, old → new project id +
+url, and the resolving user) so the source of a write is still discoverable. No
+`audit_log` row is written for a TeamCity sync. The `ApplicationEventPublisher`
+seam is retained so the test can assert nothing is published (and as the
+re-wire point if per-sync auditing is ever wanted).
+
+**Acceptance criteria:**
+1. A TeamCity sync that writes/updates a component's TC row publishes **no** `AuditEvent`.
+2. The TC row + sync counts (`updated` / `unchanged` / …) are unaffected.
+3. An unchanged component (idempotent re-run) still publishes nothing (unchanged behaviour).
+
+**Test method:** `TeamcitySyncServiceTest` —
+`SYS-051 happy path: writes TC row; counts updated; NO audit event`, plus the
+`ambiguousAutoResolved` and `mixed batch` cases assert
+`publisher.events.filterIsInstance<AuditEvent>().isEmpty()`.

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -1076,11 +1076,11 @@ The Portal `AuditLogPage` filter sidebar drives a server-side query — without 
 Supported filters:
 | Param | Type | Notes |
 |---|---|---|
-| `entityType` | string | Currently only `Component` is emitted (capitalized — `cb.equal` is case-sensitive). `FieldOverride` and other entity types are reserved for future audit instrumentation; field-override CRUD does not publish `AuditEvent` yet. |
+| `entityType` | string | Currently only `Component` is emitted (capitalized — `cb.equal` is case-sensitive). `FieldOverride` and other entity types are reserved for future audit instrumentation; field-override CRUD is audited as a `Component` `UPDATE` (SYS-050), not under a `FieldOverride` entity type. |
 | `entityId` | string | usually a UUID; combine with `entityType` for entity-scoped history reachable in the same query as user/source filters |
 | `changedBy` | string | username from `audit_log.changed_by`. For runtime API events the value is resolved by `CurrentUserResolver` (see TDD §6.4); for git-history backfill rows it is the git author signature. |
 | `source` | string | Currently only `api` (default for runtime events) and `git-history` (backfill from `/admin/migrate-history`) are emitted. Other values are reserved for future writers. |
-| `action` | string | `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `ARCHIVE` \| … |
+| `action` | string | `CREATE` \| `UPDATE` \| `DELETE` \| `RENAME` \| `MIGRATED` (hidden by default — see SYS-049) |
 | `from`, `to` | ISO-8601 instant | half-open `[from, to)` over `audit_log.changed_at`; either or both optional |
 
 **Preconditions:**

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -348,6 +348,7 @@ The fallback path is exercised by code paths that don't carry a request context.
 - **Actions:** `CREATE | UPDATE | DELETE | RENAME | MIGRATED`. `MIGRATED` (`AuditLogEntity.ACTION_MIGRATED`) is written by `/admin/migrate-history` for a component's first appearance instead of `CREATE`; both read endpoints hide it by default behind `includeMigrated` (SYS-049). See ADR-005 "Refinements".
 - **No-op suppression:** `AuditEventListener` drops any event whose `oldValue` and `newValue` are both present but produce an empty `change_diff`, so a Save that changes nothing leaves no row. CREATE/DELETE are unaffected (SYS-048).
 - **Field-override coverage:** `createFieldOverride` / `updateFieldOverride` / `deleteFieldOverride` publish a Component `UPDATE` event keyed by `fieldOverride[<attr>]`, so version-range edits are auditable like top-level attribute edits (SYS-050).
+- **TeamCity sync not audited:** the automated `changedBy=system` reconciliation in `TeamcitySyncService` writes no `audit_log` row (it was noise); the re-link is logged at INFO instead (SYS-051).
 
 ### 6.5 Backward Compatibility
 - v1/v2/v3 endpoints: **permit all** (existing 7+ Feign client consumers don't send JWT).

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -164,6 +164,7 @@ GET    /rest/api/4/components/{id}/field-overrides
 GET    /rest/api/4/audit/{entityType}/{entityId}?page=0&size=20
   Response: Page<AuditEntry> { action, changedBy, changedAt, oldValue, newValue, diff, source }
   Auth:     ACCESS_AUDIT
+  Filters:  includeMigrated — default false; hides action=MIGRATED rows unless true (SYS-049)
 
 GET    /rest/api/4/audit/recent
   Response: Page<AuditEntry>, default sort changedAt DESC
@@ -175,12 +176,19 @@ GET    /rest/api/4/audit/recent
               changedBy    — username from audit_log.changed_by (CurrentUserResolver)
               source       — currently only "api" or "git-history"; other values
                              reserved for future writers
-              action       — "CREATE" | "UPDATE" | "DELETE" | "RENAME" | "ARCHIVE"
+              action       — "CREATE" | "UPDATE" | "DELETE" | "RENAME" | "MIGRATED"
               from, to     — ISO-8601 instants; half-open [from, to) on changed_at
+              includeMigrated — default false; hides action=MIGRATED (migration
+                             baseline noise) unless true, or unless an explicit
+                             action=MIGRATED filter is given (SYS-049)
   Note:     `audit_log.changed_by` is populated from CurrentUserResolver
             (preferred_username from the authenticated JWT, fallback "system" for
             background jobs). Fixes the gap where API-driven audit rows used to
             store NULL.
+            MIGRATED rows are git-history baseline (one per component) and are
+            hidden by default; the empty-diff no-op guard (SYS-048) keeps "saved,
+            changed nothing" writes out of the log; field-override writes are
+            audited as Component UPDATE (SYS-050).
 ```
 
 #### Admin
@@ -334,6 +342,12 @@ Every `applicationEventPublisher.publishEvent(AuditEvent(...))` call site sets `
 - no authenticated context (background jobs, async tasks outside an HTTP thread) → `"system"`.
 
 The fallback path is exercised by code paths that don't carry a request context. `/admin/migrate-history` is a special case: it sets `changedBy` from the git author signature (`"Name <email>"`) rather than from `CurrentUserResolver`, because the historical event was originally authored by that git committer — see `GitHistoryImportServiceImpl`. SYS-036 acceptance criterion 3 (filter by `changedBy`) depends on this wiring being in place; tests live under `AuditLogFilterTest`.
+
+#### 6.4.1 Action semantics, noise suppression, and coverage
+
+- **Actions:** `CREATE | UPDATE | DELETE | RENAME | MIGRATED`. `MIGRATED` (`AuditLogEntity.ACTION_MIGRATED`) is written by `/admin/migrate-history` for a component's first appearance instead of `CREATE`; both read endpoints hide it by default behind `includeMigrated` (SYS-049). See ADR-005 "Refinements".
+- **No-op suppression:** `AuditEventListener` drops any event whose `oldValue` and `newValue` are both present but produce an empty `change_diff`, so a Save that changes nothing leaves no row. CREATE/DELETE are unaffected (SYS-048).
+- **Field-override coverage:** `createFieldOverride` / `updateFieldOverride` / `deleteFieldOverride` publish a Component `UPDATE` event keyed by `fieldOverride[<attr>]`, so version-range edits are auditable like top-level attribute edits (SYS-050).
 
 ### 6.5 Backward Compatibility
 - v1/v2/v3 endpoints: **permit all** (existing 7+ Feign client consumers don't send JWT).

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -162,7 +162,7 @@ GET    /rest/api/4/components/{id}/field-overrides
 #### Audit
 ```
 GET    /rest/api/4/audit/{entityType}/{entityId}?page=0&size=20
-  Response: Page<AuditEntry> { action, changedBy, changedAt, oldValue, newValue, diff, source }
+  Response: Page<AuditEntry> { action, changedBy, changedAt, oldValue, newValue, changeDiff, source }
   Auth:     ACCESS_AUDIT
   Filters:  includeMigrated — default false; hides action=MIGRATED rows unless true (SYS-049)
 


### PR DESCRIPTION
Fixes three audit-log issues reported on the component edit flow.

## What & why

**1. No empty audit row on a no-op save (SYS-048).**
Clicking Save on an unmodified form (or any re-save that changes nothing) used to append an `UPDATE` row with an empty `change_diff`. `AuditEventListener` now drops an event whose `oldValue` and `newValue` are both present but whose computed diff is empty. Centralised in the listener, so it also covers field-override updates and TeamCity sync. `CREATE` (null `oldValue`) and `DELETE` are unaffected.

**2. Migration baseline recorded as `MIGRATED`, hidden by default (SYS-049).**
The git-history backfill recorded one `CREATE` row per component for its first appearance — pure migration noise. That first-appearance action is now `MIGRATED` (`AuditLogEntity.ACTION_MIGRATED`); genuine historical `UPDATE`/`DELETE` are unchanged, and runtime API creates stay `CREATE`. Both read endpoints (`GET /audit/recent`, `GET /audit/{entityType}/{entityId}`) hide `MIGRATED` by default, accept `includeMigrated=true` to opt in, and always honour an explicit `action=MIGRATED` filter — backing the Portal "Show migration" toggle (Portal PR follows).

**3. Field-override (version-range) writes are audited (SYS-050).**
`createFieldOverride` / `updateFieldOverride` / `deleteFieldOverride` now publish a Component `UPDATE` event with an old/new snapshot keyed by the overridden attribute, so version-range edits appear in the component history like top-level attribute edits. No-op override PATCHes are dropped by the SYS-048 guard.

## Tests (TDD, red→green; separate `test:`/`fix:` commits per bug)
- `AuditEventListenerTest` — no-op suppression; CREATE/DELETE (incl. null-newValue) always persisted.
- `GitHistoryImportActionResolutionTest` — first appearance → `MIGRATED`; DELETE/UPDATE/null unchanged.
- `AuditMigratedVisibilityTest` — hide-by-default, `includeMigrated`, explicit `action=MIGRATED` on both endpoints.
- `FieldOverrideAuditTest` — create/update/delete write a Component `UPDATE`; no-op PATCH writes nothing.
- `StrictContractTest` ghost-write guard adapted to the new no-op semantics (still detects the PR #301 regression).

Full `gradlew build` green (857 tests). Independent Sonnet review + re-review: APPROVE.

## Docs
requirements-common.md (SYS-048/049/050), ADR-005 (Refinements), technical-design.md (audit API + §6.4.1), functional-spec.md (§4 / §5.7).

## Follow-up
Portal PR (base `develop`): `MIGRATED` badge, "Show migration" toggle on the audit views, and disabling Save when the form is not dirty. Depends on this merging to `v3` (`includeMigrated` + `MIGRATED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)