### PR TITLE
ci: fold package+publish back into [1.0]; keep DB-test split + fix Ryuk

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -46,7 +46,6 @@ project {
     // unsupported by this server's kotlin-dsl distribution.)
 
     buildType(id10CompileUtAuto)
-    buildType(id11PackagePublishAuto)
     buildType(id12IntegrationDbTestsAuto)
     buildType(id15CompatManual)
     buildType(id16CompatTraceReplayManual)
@@ -63,7 +62,6 @@ project {
 
     buildTypesOrder = arrayListOf(
         id10CompileUtAuto,
-        id11PackagePublishAuto,
         id12IntegrationDbTestsAuto,
         id15CompatManual,
         id16CompatTraceReplayManual,
@@ -150,11 +148,13 @@ object id10CompileUtAuto : BuildType({
             -Pokd.cluster-domain=%OKD_APPS_DOMAIN_DEV%
             -Pokd.project=%OKD_F1_TEST_PROJECT%
         """.trimIndent())
-        // Fast gate: compile + unit + H2/MOCK smoke + static quality only. Heavy
-        // DB/Spring/integration tests (@Tag("integration")) are excluded from `check`
-        // and run in [1.2]; packaging (publish + image + fat-jar FT) runs in [1.1].
-        // automation:test is CI-only and runs in [1.2], so exclude it here too.
-        param("GRADLE_TASK", "clean check -x :components-registry-automation:test")
+        // [1.0] compiles, runs unit + H2/MOCK smoke + static quality, publishes artifacts and
+        // pushes the image — one step, so the image carries [1.0]'s OWN version (no cross-config
+        // propagation). `build` also runs the fat-jar FT (dockerPushImage depends on it, so it
+        // gates the push) and :…-automation:test (depends on ocCreate -> dockerPushImage, so it
+        // deploys the just-pushed image). Only the heavy @Tag("integration") DB suite is split
+        // out, to [1.2] (excluded from build/check by the gradle tag filter).
+        param("GRADLE_TASK", "clean build publish dockerPushImage")
         param("COMPONENTS_REGISTRY_BRANCH", "master")
     }
 
@@ -217,8 +217,10 @@ object id10CompileUtAuto : BuildType({
         xmlReport {
             id = "BUILD_EXT_1815"
             reportType = XmlReport.XmlReportType.JUNIT
-            // [1.0] now runs `check` (unit + smoke only); integrationTest moved to [1.1].
-            rules = "+:**/build/test-results/test/*.xml"
+            rules = """
+                +:**/build/test-results/integrationTest/*.xml
+                +:**/build/test-results/test/*.xml
+            """.trimIndent()
         }
         xmlReport {
             id = "BUILD_EXT_1817"
@@ -232,117 +234,11 @@ object id10CompileUtAuto : BuildType({
     }
 })
 
-// [1.1] Package & Publish — runs right after the fast [1.0] gate on EVERY id10
-// success. It does the work [1.0] used to do at the end of its step: assemble +
-// publish the Maven artifacts + build & push the Docker image, and runs the fat-jar
-// startup FT (the FT gates publish/push at the Gradle level — see root build.gradle).
-// Inherits id10's PROJECT_VERSION + BUILD_NUMBER (the id40 pattern) so the pushed
-// image keeps id10's build-number tag; downstream image consumers (id17/id18) and the
-// deploy (id30) now take the image/version from THIS build, not id10.
-object id11PackagePublishAuto : BuildType({
-    templates(AbsoluteId("Octopus_OctopusGradleBuild"))
-    id("11PackagePublishAuto")
-    name = "[1.1] Package & Publish [AUTO]"
-
-    buildNumberPattern = "%BUILD_NUMBER%"
-
-    artifactRules = """
-        **/*.log => logs.zip
-        %ARTIFACT_PATH%
-        **/reports
-        **/test-results
-    """.trimIndent()
-
-    params {
-        param("ARTIFACT_PATH", """      **/build/reports/** => reports
-      **/build/test-results/**/*.xml => test-results
-      build/**/logs/** => logs
-      build/**/diagnostics/** => diagnostics""")
-        param("GRADLE_EXTRA_PARAMETERS", """
-            -Pokd.cluster-domain=%OKD_APPS_DOMAIN_DEV%
-            -Pokd.project=%OKD_F1_TEST_PROJECT%
-        """.trimIndent())
-        // automation:test runs HERE (not [1.2]): it deploys the just-pushed image to OKD
-        // via ocCreate (ocCreate dependsOn dockerPushImage), so it must run in the same
-        // invocation that pushes — otherwise it would re-push the image and race [1.1].
-        param("GRADLE_TASK", "clean assemble :components-registry-service-server:integrationTest publish dockerPushImage :components-registry-automation:test")
-        param("COMPONENTS_REGISTRY_BRANCH", "master")
-        // Reuse id10's computed version + build number so the image tag and published
-        // artifact version match id10 and the chain view shows one number throughout.
-        param("PROJECT_VERSION", "${id10CompileUtAuto.depParamRefs["PROJECT_VERSION"]}")
-        param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
-    }
-
-    steps {
-        script {
-            name = "Login to the OKD cluster"
-            id = "Login_to_the_OKD_cluster"
-            scriptContent = """
-                oc login --token=%OKD_F1_FT_TOKEN% %OKD_SERVER_DEV_URL%
-                oc project %OKD_F1_TEST_PROJECT%
-            """.trimIndent()
-            param("org.jfrog.artifactory.selectedDeployableServer.useSpecs", "false")
-            param("org.jfrog.artifactory.selectedDeployableServer.uploadSpecSource", "Job configuration")
-            param("org.jfrog.artifactory.selectedDeployableServer.downloadSpecSource", "Job configuration")
-        }
-        gradle {
-            name = "Gradle Package & Publish"
-            id = "RUNNER_1768"
-            tasks = "%GRADLE_TASK%"
-            workingDir = "%WORK_DIR%"
-            gradleParams = """
-                --info
-                %GRADLE_STANDARD_PARAMETERS%
-                %GRADLE_EXTRA_PARAMETERS%
-            """.trimIndent()
-            enableStacktrace = true
-            jdkHome = "%env.JAVA_HOME%"
-            jvmArgs = "%JDK_CMDLINE_PARAMETERS%"
-            dockerRunParameters = "--userns=keep-id -e JAVA_HOME=/opt/java/openjdk -v %env.BUILD_ENV%:/opt/BUILD_ENV -v %teamcity.build.checkoutDir%:/home/tcagent/work -v %teamcity.agent.jvm.user.home%:/home/tcagent -w /home/tcagent/work -e TZ=Europe/Brussels"
-            param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
-        }
-        stepsOrder = arrayListOf("Login_to_the_OKD_cluster", "RUNNER_1720", "RUNNER_1768")
-    }
-
-    failureConditions {
-        executionTimeoutMin = 240
-    }
-
-    features {
-        xmlReport {
-            id = "BUILD_EXT_1815"
-            reportType = XmlReport.XmlReportType.JUNIT
-            rules = """
-                +:**/build/test-results/integrationTest/*.xml
-                +:components-registry-automation/build/test-results/test/*.xml
-            """.trimIndent()
-        }
-    }
-
-    requirements {
-        doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
-    }
-
-    triggers {
-        finishBuildTrigger {
-            buildType = "${id10CompileUtAuto.id}"
-            successfulOnly = true
-            branchFilter = "+:*"
-        }
-    }
-
-    dependencies {
-        snapshot(id10CompileUtAuto) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-    }
-})
-
 // [1.2] Integration & DB Tests — runs the heavy @Tag("integration") DB suite (Postgres
-// Testcontainers / full Spring context, across server/client/light-client) in parallel
-// with [1.1] after every id10 success. These are the tests excluded from the fast [1.0]
-// gate; they still gate the deploy via id30's snapshot dependency below. automation:test
-// runs in [1.1], NOT here — it transitively triggers dockerPushImage (see its GRADLE_TASK).
+// Testcontainers / full Spring context, across server/client/light-client), triggered off
+// id10 alongside the compat/validate chain. This is the ONLY thing split out of [1.0]
+// (tagged out of `build`/`check`); it gates the deploy via id30's snapshot below.
+// automation:test runs in [1.0] (it transitively triggers dockerPushImage), NOT here.
 object id12IntegrationDbTestsAuto : BuildType({
     templates(AbsoluteId("Octopus_OctopusGradleBuild"))
     id("12IntegrationDbTestsAuto")
@@ -366,9 +262,10 @@ object id12IntegrationDbTestsAuto : BuildType({
             -Pokd.cluster-domain=%OKD_APPS_DOMAIN_DEV%
             -Pokd.project=%OKD_F1_TEST_PROJECT%
         """.trimIndent())
-        // Pure DB/Spring heavy suite only. automation:test is intentionally NOT here: it
-        // transitively triggers dockerPushImage (ocCreate -> dockerPushImage), which would
-        // re-push the image; it runs in [1.1] instead. dbTest pulls no docker/publish task.
+        // Pure DB/Spring heavy suite only. automation:test is intentionally NOT here: its test
+        // task depends on ocCreate -> dockerPushImage, so running it would push the image; it
+        // belongs in [1.0] (where `build`'s subproject sweep already runs it and the push
+        // happens). dbTest itself pulls no docker/publish/ocCreate task.
         param("GRADLE_TASK", "clean :components-registry-service-server:dbTest :components-registry-service-client:dbTest :components-registry-service-light-client:dbTest")
         param("COMPONENTS_REGISTRY_BRANCH", "master")
         param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
@@ -1054,7 +951,7 @@ object id17CompatLocalStandManual : BuildType({
         // Run from any branch — including main — still works because
         // the snapshot dep is the only hard requirement.
         finishBuildTrigger {
-            buildType = "${id11PackagePublishAuto.id}"
+            buildType = "${id10CompileUtAuto.id}"
             successfulOnly = true
             branchFilter = """
                 +:*
@@ -1064,7 +961,7 @@ object id17CompatLocalStandManual : BuildType({
     }
 
     dependencies {
-        snapshot(id11PackagePublishAuto) {
+        snapshot(id10CompileUtAuto) {
             onDependencyFailure = FailureAction.CANCEL
         }
     }
@@ -1300,7 +1197,7 @@ object id18CompatLocalStandGitModeAuto : BuildType({
         // but mirror id17's main exclusion to avoid burning agent minutes on the
         // release trunk; Manual Run from any branch still works.
         finishBuildTrigger {
-            buildType = "${id11PackagePublishAuto.id}"
+            buildType = "${id10CompileUtAuto.id}"
             successfulOnly = true
             branchFilter = """
                 +:*
@@ -1310,7 +1207,7 @@ object id18CompatLocalStandGitModeAuto : BuildType({
     }
 
     dependencies {
-        snapshot(id11PackagePublishAuto) {
+        snapshot(id10CompileUtAuto) {
             onDependencyFailure = FailureAction.CANCEL
         }
     }
@@ -1354,7 +1251,7 @@ object id20ValidateComponentsRegistryProductionDataAuto : BuildType({
 
     triggers {
         finishBuildTrigger {
-            buildType = "${id11PackagePublishAuto.id}"
+            buildType = "${id10CompileUtAuto.id}"
             successfulOnly = true
             branchFilter = "+:*"
         }
@@ -1366,7 +1263,7 @@ object id20ValidateComponentsRegistryProductionDataAuto : BuildType({
     }
 
     dependencies {
-        snapshot(id11PackagePublishAuto) {
+        snapshot(id10CompileUtAuto) {
             onDependencyFailure = FailureAction.FAIL_TO_START
         }
         artifacts(AbsoluteId("bt774")) {
@@ -1399,12 +1296,8 @@ object id30DeployToOkdQaDevAuto : BuildType({
     dependencies {
         snapshot(id20ValidateComponentsRegistryProductionDataAuto) {
         }
-        // The image to deploy is pushed by [1.1], and the heavy DB/integration suite
-        // [1.2] must pass before we deploy — both block the deploy from starting on
-        // failure (they run in parallel off [1.0], so by deploy time both are done).
-        snapshot(id11PackagePublishAuto) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
+        // The heavy DB/integration suite [1.2] must pass before we deploy (it runs in
+        // parallel off [1.0], so by deploy time it's done). The image comes from [1.0].
         snapshot(id12IntegrationDbTestsAuto) {
             onDependencyFailure = FailureAction.FAIL_TO_START
         }

--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,13 @@ configure(subprojects) {
         // enable with -Pcompat.mig029.enabled=true to reproduce the bug or verify a fix.
         // See MigrationIntegrationTest.MIG-029 + docs/registry/requirements-migration.md.
         systemProperty 'compat.mig029.enabled', project.findProperty('compat.mig029.enabled') ?: 'false'
-        // Testcontainers + Colima: override socket path mounted into Ryuk container
+        // Disable Ryuk (the Testcontainers reaper): it mounts /var/run/docker.sock into its
+        // own container, which Podman-rootless CI agents forbid (statfs ... permission denied
+        // -> ContainerLaunchException). Set for EVERY Test task so client/light-client dbTest
+        // work on those agents too, not just the server module (which set it before).
+        environment 'TESTCONTAINERS_RYUK_DISABLED', 'true'
+        // Socket path Testcontainers advertises to any container that mounts docker.sock
+        // (e.g. on Colima). With Ryuk disabled above this is mostly moot, but harmless.
         environment 'TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE', '/var/run/docker.sock'
         // Route Testcontainers image pulls through the internal Docker registry when
         // -Pdocker.registry is set (CI path). Without this, unauthenticated agents
@@ -479,8 +485,8 @@ gradle.projectsEvaluated {
     // Part A.7: gate publish + image push on the server fat-jar FT. dockerPushImage HARD-depends
     // on the FT — an image is never pushed without a validated boot jar. Maven publish is only
     // ORDERED after the FT (mustRunAfter): when the FT is part of the same invocation — as in
-    // CI [1.1] (`assemble :…server:integrationTest publish dockerPushImage`) — default fail-fast
-    // aborts before any publish. A standalone `publish`/`publishToMavenLocal` elsewhere is
+    // CI [1.0] (`clean build publish dockerPushImage`, where dockerPushImage pulls in the FT) —
+    // default fail-fast aborts before any publish. A standalone `publish`/`publishToMavenLocal` is
     // deliberately NOT forced to run the (slow) fat-jar FT.
     def serverFt = project(':components-registry-service-server').tasks.named('integrationTest')
     project(':components-registry-service-server').tasks.named('dockerPushImage').configure {

--- a/components-registry-service-client/build.gradle
+++ b/components-registry-service-client/build.gradle
@@ -67,8 +67,5 @@ sourceSets {
     }
 }
 
-test {
-    // Ryuk (Testcontainers resource reaper) requires mounting /var/run/docker.sock inside itself,
-    // which Podman rootless forbids on CI. Disable Ryuk so PostgreSQLContainer can start normally.
-    environment 'TESTCONTAINERS_RYUK_DISABLED', 'true'
-}
+// Ryuk is disabled for all Test tasks (incl. this module's dbTest) globally in the root
+// build.gradle — no per-task Testcontainers config needed here.

--- a/components-registry-service-server/build.gradle
+++ b/components-registry-service-server/build.gradle
@@ -64,11 +64,9 @@ dependencies {
 }
 
 // Applies to EVERY Test task (test, dbTest, integrationTest) so the heavy DB/Spring tests
-// get the same Testcontainers/Docker env no matter which task runs them.
+// get the same Docker env no matter which task runs them. (Ryuk is disabled globally for
+// all modules in the root build.gradle.)
 tasks.withType(Test).configureEach {
-    // Ryuk (Testcontainers resource reaper) requires mounting /var/run/docker.sock inside itself,
-    // which Podman rootless forbids on CI. Disable Ryuk so containers can start normally.
-    environment 'TESTCONTAINERS_RYUK_DISABLED', 'true'
     // Expose DOCKER_REGISTRY so DockerRegistryImageSubstitutor can redirect image pulls
     // through the internal registry mirror (avoids Docker Hub anonymous rate limits).
     def registry = System.getenv().getOrDefault("DOCKER_REGISTRY", project.findProperty("docker.registry")?.toString() ?: "")
@@ -134,9 +132,10 @@ tasks.register('jacocoIntegrationTestReport', org.gradle.testing.jacoco.tasks.Ja
     }
 }
 
-// integrationTest (fat-jar boot FT) is intentionally NOT wired into `check`: it runs in
-// CI [1.1] (where it gates publish/dockerPushImage) and in GH `qualityCoverage`, never in
-// the fast [1.0] Compile&UT gate. See root build.gradle (qualityCoverage + publish gating).
+// integrationTest (fat-jar boot FT) is intentionally NOT wired into `check`/`build`: in CI it
+// runs in [1.0] only because dockerPushImage HARD-depends on it (so it gates publish/push),
+// and on GH PRs it runs under `qualityCoverage`. See root build.gradle (qualityCoverage +
+// publish gating).
 integrationTest.dependsOn bootJar
 integrationTest.finalizedBy jacocoIntegrationTestReport
 

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -428,7 +428,7 @@ class ComponentRoutingResolver(
 
 | Layer | Tool | What | Runs in |
 |-------|------|------|---------|
-| Unit | JUnit 5 + Mockito | Service logic, DSL→Entity mappers, DTO converters | Fast gate `[1.0]` + every PR |
+| Unit | JUnit 5 + Mockito | Service logic, DSL→Entity mappers, DTO converters | `[1.0]` + every PR |
 | Integration | Testcontainers (PostgreSQL) | Repository queries, Flyway migrations, transactions | `@Tag("integration")` → `[1.2]` / `qualityCoverage` (every PR) |
 | Contract | Spring Cloud Contract / Pact | Feign client compatibility (28 methods) | Every PR |
 | API Snapshot | Custom JSON diff | v1/v2/v3 response structure unchanged | Every PR |
@@ -467,41 +467,45 @@ See [Non-Functional Specification §5](non-functional-spec.md#5-reliability--fit
 
 ### 8.4 Fast gate vs heavy suite (`@Tag("integration")` split)
 
-To keep the `[1.0] Compile & UT` gate fast (target < 5 min, Docker-free) without losing
-coverage, tests are split by JUnit 5 tag:
+The build splits tests by JUnit 5 tag so the heavy DB suite runs off the critical path
+(in `[1.2]`, parallel to deploy prep) instead of inside the build, without losing coverage:
 
 - **Unit + smoke** (untagged) — pure unit tests, plus `NoDbModeContextTest` (boots the
   prod Spring context in git/`no-db` mode) and `BasicFunctionalitySmokeTest` (boots the
   full DB-backed context on in-memory **H2** — profile `smoke`, no Testcontainers — and
   exercises the v4 read path + a JPA `@JdbcTypeCode(JSON)`→`TEXT` round-trip). The root
-  `test` task runs `useJUnitPlatform { excludeTags 'integration' }`, so these are all
-  that `check` (hence the `[1.0]` gate) runs.
+  `test` task runs `useJUnitPlatform { excludeTags 'integration' }`, so `check`/`build`
+  (the `[1.0]` step) run these only.
 - **Heavy** (`@Tag("integration")`) — anything needing a Postgres Testcontainer or a full
   Spring context on the `test`/`test-db`/`ft-db`/… profiles, across
   `server`/`client`/`light-client`. These run in the `dbTest` task
-  (`includeTags 'integration'`) — **not** in `check` — together with the fat-jar
-  `integrationTest`. They run in CI `[1.2]` and, on GitHub PRs, under `qualityCoverage`
-  (the `quality` job), so coverage **and** correctness are still gated on every PR.
+  (`includeTags 'integration'`) — **not** in `check`/`build` — in CI `[1.2]`, and on
+  GitHub PRs under `qualityCoverage` (the `quality` job), so coverage **and** correctness
+  are still gated on every PR.
 
-JaCoCo aggregates `test` + `dbTest` + `integrationTest` exec data, so the 70% coverage
-gate is unchanged by the split. `dockerPushImage` depends on the fat-jar `integrationTest`
-and Maven `publish` is ordered after it, so a broken boot jar can never be published/pushed.
+JaCoCo aggregates `test` + `dbTest` + `integrationTest` exec data, so the 70% coverage gate
+is unchanged. All `Test` tasks set `TESTCONTAINERS_RYUK_DISABLED=true` (the Ryuk reaper
+can't mount the docker socket on Podman-rootless CI agents). `dockerPushImage` depends on
+the fat-jar `integrationTest` and Maven `publish` is ordered after it, so a broken boot jar
+is never published/pushed.
 
 **TeamCity build chain** (`.teamcity/settings.kts`):
 
 ```
-[1.0] Compile & UT [AUTO]   gradle `check -x :…-automation:test`
-   │     (compile + unit + smoke + static quality; no Docker; target < 5 min)
-   ├─→ [1.1] Package & Publish [AUTO]   assemble + publish + dockerPushImage + fat-jar FT + automation:test
-   │        │   (inherits [1.0]'s PROJECT_VERSION/BUILD_NUMBER → image keeps its build-number tag;
-   │        │    automation:test deploys the pushed image to OKD via ocCreate → runs where the push is)
-   │        └─→ [1.7]/[1.8] Compat, [2.0] Validate, [3.0] Deploy   (consume the image/artifacts from [1.1])
+[1.0] Compile & UT [AUTO]   gradle `clean build publish dockerPushImage`
+   │     compile + unit + smoke + static quality + publish + image (~10 min). `build` also
+   │     pulls the fat-jar FT (dockerPushImage depends on it → gates the push) and
+   │     automation:test (depends on ocCreate → dockerPushImage). Heavy @Tag("integration")
+   │     DB tests excluded by tag. The image carries [1.0]'s OWN build number (no cross-
+   │     config version-propagation) — exactly what the downstream configs pull.
+   ├─→ [1.7]/[1.8] Compat, [2.0] Validate, [3.0] Deploy   (consume id10's image/artifacts)
    └─→ [1.2] Integration & DB Tests [AUTO]   dbTest (server/client/light-client)
             └─ gates [3.0] Deploy (snapshot, FAIL_TO_START)
 ```
 
-> A new heavy `@SpringBootTest` (Postgres / `ft-db` / …) MUST be tagged
-> `@Tag("integration")`, otherwise it runs in the fast gate and pulls a container into `[1.0]`.
+> A new heavy `@SpringBootTest` (Postgres / `ft-db` / …) should be tagged `@Tag("integration")`
+> so it runs in `[1.2]`, not inside `[1.0]`. (`[1.0]` has Docker, so an untagged one only
+> slows the step — it won't break.)
 
 ## 9. New Dependencies (build.gradle)
 


### PR DESCRIPTION
## Why

PR #328 moved package+publish into a separate TeamCity config `[1.1]`, leaving `[1.0]` to run only `clean check`. That broke in production: the server-side build template **recomputed `PROJECT_VERSION`** in `[1.1]` instead of inheriting `[1.0]`'s, so the pushed image was tagged with the wrong version and downstream compat (`[1.8]`) pulled a nonexistent tag → `docker exit 125`.

This reverts the `[1.1]` split and folds package+publish back into `[1.0]`, while **keeping the actual win** (the heavy DB-test split) and fixing the Ryuk failure that broke `[1.2]`.

## The chain now

```
[1.0] Compile & UT [AUTO]   clean build publish dockerPushImage   (~10 min, atomic)
   │     compile + unit + H2 smoke + static quality + publish + image + fat-jar FT + automation:test
   │     (heavy @Tag("integration") DB tests excluded by tag; image carries [1.0]'s own build number)
   ├─→ [1.7]/[1.8] Compat, [2.0] Validate, [3.0] Deploy   (consume id10's image/artifacts)
   └─→ [1.2] Integration & DB Tests [AUTO]   dbTest (server/client/light-client)
            └─ gates [3.0] Deploy (snapshot, FAIL_TO_START)
```

`[1.0]` ≈ 10 min (down from 25–90 min) because the heavy Postgres/Spring suite is gone from it; the publish/image/FT it always did stay in one atomic step, so there is no cross-config version-propagation to break.

## Changes

- **`.teamcity/settings.kts`** — delete `id11PackagePublishAuto`; `[1.0]` (`id10`) runs `clean build publish dockerPushImage` again; re-point `id17`/`id18`/`id20` trigger+snapshot to `id10`; `id30` deploy gates on `id20` + `id12` (the image to deploy comes from `id10`).
- **`build.gradle`** — disable Testcontainers Ryuk for **all** `Test` tasks. Ryuk can't mount `docker.sock` on the Podman-rootless CI agents (`statfs … permission denied → ContainerLaunchException`); previously only the server module set it, so `[1.2]` client/light-client `dbTest` failed.
- drop the now-redundant per-module Ryuk env (server keeps its `DOCKER_REGISTRY` block; the client's was `test`-scoped, so it never even covered `dbTest`).
- **`docs/registry/technical-design.md`** — update the test-strategy table + §8.4.

## Validation

- `gradlew build -x :components-registry-automation:test` → **BUILD SUCCESSFUL**.
- `mvn teamcity-configs:generate` → **BUILD SUCCESS** (DSL compiles; generated configs no longer contain an `id11` build type; no dangling `[1.1]` refs).
- Independent review — no blocking issues; review fixes applied.
- ⚠️ The TeamCity chain only fully validates **server-side on settings-load**. After merge, watch the next v3 settings sync: (1) settings-load green; (2) one chain run where `[1.0]` pushes the image under its own build number and `[1.8]`/`[2.0]`/`[3.0]` consume it, with `[1.2]` gating the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
