### PR TITLE
feat(v4): restore cheap field-format checks (clientCode / copyright / artifactId / beanType)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -82,8 +82,11 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.nio.file.Files
 import java.time.Instant
 import java.util.UUID
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
 
 /**
  * v4 CRUD against the v2 schema (Model A'). Top-level scalars and per-component
@@ -163,6 +166,12 @@ class ComponentManagementServiceImpl(
         // sprinkling `!!` or `?.let` at each call site.
         val buildSystemValue: String = buildAspect.buildSystem!!
         request.productType?.let { validateProductType(it) }
+        request.clientCode?.let {
+            if (!fieldConfigService.isHidden("component.clientCode")) validateClientCode(it)
+        }
+        request.copyright?.let {
+            if (!fieldConfigService.isHidden("component.copyright")) validateCopyright(it)
+        }
         baseConfigRequest.versionRange?.let { validateRangeSyntax(it) }
         validateBuildSystem(buildSystemValue)
         baseConfigRequest.escrow?.generation?.let { validateEscrowGenerationMode(it) }
@@ -451,7 +460,12 @@ class ComponentManagementServiceImpl(
         request.displayName?.let { if (!fieldConfigService.isHidden("component.displayName")) entity.displayName = it }
         request.componentOwner?.let { if (!fieldConfigService.isHidden("component.componentOwner")) entity.componentOwner = it }
         request.productType?.let { if (!fieldConfigService.isHidden("component.productType")) entity.productType = it }
-        request.clientCode?.let { if (!fieldConfigService.isHidden("component.clientCode")) entity.clientCode = it }
+        request.clientCode?.let {
+            if (!fieldConfigService.isHidden("component.clientCode")) {
+                validateClientCode(it)
+                entity.clientCode = it
+            }
+        }
         request.solution?.let { if (!fieldConfigService.isHidden("component.solution")) entity.solution = it }
         request.archived?.let { entity.archived = it }
         // canBeParent is structural (not field-config-gated). Invariants are
@@ -465,7 +479,12 @@ class ComponentManagementServiceImpl(
         request.securityChampion?.let {
             if (!fieldConfigService.isHidden("component.securityChampion")) entity.replaceSecurityChampionUsernames(it)
         }
-        request.copyright?.let { if (!fieldConfigService.isHidden("component.copyright")) entity.copyright = it }
+        request.copyright?.let {
+            if (!fieldConfigService.isHidden("component.copyright")) {
+                validateCopyright(it)
+                entity.copyright = it
+            }
+        }
         request.releasesInDefaultBranch?.let {
             if (!fieldConfigService.isHidden("component.releasesInDefaultBranch")) entity.releasesInDefaultBranch = it
         }
@@ -920,6 +939,9 @@ class ComponentManagementServiceImpl(
         component: ComponentEntity,
         requests: List<org.octopusden.octopus.components.registry.server.dto.v4.ArtifactIdRequest>,
     ) {
+        // artifactId patterns must be valid regexes (audit #9). Validated here so
+        // both the create and the PATCH (REPLACE) paths are covered by one call site.
+        requests.forEach { validateArtifactIdPattern(it.artifactPattern) }
         requests.forEachIndexed { index, req ->
             component.artifactIds.add(
                 ComponentArtifactIdEntity(
@@ -1433,6 +1455,13 @@ class ComponentManagementServiceImpl(
 
     private fun validateBuildToolBeans(beans: List<BuildToolBeanRequest>) {
         beans.forEach { bean ->
+            // Build-tool per-field required (audit #19; old
+            // EscrowConfigValidator.validateBuildConfigurationTools required each
+            // tool's identifying fields). In v4 a build-tool is a typed bean whose
+            // identifying field is `beanType`; require it to be specified. The
+            // message is field-name-prefixed so the contract matches the other
+            // cheap field checks (→ 400).
+            require(bean.beanType.isNotBlank()) { "beanType is not specified for a buildToolBean" }
             require(bean.beanType in BEAN_TYPE_NAMES) {
                 "Invalid beanType '${bean.beanType}'; must be one of $BEAN_TYPE_NAMES"
             }
@@ -2096,6 +2125,80 @@ class ComponentManagementServiceImpl(
         }
     }
 
+    // ------------------------------------------------------------------
+    // Cheap field-format checks (Stage 5 / validation-parity audit #9,#16,#19,#21).
+    //
+    // Restores the single-field shape/format validations the old
+    // EscrowConfigValidator ran at config-load time but that the v4 write
+    // path dropped. All four are field-name-prefixed `require(...)` →
+    // IllegalArgumentException → 400 (ControllerExceptionHandler).
+    // ------------------------------------------------------------------
+
+    /**
+     * `clientCode` must match `[A-Z_0-9]+` when present (audit #16; old
+     * `EscrowConfigValidator.validateClientCode`). A blank/whitespace value is
+     * treated as "no client code" and skipped — only a non-blank value that
+     * fails the pattern is rejected.
+     */
+    private fun validateClientCode(value: String) {
+        if (value.isBlank()) return
+        require(CLIENT_CODE_PATTERN.matches(value)) {
+            "clientCode '$value' does not match the required pattern '${CLIENT_CODE_PATTERN.pattern}'"
+        }
+    }
+
+    /**
+     * `copyright` must name a file in the configured copyright directory (audit
+     * #21; old `EscrowConfigValidator.validateCopyright`). The supported list is
+     * the same source the old validator used: the regular files under
+     * `components-registry.copyright-path`. When that path is not configured (or
+     * cannot be listed), the check is a no-op — mirroring the old behaviour of
+     * skipping when `copyrightPath == null`. A blank value is skipped.
+     */
+    private fun validateCopyright(value: String) {
+        if (value.isBlank()) return
+        val supported = supportedCopyrights() ?: return
+        require(value in supported) {
+            "copyright '$value' is not supported. Available values are $supported"
+        }
+    }
+
+    /**
+     * The supported-copyright names, read from the configured copyright
+     * directory (regular files only). Returns null when no path is configured or
+     * the directory cannot be listed, so the caller can skip the check.
+     */
+    private fun supportedCopyrights(): List<String>? {
+        val path = configHelper.copyrightPath() ?: return null
+        return runCatching {
+            Files.list(path).use { stream ->
+                stream.filter { Files.isRegularFile(it) }
+                    .map { it.fileName.toString() }
+                    .sorted()
+                    .toList()
+            }
+        }.onFailure {
+            log.warn("Copyright directory '{}' is unreadable; copyright validation skipped", path, it)
+        }.getOrNull()
+    }
+
+    /**
+     * An `artifactId` pattern must be a compilable regular expression (audit #9;
+     * old `EscrowConfigValidator.validateArtifactId`). Applied per
+     * `artifactIds[].artifactPattern` on the create/update paths.
+     */
+    private fun validateArtifactIdPattern(pattern: String) {
+        require(pattern.isNotBlank()) { "artifactId pattern must not be blank" }
+        try {
+            Pattern.compile(pattern)
+        } catch (e: PatternSyntaxException) {
+            throw IllegalArgumentException(
+                "artifactId pattern '$pattern' is not a valid regular expression",
+                e,
+            )
+        }
+    }
+
     private fun buildSpecification(filter: ComponentFilter): Specification<ComponentEntity> {
         var spec = Specification.where<ComponentEntity>(null)
 
@@ -2449,5 +2552,8 @@ class ComponentManagementServiceImpl(
 
         /** Split a multi-valued `groupPattern` on comma or pipe (legacy DSL semantics). */
         private val GROUP_ID_SPLIT = Regex("[,|]")
+
+        // Same shape as the old EscrowConfigValidator.CLIENT_CODE_PATTERN.
+        private val CLIENT_CODE_PATTERN = Regex("[A-Z_0-9]+")
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ListComponentsExtendedFiltersTest.kt
@@ -2,6 +2,8 @@ package org.octopusden.octopus.components.registry.server.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -123,20 +125,20 @@ class ListComponentsExtendedFiltersTest {
         val match = uniqueName("ext_cc_match")
         val other = uniqueName("ext_cc_other")
         val third = uniqueName("ext_cc_third")
-        create(baseBody(match, ""","clientCode":"ACME-PORTAL""""))
-        create(baseBody(other, ""","clientCode":"OTHER-CC""""))
-        create(baseBody(third, ""","clientCode":"THIRD-CC""""))
+        create(baseBody(match, ""","clientCode":"ACME_PORTAL""""))
+        create(baseBody(other, ""","clientCode":"OTHER_CC""""))
+        create(baseBody(third, ""","clientCode":"THIRD_CC""""))
         // Exact: a partial value no longer matches (was a substring LIKE pre-SYS-046).
         val partial = names("clientCode" to "ACME")
-        assert(!partial.contains(match)) { "partial 'ACME' must not match 'ACME-PORTAL' after LIKE→IN; got $partial" }
+        assertFalse(partial.contains(match), "partial 'ACME' must not match 'ACME_PORTAL' after LIKE→IN; got $partial")
         // Exact single value matches only the exact code.
-        val exact = names("clientCode" to "ACME-PORTAL")
-        assert(exact.contains(match)) { "expected $match in $exact" }
-        assert(!exact.contains(other)) { "did not expect $other in $exact" }
-        // Multi-value OR: ACME-PORTAL,OTHER-CC returns both, excludes the third.
-        val multi = names("clientCode" to "ACME-PORTAL,OTHER-CC")
-        assert(multi.contains(match) && multi.contains(other)) { "expected both in $multi" }
-        assert(!multi.contains(third)) { "did not expect $third in $multi" }
+        val exact = names("clientCode" to "ACME_PORTAL")
+        assertTrue(exact.contains(match), "expected $match in $exact")
+        assertFalse(exact.contains(other), "did not expect $other in $exact")
+        // Multi-value OR: ACME_PORTAL,OTHER_CC returns both, excludes the third.
+        val multi = names("clientCode" to "ACME_PORTAL,OTHER_CC")
+        assertTrue(multi.contains(match) && multi.contains(other), "expected both in $multi")
+        assertFalse(multi.contains(third), "did not expect $third in $multi")
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaInUseOptionsEndpointsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaInUseOptionsEndpointsTest.kt
@@ -111,8 +111,10 @@ class MetaInUseOptionsEndpointsTest {
     @Test
     @DisplayName("SYS-046: GET /meta/client-codes returns sorted distinct in-use client codes")
     fun `SYS-046 meta client-codes returns sorted distinct in-use values`() {
-        val a = uniqueName("ZCC")
-        val b = uniqueName("ACC")
+        // clientCode must match [A-Z_0-9]+ (restored validation); uppercase the
+        // uniqueName suffix (UUID hex is lowercase) so the seed is accepted.
+        val a = uniqueName("ZCC").uppercase()
+        val b = uniqueName("ACC").uppercase()
         create(baseBody(uniqueName("cc_one"), ""","clientCode":"$a""""))
         create(baseBody(uniqueName("cc_two"), ""","clientCode":"$b""""))
         // Duplicate the first code on a separate component to exercise DISTINCT.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/CheapFieldFormatValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/CheapFieldFormatValidationTest.kt
@@ -1,0 +1,371 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Optional
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.regex.PatternSyntaxException
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.octopusden.octopus.components.registry.server.dto.v4.ArtifactIdRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.BaseConfigurationRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.BuildAspectRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.BuildToolBeanRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.ComponentCreateRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateRequest
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionDockerImageRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionMavenArtifactRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
+import org.octopusden.octopus.components.registry.server.util.ComponentCodeRenderer
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.core.env.Environment
+
+/**
+ * Stage 5 (cheap field-format checks) — restores the pre-publish single-field
+ * validations the old `EscrowConfigValidator` ran but that the v4 write path
+ * dropped:
+ *
+ *  - `clientCode` must match `[A-Z_0-9]+` when present (OLD-VALIDATOR.validateClientCode, audit #16);
+ *  - `copyright` must be in the supported list (OLD-VALIDATOR.validateCopyright, audit #21);
+ *  - each `artifactIds[].artifactPattern` must be a valid regex (OLD-VALIDATOR.validateArtifactId, audit #9);
+ *  - each `buildToolBeans[].beanType` must be specified — the v4 analogue of the old
+ *    build-tool per-field requireds (OLD-VALIDATOR.validateBuildConfigurationTools, audit #19).
+ *
+ * All four are pure `require(...)` checks that run before any DB write, so a
+ * unit test with mocked repositories (no Spring context, no DB) is sufficient —
+ * same shape as MIG047FieldOverrideWriteGuardTest.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class CheapFieldFormatValidationTest {
+
+    private lateinit var componentRepository: ComponentRepository
+    private lateinit var environment: Environment
+    private lateinit var fieldConfigService: FieldConfigService
+    private lateinit var service: ComponentManagementServiceImpl
+
+    @TempDir
+    private lateinit var copyrightDir: Path
+
+    private val existingId = UUID.randomUUID()
+    private lateinit var existing: ComponentEntity
+
+    @BeforeEach
+    fun setUp() {
+        componentRepository = mock(ComponentRepository::class.java)
+        environment = mock(Environment::class.java)
+        fieldConfigService = mock(FieldConfigService::class.java)
+
+        // A copyright directory holding a single supported file, wired through
+        // ConfigHelper.copyrightPath() (env property `components-registry.copyright-path`).
+        Files.createFile(copyrightDir.resolve(SUPPORTED_COPYRIGHT))
+        doReturn(copyrightDir.toString())
+            .`when`(environment).getProperty("components-registry.copyright-path")
+
+        val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+
+        service =
+            ComponentManagementServiceImpl(
+                componentRepository = componentRepository,
+                configurationRepository = mock(ComponentConfigurationRepository::class.java),
+                componentLabelRepository = mock(ComponentLabelRepository::class.java),
+                componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+                componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+                mavenArtifactRepository = mock(DistributionMavenArtifactRepository::class.java),
+                dockerImageRepository = mock(DistributionDockerImageRepository::class.java),
+                labelRepository = mock(LabelRepository::class.java),
+                systemRepository = mock(SystemRepository::class.java),
+                toolRepository = mock(ToolRepository::class.java),
+                sourceRegistry = mock(ComponentSourceRegistry::class.java),
+                applicationEventPublisher = mock(ApplicationEventPublisher::class.java),
+                currentUserResolver = mock(CurrentUserResolver::class.java),
+                fieldConfigService = fieldConfigService,
+                teamcityProperties = mock(TeamcityProperties::class.java),
+                versionRangeFactory = VersionRangeFactory(versionNames),
+                environment = environment,
+                componentCodeRenderer =
+                    ComponentCodeRenderer(
+                        VersionRangeFactory(versionNames),
+                        NumericVersionFactory(versionNames),
+                    ),
+                employeeDirectory = EmployeeDirectoryService(EmptyObjectProvider()),
+            )
+
+        // CREATE path: no name collision.
+        doReturn(false).`when`(componentRepository).existsByComponentKey(anyString())
+        doAnswer { invocation ->
+            (invocation.arguments[0] as ComponentEntity).apply {
+                if (id == null) id = UUID.randomUUID()
+                artifactIds.forEach { if (it.id == null) it.id = UUID.randomUUID() }
+                configurations.forEach { config ->
+                    if (config.id == null) config.id = UUID.randomUUID()
+                    config.buildToolBeans.forEach { if (it.id == null) it.id = UUID.randomUUID() }
+                }
+            }
+        }.`when`(componentRepository).saveAndFlush(any(ComponentEntity::class.java))
+
+        // UPDATE path: an existing component with a matching optimistic-lock version.
+        // FieldConfigService is a Mockito mock → isHidden(...) defaults to false,
+        // so update writes are NOT silently stripped.
+        existing =
+            ComponentEntity(
+                id = existingId,
+                componentKey = "cheap-fixture",
+                version = 0L,
+                // Required by the foundation contract (componentOwner non-blank). Without it
+                // a buildToolBeans/artifactIds-only PATCH would 400 on the owner check (which
+                // runs before the beanType/artifactId checks) instead of the field under test.
+                componentOwner = "owner1",
+            )
+        doReturn(Optional.of(existing)).`when`(componentRepository).findById(existingId)
+    }
+
+    private fun minimalCreate(
+        name: String = "cheap-create",
+        componentOwner: String? = "owner1",
+        clientCode: String? = null,
+        copyright: String? = null,
+        artifactIds: List<ArtifactIdRequest> = emptyList(),
+        buildToolBeans: List<BuildToolBeanRequest>? = null,
+    ) = ComponentCreateRequest(
+        name = name,
+        componentOwner = componentOwner,
+        clientCode = clientCode,
+        copyright = copyright,
+        artifactIds = artifactIds,
+        baseConfiguration =
+            BaseConfigurationRequest(
+                build = BuildAspectRequest(buildSystem = "MAVEN"),
+                buildToolBeans = buildToolBeans,
+            ),
+    )
+
+    private fun minimalUpdate(
+        clientCode: String? = null,
+        copyright: String? = null,
+        artifactIds: List<ArtifactIdRequest>? = null,
+        buildToolBeans: List<BuildToolBeanRequest>? = null,
+    ) = ComponentUpdateRequest(
+        version = 0L,
+        clientCode = clientCode,
+        copyright = copyright,
+        artifactIds = artifactIds,
+        baseConfiguration =
+            if (buildToolBeans != null) {
+                BaseConfigurationRequest(buildToolBeans = buildToolBeans)
+            } else {
+                null
+            },
+    )
+
+    private fun assertFieldPrefixed(
+        field: String,
+        block: () -> Unit,
+    ) {
+        val ex = assertThrows(IllegalArgumentException::class.java, block)
+        assertTrue(
+            ex.message!!.startsWith(field),
+            "message must start with the field name '$field'; got: '${ex.message}'",
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // clientCode  —  [A-Z_0-9]+   (audit #16)
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("CREATE rejects clientCode not matching [A-Z_0-9]+")
+    fun create_rejects_badClientCode() {
+        assertFieldPrefixed("clientCode") {
+            service.createComponent(minimalCreate(clientCode = "bad-code!"))
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH rejects clientCode not matching [A-Z_0-9]+")
+    fun patch_rejects_badClientCode() {
+        assertFieldPrefixed("clientCode") {
+            service.updateComponent(existingId, minimalUpdate(clientCode = "bad code"))
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // copyright  —  supported list   (audit #21)
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("CREATE rejects copyright outside the supported list")
+    fun create_rejects_unsupportedCopyright() {
+        assertFieldPrefixed("copyright") {
+            service.createComponent(minimalCreate(copyright = "NOT_A_KNOWN_COPYRIGHT"))
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH rejects copyright outside the supported list")
+    fun patch_rejects_unsupportedCopyright() {
+        assertFieldPrefixed("copyright") {
+            service.updateComponent(existingId, minimalUpdate(copyright = "NOT_A_KNOWN_COPYRIGHT"))
+        }
+    }
+
+    @Test
+    @DisplayName("copyright error lists available values in deterministic order")
+    fun copyright_errorListsSupportedValuesSorted() {
+        Files.createFile(copyrightDir.resolve("z-license.txt"))
+        Files.createFile(copyrightDir.resolve("a-license.txt"))
+
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                service.createComponent(minimalCreate(copyright = "NOT_A_KNOWN_COPYRIGHT"))
+            }
+        assertTrue(
+            ex.message!!.contains("Available values are [a-license.txt, $SUPPORTED_COPYRIGHT, z-license.txt]"),
+            "available copyright values must be sorted; got: '${ex.message}'",
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // artifactId pattern  —  valid regex   (audit #9)
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("CREATE rejects an artifactPattern that is not a valid regex")
+    fun create_rejects_invalidArtifactRegex() {
+        val ex =
+            assertThrows(IllegalArgumentException::class.java) {
+                service.createComponent(
+                    minimalCreate(
+                        artifactIds = listOf(ArtifactIdRequest(groupPattern = "org.example", artifactPattern = "[unclosed")),
+                    ),
+                )
+            }
+        assertTrue(ex.message!!.startsWith("artifactId"))
+        assertTrue(
+            ex.cause is PatternSyntaxException,
+            "invalid regex must preserve PatternSyntaxException as the cause; got: ${ex.cause}",
+        )
+    }
+
+    @Test
+    @DisplayName("PATCH rejects an artifactPattern that is not a valid regex")
+    fun patch_rejects_invalidArtifactRegex() {
+        assertFieldPrefixed("artifactId") {
+            service.updateComponent(
+                existingId,
+                minimalUpdate(
+                    artifactIds = listOf(ArtifactIdRequest(groupPattern = "org.example", artifactPattern = "(")),
+                ),
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // buildToolBeans per-field requireds   (audit #19)
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("CREATE rejects a buildToolBean with a blank beanType")
+    fun create_rejects_blankBeanType() {
+        assertFieldPrefixed("beanType") {
+            service.createComponent(
+                minimalCreate(buildToolBeans = listOf(BuildToolBeanRequest(beanType = "   "))),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH rejects a buildToolBean with a blank beanType")
+    fun patch_rejects_blankBeanType() {
+        assertFieldPrefixed("beanType") {
+            service.updateComponent(
+                existingId,
+                minimalUpdate(buildToolBeans = listOf(BuildToolBeanRequest(beanType = ""))),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("valid clientCode, copyright, artifactId regex, and beanType pass validation (green-path)")
+    fun greenPath_validationPasses() {
+        doReturn(false).`when`(fieldConfigService).isHidden(anyString())
+
+        // CREATE green path
+        val createReq =
+            minimalCreate(
+                clientCode = "VALID_CODE_1",
+                copyright = SUPPORTED_COPYRIGHT,
+                artifactIds = listOf(ArtifactIdRequest(groupPattern = "org.example", artifactPattern = "match-.*")),
+                buildToolBeans = listOf(BuildToolBeanRequest(beanType = "oracleDatabase")),
+            )
+        org.junit.jupiter.api.assertDoesNotThrow {
+            service.createComponent(createReq)
+        }
+
+        // PATCH green path
+        val updateReq =
+            minimalUpdate(
+                clientCode = "VALID_CODE_2",
+                copyright = SUPPORTED_COPYRIGHT,
+                artifactIds = listOf(ArtifactIdRequest(groupPattern = "org.example", artifactPattern = "another-.*")),
+                buildToolBeans = listOf(BuildToolBeanRequest(beanType = "odbc")),
+            )
+        org.junit.jupiter.api.assertDoesNotThrow {
+            service.updateComponent(existingId, updateReq)
+        }
+    }
+
+    @Test
+    @DisplayName("validation is skipped for hidden fields (hidden-field-skip)")
+    fun hiddenFields_skipValidation() {
+        doReturn(true).`when`(fieldConfigService).isHidden("component.clientCode")
+        doReturn(true).`when`(fieldConfigService).isHidden("component.copyright")
+
+        // Create/Update with invalid clientCode and copyright should not throw because they are hidden and skipped.
+        val createReq =
+            minimalCreate(
+                clientCode = "invalid-code-due-to-lowercase!",
+                copyright = "INVALID_UNSUPPORTED_COPYRIGHT",
+            )
+        org.junit.jupiter.api.assertDoesNotThrow {
+            service.createComponent(createReq)
+        }
+
+        val updateReq =
+            minimalUpdate(
+                clientCode = "invalid-code-due-to-spaces ",
+                copyright = "INVALID_COPYRIGHT_2",
+            )
+        org.junit.jupiter.api.assertDoesNotThrow {
+            service.updateComponent(existingId, updateReq)
+        }
+    }
+
+    companion object {
+        private const val SUPPORTED_COPYRIGHT = "supported-copyright.txt"
+    }
+}

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -83,6 +83,26 @@ Base URLs for links are configurable per deployment via `registry_config` (same 
 - **Optimistic locking**: `@Version` field prevents lost updates (409 Conflict on stale version)
 - **Audit**: UPDATE event logged with old_value, new_value, change_diff
 
+#### Field-format validation (create + update)
+
+Beyond the structural/enum checks (name uniqueness, `productType` / `buildSystem` /
+`repositoryType` / `packageType` / `escrow.generation` enums, version-range syntax,
+per-field range non-overlap), the v4 write path enforces the following single-field
+shape/format rules on both `POST /rest/api/4/components` and
+`PATCH /rest/api/4/components/{id}`. Each is a field-name-prefixed `400 Bad Request`
+(`{ "errorMessage": "<field> …" }`). These restore the corresponding checks the legacy
+`EscrowConfigValidator` ran at config-load time.
+
+| Field | Rule | Notes |
+|-------|------|-------|
+| `clientCode` | Matches `[A-Z_0-9]+` when present | Blank/whitespace is treated as "no client code" and skipped. |
+| `copyright` | Must name a file under the configured copyright directory | The supported list is read from `components-registry.copyright-path` (same source as the read-side `CopyrightService`). When that path is not configured (or cannot be listed), the check is a no-op — matching the legacy behaviour of skipping when no copyright path is set. Blank is skipped. |
+| `artifactIds[].artifactPattern` | Must be a compilable regular expression (and non-blank) | Validated on both create and the PATCH REPLACE path. |
+| `buildToolBeans[].beanType` | Must be specified (non-blank) | The v4 build-tool is a typed bean whose identifying field is `beanType`; this is the v4 analogue of the legacy build-tool per-field requireds (`name` / `escrowEnvironmentVariable` / `sourceLocation` / `targetLocation`). The legacy `Tool` fields themselves live in the global tools master, which is not writable through the component create/update payload. |
+
+These format checks are skipped for a field whose admin field-config visibility is
+`HIDDEN`. On `PATCH`, the hidden value is also stripped before persistence.
+
 ### 1.5 Delete Component
 - **Behavior**: Soft delete — sets `archived = true`
 - **Cascading**: Does NOT delete versions or sub-components


### PR DESCRIPTION
## What

Restores the single-field **format** validations the v4 DB API had dropped (audit `.github/audit/VALIDATION-PARITY-2026-06-03.md`, rows #9/#16/#19/#21). All `require(...)` → **400**, field-name-prefixed so the Portal maps them inline:

- `clientCode` must match `[A-Z_0-9]+` when present.
- `copyright` must be in the supported list (from the configured copyright directory; unreadable dir logs a WARN and skips — review fix).
- each `artifactIds[].artifactPattern` must be a compilable regex.
- build-tool `beanType` must be specified (the v4 analogue of the old per-tool requireds).

## Notes

- Stacked on `feat/v4-cross-component-checks` — **base that PR (and its base) first**.
- Green end-to-end: `:test` + `:dbTest`, 0 failures. Independently reviewed.
- Follow-up (minor, coverage only): add green-path acceptance + hidden-field-skip unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
