### PR TITLE
chore(security): rename ADMIN_DATA permission to EDIT_METADATA

### DIFF
--- a/components-registry-automation/data/components-registry-service.yaml
+++ b/components-registry-automation/data/components-registry-service.yaml
@@ -57,7 +57,7 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      - ADMIN_DATA
+      - EDIT_METADATA
 
 logging:
   level:

--- a/components-registry-service-client/src/test/resources/application-common.yml
+++ b/components-registry-service-client/src/test/resources/application-common.yml
@@ -55,4 +55,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      - ADMIN_DATA
+      - EDIT_METADATA

--- a/components-registry-service-client/src/test/resources/application-v3.yml
+++ b/components-registry-service-client/src/test/resources/application-v3.yml
@@ -53,4 +53,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      - ADMIN_DATA
+      - EDIT_METADATA

--- a/components-registry-service-light-client/src/test/resources/application-common.yml
+++ b/components-registry-service-light-client/src/test/resources/application-common.yml
@@ -52,4 +52,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      - ADMIN_DATA
+      - EDIT_METADATA

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/PermissionEvaluator.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/PermissionEvaluator.kt
@@ -29,12 +29,12 @@ class PermissionEvaluator(
     fun canImport(): Boolean = hasPermission(IMPORT_DATA)
 
     /**
-     * Admin-tier data administration — gates power-user / escape-hatch editing
-     * surfaces (e.g. the Portal Field-Overrides tab's add/edit/delete actions,
-     * incl. marker editing). Distinct from IMPORT_DATA (bulk import). Mapped to
-     * ROLE_ADMIN in octopus-security.roles.
+     * Edit component-configuration metadata — gates the raw Field-Overrides edit
+     * surface (add/edit/delete, incl. marker editing); a power-user / escape-hatch
+     * capability. Distinct from EDIT_COMPONENTS (inline per-field scalar edits) and
+     * IMPORT_DATA (bulk import). Mapped to ROLE_ADMIN in octopus-security.roles today.
      */
-    fun canAdminData(): Boolean = hasPermission(ADMIN_DATA)
+    fun canEditMetadata(): Boolean = hasPermission(EDIT_METADATA)
 
     companion object {
         const val ACCESS_COMPONENTS = "ACCESS_COMPONENTS"
@@ -44,6 +44,6 @@ class PermissionEvaluator(
         const val DELETE_COMPONENTS = "DELETE_COMPONENTS"
         const val IMPORT_DATA = "IMPORT_DATA"
         const val ACCESS_AUDIT = "ACCESS_AUDIT"
-        const val ADMIN_DATA = "ADMIN_DATA"
+        const val EDIT_METADATA = "EDIT_METADATA"
     }
 }

--- a/components-registry-service-server/src/main/resources/application-dev.yml
+++ b/components-registry-service-server/src/main/resources/application-dev.yml
@@ -14,4 +14,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      - ADMIN_DATA
+      - EDIT_METADATA

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -98,5 +98,5 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      # Admin-tier data administration (e.g. Portal Field-Overrides edit surface).
-      - ADMIN_DATA
+      # Edit component-configuration metadata (e.g. Portal Field-Overrides edit surface).
+      - EDIT_METADATA

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/UserInfoConverterIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/UserInfoConverterIntegrationTest.kt
@@ -92,9 +92,9 @@ class UserInfoConverterIntegrationTest {
             .andExpect(jsonPath("$.username").value("alice"))
             .andExpect(jsonPath("$.roles[0].name").value("ROLE_ADMIN"))
             .andExpect(jsonPath("$.roles[0].permissions", org.hamcrest.Matchers.hasItem("ACCESS_COMPONENTS")))
-            // ADMIN_DATA gates the admin-only data-administration surface
+            // EDIT_METADATA gates the admin-only data-administration surface
             // (e.g. the Portal Field-Overrides edit tab). Admins must carry it.
-            .andExpect(jsonPath("$.roles[0].permissions", org.hamcrest.Matchers.hasItem("ADMIN_DATA")))
+            .andExpect(jsonPath("$.roles[0].permissions", org.hamcrest.Matchers.hasItem("EDIT_METADATA")))
     }
 
     @Test

--- a/components-registry-service-server/src/test/resources/application-common.yml
+++ b/components-registry-service-server/src/test/resources/application-common.yml
@@ -65,4 +65,4 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      - ADMIN_DATA
+      - EDIT_METADATA

--- a/docs/registry/adr/004-auth-keycloak.md
+++ b/docs/registry/adr/004-auth-keycloak.md
@@ -188,7 +188,7 @@ Permissions (8):
 | `DELETE_COMPONENTS` | `DELETE /{id}` — hard delete, ADMIN-only |
 | `IMPORT_DATA` | `POST /rest/api/4/admin/**`, `PUT /rest/api/4/admin/config/**` (migrate/import/global-config writes) |
 | `ACCESS_AUDIT` | `GET /rest/api/4/audit/**` |
-| `ADMIN_DATA` | admin-tier data administration — gates the Portal Field-Overrides edit surface (add/edit/delete, incl. marker editing). `ROLE_ADMIN` only. Currently enforced client-side in the Portal; the permission is surfaced via `/auth/me` |
+| `EDIT_METADATA` | edit component-configuration metadata — gates the Portal Field-Overrides edit surface (add/edit/delete, incl. marker editing). `ROLE_ADMIN` only. Currently enforced client-side in the Portal; the permission is surfaced via `/auth/me` |
 
 Role map (`octopus-security.roles` in `components-registry-service.yml`):
 
@@ -223,7 +223,7 @@ octopus-security:
       - DELETE_COMPONENTS
       - IMPORT_DATA
       - ACCESS_AUDIT
-      - ADMIN_DATA
+      - EDIT_METADATA
 ```
 
 Notes on the model:

--- a/docs/registry/deployment/keycloak-setup.md
+++ b/docs/registry/deployment/keycloak-setup.md
@@ -32,7 +32,7 @@ out of the box:
 |---|---|---|
 | `ROLE_COMPONENTS_REGISTRY_VIEWER` | `ACCESS_COMPONENTS`, `ACCESS_AUDIT` | `COMPONENTS_REGISTRY_VIEWER` |
 | `ROLE_COMPONENTS_REGISTRY_EDITOR` | `+ EDIT_COMPONENTS` | `COMPONENTS_REGISTRY_EDITOR` |
-| `ROLE_ADMIN` | all permissions including `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA`, `ADMIN_DATA` | usually a platform-wide `ADMIN` realm-role you already have |
+| `ROLE_ADMIN` | all permissions including `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA`, `EDIT_METADATA` | usually a platform-wide `ADMIN` realm-role you already have |
 | `ROLE_ANONYMOUS` | `ACCESS_COMPONENTS` (public read on v4 GETs) | implicit Spring authority — no Keycloak action needed |
 
 Authority naming convention: `UserInfoGrantedAuthoritiesConverter` (from
@@ -153,7 +153,7 @@ In the impersonated session, open the portal and check:
   merges over the bundled `application.yml`. YAML *list* properties are
   replaced wholesale, so an overlay that redefines `ROLE_ADMIN` shadows the
   bundled permission list entirely. **When a new permission is added (e.g.
-  `ADMIN_DATA`), it must be added to `ROLE_ADMIN` in every overlay too** —
+  `EDIT_METADATA`), it must be added to `ROLE_ADMIN` in every overlay too** —
   otherwise admins keep `ROLE_ADMIN` but silently lose the new capability
   (here: the Portal Field-Overrides edit surface). Verify post-deploy via an
   admin's `/auth/me` or the startup role-→-permission log.

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -234,7 +234,7 @@ All admin endpoints below live under `POST /rest/api/4/admin/**` and require `IM
 
 The canonical role/permission matrix, filter-chain rules, and Keycloak role naming convention live in [ADR-004 — Authentication & Authorization via Keycloak](adr/004-auth-keycloak.md). That document is the source of truth; this section only sketches the shape so a reader of the functional spec has enough context without jumping.
 
-- **Permissions** (8): `ACCESS_COMPONENTS`, `EDIT_COMPONENTS`, `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA`, `ACCESS_AUDIT`, `ADMIN_DATA` (admin-tier data administration — gates the Portal Field-Overrides edit surface; `ROLE_ADMIN` only).
+- **Permissions** (8): `ACCESS_COMPONENTS`, `EDIT_COMPONENTS`, `ARCHIVE_COMPONENTS`, `RENAME_COMPONENTS`, `DELETE_COMPONENTS`, `IMPORT_DATA`, `ACCESS_AUDIT`, `EDIT_METADATA` (edit component-configuration metadata — gates the Portal Field-Overrides edit surface; `ROLE_ADMIN` only).
 - **Roles** (4): `ROLE_ANONYMOUS` → public reads only; `ROLE_COMPONENTS_REGISTRY_VIEWER`; `ROLE_COMPONENTS_REGISTRY_EDITOR`; `ROLE_ADMIN` (super-admin, reuses the existing Keycloak `ADMIN` realm-role). No separate `COMPONENTS_REGISTRY_ADMIN` — we piggyback on the platform admin role.
 - **v1/v2/v3 reads**: public (Phase 1 backward compat).
 - **v4 GET `/components/**` and `/config/**`**: public via `ROLE_ANONYMOUS` → `ACCESS_COMPONENTS`. All other v4 endpoints (writes, admin, audit) require authentication + the permission named in ADR-004.


### PR DESCRIPTION
Pure rename of the permission introduced in #318, before it's deployed or consumed anywhere.

**Why:** the permission model is capability-based (`ACCESS_COMPONENTS`, `EDIT_COMPONENTS`, `IMPORT_DATA`, …). `ADMIN_DATA` was the lone *tier*-style name, and encoding the tier in the permission couples it to the role mapping. `EDIT_METADATA` is a capability name consistent with `EDIT_COMPONENTS`; which role holds it stays a `octopus-security.roles` concern.

**No behavior change** — same semantics (gates the Portal Field-Overrides edit surface, mapped to `ROLE_ADMIN`). Renames:
- `PermissionEvaluator`: const + `canEditMetadata()` helper.
- All 7 role-config files (server main/test, automation OKD data, client + light-client test resources).
- Docs (ADR-004, functional-spec, keycloak-setup); permission count stays 8.

Safe to do now because nothing consumes the old name yet (the service-config overlay PR and Portal PR are renamed in lockstep).

Verification: `UserInfoConverterIntegrationTest` (asserts `EDIT_METADATA`) BUILD SUCCESSFUL. Sonnet review: no stray `ADMIN_DATA`/`canAdminData`; const value / yaml entries / Portal string all byte-identical `EDIT_METADATA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)