### PR TITLE
fix(compat): collision-free jira-ranges sort key + id17/id18 green-skip on main

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -643,6 +643,17 @@ object id17CompatLocalStandManual : BuildType({
             // so there is no port / Postgres collision between them.
             scriptContent = """
                 set -euo pipefail
+                # Green-skip when the compat-test infra isn't in this checkout. [1.7]/[1.8]
+                # auto-fire on [1.0] success for ANY branch; if a build resolves to `main`
+                # (the legacy V1 trunk) — or a deleted feature branch falls back to the
+                # default branch — `scripts/local-stands/` is absent and the wrapper below
+                # would exit 127. Mirror id15/id16: succeed with a clear status, not a red 127.
+                if [ ! -f scripts/local-stands/teamcity-run.sh ]; then
+                    echo "::: scripts/local-stands/teamcity-run.sh not present in this checkout."
+                    echo "::: [1.7] is only meaningful on v3-family branches that carry the compat-test infra."
+                    echo "##teamcity[buildStatus status='SUCCESS' text='Skipped: compat-test infra absent on this branch (likely main); run from v3 family instead.']"
+                    exit 0
+                fi
                 WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
                 TRACE_DATA_DIR="%teamcity.build.checkoutDir%/trace-data"
 
@@ -936,6 +947,17 @@ object id18CompatLocalStandGitModeAuto : BuildType({
             // Runs on a separate agent from id17 so the shared default ports don't collide.
             scriptContent = """
                 set -euo pipefail
+                # Green-skip when the compat-test infra isn't in this checkout. [1.7]/[1.8]
+                # auto-fire on [1.0] success for ANY branch; if a build resolves to `main`
+                # (the legacy V1 trunk) — or a deleted feature branch falls back to the
+                # default branch — `scripts/local-stands/` is absent and the wrapper below
+                # would exit 127. Mirror id15/id16: succeed with a clear status, not a red 127.
+                if [ ! -f scripts/local-stands/teamcity-run.sh ]; then
+                    echo "::: scripts/local-stands/teamcity-run.sh not present in this checkout."
+                    echo "::: [1.8] is only meaningful on v3-family branches that carry the compat-test infra."
+                    echo "##teamcity[buildStatus status='SUCCESS' text='Skipped: compat-test infra absent on this branch (likely main); run from v3 family instead.']"
+                    exit 0
+                fi
                 WORK_DIR="/tmp/crs-id18-%teamcity.build.id%"
                 TRACE_DATA_DIR="%teamcity.build.checkoutDir%/trace-data"
 

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
@@ -52,12 +52,12 @@ object RawArraySorters {
         // (observed in production: several entries share it but differ in distribution /
         // vcsSettings / component.displayName). A colliding key lets the stable sort keep
         // each stand's arbitrary Set-iteration order → positional misalignment → false
-        // STRUCTURAL_DIFFs. Append a canonical (recursively field-name-sorted) serialization
-        // of the WHOLE element as a tie-breaker: collision-free and deterministic on both
-        // stands. It never masks a real diff — two elements differing in any field get
-        // different keys, so a genuine divergence still surfaces as that element, not as
-        // positional noise.
-        componentName + KEY_SEP + versionRange + KEY_SEP + canonicalJson(node)
+        // STRUCTURAL_DIFFs. Append a canonical (recursively field-name-sorted) KEY STRING of
+        // the WHOLE element as a tie-breaker — collision-free and deterministic on both
+        // stands (it is a stable sort key, NOT a JSON document). It never masks a real diff:
+        // two elements differing in any field get different keys, so a genuine divergence
+        // still surfaces as that element, not as positional noise.
+        componentName + KEY_SEP + versionRange + KEY_SEP + canonicalSortKey(node)
     }
 
     /**
@@ -168,14 +168,15 @@ object RawArraySorters {
     }
 
     /**
-     * Deterministic, field-order-independent serialization of [node]: object field
-     * names are sorted recursively, so two structurally-equal elements that differ
-     * only in JSON field ORDER (Jackson preserves wire order, which can differ between
-     * the two stands) produce the SAME string. Used only as a Set-sort tie-breaker —
-     * inner-array order is left as-is, since a size/content difference inside an element
-     * is a real per-element difference and SHOULD change the key.
+     * Deterministic, field-order-independent KEY STRING for [node]: object field names are
+     * sorted recursively (and quoted), so two structurally-equal elements that differ only
+     * in JSON field ORDER (Jackson preserves wire order, which can differ between the two
+     * stands) produce the SAME string. This is a stable SORT KEY, not a JSON document —
+     * field names are quoted so the concatenation is unambiguous. Used only as a Set-sort
+     * tie-breaker; inner-array order is left as-is, since a size/content difference inside
+     * an element is a real per-element difference and SHOULD change the key.
      */
-    private fun canonicalJson(node: JsonNode): String {
+    private fun canonicalSortKey(node: JsonNode): String {
         val sb = StringBuilder()
         appendCanonical(node, sb)
         return sb.toString()
@@ -189,7 +190,7 @@ object RawArraySorters {
                 node.fieldNames().asSequence().sorted().forEach { name ->
                     if (!first) sb.append(',')
                     first = false
-                    sb.append(name).append(':')
+                    sb.append('"').append(name).append('"').append(':')
                     appendCanonical(node.get(name), sb)
                 }
                 sb.append('}')

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySorters.kt
@@ -48,7 +48,16 @@ object RawArraySorters {
         // JiraComponentDTO with projectKey / displayName / componentInfo — no `id`).
         val componentName = node.path("componentName").asText("")
         val versionRange = node.path("versionRange").asText("")
-        componentName + KEY_SEP + versionRange
+        // (componentName, versionRange) is NOT unique within a project's response
+        // (observed in production: several entries share it but differ in distribution /
+        // vcsSettings / component.displayName). A colliding key lets the stable sort keep
+        // each stand's arbitrary Set-iteration order → positional misalignment → false
+        // STRUCTURAL_DIFFs. Append a canonical (recursively field-name-sorted) serialization
+        // of the WHOLE element as a tie-breaker: collision-free and deterministic on both
+        // stands. It never masks a real diff — two elements differing in any field get
+        // different keys, so a genuine divergence still surfaces as that element, not as
+        // positional noise.
+        componentName + KEY_SEP + versionRange + KEY_SEP + canonicalJson(node)
     }
 
     /**
@@ -156,5 +165,46 @@ object RawArraySorters {
         val out = JsonNodeFactory.instance.arrayNode(sorted.size)
         sorted.forEach { out.add(it) }
         return out
+    }
+
+    /**
+     * Deterministic, field-order-independent serialization of [node]: object field
+     * names are sorted recursively, so two structurally-equal elements that differ
+     * only in JSON field ORDER (Jackson preserves wire order, which can differ between
+     * the two stands) produce the SAME string. Used only as a Set-sort tie-breaker —
+     * inner-array order is left as-is, since a size/content difference inside an element
+     * is a real per-element difference and SHOULD change the key.
+     */
+    private fun canonicalJson(node: JsonNode): String {
+        val sb = StringBuilder()
+        appendCanonical(node, sb)
+        return sb.toString()
+    }
+
+    private fun appendCanonical(node: JsonNode, sb: StringBuilder) {
+        when {
+            node.isObject -> {
+                sb.append('{')
+                var first = true
+                node.fieldNames().asSequence().sorted().forEach { name ->
+                    if (!first) sb.append(',')
+                    first = false
+                    sb.append(name).append(':')
+                    appendCanonical(node.get(name), sb)
+                }
+                sb.append('}')
+            }
+            node.isArray -> {
+                sb.append('[')
+                var first = true
+                node.forEach { child ->
+                    if (!first) sb.append(',')
+                    first = false
+                    appendCanonical(child, sb)
+                }
+                sb.append(']')
+            }
+            else -> sb.append(node.toString())
+        }
     }
 }

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/RawArraySortersTest.kt
@@ -113,6 +113,36 @@ class RawArraySortersTest {
 
     @Test
     @DisplayName(
+        "Set elements sharing (componentName, versionRange) but differing in content still align (canonical tie-breaker)",
+    )
+    fun jiraComponentVersionRanges_collidingPrimaryKey_zeroDiffsAfterSort() {
+        // Real production shape: two entries share componentName+versionRange but differ
+        // in content (here one carries component.displayName, one doesn't). As a multiset
+        // both stands are identical — only the wire order differs. The (name,range) key
+        // alone COLLIDES, so a stable sort preserves each stand's arbitrary input order and
+        // the positional compare reports false displayName KEY_MISSING diffs. The canonical
+        // tie-breaker must make the order deterministic on both sides so they realign.
+        val endpoint = "GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges"
+        val baseline = factory.arrayNode().apply {
+            add(rangeEntry("dup-fixture", "[1.0,)", displayName = "Alpha"))
+            add(rangeEntry("dup-fixture", "[1.0,)"))
+        }
+        val candidate = factory.arrayNode().apply {
+            add(rangeEntry("dup-fixture", "[1.0,)"))
+            add(rangeEntry("dup-fixture", "[1.0,)", displayName = "Alpha"))
+        }
+        val diffs = JsonShape.diff(
+            RawArraySorters.stableSorted(endpoint, baseline),
+            RawArraySorters.stableSorted(endpoint, candidate),
+        )
+        assertTrue(
+            diffs.isEmpty(),
+            "colliding (componentName, versionRange) entries must realign via the canonical tie-breaker; got: $diffs",
+        )
+    }
+
+    @Test
+    @DisplayName(
         "regression guard: heterogeneous-shape entries (one with displayName, one without) " +
             "produce zero diffs ONLY after key-correct sort — no-op or wrong-key sorter would surface KEY_MISSING",
     )


### PR DESCRIPTION
## What

Two fixes for the v3 `[1.7]/[1.8]` compat-gate fallout (builds **3778** = exit 127, **3779** = 50 diffs):

### 1. Collision-free `jira-component-version-ranges` sort key (fixes 44/50 diffs on 3779)
`RawArraySorters` sorts `/projects/{p}/jira-component-version-ranges` (and the `/common/` variant) by `(componentName, versionRange)` — but that pair is **not unique** within a project's response: several entries share it yet differ in `distribution` / `vcsSettings` / `component.displayName`. The colliding key let the stable sort keep each stand's arbitrary Set-iteration order → positional misalignment → **44 false `STRUCTURAL_DIFF`s** (the `displayName`/`externalRegistry`/`versionControlSystemRoots` NULL↔STRING / 1↔0 flips, and the `distribution.GAV` element landing at index 6 on one stand, 8 on the other).

**Fix:** append a **canonical** (recursively field-name-sorted) serialization of the whole element as a tie-breaker → collision-free + deterministic on both stands. It's **non-masking** — a genuine per-element diff still surfaces (the existing anti-regression tests prove real value/size/shape diffs still fire). RED→GREEN unit test added.

### 2. id17/id18 green-skip when the compat infra is absent (fixes the 3778 exit 127)
`[1.7]/[1.8]` auto-fire on `[1.0]` success for any branch. When a build resolves to `main` (no compat infra) — or a **deleted feature branch falls back to the default branch** (exactly what happened to 3778 after #325 merged + the branch was deleted) — `scripts/local-stands/teamcity-run.sh` is absent and the step exited **127**. Now it green-skips with a clear status, mirroring the existing id15/id16 main-absent guard.

## Not included
The remaining **6/50 diffs** are a real status divergence — `GET /rest/api/2/components/{c}/versions/{v}/distribution` returns baseline **404** vs candidate **200** — under separate investigation (over-resolution vs intended). Not a comparator issue.

## Verification
- `:components-registry-compat-test:unitTest` green — new collision test + all anti-regression non-masking guards.
- `.teamcity` `mvn compile` green (DSL).

Targets `v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
