### PR TITLE
ci: TeamCity chain for the fast gate — [1.0]->check + [1.1]/[1.2] (PR2/2)

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -46,6 +46,8 @@ project {
     // unsupported by this server's kotlin-dsl distribution.)
 
     buildType(id10CompileUtAuto)
+    buildType(id11PackagePublishAuto)
+    buildType(id12IntegrationDbTestsAuto)
     buildType(id15CompatManual)
     buildType(id16CompatTraceReplayManual)
     buildType(id17CompatLocalStandManual)
@@ -61,6 +63,8 @@ project {
 
     buildTypesOrder = arrayListOf(
         id10CompileUtAuto,
+        id11PackagePublishAuto,
+        id12IntegrationDbTestsAuto,
         id15CompatManual,
         id16CompatTraceReplayManual,
         id17CompatLocalStandManual,
@@ -146,7 +150,11 @@ object id10CompileUtAuto : BuildType({
             -Pokd.cluster-domain=%OKD_APPS_DOMAIN_DEV%
             -Pokd.project=%OKD_F1_TEST_PROJECT%
         """.trimIndent())
-        param("GRADLE_TASK", "clean build publish dockerPushImage")
+        // Fast gate: compile + unit + H2/MOCK smoke + static quality only. Heavy
+        // DB/Spring/integration tests (@Tag("integration")) are excluded from `check`
+        // and run in [1.2]; packaging (publish + image + fat-jar FT) runs in [1.1].
+        // automation:test is CI-only and runs in [1.2], so exclude it here too.
+        param("GRADLE_TASK", "clean check -x :components-registry-automation:test")
         param("COMPONENTS_REGISTRY_BRANCH", "master")
     }
 
@@ -209,10 +217,8 @@ object id10CompileUtAuto : BuildType({
         xmlReport {
             id = "BUILD_EXT_1815"
             reportType = XmlReport.XmlReportType.JUNIT
-            rules = """
-                +:**/build/test-results/integrationTest/*.xml
-                +:**/build/test-results/test/*.xml
-            """.trimIndent()
+            // [1.0] now runs `check` (unit + smoke only); integrationTest moved to [1.1].
+            rules = "+:**/build/test-results/test/*.xml"
         }
         xmlReport {
             id = "BUILD_EXT_1817"
@@ -223,6 +229,210 @@ object id10CompileUtAuto : BuildType({
 
     requirements {
         doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
+    }
+})
+
+// [1.1] Package & Publish — runs right after the fast [1.0] gate on EVERY id10
+// success. It does the work [1.0] used to do at the end of its step: assemble +
+// publish the Maven artifacts + build & push the Docker image, and runs the fat-jar
+// startup FT (the FT gates publish/push at the Gradle level — see root build.gradle).
+// Inherits id10's PROJECT_VERSION + BUILD_NUMBER (the id40 pattern) so the pushed
+// image keeps id10's build-number tag; downstream image consumers (id17/id18) and the
+// deploy (id30) now take the image/version from THIS build, not id10.
+object id11PackagePublishAuto : BuildType({
+    templates(AbsoluteId("Octopus_OctopusGradleBuild"))
+    id("11PackagePublishAuto")
+    name = "[1.1] Package & Publish [AUTO]"
+
+    buildNumberPattern = "%BUILD_NUMBER%"
+
+    artifactRules = """
+        **/*.log => logs.zip
+        %ARTIFACT_PATH%
+        **/reports
+        **/test-results
+    """.trimIndent()
+
+    params {
+        param("ARTIFACT_PATH", """      **/build/reports/** => reports
+      **/build/test-results/**/*.xml => test-results
+      build/**/logs/** => logs
+      build/**/diagnostics/** => diagnostics""")
+        param("GRADLE_EXTRA_PARAMETERS", """
+            -Pokd.cluster-domain=%OKD_APPS_DOMAIN_DEV%
+            -Pokd.project=%OKD_F1_TEST_PROJECT%
+        """.trimIndent())
+        // automation:test runs HERE (not [1.2]): it deploys the just-pushed image to OKD
+        // via ocCreate (ocCreate dependsOn dockerPushImage), so it must run in the same
+        // invocation that pushes — otherwise it would re-push the image and race [1.1].
+        param("GRADLE_TASK", "clean assemble :components-registry-service-server:integrationTest publish dockerPushImage :components-registry-automation:test")
+        param("COMPONENTS_REGISTRY_BRANCH", "master")
+        // Reuse id10's computed version + build number so the image tag and published
+        // artifact version match id10 and the chain view shows one number throughout.
+        param("PROJECT_VERSION", "${id10CompileUtAuto.depParamRefs["PROJECT_VERSION"]}")
+        param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
+    }
+
+    steps {
+        script {
+            name = "Login to the OKD cluster"
+            id = "Login_to_the_OKD_cluster"
+            scriptContent = """
+                oc login --token=%OKD_F1_FT_TOKEN% %OKD_SERVER_DEV_URL%
+                oc project %OKD_F1_TEST_PROJECT%
+            """.trimIndent()
+            param("org.jfrog.artifactory.selectedDeployableServer.useSpecs", "false")
+            param("org.jfrog.artifactory.selectedDeployableServer.uploadSpecSource", "Job configuration")
+            param("org.jfrog.artifactory.selectedDeployableServer.downloadSpecSource", "Job configuration")
+        }
+        gradle {
+            name = "Gradle Package & Publish"
+            id = "RUNNER_1768"
+            tasks = "%GRADLE_TASK%"
+            workingDir = "%WORK_DIR%"
+            gradleParams = """
+                --info
+                %GRADLE_STANDARD_PARAMETERS%
+                %GRADLE_EXTRA_PARAMETERS%
+            """.trimIndent()
+            enableStacktrace = true
+            jdkHome = "%env.JAVA_HOME%"
+            jvmArgs = "%JDK_CMDLINE_PARAMETERS%"
+            dockerRunParameters = "--userns=keep-id -e JAVA_HOME=/opt/java/openjdk -v %env.BUILD_ENV%:/opt/BUILD_ENV -v %teamcity.build.checkoutDir%:/home/tcagent/work -v %teamcity.agent.jvm.user.home%:/home/tcagent -w /home/tcagent/work -e TZ=Europe/Brussels"
+            param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
+        }
+        stepsOrder = arrayListOf("Login_to_the_OKD_cluster", "RUNNER_1720", "RUNNER_1768")
+    }
+
+    failureConditions {
+        executionTimeoutMin = 240
+    }
+
+    features {
+        xmlReport {
+            id = "BUILD_EXT_1815"
+            reportType = XmlReport.XmlReportType.JUNIT
+            rules = """
+                +:**/build/test-results/integrationTest/*.xml
+                +:components-registry-automation/build/test-results/test/*.xml
+            """.trimIndent()
+        }
+    }
+
+    requirements {
+        doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
+    }
+
+    triggers {
+        finishBuildTrigger {
+            buildType = "${id10CompileUtAuto.id}"
+            successfulOnly = true
+            branchFilter = "+:*"
+        }
+    }
+
+    dependencies {
+        snapshot(id10CompileUtAuto) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
+    }
+})
+
+// [1.2] Integration & DB Tests — runs the heavy @Tag("integration") DB suite (Postgres
+// Testcontainers / full Spring context, across server/client/light-client) in parallel
+// with [1.1] after every id10 success. These are the tests excluded from the fast [1.0]
+// gate; they still gate the deploy via id30's snapshot dependency below. automation:test
+// runs in [1.1], NOT here — it transitively triggers dockerPushImage (see its GRADLE_TASK).
+object id12IntegrationDbTestsAuto : BuildType({
+    templates(AbsoluteId("Octopus_OctopusGradleBuild"))
+    id("12IntegrationDbTestsAuto")
+    name = "[1.2] Integration & DB Tests [AUTO]"
+
+    buildNumberPattern = "%BUILD_NUMBER%"
+
+    artifactRules = """
+        **/*.log => logs.zip
+        %ARTIFACT_PATH%
+        **/reports
+        **/test-results
+    """.trimIndent()
+
+    params {
+        param("ARTIFACT_PATH", """      **/build/reports/** => reports
+      **/build/test-results/**/*.xml => test-results
+      build/**/logs/** => logs
+      build/**/diagnostics/** => diagnostics""")
+        param("GRADLE_EXTRA_PARAMETERS", """
+            -Pokd.cluster-domain=%OKD_APPS_DOMAIN_DEV%
+            -Pokd.project=%OKD_F1_TEST_PROJECT%
+        """.trimIndent())
+        // Pure DB/Spring heavy suite only. automation:test is intentionally NOT here: it
+        // transitively triggers dockerPushImage (ocCreate -> dockerPushImage), which would
+        // re-push the image; it runs in [1.1] instead. dbTest pulls no docker/publish task.
+        param("GRADLE_TASK", "clean :components-registry-service-server:dbTest :components-registry-service-client:dbTest :components-registry-service-light-client:dbTest")
+        param("COMPONENTS_REGISTRY_BRANCH", "master")
+        param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
+    }
+
+    steps {
+        script {
+            name = "Login to the OKD cluster"
+            id = "Login_to_the_OKD_cluster"
+            scriptContent = """
+                oc login --token=%OKD_F1_FT_TOKEN% %OKD_SERVER_DEV_URL%
+                oc project %OKD_F1_TEST_PROJECT%
+            """.trimIndent()
+            param("org.jfrog.artifactory.selectedDeployableServer.useSpecs", "false")
+            param("org.jfrog.artifactory.selectedDeployableServer.uploadSpecSource", "Job configuration")
+            param("org.jfrog.artifactory.selectedDeployableServer.downloadSpecSource", "Job configuration")
+        }
+        gradle {
+            name = "Gradle Integration & DB Tests"
+            id = "RUNNER_1768"
+            tasks = "%GRADLE_TASK%"
+            workingDir = "%WORK_DIR%"
+            gradleParams = """
+                --info
+                %GRADLE_STANDARD_PARAMETERS%
+                %GRADLE_EXTRA_PARAMETERS%
+            """.trimIndent()
+            enableStacktrace = true
+            jdkHome = "%env.JAVA_HOME%"
+            jvmArgs = "%JDK_CMDLINE_PARAMETERS%"
+            dockerRunParameters = "--userns=keep-id -e JAVA_HOME=/opt/java/openjdk -v %env.BUILD_ENV%:/opt/BUILD_ENV -v %teamcity.build.checkoutDir%:/home/tcagent/work -v %teamcity.agent.jvm.user.home%:/home/tcagent -w /home/tcagent/work -e TZ=Europe/Brussels"
+            param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
+        }
+        stepsOrder = arrayListOf("Login_to_the_OKD_cluster", "RUNNER_1720", "RUNNER_1768")
+    }
+
+    failureConditions {
+        executionTimeoutMin = 240
+    }
+
+    features {
+        xmlReport {
+            id = "BUILD_EXT_1815"
+            reportType = XmlReport.XmlReportType.JUNIT
+            rules = "+:**/build/test-results/dbTest/*.xml"
+        }
+    }
+
+    requirements {
+        doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
+    }
+
+    triggers {
+        finishBuildTrigger {
+            buildType = "${id10CompileUtAuto.id}"
+            successfulOnly = true
+            branchFilter = "+:*"
+        }
+    }
+
+    dependencies {
+        snapshot(id10CompileUtAuto) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
     }
 })
 
@@ -833,7 +1043,7 @@ object id17CompatLocalStandManual : BuildType({
         // Run from any branch — including main — still works because
         // the snapshot dep is the only hard requirement.
         finishBuildTrigger {
-            buildType = "${id10CompileUtAuto.id}"
+            buildType = "${id11PackagePublishAuto.id}"
             successfulOnly = true
             branchFilter = """
                 +:*
@@ -843,7 +1053,7 @@ object id17CompatLocalStandManual : BuildType({
     }
 
     dependencies {
-        snapshot(id10CompileUtAuto) {
+        snapshot(id11PackagePublishAuto) {
             onDependencyFailure = FailureAction.CANCEL
         }
     }
@@ -1068,7 +1278,7 @@ object id18CompatLocalStandGitModeAuto : BuildType({
         // but mirror id17's main exclusion to avoid burning agent minutes on the
         // release trunk; Manual Run from any branch still works.
         finishBuildTrigger {
-            buildType = "${id10CompileUtAuto.id}"
+            buildType = "${id11PackagePublishAuto.id}"
             successfulOnly = true
             branchFilter = """
                 +:*
@@ -1078,7 +1288,7 @@ object id18CompatLocalStandGitModeAuto : BuildType({
     }
 
     dependencies {
-        snapshot(id10CompileUtAuto) {
+        snapshot(id11PackagePublishAuto) {
             onDependencyFailure = FailureAction.CANCEL
         }
     }
@@ -1122,7 +1332,7 @@ object id20ValidateComponentsRegistryProductionDataAuto : BuildType({
 
     triggers {
         finishBuildTrigger {
-            buildType = "${id10CompileUtAuto.id}"
+            buildType = "${id11PackagePublishAuto.id}"
             successfulOnly = true
             branchFilter = "+:*"
         }
@@ -1134,7 +1344,7 @@ object id20ValidateComponentsRegistryProductionDataAuto : BuildType({
     }
 
     dependencies {
-        snapshot(id10CompileUtAuto) {
+        snapshot(id11PackagePublishAuto) {
             onDependencyFailure = FailureAction.FAIL_TO_START
         }
         artifacts(AbsoluteId("bt774")) {
@@ -1166,6 +1376,15 @@ object id30DeployToOkdQaDevAuto : BuildType({
 
     dependencies {
         snapshot(id20ValidateComponentsRegistryProductionDataAuto) {
+        }
+        // The image to deploy is pushed by [1.1], and the heavy DB/integration suite
+        // [1.2] must pass before we deploy — both block the deploy from starting on
+        // failure (they run in parallel off [1.0], so by deploy time both are done).
+        snapshot(id11PackagePublishAuto) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
+        snapshot(id12IntegrationDbTestsAuto) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
         }
     }
 })

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditMigratedVisibilityTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
@@ -44,6 +45,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @ActiveProfiles("common", "ft-db")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Timeout(180)
+@Tag("integration")
 class AuditMigratedVisibilityTest {
     @MockBean
     @Suppress("UnusedPrivateProperty")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
@@ -7,6 +7,7 @@ import java.util.UUID
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
@@ -44,6 +45,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @ActiveProfiles("common", "ft-db")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @Timeout(180)
+@Tag("integration")
 class FieldOverrideAuditTest {
     @MockBean
     @Suppress("UnusedPrivateProperty")

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -428,8 +428,8 @@ class ComponentRoutingResolver(
 
 | Layer | Tool | What | Runs in |
 |-------|------|------|---------|
-| Unit | JUnit 5 + Mockito | Service logic, DSL→Entity mappers, DTO converters | Every PR |
-| Integration | Testcontainers (PostgreSQL) | Repository queries, Flyway migrations, transactions | Every PR |
+| Unit | JUnit 5 + Mockito | Service logic, DSL→Entity mappers, DTO converters | Fast gate `[1.0]` + every PR |
+| Integration | Testcontainers (PostgreSQL) | Repository queries, Flyway migrations, transactions | `@Tag("integration")` → `[1.2]` / `qualityCoverage` (every PR) |
 | Contract | Spring Cloud Contract / Pact | Feign client compatibility (28 methods) | Every PR |
 | API Snapshot | Custom JSON diff | v1/v2/v3 response structure unchanged | Every PR |
 | Architecture | ArchUnit | Layering, security annotations, no cycles | Every PR |
@@ -464,6 +464,44 @@ fun `DB resolver returns same result as Git resolver`(componentName: String) {
 ```
 
 See [Non-Functional Specification §5](non-functional-spec.md#5-reliability--fitness-functions) for complete fitness function catalog.
+
+### 8.4 Fast gate vs heavy suite (`@Tag("integration")` split)
+
+To keep the `[1.0] Compile & UT` gate fast (target < 5 min, Docker-free) without losing
+coverage, tests are split by JUnit 5 tag:
+
+- **Unit + smoke** (untagged) — pure unit tests, plus `NoDbModeContextTest` (boots the
+  prod Spring context in git/`no-db` mode) and `BasicFunctionalitySmokeTest` (boots the
+  full DB-backed context on in-memory **H2** — profile `smoke`, no Testcontainers — and
+  exercises the v4 read path + a JPA `@JdbcTypeCode(JSON)`→`TEXT` round-trip). The root
+  `test` task runs `useJUnitPlatform { excludeTags 'integration' }`, so these are all
+  that `check` (hence the `[1.0]` gate) runs.
+- **Heavy** (`@Tag("integration")`) — anything needing a Postgres Testcontainer or a full
+  Spring context on the `test`/`test-db`/`ft-db`/… profiles, across
+  `server`/`client`/`light-client`. These run in the `dbTest` task
+  (`includeTags 'integration'`) — **not** in `check` — together with the fat-jar
+  `integrationTest`. They run in CI `[1.2]` and, on GitHub PRs, under `qualityCoverage`
+  (the `quality` job), so coverage **and** correctness are still gated on every PR.
+
+JaCoCo aggregates `test` + `dbTest` + `integrationTest` exec data, so the 70% coverage
+gate is unchanged by the split. `dockerPushImage` depends on the fat-jar `integrationTest`
+and Maven `publish` is ordered after it, so a broken boot jar can never be published/pushed.
+
+**TeamCity build chain** (`.teamcity/settings.kts`):
+
+```
+[1.0] Compile & UT [AUTO]   gradle `check -x :…-automation:test`
+   │     (compile + unit + smoke + static quality; no Docker; target < 5 min)
+   ├─→ [1.1] Package & Publish [AUTO]   assemble + publish + dockerPushImage + fat-jar FT + automation:test
+   │        │   (inherits [1.0]'s PROJECT_VERSION/BUILD_NUMBER → image keeps its build-number tag;
+   │        │    automation:test deploys the pushed image to OKD via ocCreate → runs where the push is)
+   │        └─→ [1.7]/[1.8] Compat, [2.0] Validate, [3.0] Deploy   (consume the image/artifacts from [1.1])
+   └─→ [1.2] Integration & DB Tests [AUTO]   dbTest (server/client/light-client)
+            └─ gates [3.0] Deploy (snapshot, FAIL_TO_START)
+```
+
+> A new heavy `@SpringBootTest` (Postgres / `ft-db` / …) MUST be tagged
+> `@Tag("integration")`, otherwise it runs in the fast gate and pulls a container into `[1.0]`.
 
 ## 9. New Dependencies (build.gradle)
 


### PR DESCRIPTION
## What

**PR2 of 2** — switches the TeamCity chain to use the unit/integration split from #327, so `[1.0] Compile & UT` becomes the fast gate. Depends on #327 (merged).

`[1.0]` now runs `gradle clean check -x :components-registry-automation:test` (compile + unit + H2/MOCK smoke + static quality — **no Docker, no publish, no image push**). The packaging/heavy work moves into two new AUTO configs that fan out from `[1.0]`:

```
[1.0] Compile & UT [AUTO]   check -x automation   (target < 5 min, Docker-free)
   ├─→ [1.1] Package & Publish [AUTO]   assemble + publish + dockerPushImage + fat-jar FT + automation:test
   │        └─→ [1.7]/[1.8] Compat, [2.0] Validate, [3.0] Deploy   (image/artifacts from [1.1])
   └─→ [1.2] Integration & DB Tests [AUTO]   dbTest (server/client/light-client)
            └─ gates [3.0] Deploy (snapshot, FAIL_TO_START)
```

## How

- **`[1.1]`** inherits `[1.0]`'s `PROJECT_VERSION` + `BUILD_NUMBER` (the existing `id40` pattern) so the pushed image keeps `[1.0]`'s build-number tag. **`automation:test` runs in `[1.1]`** (not `[1.2]`): it is an OKD deploy + functional test that transitively triggers `dockerPushImage` (`ocCreate → dockerPushImage`), so it must run in the same invocation that pushes — otherwise it would re-push the image and race `[1.1]`.
- **Re-pointed** `id17`/`id18` (compat — `docker cp` the candidate image) and `id20` (validate — needs the published artifact) to snapshot/trigger on `[1.1]`. `id30` (deploy) gains `FAIL_TO_START` snapshots on `[1.1]` (image must exist) **and** `[1.2]` (heavy tests must pass before deploy).
- `BUILD_NUMBER` param refs stay on `id10` — they resolve transitively (consumer → id11 → id10) and id11 carries id10's number.
- Tagged 2 heavy `ft-db` tests that merged after #327 (`FieldOverrideAuditTest`, `AuditMigratedVisibilityTest`) so they stay out of the fast gate.
- Docs: `docs/registry/technical-design.md` §8.4 (split + chain).

## Validation done

- **TeamCity DSL compiles + generates all configs**: `mvn teamcity-configs:generate` → BUILD SUCCESS, incl. `RootProjectId_11PackagePublishAuto.xml` + `_12IntegrationDbTestsAuto.xml` and the rewired id17/id18/id20/id30.
- **`--dry-run` of both configs' task graphs** (the definitive check): `[1.2]` pulls **only** `dbTest` (server/client/light-client) — no `dockerPushImage`/`integrationTest`/`ocCreate`; `[1.1]` runs `dockerPushImage` + `integrationTest` + `automation:test` (`ocProcess→ocCreate→test→ocLogs→ocDelete`) **exactly once** each.
- Full `gradle build` green; subagent review (Sonnet) — no P1; P2s fixed.
- **Review caught a duplicate-push bug** (initially `automation:test` was in `[1.2]`, which re-pushed the image via `ocCreate→dockerPushImage`); fixed by moving it to `[1.1]` and making `[1.2]` pure `dbTest` — verified by the dry-runs above.

## ⚠️ Draft — needs server-side validation before merge

1. **Settings-load must succeed** on this branch (a DSL the server rejects breaks versioned-settings compile).
2. **`[1.1]` image-tag version-propagation** — that the `Octopus_OctopusGradleBuild` template's "Calculate build parameters" step does **not** overwrite the inherited `PROJECT_VERSION`, so the pushed image is tagged with `[1.0]`'s build number (what id17/id18/id30 expect). Confirm with one full chain run: `[1.0]→[1.1]→[1.7]/[1.8]/[2.0]→[3.0]` green + `[1.2]` green. If the template overwrites it, the fix is to inject the version via the release-management property instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
