### PR TITLE
fix(as-code): render BASE row aspects in FULL view (synthetic base)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
@@ -91,23 +91,26 @@ class ComponentCodeRenderer(
             return cb.toString()
         }
 
-        // Per schema-spec.md §3.4 (MIG-029): a synthetic base whose component also
-        // has overrides is just a placeholder anchor — its row-level aspects are
-        // not a meaningful default view, so suppress them at top level. The
-        // per-component fields (identity / people / docs / …) still render once.
-        val renderRowAspects = !(base.isSyntheticBase && overrides.isNotEmpty())
-        val view = if (renderRowAspects) ComponentConfigurationView.from(base) else ComponentConfigurationView()
+        // Always render the base row's aspects. Even a "synthetic" base (one with
+        // no explicit all-versions DSL block) carries the real shared values the
+        // Groovy loader merged in from the component's top-level fields, and the
+        // resolver starts from the base row for EVERY version — so these are the
+        // fallback that applies to all version ranges. Suppressing them made
+        // base-level vcsSettings / build / jira / distribution look range-only.
+        // (The earlier MIG-029 suppression was about not emitting a spurious
+        // all-versions *variant* in the v1-v3 map — a different concern that does
+        // not apply to this code view.)
         writeComponentBody(
             cb = cb,
             component = component,
-            scalars = view,
-            vcsEntries = if (renderRowAspects) base.vcsEntries.toList() else emptyList(),
-            mavenArtifacts = if (renderRowAspects) base.mavenArtifacts.toList() else emptyList(),
-            fileUrlArtifacts = if (renderRowAspects) base.fileUrlArtifacts.toList() else emptyList(),
-            dockerImages = if (renderRowAspects) base.dockerImages.toList() else emptyList(),
-            packages = if (renderRowAspects) base.packages.toList() else emptyList(),
-            requiredTools = if (renderRowAspects) base.requiredToolJunctions.map { it.toolName } else emptyList(),
-            buildToolBeans = if (renderRowAspects) base.buildToolBeans.toList() else emptyList(),
+            scalars = ComponentConfigurationView.from(base),
+            vcsEntries = base.vcsEntries.toList(),
+            mavenArtifacts = base.mavenArtifacts.toList(),
+            fileUrlArtifacts = base.fileUrlArtifacts.toList(),
+            dockerImages = base.dockerImages.toList(),
+            packages = base.packages.toList(),
+            requiredTools = base.requiredToolJunctions.map { it.toolName },
+            buildToolBeans = base.buildToolBeans.toList(),
         )
 
         // Distinct override ranges in deterministic (DSL declaration) order.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
@@ -343,16 +343,55 @@ class ComponentCodeRendererTest {
     }
 
     @Test
-    @DisplayName("FULL: synthetic base with overrides suppresses base row aspects but keeps range blocks")
-    fun fullSyntheticBaseSuppression() {
+    @DisplayName("FULL: synthetic base still renders its base row aspects (they are the fallback for all versions)")
+    fun fullSyntheticBaseRendersBaseAspects() {
+        // A "synthetic" base (no explicit all-versions DSL block) still carries the
+        // real shared values the Groovy loader merged in from top-level fields, and
+        // those values resolve as the fallback for every version — so they MUST show
+        // at the top level, not be hidden behind the overriding ranges.
         val c = component()
-        base(c, synthetic = true) { buildSystem = "MAVEN" }
+        base(c, synthetic = true) {
+            buildSystem = "MAVEN"
+            jiraProjectKey = "BASE"
+        }
         scalarOverride(c, "[1,2)", "jira.projectKey") { jiraProjectKey = "AAA" }
 
         val out = renderer.renderFull(c)
-        assertFalse(out.contains("buildSystem"), "synthetic base row aspects must be suppressed:\n$out")
+        assertTrue(out.contains("buildSystem = MAVEN"), "base build aspect must render:\n$out")
+        assertTrue(out.contains("projectKey = \"BASE\""), "base jira aspect must render:\n$out")
         assertTrue(out.contains("\"[1,2)\" {"), out)
         assertTrue(out.contains("projectKey = \"AAA\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: synthetic-base VCS renders at top level, not only in the overriding range")
+    fun fullSyntheticBaseVcsRendersAtTopLevel() {
+        // Repro of the reported bug: a component whose top-level vcsUrl/tag is merged
+        // onto a synthetic base, with a later range overriding the VCS (e.g. a new
+        // tag). The base VCS applies to the earlier versions and must render at the
+        // top level — previously it was suppressed and looked range-only.
+        val c = component()
+        val b = base(c, synthetic = true) {}
+        b.vcsEntries.add(vcs(b, name = "main", path = "ssh://git/repo.git", branch = "master"))
+        val m = marker(c, "[1.0.107,)", MarkerAttributes.VCS_SETTINGS) {}
+        m.vcsEntries.add(vcs(m, name = "main", path = "ssh://git/repo.git", branch = "release"))
+
+        val out = renderer.renderFull(c)
+        val rangeHeaderIdx = out.indexOf("\"[1.0.107,)\" {")
+        val baseVcsIdx = out.indexOf("vcsSettings {")
+        val baseBranchIdx = out.indexOf("branch = \"master\"")
+        assertTrue(rangeHeaderIdx >= 0, out)
+        // A top-level vcsSettings block opens before the range block (structural)…
+        assertTrue(
+            baseVcsIdx in 0 until rangeHeaderIdx,
+            "a top-level vcsSettings block must open before the range block:\n$out",
+        )
+        // …and it carries the base branch (the override's branch lives in the range block).
+        assertTrue(
+            baseBranchIdx in 0 until rangeHeaderIdx,
+            "base vcsSettings must render at the top level, before the range block:\n$out",
+        )
+        assertTrue(out.contains("branch = \"release\""), "range vcs override must still render:\n$out")
     }
 
     // ----------------------------------------------------------------------

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -65,7 +65,12 @@ This document is the canonical reference for the v2 schema. ADR-014 records the 
 ### 3.1 Base row
 - `row_type = 'BASE'`, `overridden_attribute IS NULL`
 - All typed columns may carry values (defaults for that component)
-- `is_synthetic_base = true` when populated from `Defaults.groovy` only (DSL has no top-level fields); otherwise `false`
+- `is_synthetic_base` is a **structural** flag, not a "base has no content" flag: the import
+  (`ImportServiceImpl`) sets it `true` when the DSL has no explicit all-versions block AND ≥2
+  version-range blocks. Because the Groovy loader merges a component's top-level fields into every
+  range config, a synthetic base **still carries the real shared values** (vcsUrl/jira/build/…) the
+  component declared at top level — it is NOT necessarily a Defaults-only placeholder. Consumers
+  must therefore NOT treat `is_synthetic_base = true` as "the base row is empty/ignorable".
 
 ### 3.2 Scalar override row
 - `row_type = 'SCALAR_OVERRIDE'`, `overridden_attribute = '<aspect.field>'` (e.g., `build.javaVersion`, `escrow.generation`, `jira.projectKey`)
@@ -162,7 +167,7 @@ Per-(component, version_range) typed rows; the spine of Model A'.
 | `version_range` | VARCHAR(255) | NOT NULL | DSL range string, e.g., `(,0),[0,)`, `[1.0,2.0)` |
 | `overridden_attribute` | VARCHAR(50) | nullable | NULL for BASE/RANGE_PRESENCE; non-NULL for SCALAR_OVERRIDE/MARKER |
 | `row_type` | VARCHAR(32) | NOT NULL | `BASE` / `SCALAR_OVERRIDE` / `MARKER` / `RANGE_PRESENCE` — source-of-truth row classifier |
-| `is_synthetic_base` | BOOLEAN | NOT NULL DEFAULT false | true only on base rows synthesised from Defaults.groovy |
+| `is_synthetic_base` | BOOLEAN | NOT NULL DEFAULT false | structural flag: no all-versions block + ≥2 ranges (see §3.1); base may still carry real merged values |
 | Build aspect | | | |
 | `build_system` | VARCHAR(50) | | MAVEN/GRADLE/ESCROW_PROVIDED_MANUALLY/PROVIDED/etc. |
 | `build_system_version` | VARCHAR(50) | | |
@@ -385,7 +390,7 @@ string builder — no GroovyShell). `ComponentCodeRenderer` walks the entity:
 
 | Mode | Source | Shape |
 |---|---|---|
-| **FULL** (no `version`) | `ComponentEntity` + its `configurations` rows | Delta-style: top-level block (per-component fields + BASE-row aspects) + one `"<range>" { … }` block per distinct override range. Reuses the §3 row taxonomy — SCALAR_OVERRIDE rows become `field = value` (or `field = null` for the import-only null-clear, §3.2), MARKER rows become the replaced child block. RANGE_PRESENCE-only ranges (§3.4) and the synthetic-base row aspects (§3.4, when overrides exist) are suppressed. |
+| **FULL** (no `version`) | `ComponentEntity` + its `configurations` rows | Delta-style: top-level block (per-component fields + BASE-row aspects) + one `"<range>" { … }` block per distinct override range. Reuses the §3 row taxonomy — SCALAR_OVERRIDE rows become `field = value` (or `field = null` for the import-only null-clear, §3.2), MARKER rows become the replaced child block. RANGE_PRESENCE-only ranges (§3.4) are skipped. The BASE row's aspects are **always rendered** — even for a synthetic base (§3.1, §6.4) they hold the values the loader merged from the component's top-level fields and are the resolver's fallback for every version, so they belong at the top level, NOT hidden behind the overriding ranges. |
 | **RESOLVED** (`?version=X`) | merged single view | Reuses the §3.5 resolve primitives (`ComponentConfigurationView.applyScalarOverride` for scalars, marker-pick for child collections) — values match the v2 version-resolution endpoints. Single block, no range sub-blocks. **Difference vs the v2 resolver:** distribution `$version` substitution (§6.8, a runtime concern) is intentionally not applied, so distribution patterns render as the stored templates — consistent with the FULL view. |
 
 Null-clear (§3.2) is preserved in FULL: a SCALAR_OVERRIDE row is rendered by *presence* of the
@@ -458,9 +463,14 @@ Grouping is keyed off the loader's `EscrowConfiguration.aggregatorSubComponents`
 
 ### 6.4 Base row determination
 
-For each component:
-- If DSL has any top-level fields (vcsUrl, jira, build, escrow, distribution, etc.) → base row from those values, `is_synthetic_base = false`.
-- If DSL has only version-range blocks (no top-level fields) → base row populated purely from `Defaults.groovy` resolved values, `is_synthetic_base = true`.
+For each component, the base config is the `(,0),[0,)` (ALL_VERSIONS) config if the loader emitted
+one, else `configs.first()`. The base row always carries that config's resolved values (top-level
+DSL fields merged in by the loader, plus `Defaults.groovy`).
+
+`is_synthetic_base` is then set **structurally**: `true` when there is no ALL_VERSIONS config AND
+`configs.size > 1` (i.e. the DSL declared only version-range blocks, with no explicit all-versions
+block). Note this fires even when the component HAS top-level fields — those get merged onto the
+first range, which becomes the base — so a synthetic base is not necessarily Defaults-only (see §3.1).
 
 ### 6.5 Override row generation
 


### PR DESCRIPTION
## Bug

In the as-code FULL view (PR #319), the BASE configuration row's aspects (`vcsSettings`, `build`, `jira.projectKey`/`releaseVersionFormat`, `escrow`, `distribution.maven`) were **suppressed** whenever `base.isSyntheticBase && overrides.isNotEmpty()`. So for affected components, `vcsSettings`/`vcsUrl` appeared **only in the last version range** even though those settings apply to earlier versions too.

## Root cause

The Groovy loader merges a component's top-level fields into every version-range config. When there is no explicit all-versions block and ≥2 ranges, the import (`ImportServiceImpl:996-999`) sets `isSyntheticBase = true` — **even though the base row carries the real shared values** (top-level `vcsUrl`/`tag`/`jira`/`build`/`distribution`). The renderer treated `isSyntheticBase` as "base is an ignorable placeholder" and blanked those aspects. The resolver, by contrast, starts from the base row for **every** version — so the base is the genuine fallback and must be shown.

The suppression was copied from the MIG-029 rule, which is about not emitting a spurious all-versions *variant* in the v1‑v3 variants map (`EntityMappers.toEscrowModule` — a different code path, unchanged here).

## Fix

`ComponentCodeRenderer.renderFull` now **always** renders the BASE row's aspects. Per-range blocks remain delta-only, so no duplication. `renderResolved` is untouched. The base aspects now render at the top level, with later ranges carrying only their deltas — matching the original DSL semantics.

## TDD

- `test:` commit — flips `fullSyntheticBaseSuppression` → `fullSyntheticBaseRendersBaseAspects` and adds `fullSyntheticBaseVcsRendersAtTopLevel` (base VCS must render before the overriding range block). Both **RED** against the old renderer.
- `fix:` commit — the renderer change; both **GREEN**.

## Validation

Full `:components-registry-service-server:test` suite + JaCoCo coverage gate green locally; renderer golden/structural tests green. Independent review: ship. Docs `schema-spec.md` §3.1/§5.2/§6.4 + column note corrected — `is_synthetic_base` is a structural flag, not 'Defaults-only'; the base still carries real merged values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)