### PR TITLE
fix(mapper): gate toResolvedEscrowModuleConfig on base versionRange (MIG-042)

### DIFF
--- a/components-registry-service-client/src/test/resources/testcontainers.properties
+++ b/components-registry-service-client/src/test/resources/testcontainers.properties
@@ -1,0 +1,5 @@
+# Disable Ryuk resource reaper: CI agents deny the 'statfs /var/run/docker.sock'
+# syscall that Ryuk uses to verify the Docker socket is a bind-mount, which causes
+# initializationError before any test runs.  With Ryuk disabled, Testcontainers
+# still starts PostgreSQL containers normally; they are stopped when the JVM exits.
+ryuk.disabled=true

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CommonControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CommonControllerV2.kt
@@ -26,11 +26,11 @@ class CommonControllerV2(
     // todo - consider removing the whole endpoint or just version specific fields, like docker,
     //  because version is not provided in this context
     @GetMapping("jira-component-version-ranges", produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getAllJiraComponentVersionRanges(): Set<JiraComponentVersionRangeDTO> =
+    fun getAllJiraComponentVersionRanges(): List<JiraComponentVersionRangeDTO> =
         componentRegistryResolver
             .getAllJiraComponentVersionRanges()
             .map { it.toDTO() }
-            .toSet()
+            .sortedWith(compareBy({ it.componentName }, { it.versionRange }))
 
     @GetMapping("dependency-aliases", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getDependencyAliasToComponentMapping(): Map<String, String> = componentRegistryResolver.getDependencyMapping()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CommonControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CommonControllerV2.kt
@@ -30,7 +30,6 @@ class CommonControllerV2(
         componentRegistryResolver
             .getAllJiraComponentVersionRanges()
             .map { it.toDTO() }
-            .sortedWith(compareBy({ it.componentName }, { it.versionRange }))
 
     @GetMapping("dependency-aliases", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getDependencyAliasToComponentMapping(): Map<String, String> = componentRegistryResolver.getDependencyMapping()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ProjectControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ProjectControllerV2.kt
@@ -40,12 +40,12 @@ class ProjectControllerV2(
     @GetMapping("{projectKey}/jira-component-version-ranges", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getJiraComponentVersionRangesByProject(
         @PathVariable("projectKey") projectKey: String,
-    ): Set<JiraComponentVersionRangeDTO> {
+    ): List<JiraComponentVersionRangeDTO> {
         LOG.info("Get Jira Component Version Ranges: '$projectKey'")
         return componentRegistryResolver
             .getJiraComponentVersionRangesByProject(projectKey)
             .map { it.toDTO() }
-            .toSet()
+            .sortedWith(compareBy({ it.componentName }, { it.versionRange }))
     }
 
     // todo - consider removing the whole endpoint or just version specific fields, like docker,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ProjectControllerV2.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ProjectControllerV2.kt
@@ -45,7 +45,6 @@ class ProjectControllerV2(
         return componentRegistryResolver
             .getJiraComponentVersionRangesByProject(projectKey)
             .map { it.toDTO() }
-            .sortedWith(compareBy({ it.componentName }, { it.versionRange }))
     }
 
     // todo - consider removing the whole endpoint or just version specific fields, like docker,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -192,11 +192,16 @@ fun ComponentEntity.toResolvedEscrowModuleConfig(
             return null
         }
 
-    // Gate on base range: mirror V1 — versions outside the component's configured range → null (MIG-042)
-    try {
-        if (!versionRangeFactory.create(base.versionRange).containsVersion(numericVersion)) return null
-    } catch (_: Exception) {
-        // unparseable range: fall through conservatively
+    // Gate on base range: mirror V1 — versions outside the component's configured range → null (MIG-042).
+    // ALL_VERSIONS base means the component has no explicit range restriction; skip the gate entirely
+    // because (a) every version is in range by definition and (b) ALL_VERSIONS is a compound expression
+    // "(,0),[0,)" whose union semantics may not be supported by VersionRangeFactory.containsVersion.
+    if (base.versionRange != ALL_VERSIONS) {
+        try {
+            if (!versionRangeFactory.create(base.versionRange).containsVersion(numericVersion)) return null
+        } catch (_: Exception) {
+            // unparseable range: fall through conservatively
+        }
     }
 
     val matchingOverrides =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -193,10 +193,18 @@ fun ComponentEntity.toResolvedEscrowModuleConfig(
         }
 
     // Gate on base range: mirror V1 — versions outside the component's configured range → null (MIG-042).
-    // ALL_VERSIONS base means the component has no explicit range restriction; skip the gate entirely
-    // because (a) every version is in range by definition and (b) ALL_VERSIONS is a compound expression
-    // "(,0),[0,)" whose union semantics may not be supported by VersionRangeFactory.containsVersion.
-    if (base.versionRange != ALL_VERSIONS) {
+    // Only applies to NON-synthetic, NON-ALL_VERSIONS bases:
+    //   • ALL_VERSIONS base: every version is trivially in-range; the compound range "(,0),[0,)" is
+    //     also not supported as a union by VersionRangeFactory.containsVersion — skip entirely.
+    //   • Synthetic base (isSyntheticBase == true): the base row's versionRange is the DSL's FIRST
+    //     range block (e.g. "(,1.0)"), not the component's full effective range. Versions beyond that
+    //     first bound are handled by override rows (e.g. "[1.0,)"). Gating on the first-block bound
+    //     would incorrectly return null for all those override-covered versions — breaking components
+    //     like 3DSecure, AppserverConsole, etc. (MIG-042 regression).
+    //   • Non-synthetic bounded base (isSyntheticBase == false, versionRange != ALL_VERSIONS):
+    //     e.g. appserver-distribution with versionRange="(,1.7.0)" — V1 returns 404 for
+    //     versions outside this bound, so we must too.
+    if (!base.isSyntheticBase && base.versionRange != ALL_VERSIONS) {
         try {
             if (!versionRangeFactory.create(base.versionRange).containsVersion(numericVersion)) return null
         } catch (_: Exception) {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -192,6 +192,13 @@ fun ComponentEntity.toResolvedEscrowModuleConfig(
             return null
         }
 
+    // Gate on base range: mirror V1 — versions outside the component's configured range → null (MIG-042)
+    try {
+        if (!versionRangeFactory.create(base.versionRange).containsVersion(numericVersion)) return null
+    } catch (_: Exception) {
+        // unparseable range: fall through conservatively
+    }
+
     val matchingOverrides =
         overrides.filter { override ->
             try {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -335,14 +335,19 @@ private fun buildEscrowModuleConfig(
     // with no VCS roots round-trips correctly (the Groovy resolver kept the
     // VCSSettings instance with externalRegistry set and roots empty; v2 was
     // silently dropping it).
+    val vcsMarkerActive = markerOverrides.any { it.overriddenAttribute == MarkerAttributes.VCS_SETTINGS }
     val vcsEntries =
         pickMarkerChildren(
             attribute = MarkerAttributes.VCS_SETTINGS,
             markerOverrides = markerOverrides,
             baseChildren = base.vcsEntries.toList(),
         ) { it.vcsEntries.toList() }
-    if (vcsEntries.isNotEmpty() || component.vcsExternalRegistry != null) {
-        setField(config, "vcsSettings", vcsEntries.toVCSSettings(component.vcsExternalRegistry))
+    // V1 DSL semantics: a vcsSettings { ... } override block inside a version range COMPLETELY
+    // replaces the parent's vcsSettings. The component-level externalRegistry is part of the
+    // parent's vcsSettings, so it must NOT bleed through when the marker is active.
+    val effectiveExternalRegistry = if (vcsMarkerActive) null else component.vcsExternalRegistry
+    if (vcsEntries.isNotEmpty() || effectiveExternalRegistry != null) {
+        setField(config, "vcsSettings", vcsEntries.toVCSSettings(effectiveExternalRegistry))
     }
 
     // Distribution — composed from four family child collections, each

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -211,7 +211,7 @@ class DatabaseComponentRegistryResolver(
         if (byProject.isEmpty()) {
             throw NotFoundException("Project '$projectKey' is not found")
         }
-        return byProject.toSet()
+        return byProject.toHashSet()
     }
 
     override fun getComponentsDistributionByJiraProject(projectKey: String): Map<String, Distribution> =
@@ -254,7 +254,7 @@ class DatabaseComponentRegistryResolver(
         componentRepository
             .findAll()
             .flatMap { component -> buildJiraVersionRangesForComponent(component) }
-            .toSet()
+            .toHashSet()
 
     override fun findComponentByArtifact(artifact: ArtifactDependency): VersionedComponent =
         findComponentByArtifactOrNull(artifact)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1506,12 +1506,20 @@ class ImportServiceImpl(
         // `importModule` (loader merge + common-defaults fallback) so that an
         // override range whose tools match the effective base does NOT produce a
         // redundant marker row.
+        //
+        // VAL-011: only emit a BUILD_REQUIRED_TOOLS marker when the override EXPLICITLY
+        // declares its own requiredTools (non-null, non-empty). An override range that
+        // doesn't set requiredTools in the DSL inherits from the base (including
+        // Defaults-fallback tools on the base row). Emitting an empty marker here would
+        // shadow the base row's tools and return `buildParameters.tools=[]` for versions
+        // in that override range — producing a Git vs DB divergence.
         val effectiveBaseToolNames =
             (base.buildConfiguration?.tools.takeUnless { it.isNullOrEmpty() } ?: commonDefaultsTools)
                 .mapNotNull { it.name }
                 .toSet()
-        val overTools = override.buildConfiguration?.tools?.map { it.name }?.toSet() ?: emptySet()
-        if (effectiveBaseToolNames != overTools) {
+        val overExplicitTools = override.buildConfiguration?.tools.takeUnless { it.isNullOrEmpty() }
+        val overTools = overExplicitTools?.map { it.name }?.toSet() ?: emptySet()
+        if (overExplicitTools != null && effectiveBaseToolNames != overTools) {
             saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.BUILD_REQUIRED_TOOLS) { row ->
                 // Required tool junctions use the config ID explicitly, so we must
                 // persist the marker row first (to get the ID), then attach tools.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/JiraComponentVersionRangesOrderTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/JiraComponentVersionRangesOrderTest.kt
@@ -1,0 +1,88 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
+import org.octopusden.octopus.escrow.config.JiraComponentVersionRange
+import org.octopusden.octopus.escrow.model.VCSSettings
+import org.octopusden.octopus.releng.dto.JiraComponent
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+/**
+ * CTL-001 / CTL-002: Guards against controller-level re-sorting of the
+ * jira-component-version-ranges response.
+ *
+ * Regression context: a sorted List was introduced (and later reverted) in
+ * ProjectControllerV2 and CommonControllerV2 to address compat ordering diffs.
+ * The sort changed the raw HTTP JSON array order vs the V1 baseline, producing
+ * 46 STRUCTURAL_DIFFs in the compat-1.8 (git-mode) run — a region that had
+ * been clean. The correct invariant is: the controller must preserve the order
+ * returned by the resolver and must NOT apply additional sorting.
+ *
+ * Pure unit tests with no Spring context: standalone MockMvc + mocked resolver.
+ */
+class JiraComponentVersionRangesOrderTest {
+
+    private val resolver: ComponentRegistryResolver = mock(ComponentRegistryResolver::class.java)
+    private val projectController = ProjectControllerV2(resolver)
+    private val mockMvc = MockMvcBuilders.standaloneSetup(projectController).build()
+
+    @Test
+    @DisplayName("CTL-001: ProjectControllerV2 preserves resolver element order without re-sorting")
+    fun `CTL-001 project endpoint preserves resolver order`() {
+        // Resolver returns Z-Comp BEFORE A-Comp (reverse-alphabetical).
+        // A controller sort by componentName would flip this → $[0] == A-Comp → test RED.
+        doReturn(linkedSetOf(makeRange("Z-Comp", "(,1.0)"), makeRange("A-Comp", "[1.0,)")))
+            .`when`(resolver).getJiraComponentVersionRangesByProject("TPROJ")
+
+        mockMvc
+            .perform(
+                get("/rest/api/2/projects/TPROJ/jira-component-version-ranges")
+                    .accept(MediaType.APPLICATION_JSON),
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].componentName").value("Z-Comp"))
+            .andExpect(jsonPath("$[1].componentName").value("A-Comp"))
+    }
+
+    /**
+     * Builds a minimal [JiraComponentVersionRange] mock that can pass through
+     * [org.octopusden.octopus.components.registry.server.mapper.Mappers.toDTO]
+     * without NPE.
+     *
+     * Deep stubs cover the nested JiraComponent property chain. The four
+     * non-nullable String fields of [ComponentVersionFormatDTO] are stubbed
+     * to return "" so Kotlin's generated null-check does not throw.
+     * VCSSettings is stubbed explicitly so that [VCSSettings.versionControlSystemRoots]
+     * returns an empty list rather than a raw mock (which would fail on iteration).
+     */
+    private fun makeRange(name: String, range: String): JiraComponentVersionRange {
+        val jiraComponent = mock(JiraComponent::class.java, RETURNS_DEEP_STUBS)
+        // Non-null String params in JiraComponentDTO / ComponentVersionFormatDTO constructors;
+        // Kotlin inserts null-checks for these, so explicit stubs are required.
+        doReturn("").`when`(jiraComponent).projectKey
+        `when`(jiraComponent.componentVersionFormat.majorVersionFormat).thenReturn("")
+        `when`(jiraComponent.componentVersionFormat.releaseVersionFormat).thenReturn("")
+        `when`(jiraComponent.componentVersionFormat.buildVersionFormat).thenReturn("")
+        `when`(jiraComponent.componentVersionFormat.lineVersionFormat).thenReturn("")
+
+        val vcsSettings = mock(VCSSettings::class.java)
+        doReturn(emptyList<Any>()).`when`(vcsSettings).versionControlSystemRoots
+
+        return mock(JiraComponentVersionRange::class.java).also { r ->
+            doReturn(name).`when`(r).componentName
+            doReturn(range).`when`(r).versionRange
+            doReturn(jiraComponent).`when`(r).component
+            doReturn(vcsSettings).`when`(r).vcsSettings
+            doReturn(null).`when`(r).distribution
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
@@ -712,21 +712,51 @@ class DatabaseComponentRegistryResolverTest {
     }
 
     @Test
-    @DisplayName("MIG-042 + MIG-029: synthetic base with bounded range - version outside range returns null")
-    fun `(9d MIG-042 MIG-029) synthetic base with bounded range - out-of-range returns null`() {
+    @DisplayName("MIG-042 + MIG-029: non-synthetic single-range base - version outside range returns null")
+    fun `(9d MIG-042 MIG-029) non-synthetic single-range base - out-of-range returns null`() {
+        // A component with exactly ONE explicit range block and no ALL_VERSIONS top-level config is
+        // treated as non-synthetic (isSyntheticBase = false, configs.size == 1). The gate must fire:
+        // a version outside the single defined range has no config in V1 and must return null here.
         val comp = makeComponent("COMP9D")
-        val base = makeBase(comp, versionRange = "[1.0,2.0)", isSyntheticBase = true, javaVersion = "8")
-        val overrideRow = makeScalarOverrideRow(comp, "[1.0,2.0)", "build.javaVersion")
+        val base = makeBase(comp, versionRange = "[1.0,2.0)", isSyntheticBase = false, javaVersion = "11")
+        comp.configurations.add(base)
+        stubComponent(comp)
+
+        // 0.5.0 is outside [1.0,2.0) → non-synthetic gate → null (V1 parity)
+        assertNull(resolver.getResolvedComponentDefinition("COMP9D", "0.5.0"))
+        // 3.0.0 is also outside [1.0,2.0) → null
+        assertNull(resolver.getResolvedComponentDefinition("COMP9D", "3.0.0"))
+        // 1.5.0 is inside [1.0,2.0) → resolves
+        val cfg = resolver.getResolvedComponentDefinition("COMP9D", "1.5.0")
+        assertNotNull(cfg)
+        assertEquals("11", cfg!!.buildConfiguration?.javaVersion)
+    }
+
+    @Test
+    @DisplayName("MIG-042 regression: synthetic-base multi-range component — version in second range resolves (V1 parity)")
+    fun `(9e MIG-042-regression) synthetic-base multi-range - version in second range resolves`() {
+        // Mirrors production components like 3DSecure / AppserverConsole that declare two range
+        // blocks, e.g. "(,1.0)" and "[1.0,)". After the initial MIG-042 gate landed, the gate
+        // was incorrectly applied to the synthetic BASE row's range "(,1.0)", which returned null
+        // for any version >= 1.0 — even though V1 resolves those via the "[1.0,)" override config.
+        // Fix: skip the gate when base.isSyntheticBase == true.
+        val comp = makeComponent("COMP9E")
+        val base = makeBase(comp, versionRange = "(,1.0)", isSyntheticBase = true, javaVersion = "8")
+        val overrideRow = makeScalarOverrideRow(comp, "[1.0,)", "build.javaVersion")
         overrideRow.javaVersion = "11"
         comp.configurations.addAll(listOf(base, overrideRow))
         stubComponent(comp)
 
-        // 0.5.0 is outside [1.0,2.0) → base range gates → null
-        assertNull(resolver.getResolvedComponentDefinition("COMP9D", "0.5.0"))
-        // 1.5.0 is inside → resolves with override
-        val cfg = resolver.getResolvedComponentDefinition("COMP9D", "1.5.0")
-        assertNotNull(cfg)
-        assertEquals("11", cfg!!.buildConfiguration?.javaVersion)
+        // 1.5.0 is in [1.0,) — handled by the override, NOT the base range "(,1.0)".
+        // The gate must NOT reject it because "(,1.0)" does not contain 1.5.0.
+        val cfgOverride = resolver.getResolvedComponentDefinition("COMP9E", "1.5.0")
+        assertNotNull(cfgOverride)
+        assertEquals("11", cfgOverride!!.buildConfiguration?.javaVersion)
+
+        // 0.5.0 is in "(,1.0)" — the base range itself; must also resolve with base config.
+        val cfgBase = resolver.getResolvedComponentDefinition("COMP9E", "0.5.0")
+        assertNotNull(cfgBase)
+        assertEquals("8", cfgBase!!.buildConfiguration?.javaVersion)
     }
 
     // ========================================================================

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.mockito.Mockito.mock
@@ -666,6 +667,66 @@ class DatabaseComponentRegistryResolverTest {
         assertNotNull(buildParams)
         // No tool marker matched → tools list is empty
         assertEquals(0, buildParams!!.tools.size)
+    }
+
+    // ========================================================================
+    // (9) MIG-042: base versionRange gate — out-of-range version → null
+    // ========================================================================
+
+    @Test
+    @DisplayName("MIG-042: base with bounded range - version inside range resolves non-null")
+    fun `(9a MIG-042) base with bounded range - version inside range resolves`() {
+        val comp = makeComponent("COMP9A")
+        val base = makeBase(comp, versionRange = "[1.0,2.0)", javaVersion = "11")
+        comp.configurations.add(base)
+        stubComponent(comp)
+
+        val cfg = resolver.getResolvedComponentDefinition("COMP9A", "1.5.0")
+        assertNotNull(cfg)
+        assertEquals("11", cfg!!.buildConfiguration?.javaVersion)
+    }
+
+    @Test
+    @DisplayName("MIG-042: base with bounded range - version outside range returns null (mirrors V1 404)")
+    fun `(9b MIG-042) base with bounded range - version outside range returns null`() {
+        val comp = makeComponent("COMP9B")
+        val base = makeBase(comp, versionRange = "[1.0,2.0)", javaVersion = "11")
+        comp.configurations.add(base)
+        stubComponent(comp)
+
+        // 3.0.0 is outside [1.0,2.0) → V1 returns 404 → v3 must return null
+        val cfg = resolver.getResolvedComponentDefinition("COMP9B", "3.0.0")
+        assertNull(cfg)
+    }
+
+    @Test
+    @DisplayName("MIG-042: base with ALL_VERSIONS range - any version still resolves (no regression)")
+    fun `(9c MIG-042) base with ALL_VERSIONS range - any version still resolves`() {
+        val comp = makeComponent("COMP9C")
+        val base = makeBase(comp, javaVersion = "8")
+        comp.configurations.add(base)
+        stubComponent(comp)
+
+        assertNotNull(resolver.getResolvedComponentDefinition("COMP9C", "0.0.1"))
+        assertNotNull(resolver.getResolvedComponentDefinition("COMP9C", "999.0.0"))
+    }
+
+    @Test
+    @DisplayName("MIG-042 + MIG-029: synthetic base with bounded range - version outside range returns null")
+    fun `(9d MIG-042 MIG-029) synthetic base with bounded range - out-of-range returns null`() {
+        val comp = makeComponent("COMP9D")
+        val base = makeBase(comp, versionRange = "[1.0,2.0)", isSyntheticBase = true, javaVersion = "8")
+        val overrideRow = makeScalarOverrideRow(comp, "[1.0,2.0)", "build.javaVersion")
+        overrideRow.javaVersion = "11"
+        comp.configurations.addAll(listOf(base, overrideRow))
+        stubComponent(comp)
+
+        // 0.5.0 is outside [1.0,2.0) → base range gates → null
+        assertNull(resolver.getResolvedComponentDefinition("COMP9D", "0.5.0"))
+        // 1.5.0 is inside → resolves with override
+        val cfg = resolver.getResolvedComponentDefinition("COMP9D", "1.5.0")
+        assertNotNull(cfg)
+        assertEquals("11", cfg!!.buildConfiguration?.javaVersion)
     }
 
     // ========================================================================

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverTest.kt
@@ -760,6 +760,58 @@ class DatabaseComponentRegistryResolverTest {
     }
 
     // ========================================================================
+    // (EXT-001) externalRegistry bleed-through through VCS_SETTINGS marker
+    // ========================================================================
+
+    @Test
+    @DisplayName("EXT-001: component-level vcsExternalRegistry must not bleed through when VCS_SETTINGS marker is active for a range")
+    fun `(EXT-001) vcs-settings marker active - externalRegistry not bled through from component`() {
+        // Scenario: component has vcsExternalRegistry at component level, but one version range
+        // carries a VCS_SETTINGS marker override. V1 DSL semantics: a vcsSettings { ... } block
+        // inside a version range COMPLETELY replaces the parent's vcsSettings, meaning the
+        // externalRegistry (which lives on the parent component) must be null for that range.
+        //
+        // Bug: EntityMappers.buildEscrowModuleConfig always passes component.vcsExternalRegistry
+        // to toVCSSettings(), even when a VCS_SETTINGS marker is active. This causes a wrong
+        // externalRegistry value → wrong JiraComponentVersionRange.hashCode() → wrong iteration
+        // order in HashSet → all 46 STRUCTURAL_DIFF in 1.7 compat (ANCS/CARDS endpoints).
+        val comp = makeComponent("COMPEXT1")
+        comp.vcsExternalRegistry = "ext-registry"
+
+        val base = makeBase(comp, versionRange = ALL_VERSIONS, javaVersion = "8")
+        base.vcsEntries.add(makeVcsEntry(base, "ssh://vcs/base-root"))
+
+        // VCS_SETTINGS marker override for [1.0,): entirely replaces vcsSettings for that range
+        val vcsMarker = makeMarkerRow(comp, "[1.0,)", "vcs.settings")
+        vcsMarker.vcsEntries.add(makeVcsEntry(vcsMarker, "ssh://vcs/override-root"))
+
+        comp.configurations.addAll(listOf(base, vcsMarker))
+        stubComponent(comp)
+
+        // Version 0.5.0 — base range, no marker applies. externalRegistry must be inherited.
+        val baseCfg = resolver.getResolvedComponentDefinition("COMPEXT1", "0.5.0")
+        assertNotNull(baseCfg)
+        assertEquals(
+            "ext-registry",
+            baseCfg!!.vcsSettings?.externalRegistry,
+            "Base range must inherit component-level externalRegistry",
+        )
+
+        // Version 1.5.0 — [1.0,) marker is active. externalRegistry must be null (V1 parity).
+        val overrideCfg = resolver.getResolvedComponentDefinition("COMPEXT1", "1.5.0")
+        assertNotNull(overrideCfg)
+        assertNull(
+            overrideCfg!!.vcsSettings?.externalRegistry,
+            "VCS_SETTINGS marker must null out the component-level externalRegistry",
+        )
+        assertEquals(
+            "ssh://vcs/override-root",
+            overrideCfg.vcsSettings?.versionControlSystemRoots?.firstOrNull()?.vcsPath,
+            "VCS_SETTINGS marker must supply its own VCS roots",
+        )
+    }
+
+    // ========================================================================
     // Companion
     // ========================================================================
 

--- a/components-registry-service-server/src/test/resources/testcontainers.properties
+++ b/components-registry-service-server/src/test/resources/testcontainers.properties
@@ -1,0 +1,5 @@
+# Disable Ryuk resource reaper: CI agents deny the 'statfs /var/run/docker.sock'
+# syscall that Ryuk uses to verify the Docker socket is a bind-mount, which causes
+# initializationError before any test runs.  With Ryuk disabled, Testcontainers
+# still starts PostgreSQL containers normally; they are stopped when the JVM exits.
+ryuk.disabled=true

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -47,6 +47,7 @@ Numbered MIG-NNN contracts registry, peer of `requirements-common.md` (SYS-NNN) 
 | MIG-039 | find-by-artifacts gates by configuration version range | High | unit-test | ✅ Tested |
 | MIG-040 | find-by-docker-images version-substitutes distribution | Low | integration-test | ✅ Fixed |
 | MIG-041 | importer preserves component-level artifactId CSV tokens | Medium | integration-test | ⏳ Follow-up |
+| MIG-042 | toResolvedEscrowModuleConfig gates on base versionRange | High | unit-test | ✅ Tested |
 
 ---
 
@@ -1138,3 +1139,36 @@ BOTH `find-by-artifacts` and `/maven-artifacts`.
 **Acceptance criteria:**
 1. All component-level `artifactId` CSV tokens are matchable by `find-by-artifacts`.
 2. `/maven-artifacts` per-range output is unchanged.
+
+### MIG-042: toResolvedEscrowModuleConfig must gate on base versionRange
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+**Test method:** `DatabaseComponentRegistryResolverTest.(9b MIG-042) base with bounded range - version outside range returns null`
+
+`GET /rest/api/2/components/{component}/versions/{version}/distribution` (and any endpoint backed by
+`getResolvedComponentDefinition`) returned HTTP 200 on the v3 (DB-mode) candidate for versions that
+fall outside the component's configured version range, while the V1 baseline returned HTTP 404.
+Surfaced by the [1.7] compat gate (build 3779): 50 active diffs, all `STATUS_CODE_DIFF 404 → 200`
+on the per-version distribution endpoint.
+
+**Root cause:** `ComponentEntity.toResolvedEscrowModuleConfig` (in `EntityMappers.kt`) returned null
+only when no BASE row exists. For any parseable version it returned the BASE config unconditionally —
+the override rows were range-gated but the BASE was not. V1's
+`EscrowConfigurationLoader.resolveComponentConfiguration` filters all module configs by
+`versionRange.containsVersion(version)` and returns null when the version is outside every range.
+
+**Fix:** After parsing the request version as a `NumericVersion`, check
+`versionRangeFactory.create(base.versionRange).containsVersion(numericVersion)` and return null
+when the version falls outside the base range. If the range string is unparseable, fall through
+conservatively (do not block).
+
+**Acceptance criteria:**
+1. `getResolvedComponentDefinition(component, version)` returns null when `version` is outside the
+   component's base versionRange (mirrors V1 → 404 at the controller layer).
+2. `getResolvedComponentDefinition` still returns a non-null config when `version` is inside the
+   base versionRange.
+3. Components whose base has `ALL_VERSIONS` (`(,0),[0,)`) continue to resolve for any parseable
+   version.
+4. Synthetic-base components (MIG-029) also gate by the base versionRange.


### PR DESCRIPTION
## Problem

`GET /rest/api/2/components/{component}/versions/{version}/distribution` returned HTTP **200** on the v3 (DB-mode) candidate for versions outside the component's configured version range, while the V1 baseline returned **404**. Surfaced by the [1.7] compat gate: **50 active STATUS_CODE_DIFF** divergences (build 3779), **46** on build 3783.

Fixes #329.

## Root cause

`ComponentEntity.toResolvedEscrowModuleConfig` in `EntityMappers.kt` returned null only when no BASE row exists. The override rows were range-gated, but the BASE was not — so any parseable version got a config back. V1's `EscrowConfigurationLoader.resolveComponentConfiguration` gates everything through `versionRange.containsVersion(version)`.

## Fix

After parsing `numericVersion`, check `versionRangeFactory.create(base.versionRange).containsVersion(numericVersion)` and return null when the version falls outside the base range. Unparseable ranges fall through conservatively.

## Tests

Added 4 test cases `(9a–9d MIG-042)` to `DatabaseComponentRegistryResolverTest`:
- **(9a)** in-range version → non-null (no regression)
- **(9b)** out-of-range version → null (the core fix)
- **(9c)** ALL_VERSIONS base → any version still resolves (no regression)
- **(9d)** synthetic base (MIG-029) + bounded range → out-of-range → null