### PR TITLE
feat(compat): [1.7]/[1.8] replay 30k trace slice + full business-endpoint coverage (closes #324)

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -747,6 +747,19 @@ object id17CompatLocalStandManual : BuildType({
                 fi
                 export COMPAT_BODIES_FILE="${'$'}BODIES_FILE_PATH"
                 echo "Bodies file:     ${'$'}BODIES_FILE_PATH"
+                # Deduplicated production trace (latest-top.txt) replayed by
+                # TraceReplayCompatTest. [1.7]/[1.8] are the AUTO gate, so cap the
+                # replay at the top-30000 most-frequent business tuples (the file is
+                # ranked desc; id16 replays it unlimited). Fail-FAST on a missing file,
+                # same rationale as the bodies sidecar above.
+                TRACE_FILE_PATH="${'$'}TRACE_DATA_DIR/latest-top.txt"
+                if [ ! -f "${'$'}TRACE_FILE_PATH" ]; then
+                    echo "ERROR: trace file ${'$'}TRACE_FILE_PATH does not exist (CrsCompatTrace checkout failed or top-N trace missing)" >&2
+                    exit 2
+                fi
+                export COMPAT_TRACE_FILE="${'$'}TRACE_FILE_PATH"
+                export COMPAT_TRACE_LIMIT=30000
+                echo "Trace file:      ${'$'}TRACE_FILE_PATH (limit 30000)"
                 # Route the postgres pull through the artifactory mirror so
                 # id17 doesn't hit Docker Hub's anonymous-pull rate limit
                 # (#3636 failed mid-Stage-1 with `toomanyrequests`). The
@@ -998,6 +1011,19 @@ object id18CompatLocalStandGitModeAuto : BuildType({
                 fi
                 export COMPAT_BODIES_FILE="${'$'}BODIES_FILE_PATH"
                 echo "Bodies file:     ${'$'}BODIES_FILE_PATH"
+                # Deduplicated production trace (latest-top.txt) replayed by
+                # TraceReplayCompatTest. [1.7]/[1.8] are the AUTO gate, so cap the
+                # replay at the top-30000 most-frequent business tuples (the file is
+                # ranked desc; id16 replays it unlimited). Fail-FAST on a missing file,
+                # same rationale as the bodies sidecar above.
+                TRACE_FILE_PATH="${'$'}TRACE_DATA_DIR/latest-top.txt"
+                if [ ! -f "${'$'}TRACE_FILE_PATH" ]; then
+                    echo "ERROR: trace file ${'$'}TRACE_FILE_PATH does not exist (CrsCompatTrace checkout failed or top-N trace missing)" >&2
+                    exit 2
+                fi
+                export COMPAT_TRACE_FILE="${'$'}TRACE_FILE_PATH"
+                export COMPAT_TRACE_LIMIT=30000
+                echo "Trace file:      ${'$'}TRACE_FILE_PATH (limit 30000)"
                 # git-mode (no-db, issue #310) does NOT start Postgres, so no POSTGRES_IMAGE
                 # pull is needed. RESET_DB=1 only drives teamcity-run.sh's pre-run teardown
                 # of any stale Postgres left by a prior db-mode run on this (persistent) agent.

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -157,6 +157,7 @@ test {
      'compat.max-components',
      'compat.smoke-components',
      'compat.trace.file',
+     'compat.trace.limit',
      'compat.bodies.file',
      'compat.verbose',
      'compat.allow-non-db-candidate',

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComponentsListV1CompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComponentsListV1CompatTest.kt
@@ -1,0 +1,87 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.octopusden.octopus.components.registry.core.dto.ComponentV1
+import org.octopusden.octopus.components.registry.core.dto.ComponentsDTO
+import java.util.stream.Stream
+
+/**
+ * v1 components surface (BaseComponentController / ComponentControllerV1):
+ *   GET /rest/api/1/components             → [ComponentsDTO]<[ComponentV1]>
+ *   GET /rest/api/1/components/{component}  → [ComponentV1]
+ *
+ * Closes part of #324: only the v2/v3 list/detail had dedicated tests, and the
+ * bare v1 list had zero production-trace hits, so the v1 surface was exercised by
+ * nothing. v1 is structurally inherited from BaseComponentController but serialises
+ * the v1 DTO shape, so a migration regression there is otherwise invisible.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ComponentsListV1CompatTest : CompatibilityTestBase() {
+
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    fun `GET v1 components list must match`() {
+        val endpoint = "GET /rest/api/1/components"
+        val params = emptyMap<String, String>()
+        val (baseline, candidate) = fetchPair("/rest/api/1/components")
+        val before = DiffCollector.count()
+        compareRaw(endpoint, params, baseline, candidate)
+        if (baseline.status in 200..299 && candidate.status in 200..299) {
+            val baselineDto = runCatching { mapper.readValue<ComponentsDTO<ComponentV1>>(baseline.bodyBytes) }.getOrNull()
+            val candidateDto = runCatching { mapper.readValue<ComponentsDTO<ComponentV1>>(candidate.bodyBytes) }.getOrNull()
+            compareDto(endpoint, params, baselineDto, candidateDto)
+        }
+        val after = DiffCollector.count()
+        logExecution(
+            endpoint = endpoint,
+            pathParams = params,
+            baseline = baseline,
+            candidate = candidate,
+            layer = "raw+typed",
+            diffsBefore = before,
+            diffsAfter = after,
+        )
+    }
+
+    @ParameterizedTest(name = "GET /rest/api/1/components/{0}")
+    @MethodSource("smokeComponentArgs")
+    fun `GET v1 component detail must match`(componentName: String) {
+        skipIfNoSmokeConfig(componentName)
+        val endpoint = "GET /rest/api/1/components/{component}"
+        val params = mapOf("component" to componentName)
+        val (baseline, candidate) = fetchPair("/rest/api/1/components/$componentName")
+        val before = DiffCollector.count()
+        compareRaw(endpoint, params, baseline, candidate)
+        if (baseline.status in 200..299 && candidate.status in 200..299) {
+            val baselineDto = runCatching { mapper.readValue<ComponentV1>(baseline.bodyBytes) }.getOrNull()
+            val candidateDto = runCatching { mapper.readValue<ComponentV1>(candidate.bodyBytes) }.getOrNull()
+            compareDto(endpoint, params, baselineDto, candidateDto)
+        }
+        val after = DiffCollector.count()
+        logExecution(
+            endpoint = endpoint,
+            pathParams = params,
+            baseline = baseline,
+            candidate = candidate,
+            layer = "raw+typed",
+            diffsBefore = before,
+            diffsAfter = after,
+        )
+    }
+
+    @AfterAll
+    fun closeStreams() {
+        DiffCollector.close()
+        ExecutionLogger.close()
+    }
+
+    private fun smokeComponentArgs(): Stream<Arguments> = singleArgsOrSentinel(smokeComponents())
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CopyrightCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CopyrightCompatTest.kt
@@ -1,0 +1,88 @@
+package org.octopusden.octopus.components.registry.compat
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+/**
+ * GET /rest/api/3/components/{component}/copyright  (v3-only; binary octet-stream)
+ * → `ResponseEntity<Resource>`, `Content-Disposition: attachment; filename=COPYRIGHT`
+ * (`ComponentControllerV3.getCopyrightByComponent`).
+ *
+ * Closes part of #324: copyright has zero production-trace hits, so neither the
+ * trace replay nor any other suite exercised it. Here it is exercised, but:
+ *
+ *  - the body is compared by **bytes**, not parsed (it is not JSON, so the raw
+ *    layer's JSON-shape stage is a no-op — see `compareRaw`); and
+ *  - on a mismatch ONLY the byte LENGTHS are recorded, never the content.
+ *    COPYRIGHT files are licensee-identifying and must not leak into the
+ *    (potentially public) compat report or CI logs.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CopyrightCompatTest : CompatibilityTestBase() {
+
+    @ParameterizedTest(name = "GET /rest/api/3/components/{0}/copyright")
+    @MethodSource("smokeComponentArgs")
+    fun `GET v3 copyright must match per component (binary, content-redacted)`(componentName: String) {
+        skipIfNoSmokeConfig(componentName)
+        val endpoint = "GET /rest/api/3/components/{component}/copyright"
+        val params = mapOf("component" to componentName)
+        val (baseline, candidate) = fetchPair("/rest/api/3/components/$componentName/copyright")
+
+        val before = DiffCollector.count()
+        // Status + the two binary-relevant headers: Content-Type must stay
+        // application/octet-stream, Content-Disposition must keep the attachment
+        // filename. compareRaw does NOT compare the body here (both sides are
+        // non-JSON, so its JSON-shape stage is a no-op) — hence the byte compare below.
+        compareRaw(
+            endpoint = endpoint,
+            pathParams = params,
+            baseline = baseline,
+            candidate = candidate,
+            headerAllowList = setOf("Content-Type", "Content-Disposition"),
+        )
+
+        // Byte-level body parity, only when BOTH stands served the file (2xx).
+        // A status divergence (e.g. one 200 / one 404) is already recorded by compareRaw.
+        if (baseline.status in 200..299 &&
+            candidate.status in 200..299 &&
+            !baseline.bodyBytes.contentEquals(candidate.bodyBytes)
+        ) {
+            DiffCollector.record(
+                DiffRecord(
+                    ts = java.time.Instant.now().toString(),
+                    endpoint = endpoint,
+                    pathParams = params,
+                    category = DiffClassifier.VALUE_DIFF,
+                    layer = "raw-binary",
+                    // Lengths ONLY — never the bytes (licensee-identifying).
+                    baselineValue = "${baseline.bodyBytes.size} bytes",
+                    candidateValue = "${candidate.bodyBytes.size} bytes",
+                    message = "copyright payload bytes differ (content redacted)",
+                ),
+            )
+        }
+
+        val after = DiffCollector.count()
+        logExecution(
+            endpoint = endpoint,
+            pathParams = params,
+            baseline = baseline,
+            candidate = candidate,
+            layer = "raw-binary",
+            diffsBefore = before,
+            diffsAfter = after,
+        )
+    }
+
+    @AfterAll
+    fun closeStreams() {
+        DiffCollector.close()
+        ExecutionLogger.close()
+    }
+
+    private fun smokeComponentArgs(): Stream<Arguments> = singleArgsOrSentinel(smokeComponents())
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DistributionCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DistributionCompatTest.kt
@@ -1,0 +1,106 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.octopusden.octopus.components.registry.core.dto.DistributionDTO
+import java.util.stream.Stream
+
+/**
+ * Component-level distribution endpoints (declared on BaseComponentController,
+ * inherited by v1 + v2), plus the v2 per-version variant:
+ *   GET /rest/api/1/components/{component}/distribution
+ *   GET /rest/api/2/components/{component}/distribution
+ *   GET /rest/api/2/components/{component}/versions/{version}/distribution
+ * → [DistributionDTO]
+ *
+ * Closes part of #324: the component-level distribution has zero production-trace
+ * hits and — unlike the `/projects/{p}/.../distribution` variant — had no dedicated
+ * test until now.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DistributionCompatTest : CompatibilityTestBase() {
+
+    private val mapper = jacksonObjectMapper()
+
+    @ParameterizedTest(name = "GET /rest/api/1/components/{0}/distribution")
+    @MethodSource("smokeComponentArgs")
+    fun `GET v1 component distribution must match`(componentName: String) {
+        skipIfNoSmokeConfig(componentName)
+        runDistribution(
+            endpoint = "GET /rest/api/1/components/{component}/distribution",
+            path = "/rest/api/1/components/$componentName/distribution",
+            params = mapOf("component" to componentName),
+        )
+    }
+
+    @ParameterizedTest(name = "GET /rest/api/2/components/{0}/distribution")
+    @MethodSource("smokeComponentArgs")
+    fun `GET v2 component distribution must match`(componentName: String) {
+        skipIfNoSmokeConfig(componentName)
+        runDistribution(
+            endpoint = "GET /rest/api/2/components/{component}/distribution",
+            path = "/rest/api/2/components/$componentName/distribution",
+            params = mapOf("component" to componentName),
+        )
+    }
+
+    @ParameterizedTest(name = "GET /rest/api/2/components/{0}/versions/{1}/distribution")
+    @MethodSource("componentVersionPairs")
+    fun `GET v2 per-version distribution must match`(componentName: String, version: String) {
+        skipIfNoSmokeConfig(componentName, version)
+        runDistribution(
+            endpoint = "GET /rest/api/2/components/{component}/versions/{version}/distribution",
+            path = "/rest/api/2/components/$componentName/versions/$version/distribution",
+            params = mapOf("component" to componentName, "version" to version),
+        )
+    }
+
+    private fun runDistribution(endpoint: String, path: String, params: Map<String, String>) {
+        val (baseline, candidate) = fetchPair(path)
+        val before = DiffCollector.count()
+        compareRaw(endpoint, params, baseline, candidate)
+        if (baseline.status in 200..299 && candidate.status in 200..299) {
+            val baselineDto = runCatching { mapper.readValue<DistributionDTO>(baseline.bodyBytes) }.getOrNull()
+            val candidateDto = runCatching { mapper.readValue<DistributionDTO>(candidate.bodyBytes) }.getOrNull()
+            compareDto(endpoint, params, baselineDto, candidateDto)
+        }
+        val after = DiffCollector.count()
+        logExecution(
+            endpoint = endpoint,
+            pathParams = params,
+            baseline = baseline,
+            candidate = candidate,
+            layer = "raw+typed",
+            diffsBefore = before,
+            diffsAfter = after,
+        )
+    }
+
+    @AfterAll
+    fun closeStreams() {
+        DiffCollector.close()
+        ExecutionLogger.close()
+    }
+
+    private fun smokeComponentArgs(): Stream<Arguments> = singleArgsOrSentinel(smokeComponents())
+
+    private fun componentVersionPairs(): Stream<Arguments> {
+        val limit = if (config.full) 5 else 1
+        val pairs =
+            smokeComponents().flatMap { c ->
+                val versions = VersionSampler.versionsFor(c, limit = limit)
+                if (versions.isEmpty()) {
+                    log.warn("No real release versions for {} from RMS — skipping versioned distribution tests", c)
+                    emptyList()
+                } else {
+                    versions.map { v -> c to v }
+                }
+            }
+        return pairArgsOrSentinel(pairs)
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
@@ -72,13 +72,12 @@ internal fun endpointTemplate(method: String, rawPath: String): String {
  */
 internal fun <T> ensureEndpointCoverage(capped: List<T>, all: List<T>, keyOf: (T) -> String): List<T> {
     if (capped.size >= all.size) return capped
-    val cappedKeys = capped.mapTo(HashSet(), keyOf)
-    val reps =
-        all.asSequence()
-            .filterNot { keyOf(it) in cappedKeys }
-            .groupBy(keyOf)
-            .values
-            .map { it.first() }
+    // Seed with the capped keys; `seen.add` is true only on the FIRST occurrence of a
+    // not-yet-covered key. `all` is rank-ordered (desc count), so that first occurrence is
+    // the busiest representative. Single pass, `keyOf` evaluated once per element, original
+    // order preserved — no intermediate per-key lists.
+    val seen = capped.mapTo(HashSet(), keyOf)
+    val reps = all.filter { seen.add(keyOf(it)) }
     return if (reps.isEmpty()) capped else capped + reps
 }
 
@@ -320,9 +319,10 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
         // Guarantee every business endpoint PRESENT IN THE TRACE is replayed, even if the
         // frequency cap ranked it below the cut — adds the busiest representative of each
         // such endpoint template on top of the cap. NOTE: endpoints with ZERO hits in the
-        // capture window are not in `entries`, so this cannot synthesise them; they rely on
-        // a dedicated *CompatTest (see TD-008 "Replay tiers & endpoint coverage" for the
-        // currently-uncovered ones: copyright, component-level distribution, the v1 list).
+        // capture window are not in `entries`, so this cannot synthesise them; they are
+        // covered by dedicated *CompatTest classes that run in the same [1.7]/[1.8] task
+        // (copyright -> CopyrightCompatTest, component distribution -> DistributionCompatTest,
+        // v1 list -> ComponentsListV1CompatTest; see TD-008 "Replay tiers & endpoint coverage").
         val replaySet = ensureEndpointCoverage(capped, entries) { endpointTemplate(it.method, it.path) }
         val coverageAdded = replaySet.size - capped.size
 

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayCompatTest.kt
@@ -13,6 +13,76 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
+ * Parses the optional trace-replay cap (`compat.trace.limit` / `COMPAT_TRACE_LIMIT`).
+ * Returns null (= no cap) for null/blank/non-numeric/non-positive input, so a
+ * misconfigured value fails OPEN to the full trace rather than silently replaying
+ * zero tuples. Extracted for unit testing (see TraceReplayParsingTest).
+ */
+internal fun parseTraceLimit(raw: String?): Int? = raw?.trim()?.toIntOrNull()?.takeIf { it > 0 }
+
+/**
+ * Applies [limit] to an already rank-ordered [entries] list. The trace file is
+ * sorted by descending count, so `take(limit)` yields the N highest-traffic tuples
+ * (the [1.7]/[1.8] auto gate caps at 30k). A null limit, or one >= the list size,
+ * returns the list unchanged (full replay — e.g. the id16 manual tier).
+ */
+internal fun <T> applyTraceLimit(entries: List<T>, limit: Int?): List<T> =
+    if (limit != null && entries.size > limit) entries.take(limit) else entries
+
+/**
+ * True when the segment after `/components/` is an ACTION, not a component id, and
+ * so must NOT be collapsed to `{component}`. The v1/v2/v3 actions are
+ * `find-by-artifact`, `find-by-artifacts`, `find-by-docker-images` (kebab) and the
+ * legacy camelCase `findByArtifacts` (v2) — all share the `find` prefix, and no real
+ * component id starts with `find`. A prefix test (vs. a hard-coded set) is
+ * staleness-proof: a future `find*` action can't silently collapse into a phantom
+ * `{component}` key the way a missing set entry would.
+ */
+private fun isComponentsAction(segment: String): Boolean = segment.startsWith("find")
+
+/**
+ * Collapses the dynamic id/version/project segments of a request path to a stable
+ * endpoint key (`"METHOD /rest/api/2/components/{component}/vcs-settings"`), so two
+ * concrete requests to the same endpoint share a key. The segment after
+ * `components` becomes `{component}` UNLESS it is a known static action
+ * (`find-by-artifacts`, …); after `projects` → `{project}`; after `versions` →
+ * `{version}`. Query string is dropped. Used to guarantee endpoint coverage of the
+ * capped replay slice (see [ensureEndpointCoverage]).
+ */
+internal fun endpointTemplate(method: String, rawPath: String): String {
+    val segs = rawPath.substringBefore('?').split('/').toMutableList()
+    for (i in 1 until segs.size) {
+        if (segs[i].isEmpty()) continue
+        when (segs[i - 1]) {
+            "components" -> if (!isComponentsAction(segs[i])) segs[i] = "{component}"
+            "projects" -> segs[i] = "{project}"
+            "versions" -> segs[i] = "{version}"
+        }
+    }
+    return "$method ${segs.joinToString("/")}"
+}
+
+/**
+ * Guarantees that every endpoint [keyOf] present in [all] is represented in the
+ * returned list, even when the frequency [capped] slice dropped it. For each key
+ * missing from [capped], the FIRST occurrence in [all] is appended — [all] is
+ * rank-ordered (desc count), so that is the busiest representative. This keeps the
+ * [1.7]/[1.8] auto gate exercising all business endpoints, not only high-traffic
+ * ones, while adding only a handful of low-frequency tuples on top of the cap.
+ */
+internal fun <T> ensureEndpointCoverage(capped: List<T>, all: List<T>, keyOf: (T) -> String): List<T> {
+    if (capped.size >= all.size) return capped
+    val cappedKeys = capped.mapTo(HashSet(), keyOf)
+    val reps =
+        all.asSequence()
+            .filterNot { keyOf(it) in cappedKeys }
+            .groupBy(keyOf)
+            .values
+            .map { it.first() }
+    return if (reps.isEmpty()) capped else capped + reps
+}
+
+/**
  * Production-trace replay (TD-008 implementation).
  *
  * Reads a deduplicated trace file (`<count>\t<METHOD>\t<path>` per line) from
@@ -240,10 +310,29 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
                 }
         assumeTrue(entries.isNotEmpty(), "trace file is empty: $traceFilePath")
 
+        // Optional cap for the auto gate: [1.7]/[1.8] replay the top-N most-frequent
+        // tuples (compat.trace.limit / COMPAT_TRACE_LIMIT); id16 replays the full file
+        // unlimited. The trace is ranked by descending count, so take(N) is the N
+        // highest-traffic business tuples. A non-positive / unparseable value = no cap.
+        val traceLimit =
+            parseTraceLimit(System.getProperty("compat.trace.limit") ?: System.getenv("COMPAT_TRACE_LIMIT"))
+        val capped = applyTraceLimit(entries, traceLimit)
+        // Guarantee every business endpoint PRESENT IN THE TRACE is replayed, even if the
+        // frequency cap ranked it below the cut — adds the busiest representative of each
+        // such endpoint template on top of the cap. NOTE: endpoints with ZERO hits in the
+        // capture window are not in `entries`, so this cannot synthesise them; they rely on
+        // a dedicated *CompatTest (see TD-008 "Replay tiers & endpoint coverage" for the
+        // currently-uncovered ones: copyright, component-level distribution, the v1 list).
+        val replaySet = ensureEndpointCoverage(capped, entries) { endpointTemplate(it.method, it.path) }
+        val coverageAdded = replaySet.size - capped.size
+
         log.info(
-            "replaying ${entries.size} unique (method, path) tuples from $traceFilePath " +
+            "replaying ${replaySet.size} unique (method, path) tuples from $traceFilePath " +
                 "(parallelism=${config.parallelism}, " +
-                "dropped $droppedDiagnostic diagnostic-surface tuples)",
+                "dropped $droppedDiagnostic diagnostic-surface tuples" +
+                (if (capped.size < entries.size) ", capped from ${entries.size} via compat.trace.limit=$traceLimit" else "") +
+                (if (coverageAdded > 0) ", +$coverageAdded endpoint-coverage tuples" else "") +
+                ")",
         )
 
         // Discover request-body fixtures once, before the parallel replay starts.
@@ -328,7 +417,7 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
 
         try {
             val futures =
-                entries.map { entry ->
+                replaySet.map { entry ->
                     pool.submit {
                         // ThreadLocal count — `snapshot().size` is the global queue and
                         // races with other workers between read points. count() is
@@ -387,7 +476,7 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
                         if (newDiffs > 0) withDiffs.incrementAndGet()
                         if (n % 100 == 0) {
                             log.info(
-                                "trace-replay progress: $n / ${entries.size} " +
+                                "trace-replay progress: $n / ${replaySet.size} " +
                                     "(${withDiffs.get()} tuples with diffs, ${hungEntries.size} hung)",
                             )
                         }
@@ -441,7 +530,7 @@ class TraceReplayCompatTest : CompatibilityTestBase() {
         // test-results XML). For a richer report, see `CompatibilityReporter` —
         // this in-test print is a stop-gap until that task is extended.
         val topN = weightByBucket.entries.sortedByDescending { it.value }.take(20)
-        val totalTuples = entries.size
+        val totalTuples = replaySet.size
         val totalWithDiffs = withDiffs.get()
         log.info(
             "trace-replay done: $totalTuples tuples replayed, " +

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayParsingTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/TraceReplayParsingTest.kt
@@ -101,4 +101,92 @@ class TraceReplayParsingTest {
         assertThat(endpoint).doesNotContain("?")
         assertThat(endpoint).isEqualTo("GET /rest/api/2/components")
     }
+
+    // --- trace-replay cap + endpoint-coverage (compat.trace.limit, [1.7]/[1.8] 30k gate) ---
+
+    @Test
+    @DisplayName("parseTraceLimit: positive parses; null/blank/zero/negative/garbage => null (fail-open to full)")
+    fun parseTraceLimitCases() {
+        assertThat(parseTraceLimit("30000")).isEqualTo(30000)
+        assertThat(parseTraceLimit("  30000 ")).isEqualTo(30000)
+        assertThat(parseTraceLimit(null)).isNull()
+        assertThat(parseTraceLimit("")).isNull()
+        assertThat(parseTraceLimit("0")).isNull()
+        assertThat(parseTraceLimit("-5")).isNull()
+        assertThat(parseTraceLimit("abc")).isNull()
+    }
+
+    @Test
+    @DisplayName("applyTraceLimit: caps to the top-N (rank-ordered input); null / >= size => unchanged")
+    fun applyTraceLimitCases() {
+        val list = listOf("a", "b", "c", "d", "e")
+        assertThat(applyTraceLimit(list, 3)).containsExactly("a", "b", "c")
+        assertThat(applyTraceLimit(list, null)).isEqualTo(list)
+        assertThat(applyTraceLimit(list, 5)).isEqualTo(list)
+        assertThat(applyTraceLimit(list, 99)).isEqualTo(list)
+    }
+
+    @Test
+    @DisplayName("endpointTemplate: collapses {component}/{version}/{project} but preserves static find-by-* actions")
+    fun endpointTemplateCases() {
+        assertThat(endpointTemplate("GET", "/rest/api/2/components/foo-bar/vcs-settings"))
+            .isEqualTo("GET /rest/api/2/components/{component}/vcs-settings")
+        assertThat(endpointTemplate("GET", "/rest/api/2/components/foo/versions/1.2.3"))
+            .isEqualTo("GET /rest/api/2/components/{component}/versions/{version}")
+        assertThat(endpointTemplate("GET", "/rest/api/2/projects/PRJ/jira-components"))
+            .isEqualTo("GET /rest/api/2/projects/{project}/jira-components")
+        // static actions after /components/ must NOT collapse to {component}
+        assertThat(endpointTemplate("POST", "/rest/api/3/components/find-by-artifacts"))
+            .isEqualTo("POST /rest/api/3/components/find-by-artifacts")
+        assertThat(endpointTemplate("POST", "/rest/api/2/components/find-by-artifact"))
+            .isEqualTo("POST /rest/api/2/components/find-by-artifact")
+        assertThat(endpointTemplate("POST", "/rest/api/3/components/find-by-docker-images"))
+            .isEqualTo("POST /rest/api/3/components/find-by-docker-images")
+        // legacy camelCase v2 action must ALSO be preserved (regression guard: a
+        // hard-coded kebab-only set silently collapsed this to POST .../components/{component})
+        assertThat(endpointTemplate("POST", "/rest/api/2/components/findByArtifacts"))
+            .isEqualTo("POST /rest/api/2/components/findByArtifacts")
+        // query dropped; list endpoint unchanged
+        assertThat(endpointTemplate("GET", "/rest/api/2/components?vcs-path=x"))
+            .isEqualTo("GET /rest/api/2/components")
+        assertThat(endpointTemplate("GET", "/rest/api/3/components"))
+            .isEqualTo("GET /rest/api/3/components")
+    }
+
+    @Test
+    @DisplayName("ensureEndpointCoverage: re-adds the busiest rep of an endpoint the frequency cap dropped")
+    fun ensureEndpointCoverageReAddsMissing() {
+        // `all` is rank-ordered desc: two GETs on the SAME endpoint fill the cap,
+        // one low-traffic OTHER endpoint (build-tools) sits just below it.
+        val all =
+            listOf(
+                "GET" to "/rest/api/2/components/a/vcs-settings",
+                "GET" to "/rest/api/2/components/b/vcs-settings",
+                "GET" to "/rest/api/3/components/c/build-tools",
+            )
+        val key = { e: Pair<String, String> -> endpointTemplate(e.first, e.second) }
+        val capped = all.take(2)
+        // RED: the frequency cap alone drops the build-tools endpoint
+        assertThat(capped.map(key).toSet()).doesNotContain("GET /rest/api/3/components/{component}/build-tools")
+        // GREEN: coverage union re-adds its busiest representative, on top of the cap
+        val covered = ensureEndpointCoverage(capped, all, key)
+        assertThat(covered.map(key).toSet()).contains(
+            "GET /rest/api/2/components/{component}/vcs-settings",
+            "GET /rest/api/3/components/{component}/build-tools",
+        )
+        assertThat(covered).hasSize(3)
+        assertThat(covered.subList(0, 2)).isEqualTo(capped)
+    }
+
+    @Test
+    @DisplayName("ensureEndpointCoverage: no-op when the cap already covers every endpoint")
+    fun ensureEndpointCoverageNoop() {
+        val all =
+            listOf(
+                "GET" to "/rest/api/2/components/a/vcs-settings",
+                "GET" to "/rest/api/3/components/c/build-tools",
+            )
+        val key = { e: Pair<String, String> -> endpointTemplate(e.first, e.second) }
+        assertThat(ensureEndpointCoverage(all, all, key)).isEqualTo(all)
+    }
 }

--- a/docs/registry/tech-debt/008-compat-test-trace-replay.md
+++ b/docs/registry/tech-debt/008-compat-test-trace-replay.md
@@ -139,12 +139,19 @@ to fix or waiver via `known-deltas.json`).
   window**. Unit-tested in `TraceReplayParsingTest` (`parseTraceLimit` /
   `applyTraceLimit` / `endpointTemplate` / `ensureEndpointCoverage`).
 - **Zero-hit endpoints are NOT in scope of trace replay** (they are absent from the
-  trace, so nothing can synthesise them here). They are covered ONLY where a dedicated
-  `*CompatTest` exists. The find-by-* POST endpoints are covered by
-  `RealBodyReplayCompatTest`. **Known gap — currently covered by neither trace nor a
-  dedicated test:** `GET /rest/api/3/components/{c}/copyright` (binary; needs a
-  byte-compare test), the component-level `GET /rest/api/{1,2}/components/{c}/distribution`,
-  and the bare `GET /rest/api/1/components` list. Tracked as a follow-up (see Related).
+  trace, so nothing can synthesise them here) — they are covered by dedicated
+  `*CompatTest` classes that run in the same [1.7]/[1.8] `test` task. The find-by-* POST
+  endpoints are covered by `RealBodyReplayCompatTest`; the formerly-uncovered zero-hit
+  endpoints (#324) now have dedicated suites:
+  - `CopyrightCompatTest` — `GET /rest/api/3/components/{c}/copyright` (binary octet-stream;
+    byte-compare with **content redaction** — only byte lengths are recorded on a mismatch,
+    never the licensee-identifying bytes).
+  - `DistributionCompatTest` — component-level `GET /rest/api/{1,2}/components/{c}/distribution`
+    plus the v2 per-version `.../versions/{v}/distribution`.
+  - `ComponentsListV1CompatTest` — `GET /rest/api/1/components` (+ v1 detail).
+
+  Net: every business endpoint is now exercised by the trace slice, the real-body replay,
+  or a dedicated suite.
 
 ## Implementation
 

--- a/docs/registry/tech-debt/008-compat-test-trace-replay.md
+++ b/docs/registry/tech-debt/008-compat-test-trace-replay.md
@@ -117,8 +117,34 @@ to fix or waiver via `known-deltas.json`).
 | Env / -P | Default | Purpose |
 |---|---|---|
 | `COMPAT_TRACE_FILE` / `compat.trace.file` | _(none — must set)_ | Trace dump path |
+| `COMPAT_TRACE_LIMIT` / `compat.trace.limit` | _(none — full file)_ | Replay only the top-N tuples of the (rank-ordered) file. The [1.7]/[1.8] auto gate sets `30000`; id16 leaves it unset (full ~75 k). Non-positive / unparseable ⇒ no cap (fail-open to full). |
 | `COMPAT_TRACE_TOP_N` / `compat.trace.top-n` | `20` | Top-N in the weighted table |
 | `COMPAT_TRACE_PARALLELISM` / `compat.trace.parallelism` | `8` | Concurrent in-flight per stand |
+
+## Replay tiers & endpoint coverage
+
+- **[1.7]/[1.8] auto gate (id17/id18):** `COMPAT_TRACE_LIMIT=30000` — replays the
+  30 000 highest-traffic business tuples on every build, alongside the real-body
+  replay (`RealBodyReplayCompatTest`, ~1.7 k real POST/PUT bodies). Sized so the
+  auto gate reflects realistic prod traffic without an unbounded run.
+- **id16 manual:** no limit — replays the full `latest-top.txt` (~75 k unique now,
+  growing toward 100 k as more capture windows accumulate).
+- **Endpoint-coverage guarantee (trace-present endpoints):** the cap is ranked by
+  hit-count, so a rarely-called business endpoint could fall below it. After capping,
+  `ensureEndpointCoverage` re-adds the busiest representative of every business-endpoint
+  TEMPLATE present in the trace that the cap omitted (`endpointTemplate` collapses
+  `{component}`/`{version}`/`{project}` but preserves `find*` actions —
+  `find-by-artifact[s]`, `find-by-docker-images`, the legacy camelCase `findByArtifacts`).
+  So the 30 k slice always exercises **every business endpoint seen in the capture
+  window**. Unit-tested in `TraceReplayParsingTest` (`parseTraceLimit` /
+  `applyTraceLimit` / `endpointTemplate` / `ensureEndpointCoverage`).
+- **Zero-hit endpoints are NOT in scope of trace replay** (they are absent from the
+  trace, so nothing can synthesise them here). They are covered ONLY where a dedicated
+  `*CompatTest` exists. The find-by-* POST endpoints are covered by
+  `RealBodyReplayCompatTest`. **Known gap — currently covered by neither trace nor a
+  dedicated test:** `GET /rest/api/3/components/{c}/copyright` (binary; needs a
+  byte-compare test), the component-level `GET /rest/api/{1,2}/components/{c}/distribution`,
+  and the bare `GET /rest/api/1/components` list. Tracked as a follow-up (see Related).
 
 ## Implementation
 


### PR DESCRIPTION
## What

Make the **[1.7]/[1.8] AUTO compat gate** (TeamCity id17 db-mode / id18 git-mode) replay a **30,000-request** slice of the production trace on every build, on top of the existing ~1,716 real-body replays — and guarantee **every business endpoint** is exercised. The full `latest-top.txt` (~75k unique tuples now) stays unlimited for the manual id16 tier.

## Changes

- **`TraceReplayCompatTest`** — `compat.trace.limit` / `COMPAT_TRACE_LIMIT` caps the replay to the top-N highest-traffic tuples (`parseTraceLimit` / `applyTraceLimit`; the trace is rank-ordered, so take(N) = the busiest N). After capping, `ensureEndpointCoverage` re-adds the busiest representative of every business-endpoint **template** the cap dropped. `endpointTemplate` collapses `{component}`/`{version}`/`{project}` and preserves `find*` actions (incl. the legacy camelCase `findByArtifacts`).
- **`build.gradle`** — forward `compat.trace.limit`.
- **`.teamcity/settings.kts`** — id17 + id18 export `COMPAT_TRACE_FILE=$TRACE_DATA_DIR/latest-top.txt` + `COMPAT_TRACE_LIMIT=30000` (fail-fast if the trace file is missing). `RealBodyReplayCompatTest` unchanged.
- **Dedicated tests for zero-trace endpoints (closes #324):** `CopyrightCompatTest` (`GET .../copyright` — binary, byte-compare with **content redaction**), `DistributionCompatTest` (component-level v1/v2 + per-version), `ComponentsListV1CompatTest` (v1 list + detail).
- **`TraceReplayParsingTest`** — unit tests for the four helpers (RED→GREEN coverage union; `findByArtifacts` templating regression guard).
- **TD-008 doc** — limit knob, replay tiers, and the (now-closed) endpoint-coverage map.

## Coverage scope

Every business endpoint is now exercised by one of: the **30k trace slice** (frequency-weighted, with the coverage-union backstop for any trace-present endpoint the cap dropped), the **real-body replay** (find-by-* POSTs), or a **dedicated `*CompatTest`** (copyright / component-distribution / v1 list — the three endpoints with zero prod-trace hits, **#324**).

## Verification

- `:components-registry-compat-test:unitTest` green (12 tests); `compileTestKotlin` green for the new suites.
- compat-test module `build` green; `.teamcity` Kotlin DSL `mvn compile` green.
- Two-stage review: Sonnet (correctness, APPROVE) + Opus (adversarial). Findings fixed: `findByArtifacts` templating bug, doc/test over-claims, and (new tests) warn-on-empty version sampling.

## Merge order

Merge the internal `crs-compat-trace` data PR **first** (it makes `latest-top.txt` the full ~75k set); TeamCity reads `latest-top.txt` from that repo's master at runtime. **Note:** this PR targets `v3` (not the default branch), so `#324` won't auto-close on merge — close it manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
