### PR TITLE
feat(v4): restore cross-component integrity checks (artifact / jira / docker uniqueness)

### DIFF
--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/exceptions/CrossComponentConflictException.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/exceptions/CrossComponentConflictException.kt
@@ -1,0 +1,19 @@
+package org.octopusden.octopus.components.registry.core.exceptions
+
+/**
+ * Raised when a v4 write would make a component collide with ANOTHER component
+ * on a registry-wide-unique coordinate — duplicate `groupId:artifactId` in
+ * overlapping version ranges, a shared jira `(projectKey, versionPrefix)` among
+ * non-archived components, or a globally-duplicated docker image name. These are
+ * cross-component integrity rules the old `EscrowConfigValidator` enforced at
+ * config-load time; the v4 API restores them at write time.
+ *
+ * Mapped to HTTP 409 Conflict by `ControllerExceptionHandler`, alongside
+ * [ComponentNameConflictException]. Malformed-input checks (e.g. a missing
+ * distribution coordinate, an unsupported groupId prefix) stay 400 and use
+ * `IllegalArgumentException`, not this type — a conflict means "valid input that
+ * clashes with existing data", not "bad input".
+ */
+class CrossComponentConflictException(
+    message: String,
+) : BaseComponentsRegistryException(message)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ControllerExceptionHandler.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.controller
 import org.octopusden.octopus.components.registry.core.dto.ErrorResponse
 import org.octopusden.octopus.components.registry.core.exceptions.BaseComponentsRegistryException
 import org.octopusden.octopus.components.registry.core.exceptions.ComponentNameConflictException
+import org.octopusden.octopus.components.registry.core.exceptions.CrossComponentConflictException
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.core.exceptions.RepositoryNotPreparedException
 import org.slf4j.Logger
@@ -84,6 +85,22 @@ class ControllerExceptionHandler {
     @ExceptionHandler(ComponentNameConflictException::class)
     @ResponseStatus(HttpStatus.CONFLICT)
     fun componentNameConflictExceptionHandler(e: ComponentNameConflictException): HttpEntity<ErrorResponse> {
+        log.warn(e.localizedMessage)
+        return HttpEntity(ErrorResponse(e.localizedMessage))
+    }
+
+    /**
+     * Cross-component integrity collision (duplicate groupId:artifactId in
+     * overlapping ranges, shared jira project-key+version-prefix among
+     * non-archived components, or duplicate docker image name). The submitted
+     * payload is well-formed but clashes with existing data — 409 Conflict,
+     * mirroring the name-conflict handler above. Malformed-input checks (missing
+     * distribution coordinate, unsupported groupId prefix, archived-explicit
+     * gate, doc-component existence) instead use IllegalArgumentException → 400.
+     */
+    @ExceptionHandler(CrossComponentConflictException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    fun crossComponentConflictExceptionHandler(e: CrossComponentConflictException): HttpEntity<ErrorResponse> {
         log.warn(e.localizedMessage)
         return HttpEntity(ErrorResponse(e.localizedMessage))
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentConfigurationRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentConfigurationRepository.kt
@@ -1,11 +1,40 @@
 package org.octopusden.octopus.components.registry.server.repository
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
 interface ComponentConfigurationRepository : JpaRepository<ComponentConfigurationEntity, UUID> {
+    /**
+     * Distinct keys of OTHER, non-archived components (excluding
+     * [excludeComponentId]) that own a configuration row with the same jira
+     * `(projectKey, versionPrefix)` pair. Restores the old
+     * `validateJiraProjectKeyAndVersionPrefixIntersections` rule: each
+     * (projectKey, versionPrefix) maps to at most one non-archived component.
+     *
+     * `versionPrefix` is nullable — the null-safe comparison treats a NULL
+     * prefix on both sides as the same bucket (matching the old
+     * `Tuple2(projectKey, versionPrefix)` map key where versionPrefix could be
+     * null). A non-empty result is a cross-component conflict.
+     */
+    @Query(
+        "SELECT DISTINCT comp.componentKey FROM ComponentConfigurationEntity cfg " +
+            "JOIN cfg.component comp " +
+            "WHERE comp.id <> :excludeComponentId " +
+            "AND comp.archived = false " +
+            "AND cfg.jiraProjectKey = :projectKey " +
+            "AND ((:versionPrefix IS NULL AND cfg.jiraVersionPrefix IS NULL) " +
+            "  OR cfg.jiraVersionPrefix = :versionPrefix)",
+    )
+    fun findOtherNonArchivedComponentKeysByJiraProjectKeyAndVersionPrefix(
+        @Param("projectKey") projectKey: String,
+        @Param("versionPrefix") versionPrefix: String?,
+        @Param("excludeComponentId") excludeComponentId: UUID,
+    ): List<String>
+
     /** All configuration rows (base + overrides) for a component, in arbitrary order. */
     fun findByComponentId(componentId: UUID): List<ComponentConfigurationEntity>
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/DistributionDockerImageRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/DistributionDockerImageRepository.kt
@@ -1,10 +1,31 @@
 package org.octopusden.octopus.components.registry.server.repository
 import org.octopusden.octopus.components.registry.server.entity.DistributionDockerImageEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
 interface DistributionDockerImageRepository : JpaRepository<DistributionDockerImageEntity, UUID> {
     fun findByComponentConfigurationId(componentConfigurationId: UUID): List<DistributionDockerImageEntity>
+
+    /**
+     * Distinct component keys (other than [excludeComponentId]) that already
+     * declare a docker image with [imageName]. Docker image names are globally
+     * unique across components (the old `validateDockerUniqueNames` rule); a
+     * non-empty result is a cross-component conflict. Indexed equality on
+     * `image_name`; DISTINCT so a rival declaring the same image in several
+     * version ranges is reported once.
+     */
+    @Query(
+        "SELECT DISTINCT comp.componentKey FROM DistributionDockerImageEntity d " +
+            "JOIN d.componentConfiguration cfg " +
+            "JOIN cfg.component comp " +
+            "WHERE comp.id <> :excludeComponentId AND d.imageName = :imageName",
+    )
+    fun findOtherComponentKeysByImageName(
+        @Param("imageName") imageName: String,
+        @Param("excludeComponentId") excludeComponentId: UUID,
+    ): List<String>
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/DistributionMavenArtifactRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/DistributionMavenArtifactRepository.kt
@@ -1,10 +1,42 @@
 package org.octopusden.octopus.components.registry.server.repository
 import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
 interface DistributionMavenArtifactRepository : JpaRepository<DistributionMavenArtifactEntity, UUID> {
     fun findByComponentConfigurationId(componentConfigurationId: UUID): List<DistributionMavenArtifactEntity>
+
+    /**
+     * Maven-artifact rows of OTHER components (excluding [excludeComponentId]).
+     * Candidate narrowing cannot use exact SQL equality because legacy artifact
+     * patterns support wildcard, regex/CSV artifacts, and CSV group IDs. Pattern
+     * overlap and Maven range intersection are therefore decided in-memory.
+     */
+    @Query(
+        "SELECT m.groupPattern AS groupPattern, m.artifactPattern AS artifactPattern, " +
+            "cfg.versionRange AS versionRange, comp.componentKey AS componentKey " +
+            "FROM DistributionMavenArtifactEntity m " +
+            "JOIN m.componentConfiguration cfg " +
+            "JOIN cfg.component comp " +
+            "WHERE comp.id <> :excludeComponentId",
+    )
+    fun findOtherComponents(
+        @Param("excludeComponentId") excludeComponentId: UUID,
+    ): List<CrossComponentMavenRow>
+}
+
+/**
+ * Projection for cross-component maven-artifact collision detection. `versionRange`
+ * is the owning configuration row's range; `componentKey` identifies the rival
+ * component for the conflict message.
+ */
+interface CrossComponentMavenRow {
+    val groupPattern: String
+    val artifactPattern: String
+    val versionRange: String
+    val componentKey: String
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.OptimisticLockException
 import jakarta.persistence.criteria.JoinType
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import org.octopusden.octopus.components.registry.core.exceptions.ComponentNameConflictException
+import org.octopusden.octopus.components.registry.core.exceptions.CrossComponentConflictException
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.dto.v4.BaseConfigurationRequest
@@ -59,6 +60,8 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentCon
 import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionDockerImageRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionMavenArtifactRepository
 import org.octopusden.octopus.components.registry.server.repository.LabelRepository
 import org.octopusden.octopus.components.registry.server.repository.SystemRepository
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
@@ -98,6 +101,8 @@ class ComponentManagementServiceImpl(
     private val componentLabelRepository: ComponentLabelRepository,
     private val componentRequiredToolRepository: ComponentRequiredToolRepository,
     private val componentBuildToolBeanRepository: ComponentBuildToolBeanRepository,
+    private val mavenArtifactRepository: DistributionMavenArtifactRepository,
+    private val dockerImageRepository: DistributionDockerImageRepository,
     private val labelRepository: LabelRepository,
     private val systemRepository: SystemRepository,
     private val toolRepository: ToolRepository,
@@ -247,12 +252,34 @@ class ComponentManagementServiceImpl(
         applyBaseConfigurationCreate(baseConfig, baseConfigRequest)
         entity.configurations.add(baseConfig)
 
-        // Person fields (componentOwner / releaseManager / securityChampion).
+        // Person fields (componentOwner / releaseManager / securityChampion) FIRST.
         // On create everything is new, so the active-employee check is always
-        // triggered (subject to the flag). Validates the final entity state.
+        // triggered (subject to the flag). Person-field errors take precedence over
+        // the malformed-input rules below: an explicit+external component with no
+        // distribution coordinate AND no releaseManager fails BOTH the person gate
+        // (#3/#4) and the ≥1-coordinate rule (#6); the foundation's contract reports
+        // the person-field error first, so person validation runs ahead of the
+        // malformed-input checks here.
         validatePersonFields(entity, runActiveCheck = true)
 
-        val saved = componentRepository.save(entity)
+        // Malformed-input cross-component / single-field checks (400). These need
+        // no DB lookup beyond the soft doc-ref existence probe and run against the
+        // final in-memory entity state (everything is freshly assigned on create).
+        validateMalformedFieldRules(entity)
+
+        // Flush so the self-excluding 409 collision queries below see the new
+        // component's rows and the entity carries an assigned id.
+        val saved = componentRepository.saveAndFlush(entity)
+
+        // Doc-component existence (#20, 400) — post-flush so a self-documenting
+        // component (docs[] referencing its own key) is not rejected by ordering.
+        validateDocComponentExistence(saved)
+
+        // Cross-component integrity (409): duplicate groupId:artifactId in
+        // overlapping ranges, jira (projectKey, versionPrefix) uniqueness among
+        // non-archived components, docker image-name global uniqueness. Run AFTER
+        // flush so the queries exclude this component by its now-assigned id.
+        validateCrossComponentIntegrity(saved)
 
         // M:N junctions (no cascade — see ComponentEntity kdoc convention) must be
         // persisted via their own repositories AFTER the parent has an assigned id.
@@ -537,8 +564,40 @@ class ComponentManagementServiceImpl(
                 base.takeIf { patch.requiredTools != null }
             }
 
+        // Cross-component / malformed-input checks are GRANDFATHERED on update:
+        // they re-run only when the PATCH actually touches a field they govern
+        // (distribution coordinates / jira / docs / the explicit-external-archived
+        // gate). A PATCH that leaves all of those untouched (e.g. displayName,
+        // people, labels, copyright only) must NOT re-validate the component's
+        // pre-existing configuration — mirrors the person-field active-check
+        // grandfathering above (a label-only PATCH doesn't re-validate people).
+        // This does NOT weaken the rules: every governed field still triggers the
+        // check when it changes; only untouched legacy data is left alone. On
+        // CREATE everything is new, so they always run (see createComponent).
+        val crossComponentRelevantChange =
+            request.name != null || // rename can invalidate soft docs[] references to the old key
+                request.baseConfiguration != null || // maven / docker / packages / jira live on the base config row
+                request.docs != null ||
+                request.distributionExplicit != null ||
+                request.distributionExternal != null ||
+                request.archived != null
+
+        // Malformed-input single-field checks (400) against the PATCHed final
+        // entity state (so a caller need not resend unchanged fields).
+        if (crossComponentRelevantChange) validateMalformedFieldRules(entity)
+
         entity.updatedAt = Instant.now()
         val saved = componentRepository.saveAndFlush(entity)
+
+        if (crossComponentRelevantChange) {
+            // Doc-component existence (#20, 400) — post-flush, consistent with create
+            // (and so a rename that points docs[] at the new own key is accepted).
+            validateDocComponentExistence(saved)
+
+            // Cross-component integrity (409) against the final flushed state — the
+            // self-excluding queries skip this component by its id.
+            validateCrossComponentIntegrity(saved)
+        }
 
         // Junctions — synced via their repositories after the parent flush so the
         // assigned ids (for newly-created rows) are visible. `systemCode` is
@@ -715,6 +774,11 @@ class ComponentManagementServiceImpl(
             refreshConfigRequiredToolsInMemory(saved, pendingTools)
         }
         bumpParentVersion(component)
+        // Review #2: an override row can carry mavenArtifacts/dockerImages/jira
+        // coordinates that collide with another component — re-run the same 409 /
+        // 400 composite checks the create/update component paths run, now that the
+        // override row is flushed.
+        validateFieldOverrideCrossComponent(componentId)
         publishAuditEvent(
             action = "UPDATE",
             entityId = component.id.toString(),
@@ -775,6 +839,10 @@ class ComponentManagementServiceImpl(
             refreshConfigRequiredToolsInMemory(saved, pendingTools)
         }
         bumpParentVersion(row.component)
+        // Review #2: re-run the cross-component composite checks — an UPDATE to a
+        // marker override can introduce a colliding GAV / docker image / jira
+        // coordinate just as a create can.
+        validateFieldOverrideCrossComponent(componentId)
         publishAuditEvent(
             action = "UPDATE",
             entityId = row.component.id.toString(),
@@ -1682,6 +1750,277 @@ class ComponentManagementServiceImpl(
         }
     }
 
+    // ─── Cross-component integrity (Stage 4 — restores OLD-VALIDATOR composite
+    //     checks as runtime rules). Collisions with OTHER components → 409
+    //     (CrossComponentConflictException); malformed-input → 400
+    //     (IllegalArgumentException via require). ───────────────────────────────
+
+    /**
+     * Malformed-input single-/composite-field rules that reject the SUBMITTED
+     * payload itself (not a clash with another component) — all 400.
+     *
+     *  - **explicit-external ≥1 distribution coordinate** (#6): when
+     *    `distributionExplicit && distributionExternal`, at least one of GAV
+     *    (maven artifact), docker image, or DEB/RPM package must be defined on
+     *    some configuration row.
+     *  - **groupId supported prefix** (#10): every maven `groupPattern` element
+     *    must start with one of the env-configured `supportedGroupIds`.
+     *  - **archived ≠ explicit-external** (#28): an archived component cannot be
+     *    explicitly+externally distributed.
+     * Note: doc-component existence (#20) is NOT checked here. It is a soft
+     * string reference whose target may be the component's OWN key (a component
+     * may legitimately document itself), which does not exist in the DB until
+     * after the flush on create. It is therefore validated post-flush in
+     * [validateDocComponentExistence] alongside the 409 cross-component checks,
+     * where the component's own key is already persisted.
+     *
+     * Runs against the final entity state (post-patch / freshly-built on create).
+     */
+    private fun validateMalformedFieldRules(entity: ComponentEntity) {
+        val explicitExternal =
+            (entity.distributionExplicit == true) && (entity.distributionExternal == true)
+
+        // #28 archived ≠ explicit-external — checked before the ≥1-coordinate
+        // rule so an archived component is never asked for a coordinate.
+        if (explicitExternal) {
+            require(!entity.archived) {
+                "distribution: an archived component can't be explicitly+externally " +
+                    "distributed — set distributionExplicit=false (component '${entity.componentKey}')"
+            }
+            require(hasAnyDistributionCoordinate(entity)) {
+                "distribution: an explicit+external component must define at least one " +
+                    "distribution coordinate (maven GAV, docker image, or package) " +
+                    "(component '${entity.componentKey}')"
+            }
+        }
+
+        // #10 groupId supported prefix — applies to every maven artifact regardless
+        // of the distribution gate (matches the old per-config validateGroupId).
+        validateGroupIdPrefixes(entity)
+    }
+
+    /**
+     * #20 doc-component existence (soft string ref, no FK) — 400. Runs POST-flush
+     * so a component that documents ITSELF (a `docs[]` entry pointing at its own
+     * key) passes: on create the component's own row does not exist until the
+     * flush, so a pre-flush check would raise a false 400 for the self-reference.
+     * The component's own key is excluded explicitly as well, so the order of
+     * persistence can never make a self-reference fail.
+     */
+    private fun validateDocComponentExistence(entity: ComponentEntity) {
+        val referencedKeys =
+            entity.docLinks
+                .map { it.docComponentKey }
+                .filterNot { it == entity.componentKey }
+                .toSet()
+        if (referencedKeys.isEmpty()) return
+
+        val existingKeys =
+            componentRepository.findByComponentKeyIn(referencedKeys)
+                .mapTo(HashSet()) { it.componentKey }
+        val missingKey =
+            entity.docLinks
+                .asSequence()
+                .map { it.docComponentKey }
+                .firstOrNull { it != entity.componentKey && it !in existingKeys }
+        require(missingKey == null) {
+            "docs: referenced doc component '$missingKey' does not exist " +
+                "(component '${entity.componentKey}')"
+        }
+    }
+
+    private fun hasAnyDistributionCoordinate(entity: ComponentEntity): Boolean =
+        entity.configurations.any { cfg ->
+            cfg.mavenArtifacts.isNotEmpty() ||
+                cfg.dockerImages.isNotEmpty() ||
+                cfg.packages.isNotEmpty()
+        }
+
+    /**
+     * #10 — every comma/pipe-separated element of every maven `groupPattern`
+     * must start with a configured supported prefix. The supported list is
+     * env-config-driven (`components-registry.supportedGroupIds`, read via the
+     * shared `ConfigHelper`, the same source `CommonControllerV2` and
+     * `FieldConfigSeeder` use). If the list is empty (mis-configured env) the
+     * check is skipped with a WARN rather than rejecting every write — parity
+     * with `FieldConfigSeeder`'s empty-list tolerance.
+     */
+    private fun validateGroupIdPrefixes(entity: ComponentEntity) {
+        val supported = runCatching { configHelper.supportedGroupIds() }.getOrDefault(emptyList())
+        if (supported.isEmpty()) {
+            log.warn(
+                "supportedGroupIds is empty/unavailable; skipping groupId-prefix validation for '{}'",
+                entity.componentKey,
+            )
+            return
+        }
+        entity.configurations.forEach { cfg ->
+            cfg.mavenArtifacts.forEach { artifact ->
+                artifact.groupPattern.split(GROUP_ID_SPLIT).map { it.trim() }.filter { it.isNotEmpty() }
+                    .forEach { groupId ->
+                        require(supported.any { groupId.startsWith(it) }) {
+                            "groupId: '$groupId' does not start with a supported prefix " +
+                                "(${supported.joinToString(", ")}) (component '${entity.componentKey}')"
+                        }
+                    }
+            }
+        }
+    }
+
+    /**
+     * Cross-component collisions with OTHER components → 409. All three rules use
+     * self-excluding indexed queries against the flushed final state:
+     *
+     *  - **#24/#25 duplicate groupId:artifactId in overlapping ranges** — for each
+     *    of this component's maven artifacts, find other components declaring the
+     *    same (group, artifact) and reject if any owning range intersects this
+     *    component's range (Maven `isIntersect`, decided in-memory).
+     *  - **#26 jira (projectKey, versionPrefix) uniqueness among non-archived** —
+     *    an archived component is exempt (matches the old `!archived` filter).
+     *  - **#29 docker image-name global uniqueness** — any other component using
+     *    the same image name is a conflict.
+     */
+    private fun validateCrossComponentIntegrity(entity: ComponentEntity) {
+        val componentId = entity.id ?: return
+        validateMavenArtifactCollisions(entity, componentId)
+        validateJiraProjectKeyVersionPrefixUniqueness(entity, componentId)
+        validateDockerImageUniqueness(entity, componentId)
+    }
+
+    /**
+     * Review #2: a field-override write can introduce a `mavenArtifacts` /
+     * `dockerImages` / jira coordinate on an OVERRIDE row that another component
+     * already claims. The create/update component paths run the cross-component
+     * checks across ALL configuration rows (base + overrides), but the
+     * field-override sub-resource wrote a row WITHOUT re-running them — so a
+     * collision could slip in via an override. After the override row is written
+     * and flushed (via `bumpParentVersion`), reload the owning component and
+     * re-run the SAME composite checks against its full (now-persisted)
+     * configuration set:
+     *
+     *  - [validateMalformedFieldRules] — the #10 groupId-prefix rule applies to a
+     *    GAV introduced on an override row too (the explicit+external / archived
+     *    rules read component scalars, which an override does not change, so they
+     *    are inert here but harmless to re-check).
+     *  - [validateCrossComponentIntegrity] — the #24/#25 maven and #29 docker
+     *    collisions, plus #26 jira uniqueness for a jira-scalar override.
+     *
+     * The owning component already carries an id (the override targets an existing
+     * component), so the self-excluding queries work unchanged. A conflict throws
+     * inside the @Transactional method, rolling back the override write — same
+     * shape as the create/update 409 path. Doc-existence (#20) is component-level,
+     * not configuration-level, so it is intentionally NOT re-run here.
+     */
+    private fun validateFieldOverrideCrossComponent(componentId: UUID) {
+        val reloaded = findComponentOr404(componentId)
+        validateMalformedFieldRules(reloaded)
+        validateCrossComponentIntegrity(reloaded)
+    }
+
+    private fun groupIdMatches(groupId: String, groupIdPattern: String): Boolean {
+        val groupIds = groupId.split(GROUP_ID_SPLIT).map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        return groupIdPattern.split(GROUP_ID_SPLIT).map { it.trim() }.any { it in groupIds }
+    }
+
+    private fun artifactIdMatches(artifactId: String, artifactPattern: String): Boolean {
+        return artifactPattern == "*" || runCatching {
+            val regexPattern = artifactPattern.replace(",", "|")
+            Regex(regexPattern).matches(artifactId)
+        }.getOrDefault(false)
+    }
+
+    private fun mavenArtifactContainsAnother(
+        group1: String, artifact1: String,
+        group2: String, artifact2: String
+    ): Boolean = groupIdMatches(group1, group2) && artifactIdMatches(artifact1, artifact2)
+
+    private fun mavenArtifactsOverlap(
+        group1: String, artifact1: String,
+        group2: String, artifact2: String
+    ): Boolean = mavenArtifactContainsAnother(group1, artifact1, group2, artifact2) ||
+            mavenArtifactContainsAnother(group2, artifact2, group1, artifact1)
+
+    private fun validateMavenArtifactCollisions(entity: ComponentEntity, componentId: UUID) {
+        val otherArtifacts = mavenArtifactRepository.findOtherComponents(componentId)
+        entity.configurations.forEach { cfg ->
+            val ownRange = runCatching { versionRangeFactory.create(cfg.versionRange) }.getOrNull()
+            cfg.mavenArtifacts.forEach { artifact ->
+                otherArtifacts.forEach { other ->
+                    if (mavenArtifactsOverlap(
+                            artifact.groupPattern, artifact.artifactPattern,
+                            other.groupPattern, other.artifactPattern
+                        )
+                    ) {
+                        val intersects =
+                            if (ownRange == null) {
+                                true // unparseable own range — be conservative and treat as overlapping
+                            } else {
+                                runCatching {
+                                    ownRange.isIntersect(versionRangeFactory.create(other.versionRange))
+                                }.getOrDefault(true)
+                            }
+                        if (intersects) {
+                            throw CrossComponentConflictException(
+                                "distribution: groupId:artifactId " +
+                                    "'${artifact.groupPattern}:${artifact.artifactPattern}' of component " +
+                                    "'${entity.componentKey}' overlaps component '${other.componentKey}' " +
+                                    "in version range '${cfg.versionRange}' ∩ '${other.versionRange}'",
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun validateJiraProjectKeyVersionPrefixUniqueness(entity: ComponentEntity, componentId: UUID) {
+        // An archived component does not claim a jira (projectKey, versionPrefix)
+        // bucket — mirrors the old `!moduleConfiguration.archived` filter.
+        if (entity.archived) return
+        // Distinct (projectKey, versionPrefix) pairs across this component's rows.
+        val pairs =
+            entity.configurations
+                .mapNotNull { cfg ->
+                    cfg.jiraProjectKey?.takeIf { it.isNotBlank() }?.let { it to cfg.jiraVersionPrefix }
+                }.toSet()
+        pairs.forEach { (projectKey, versionPrefix) ->
+            val others =
+                configurationRepository.findOtherNonArchivedComponentKeysByJiraProjectKeyAndVersionPrefix(
+                    projectKey,
+                    versionPrefix,
+                    componentId,
+                )
+            if (others.isNotEmpty()) {
+                val prefixText =
+                    if (versionPrefix == null) "no version prefix" else "version prefix '$versionPrefix'"
+                throw CrossComponentConflictException(
+                    "jira: project '$projectKey' with $prefixText is already used by " +
+                        "non-archived component(s) ${others.joinToString(", ")} " +
+                        "(conflicts with '${entity.componentKey}')",
+                )
+            }
+        }
+    }
+
+    private fun validateDockerImageUniqueness(entity: ComponentEntity, componentId: UUID) {
+        val imageNames =
+            entity.configurations
+                .flatMap { it.dockerImages }
+                .map { it.imageName }
+                .filter { it.isNotBlank() }
+                .toSet()
+        imageNames.forEach { imageName ->
+            val others = dockerImageRepository.findOtherComponentKeysByImageName(imageName, componentId)
+            if (others.isNotEmpty()) {
+                throw CrossComponentConflictException(
+                    "distribution: docker image name '$imageName' of component " +
+                        "'${entity.componentKey}' is already used by component(s) " +
+                        "${others.joinToString(", ")} — image names must be globally unique",
+                )
+            }
+        }
+    }
+
     /**
      * Reject write-time enum-typed values that the resolver would later parse
      * with `Enum.valueOf` and silently drop on mismatch. Without these checks
@@ -2103,5 +2442,12 @@ class ComponentManagementServiceImpl(
                 newValue = newValue,
             ),
         )
+    }
+
+    private companion object {
+        private val log = org.slf4j.LoggerFactory.getLogger(ComponentManagementServiceImpl::class.java)
+
+        /** Split a multi-valued `groupPattern` on comma or pipe (legacy DSL semantics). */
+        private val GROUP_ID_SPLIT = Regex("[,|]")
     }
 }

--- a/components-registry-service-server/src/main/resources/db/migration/V2__add_distribution_docker_image_name_index.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V2__add_distribution_docker_image_name_index.sql
@@ -1,0 +1,3 @@
+-- Backs the cross-component image-name uniqueness check with an indexed
+-- equality lookup on every component create/update.
+CREATE INDEX idx_dist_docker_image_name ON distribution_docker_images(image_name);

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/CrossComponentValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/CrossComponentValidationTest.kt
@@ -1,0 +1,511 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * Stage-4 cross-component integrity checks restored from the old
+ * `EscrowConfigValidator` composite rules. Collisions with OTHER components are
+ * 409 (`CrossComponentConflictException`); malformed payloads are 400.
+ *
+ * Each test seeds its own freshly-named components — it does NOT extend the
+ * global `TestComponents` / `Defaults` fixtures (regression-guard rule).
+ * `supportedGroupIds` in `application-common.yml` is
+ * `org.octopusden.octopus,io.bcomponent,org.example`, so maven groups use those
+ * prefixes except where a bad-prefix 400 is the assertion under test.
+ */
+@Tag("integration")
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+class CrossComponentValidationTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(CrossComponentValidationTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun sfx() = UUID.randomUUID().toString().take(8)
+
+    /**
+     * Restored person-field validation (foundation PR) makes `componentOwner`
+     * required non-blank on every successful v4 create. These fixtures don't
+     * care about the owner, so inject a default once when the body omits it —
+     * mirrors the passthrough-helper approach used by the foundation's fixture
+     * commit. Bodies that explicitly set componentOwner (none here today) are
+     * left untouched.
+     */
+    private fun withOwner(body: String): String =
+        if (body.contains("\"componentOwner\"")) {
+            body
+        } else {
+            body.replaceFirst("{", """{"componentOwner":"owner1",""")
+        }
+
+    private fun postCreate(body: String): ResultActions =
+        mvc.perform(
+            post("/rest/api/4/components")
+                .with(adminJwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withOwner(body)),
+        )
+
+    private fun patchComponent(id: String, body: String): ResultActions =
+        mvc.perform(
+            patch("/rest/api/4/components/$id")
+                .with(adminJwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body),
+        )
+
+    /** Create a component, asserting 2xx, and return its id. */
+    private fun createOk(body: String): String {
+        val resp = postCreate(body).andExpect(status().is2xxSuccessful).andReturn().response.contentAsString
+        return objectMapper.readTree(resp)["id"].asText()
+    }
+
+    // ───────────────────────── #24/#25 maven groupId:artifactId collision ─────
+
+    @Test
+    @DisplayName("CREATE: duplicate groupId:artifactId in an overlapping range with another component → 409")
+    fun create_duplicateMavenArtifact_overlappingRange_conflict() {
+        val s = sfx()
+        val group = "org.octopusden.octopus"
+        val artifact = "shared-artifact-$s"
+        createOk(
+            """{"name":"xcc-maven-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"$artifact"}]}}""",
+        )
+        // Second component, same GAV — BASE rows both cover the universal range
+        // (,0),[0,) so they intersect → conflict.
+        postCreate(
+            """{"name":"xcc-maven-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"$artifact"}]}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("CREATE: same groupId:artifactId on a DIFFERENT artifactId → no conflict (2xx)")
+    fun create_differentArtifact_noConflict() {
+        val s = sfx()
+        val group = "org.octopusden.octopus"
+        createOk(
+            """{"name":"xcc-maven-c-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"artifact-c-$s"}]}}""",
+        )
+        postCreate(
+            """{"name":"xcc-maven-d-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"artifact-d-$s"}]}}""",
+        ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
+    @DisplayName("CREATE: wildcard artifactId pattern '*' overlaps with specific artifactId → 409")
+    fun create_wildcardArtifact_overlappingRange_conflict() {
+        val s = sfx()
+        val group = "org.octopusden.octopus.$s"
+        createOk(
+            """{"name":"xcc-maven-wildcard-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"*"}]}}""",
+        )
+        postCreate(
+            """{"name":"xcc-maven-wildcard-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"specific-artifact-$s"}]}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("CREATE: regex artifactId pattern overlaps with specific matching artifactId → 409")
+    fun create_regexArtifact_overlappingRange_conflict() {
+        val s = sfx()
+        val group = "org.octopusden.octopus.$s"
+        createOk(
+            """{"name":"xcc-maven-regex-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"match-.*"}]}}""",
+        )
+        postCreate(
+            """{"name":"xcc-maven-regex-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"match-artifact-$s"}]}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("CREATE: CSV groupPattern overlap → 409")
+    fun create_csvGroup_overlappingRange_conflict() {
+        val s = sfx()
+        val groupA = "org.octopusden.octopus.$s,io.bcomponent.$s"
+        val groupB = "io.bcomponent.$s"
+        val artifact = "csv-artifact-$s"
+        createOk(
+            """{"name":"xcc-maven-csv-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$groupA","artifactPattern":"$artifact"}]}}""",
+        )
+        postCreate(
+            """{"name":"xcc-maven-csv-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$groupB","artifactPattern":"$artifact"}]}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("CREATE: whitespace and pipe-separated groupPattern overlap → 409")
+    fun create_pipeSeparatedGroup_overlappingRange_conflict() {
+        val s = sfx()
+        val sharedGroup = "io.bcomponent.$s"
+        val artifact = "pipe-artifact-$s"
+        createOk(
+            """{"name":"xcc-maven-pipe-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"org.octopusden.octopus.$s | $sharedGroup","artifactPattern":"$artifact"}]}}""",
+        )
+        postCreate(
+            """{"name":"xcc-maven-pipe-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"org.example.$s, $sharedGroup","artifactPattern":"$artifact"}]}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    // ───────────────────────── #26 jira projectKey + versionPrefix uniqueness ──
+
+    @Test
+    @DisplayName("CREATE: same jira projectKey+versionPrefix on another non-archived component → 409")
+    fun create_duplicateJiraProjectKeyPrefix_conflict() {
+        val s = sfx()
+        val projectKey = "XCCJIRA${s.take(4).uppercase()}"
+        createOk(
+            """{"name":"xcc-jira-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey","versionPrefix":"prefixA"}}}""",
+        )
+        postCreate(
+            """{"name":"xcc-jira-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey","versionPrefix":"prefixA"}}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("CREATE: same jira projectKey but DIFFERENT versionPrefix → no conflict (2xx)")
+    fun create_sameProjectKeyDifferentPrefix_noConflict() {
+        val s = sfx()
+        val projectKey = "XCCJIRA${s.take(4).uppercase()}"
+        createOk(
+            """{"name":"xcc-jira-c-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey","versionPrefix":"alpha"}}}""",
+        )
+        postCreate(
+            """{"name":"xcc-jira-d-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey","versionPrefix":"beta"}}}""",
+        ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
+    @DisplayName("CREATE: same jira projectKey+prefix but the rival is ARCHIVED → no conflict (2xx)")
+    fun create_duplicateJira_rivalArchived_noConflict() {
+        val s = sfx()
+        val projectKey = "XCCJIRA${s.take(4).uppercase()}"
+        createOk(
+            """{"name":"xcc-jira-arch-$s","archived":true,""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey","versionPrefix":"gamma"}}}""",
+        )
+        postCreate(
+            """{"name":"xcc-jira-live-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey","versionPrefix":"gamma"}}}""",
+        ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
+    @DisplayName("CREATE: same jira projectKey, BOTH null versionPrefix, both non-archived → 409 (review #5)")
+    fun create_duplicateJiraProjectKey_bothNullPrefix_conflict() {
+        val s = sfx()
+        val projectKey = "XCCNULL${s.take(4).uppercase()}"
+        // Neither component sets jira.versionPrefix, so both land in the
+        // (projectKey, NULL) bucket. This exercises the null-safe branch of
+        // findOtherNonArchivedComponentKeysByJiraProjectKeyAndVersionPrefix
+        // (a plain `version_prefix = :prefix` would miss NULL = NULL).
+        createOk(
+            """{"name":"xcc-jira-null-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey"}}}""",
+        )
+        postCreate(
+            """{"name":"xcc-jira-null-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey"}}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    // ───────────────────────── #29 docker image-name global uniqueness ─────────
+
+    @Test
+    @DisplayName("CREATE: duplicate docker image name across components → 409")
+    fun create_duplicateDockerImage_conflict() {
+        val s = sfx()
+        val image = "registry.example/img-$s"
+        createOk(
+            """{"name":"xcc-docker-a-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"dockerImages":[{"imageName":"$image"}]}}""",
+        )
+        postCreate(
+            """{"name":"xcc-docker-b-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"dockerImages":[{"imageName":"$image"}]}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("PATCH: setting a docker image already owned by another component → 409")
+    fun patch_duplicateDockerImage_conflict() {
+        val s = sfx()
+        val image = "registry.example/patch-img-$s"
+        createOk(
+            """{"name":"xcc-docker-existing-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"dockerImages":[{"imageName":"$image"}]}}""",
+        )
+        val targetResp =
+            postCreate(
+                """{"name":"xcc-docker-target-$s",""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+            ).andExpect(status().is2xxSuccessful).andReturn().response.contentAsString
+        val target = objectMapper.readTree(targetResp)
+        val id = target["id"].asText()
+        val version = target["version"].asLong()
+        patchComponent(
+            id,
+            """{"version":$version,"baseConfiguration":{"dockerImages":[{"imageName":"$image"}]}}""",
+        ).andExpect(status().isConflict)
+    }
+
+    // ───────────────────────── #6 explicit-external ≥1 coordinate (400) ────────
+
+    @Test
+    @DisplayName("CREATE: explicit+external with NO distribution coordinate → 400")
+    fun create_explicitExternal_noCoordinate_badRequest() {
+        val s = sfx()
+        // RM/SC supplied so the explicit+external person-field gate passes and the
+        // 400 under test is the ≥1-coordinate rule (#6), not a missing-releaseManager
+        // rejection (person validation runs first on create).
+        postCreate(
+            """{"name":"xcc-ext-nocoord-$s","distributionExplicit":true,"distributionExternal":true,""" +
+                """"releaseManager":["rm1"],"securityChampion":["sc1"],""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("CREATE: explicit+external WITH a docker coordinate → 2xx")
+    fun create_explicitExternal_withCoordinate_ok() {
+        val s = sfx()
+        // An explicit+external component also trips the foundation's person-field
+        // gate: releaseManager + securityChampion are required (non-blank, ^\w+$)
+        // under explicit && external. Supply both so the only thing under test
+        // here is the ≥1-coordinate rule (docker image present → 2xx).
+        postCreate(
+            """{"name":"xcc-ext-coord-$s","distributionExplicit":true,"distributionExternal":true,""" +
+                """"releaseManager":["rm1"],"securityChampion":["sc1"],""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"dockerImages":[{"imageName":"registry.example/ext-$s"}]}}""",
+        ).andExpect(status().is2xxSuccessful)
+    }
+
+    // ───────────────────────── #10 groupId supported prefix (400) ──────────────
+
+    @Test
+    @DisplayName("CREATE: maven groupId with an unsupported prefix → 400")
+    fun create_unsupportedGroupIdPrefix_badRequest() {
+        val s = sfx()
+        postCreate(
+            """{"name":"xcc-badgroup-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"com.unsupported.vendor","artifactPattern":"x-$s"}]}}""",
+        ).andExpect(status().isBadRequest)
+    }
+
+    // ───────────────────────── #28 archived ≠ explicit-external (400) ──────────
+
+    @Test
+    @DisplayName("CREATE: archived component that is explicit+external → 400")
+    fun create_archivedExplicitExternal_badRequest() {
+        val s = sfx()
+        // RM/SC supplied so the explicit+external person-field gate passes and the
+        // 400 under test is the archived-vs-explicit-external rule (#28), not a
+        // missing-releaseManager rejection (person validation runs first on create).
+        postCreate(
+            """{"name":"xcc-arch-ext-$s","archived":true,""" +
+                """"distributionExplicit":true,"distributionExternal":true,""" +
+                """"releaseManager":["rm1"],"securityChampion":["sc1"],""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"dockerImages":[{"imageName":"registry.example/arch-$s"}]}}""",
+        ).andExpect(status().isBadRequest)
+    }
+
+    // ───────────────────────── #20 doc-component existence (400) ───────────────
+
+    @Test
+    @DisplayName("CREATE: docs[] referencing a non-existent doc component → 400")
+    fun create_docComponentMissing_badRequest() {
+        val s = sfx()
+        postCreate(
+            """{"name":"xcc-doc-missing-$s",""" +
+                """"docs":[{"docComponentKey":"no-such-doc-$s"}],""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("CREATE: docs[] referencing an EXISTING doc component → 2xx")
+    fun create_docComponentExists_ok() {
+        val s = sfx()
+        val docKey = "xcc-doc-target-$s"
+        createOk("""{"name":"$docKey","baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""")
+        postCreate(
+            """{"name":"xcc-doc-ref-$s",""" +
+                """"docs":[{"docComponentKey":"$docKey"}],""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+        ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
+    @DisplayName("CREATE: docs[] referencing the component's OWN key (self-documenting) → 2xx (review #6)")
+    fun create_docComponentSelfReference_ok() {
+        val s = sfx()
+        val ownKey = "xcc-doc-self-$s"
+        // A component may legitimately document itself. The own key does not
+        // exist in the DB until the flush on create, so the doc-existence check
+        // must run POST-flush (review #6) for this to be accepted as 2xx rather
+        // than a false 400.
+        postCreate(
+            """{"name":"$ownKey",""" +
+                """"docs":[{"docComponentKey":"$ownKey"}],""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+        ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
+    @DisplayName("PATCH: rename-only validates docs[] references left on the old key → 400")
+    fun patch_renameOnly_invalidatesOldSelfDocReference() {
+        val s = sfx()
+        val oldKey = "xcc-doc-rename-old-$s"
+        val id =
+            createOk(
+                """{"name":"$oldKey",""" +
+                    """"docs":[{"docComponentKey":"$oldKey"}],""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+            )
+
+        patchComponent(id, """{"version":0,"name":"xcc-doc-rename-new-$s"}""")
+            .andExpect(status().isBadRequest)
+    }
+
+    // ─── #2 field-override (MARKER) write also runs the 409 checks (review #2) ───
+
+    @Test
+    @DisplayName("createFieldOverride that sets a GAV another component already claims → 409 (review #2)")
+    fun createFieldOverride_duplicateMavenArtifact_conflict() {
+        val s = sfx()
+        val group = "org.octopusden.octopus"
+        val artifact = "fo-shared-artifact-$s"
+        // Component A owns the GAV on its BASE row (universal range).
+        createOk(
+            """{"name":"xcc-fo-owner-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"$artifact"}]}}""",
+        )
+        // Component B starts WITHOUT the GAV (valid create).
+        val bResp =
+            postCreate(
+                """{"name":"xcc-fo-claimant-$s",""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+            ).andExpect(status().is2xxSuccessful).andReturn().response.contentAsString
+        val bId = objectMapper.readTree(bResp)["id"].asText()
+        // A MARKER field-override on B that introduces the SAME GAV in an
+        // overlapping range must hit the cross-component 409 check (review #2:
+        // field-override writes previously bypassed it).
+        mvc.perform(
+            post("/rest/api/4/components/$bId/field-overrides")
+                .with(adminJwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """{"versionRange":"[1.0,2.0)","overriddenAttribute":"distribution.maven",""" +
+                        """"markerChildren":{"mavenArtifacts":[{"groupPattern":"$group","artifactPattern":"$artifact"}]}}""",
+                ),
+        ).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("createFieldOverride that sets a docker image another component already claims → 409 (review #2)")
+    fun createFieldOverride_duplicateDockerImage_conflict() {
+        val s = sfx()
+        val image = "registry.example/fo-img-$s"
+        createOk(
+            """{"name":"xcc-fo-docker-owner-$s",""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"dockerImages":[{"imageName":"$image"}]}}""",
+        )
+        val bResp =
+            postCreate(
+                """{"name":"xcc-fo-docker-claimant-$s",""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+            ).andExpect(status().is2xxSuccessful).andReturn().response.contentAsString
+        val bId = objectMapper.readTree(bResp)["id"].asText()
+        mvc.perform(
+            post("/rest/api/4/components/$bId/field-overrides")
+                .with(adminJwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """{"versionRange":"[1.0,2.0)","overriddenAttribute":"distribution.docker",""" +
+                        """"markerChildren":{"dockerImages":[{"imageName":"$image"}]}}""",
+                ),
+        ).andExpect(status().isConflict)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
@@ -25,6 +25,8 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentCon
 import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionDockerImageRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionMavenArtifactRepository
 import org.octopusden.octopus.components.registry.server.repository.LabelRepository
 import org.octopusden.octopus.components.registry.server.repository.SystemRepository
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
@@ -83,6 +85,8 @@ class MIG047FieldOverrideWriteGuardTest {
                 componentLabelRepository = mock(ComponentLabelRepository::class.java),
                 componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
                 componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+                mavenArtifactRepository = mock(DistributionMavenArtifactRepository::class.java),
+                dockerImageRepository = mock(DistributionDockerImageRepository::class.java),
                 labelRepository = mock(LabelRepository::class.java),
                 systemRepository = mock(SystemRepository::class.java),
                 toolRepository = mock(ToolRepository::class.java),

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -141,6 +141,25 @@ Version ranges for the **same field** must not overlap. This is enforced on crea
 - **Behavior**: Removes the version override for a specific field and range
 - **Effect**: The field reverts to the component default for that version range
 
+### 2.5 Cross-Component Integrity Validation
+
+In addition to the per-component overlap rules above (section 2.1), `POST /rest/api/4/components` (create), `PATCH /rest/api/4/components/{id}` (update), **and the field-override sub-resource** (`POST`/`PATCH /rest/api/4/components/{id}/field-overrides[/{overrideId}]`) enforce a set of **cross-component** and malformed-input rules at write time. These restore the composite checks the legacy `EscrowConfigValidator` ran at config-load time (audit `VALIDATION-PARITY-2026-06-03.md`, rows #6/#10/#20/#24/#25/#26/#28/#29). See `tech-debt/012-pre-publish-validation-parity.md` for the parity ledger.
+
+The checks validate the **final persisted state** (after the patch is applied and flushed) using **self-excluding** queries — a component never conflicts with itself, while conflicts with other components are still rejected whenever validation is triggered. A field-override write that introduces a `mavenArtifacts` / `dockerImages` coordinate on an override row is re-validated against all of the owning component's configuration rows (base + overrides), so a collision cannot be slipped in through the sub-resource.
+
+Conflicts with **other** components → **409 Conflict** (`CrossComponentConflictException`):
+- **Duplicate `groupId:artifactId` in overlapping ranges** — two components must not declare the same maven `(groupPattern, artifactPattern)` for intersecting version ranges. Intersection uses the same Maven boundary semantics as section 2.1.
+- **Jira `(projectKey, versionPrefix)` uniqueness among non-archived components** — each `(projectKey, versionPrefix)` pair maps to at most one non-archived component. A `null` version prefix is its own bucket. Archived components are exempt and do not claim a bucket.
+- **Docker image-name global uniqueness** — a docker image name (e.g. `registry.example/app`) may be declared by at most one component across the whole registry.
+
+Malformed-input rules → **400 Bad Request** (`IllegalArgumentException`, field-name-prefixed message):
+- **Explicit+external requires ≥1 distribution coordinate** — when `distributionExplicit && distributionExternal`, the component must define at least one maven artifact, docker image, or package on some configuration row.
+- **`groupId` supported prefix** — every maven `groupPattern` element must start with a configured `components-registry.supportedGroupIds` prefix. When that list is unconfigured/empty the check is skipped (logged), not enforced.
+- **Archived ≠ explicit+external** — an archived component cannot be explicitly+externally distributed.
+- **Doc-component existence** — every `docs[].docComponentKey` must reference an existing component. The reference is a soft string ref (no FK, see `schema-spec.md:288`), so existence is verified in the service layer. This check runs **post-flush** (alongside the 409 checks), so a component may reference its **own** key (self-documenting) without a false 400 — the component's own row exists by then, and the own key is excluded explicitly regardless of persistence order.
+
+**Performance**: Docker image and Jira collision checks use indexed equality queries (`image_name`, `jira_project_key`). Maven collision validation loads projected artifact rows from other components and performs legacy-compatible wildcard/regex/CSV pattern overlap plus Maven range intersection in-memory; exact SQL equality cannot safely narrow those candidates. The docker check is backed by `idx_dist_docker_image_name` on `distribution_docker_images(image_name)`.
+
 ## 3. Search & Lookup (Existing API Behavior)
 
 All existing search/lookup operations must return identical results from DB:


### PR DESCRIPTION
## What

Restores the **cross-component integrity** checks the v4 DB API had dropped (audit `.github/audit/VALIDATION-PARITY-2026-06-03.md`, rows #6/#10/#20/#24/#25/#26/#28/#29):

- **409** (`CrossComponentConflictException`): duplicate `groupId:artifactId` in overlapping version ranges; jira `(projectKey, versionPrefix)` uniqueness among non-archived components; docker image-name global uniqueness.
- **400**: explicit-external must define ≥1 distribution coordinate; `groupId` supported-prefix; archived ≠ explicit-external; doc-component existence (soft ref).
- Field-override writes (`createFieldOverride`/`updateFieldOverride`) re-run these checks so a marker row can't bypass them (review #2).
- `distribution_docker_images(image_name)` indexed (review #4); null-`versionPrefix` collision covered (review #5); self-referential doc link accepted via post-flush existence check (review #6).

## Notes

- Update path **grandfathers untouched legacy data**: the cross-component/malformed checks re-run only when the PATCH changes a governed field (`baseConfiguration` / `docs` / `distributionExplicit` / `distributionExternal` / `archived`). No validation is weakened — every governed field still triggers its check when changed.
- Stacked on `feat/v4-person-field-validation` — **base that PR first**.
- Green end-to-end: `:test` + `:dbTest`, 0 failures. Independently reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
