### PR TITLE
feat(v4): close validation parity gaps

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -270,6 +270,7 @@ class ComponentManagementServiceImpl(
         // the person-field error first, so person validation runs ahead of the
         // malformed-input checks here.
         validatePersonFields(entity, runActiveCheck = true)
+        validateRequiredCopyright(entity)
 
         // Malformed-input cross-component / single-field checks (400). These need
         // no DB lookup beyond the soft doc-ref existence probe and run against the
@@ -551,6 +552,7 @@ class ComponentManagementServiceImpl(
             entity.distributionExplicit != oldExplicit ||
                 entity.distributionExternal != oldExternal
         validatePersonFields(entity, runActiveCheck = personFieldChanged || gateFlipped)
+        validateRequiredCopyright(entity)
 
         // Per-component child REPLACE — present collection wipes and refills
         request.artifactIds?.let {
@@ -2160,6 +2162,23 @@ class ComponentManagementServiceImpl(
         val supported = supportedCopyrights() ?: return
         require(value in supported) {
             "copyright '$value' is not supported. Available values are $supported"
+        }
+    }
+
+    /**
+     * Audit #5: when a copyright directory is configured, explicit+external
+     * components must select one of its entries. This requiredness check runs
+     * against the final entity state on every create/update, like the person
+     * requiredness checks, while [validateCopyright] validates a submitted
+     * non-blank value against the supported list.
+     */
+    private fun validateRequiredCopyright(entity: ComponentEntity) {
+        if (fieldConfigService.isHidden("component.copyright")) return
+        if (entity.distributionExplicit != true || entity.distributionExternal != true) return
+        if (configHelper.copyrightPath() == null) return
+
+        require(!entity.copyright.isNullOrBlank()) {
+            "copyright must not be blank for an explicit+external component when copyright-path is configured"
         }
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/CheapFieldFormatValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/CheapFieldFormatValidationTest.kt
@@ -234,6 +234,35 @@ class CheapFieldFormatValidationTest {
     }
 
     @Test
+    @DisplayName("CREATE requires copyright for explicit+external component when copyright path is configured")
+    fun create_requiresCopyrightForExplicitExternal() {
+        val request =
+            minimalCreate().copy(
+                releaseManager = listOf("releaseManager"),
+                securityChampion = listOf("securityChampion"),
+                distributionExplicit = true,
+                distributionExternal = true,
+            )
+
+        assertFieldPrefixed("copyright") {
+            service.createComponent(request)
+        }
+    }
+
+    @Test
+    @DisplayName("PATCH validates final-state copyright requiredness for explicit+external component")
+    fun patch_requiresCopyrightForExplicitExternal() {
+        existing.distributionExplicit = true
+        existing.distributionExternal = true
+        existing.replaceReleaseManagerUsernames(listOf("releaseManager"))
+        existing.replaceSecurityChampionUsernames(listOf("securityChampion"))
+
+        assertFieldPrefixed("copyright") {
+            service.updateComponent(existingId, minimalUpdate(clientCode = "VALID_CODE"))
+        }
+    }
+
+    @Test
     @DisplayName("copyright error lists available values in deterministic order")
     fun copyright_errorListsSupportedValuesSorted() {
         Files.createFile(copyrightDir.resolve("z-license.txt"))

--- a/docs/registry/functional-spec.md
+++ b/docs/registry/functional-spec.md
@@ -43,13 +43,14 @@ Base URLs for links are configurable per deployment via `registry_config` (same 
 
 ### 1.3 Create Component
 - **Required fields**: `name` (unique, alphanumeric + hyphens + underscores, max 255 chars), `componentOwner`
-- **Conditionally required**: `releaseManager`, `securityChampion`, `copyright` — required when `distribution.explicit && distribution.external`
+- **Conditionally required**: `releaseManager`, `securityChampion` — required when `distribution.explicit && distribution.external`; `copyright` — required under the same gate only when `components-registry.copyright-path` is configured
 - **Optional fields**: displayName, productType, system, clientCode, solution, groupId, labels, doc
 
 **Person-field validation (enforced on the v4 write path — see ADR-015).** Restored from the old `EscrowConfigValidator` + the (formerly default-off CI) `ComponentRegistryValidationTask`, and modernised into per-request checks on `POST /rest/api/4/components` and `PATCH /rest/api/4/components/{id}`:
 
 - **`componentOwner`** — required, non-blank, on **every** component. No format pattern.
 - **`releaseManager` / `securityChampion`** — required **only when** `distribution.explicit && distribution.external`, and **each list element** must match `^\w+$` (validated per canonical element, so an element like `"alice,bob"` is rejected — it is *not* CSV-split into two usernames). Lists are already trim/dedupe-canonicalized.
+- **`copyright`** — required when `distribution.explicit && distribution.external` and `components-registry.copyright-path` is configured. Requiredness validates the final entity state on every create/update; a hidden copyright field is skipped.
 - **Active-employee check** — when enabled (`employee-service.enabled=true` + a non-blank `employee-service.url`; off by default), each final-state `componentOwner` / `releaseManager` / `securityChampion` of a **non-archived** component is resolved through employee-service. Archived components skip only the external active lookup; required/pattern checks still run. An **inactive** (`active=false`) or **unknown** (`NotFoundException`) user → **400**. Employee-service **unreachable** (transport/timeout) or the feature **disabled** → the write is **allowed** with a WARN log (**fail-open** — it must not become a hard outage dependency). The required/pattern checks above run regardless of this flag.
 - **Timing / grandfathering.** Required/pattern validate the **final entity state** after the patch is applied (so PATCH callers needn't resend unchanged fields). The active-employee check runs only when the request **touches a person field OR flips** `distribution.explicit` / `distribution.external` — flipping the gate to `explicit && external` newly makes RM/SC required and re-validates them even if the PATCH did not set them. When neither person fields nor the gate change, pre-existing saved values are **grandfathered** (not re-checked).
 - **Hidden fields** (field-config `visibility: hidden`) are **skipped** entirely — a hidden field is stripped on write, so it cannot be required.
@@ -96,12 +97,21 @@ shape/format rules on both `POST /rest/api/4/components` and
 | Field | Rule | Notes |
 |-------|------|-------|
 | `clientCode` | Matches `[A-Z_0-9]+` when present | Blank/whitespace is treated as "no client code" and skipped. |
-| `copyright` | Must name a file under the configured copyright directory | The supported list is read from `components-registry.copyright-path` (same source as the read-side `CopyrightService`). When that path is not configured (or cannot be listed), the check is a no-op — matching the legacy behaviour of skipping when no copyright path is set. Blank is skipped. |
+| `copyright` | Must name a file under the configured copyright directory | The supported list is read from `components-registry.copyright-path` (same source as the read-side `CopyrightService`). When that path is not configured (or cannot be listed), the supported-list check is a no-op. Blank is allowed except when the explicit+external requiredness rule above applies. |
 | `artifactIds[].artifactPattern` | Must be a compilable regular expression (and non-blank) | Validated on both create and the PATCH REPLACE path. |
 | `buildToolBeans[].beanType` | Must be specified (non-blank) | The v4 build-tool is a typed bean whose identifying field is `beanType`; this is the v4 analogue of the legacy build-tool per-field requireds (`name` / `escrowEnvironmentVariable` / `sourceLocation` / `targetLocation`). The legacy `Tool` fields themselves live in the global tools master, which is not writable through the component create/update payload. |
 
 These format checks are skipped for a field whose admin field-config visibility is
 `HIDDEN`. On `PATCH`, the hidden value is also stripped before persistence.
+
+#### Intentional legacy-validation relaxations
+
+- `displayName` remains optional, including for explicit+external components. The
+  v4 contract deliberately uses the component key as the stable identity and does
+  not require a second display label.
+- Legacy hotfix version-format relationship checks are not enforced on v4 writes.
+  Hotfix formats are inherited/read-only in the Portal, while permissive storage
+  preserves imported configurations and resolver compatibility.
 
 ### 1.5 Delete Component
 - **Behavior**: Soft delete — sets `archived = true`
@@ -109,6 +119,9 @@ These format checks are skipped for a field whose admin field-config visibility 
 - **Undo**: Can un-archive by updating `archived = false`
 - **Hard delete**: Admin-only, removes component and all related data (with CASCADE)
 - **Audit**: DELETE event logged
+- **JIRA guard**: No runtime JIRA-existence check. The legacy guard compared two
+  config-repository snapshots during CI; the v4 delete path archives the component
+  in place and intentionally does not make CRS deletion depend on JIRA availability.
 
 ### 1.6 View as Code
 

--- a/docs/registry/tech-debt/012-pre-publish-validation-parity.md
+++ b/docs/registry/tech-debt/012-pre-publish-validation-parity.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-In progress · tracks the multi-PR effort restoring the pre-publish validations
-the v3 DB / v4-API dropped at runtime.
+Complete. The v3/v4 write-path gaps have either been restored or recorded as
+intentional decisions, and the companion Portal change surfaces field errors,
+employee lookup results, and inactive-person badges.
 
 Source of truth for the gap analysis: `.github/audit/VALIDATION-PARITY-2026-06-03.md`
 (old = `main` @ `3aaeecf0`; new = `v3` @ `478dd287`). This ledger is owned by the
@@ -30,29 +31,29 @@ Legend: ✅ done (this/a merged PR) · ◻ open · ⊘ intentional (to be record
 | #4 | `securityChampion` required + per-element `^\w+$` under `explicit && external` | ✅ Stage 1 |
 | #7 | active-employee check on owner/RM/SC | ✅ Stage 1 — runtime, flag-gated, **fail-open** (ADR-015) |
 | — | employee lookup endpoints for the UI picker + badge | ✅ Stage 2 — `GET /meta/employees`, `POST /meta/employees/status` |
-| #2 | `componentDisplayName` required under `explicit && external` | ◻ open — not in the headline ask; revisit (was conditional) |
-| #5 | `copyright` required if `copyrightPath` set, under `explicit && external` | ◻ open — overlaps Stage 5 (#21 copyright list) |
+| #2 | `componentDisplayName` required under `explicit && external` | ⊘ INTENTIONAL — v4 `displayName` is optional; component key is the stable identity |
+| #5 | `copyright` required if `copyrightPath` set, under `explicit && external` | ✅ final-state requiredness restored; hidden/unconfigured field is skipped |
 
 ### Cross-component integrity — Stage 4 (separate PR, independent)
 
 | Audit # | Rule | Status |
 |---|---|---|
-| #24/#25 | duplicate / intersecting `groupId:artifactId` across components | ◻ open → 409 `CrossComponentConflictException` |
-| #26 | (jira `projectKey`, `versionPrefix`) ≤1 non-archived component | ◻ open → 409 |
-| #29 | docker image-name global uniqueness | ◻ open → 409 |
-| #6 | explicit-external must define ≥1 distribution coordinate | ◻ open → 400 |
-| #10 | `groupId` supported-prefix | ◻ open → 400 |
-| #28 | archived component can't be `explicit && external` | ◻ open → 400 |
-| #20 | doc-component existence (soft ref, no FK) | ◻ open → 400/404 soft lookup |
+| #24/#25 | duplicate / intersecting `groupId:artifactId` across components | ✅ 409 `CrossComponentConflictException` |
+| #26 | (jira `projectKey`, `versionPrefix`) ≤1 non-archived component | ✅ 409 |
+| #29 | docker image-name global uniqueness | ✅ 409 |
+| #6 | explicit-external must define ≥1 distribution coordinate | ✅ 400 |
+| #10 | `groupId` supported-prefix | ✅ 400 |
+| #28 | archived component can't be `explicit && external` | ✅ 400 |
+| #20 | doc-component existence (soft ref, no FK) | ✅ 400 soft lookup |
 
 ### Cheap field-format checks — Stage 5 (separate PR, independent)
 
 | Audit # | Rule | Status |
 |---|---|---|
-| #16 | `clientCode` matches `[A-Z_0-9]+` | ◻ open → 400 |
-| #21 | `copyright` ∈ supported list | ◻ open → 400 |
-| #9 | `artifactId` non-empty + valid regex | ◻ open → 400 |
-| #19 | build-tool per-field requireds (name/env/source/target) | ◻ open → 400 |
+| #16 | `clientCode` matches `[A-Z_0-9]+` | ✅ 400 |
+| #21 | `copyright` ∈ supported list | ✅ 400 |
+| #9 | `artifactId` non-empty + valid regex | ✅ 400 |
+| #19 | build-tool per-field requireds (name/env/source/target) | ✅ v4 analogue: `beanType` required, 400 |
 
 ### Intentional / documented relaxations — Stage 6 (docs-only)
 
@@ -63,8 +64,8 @@ Legend: ✅ done (this/a merged PR) · ◻ open · ⊘ intentional (to be record
 | #15/#17/#18 | `system` / `releasesInDefaultBranch` / `solution` required→optional | ⊘ INTENTIONAL — recorded optional in functional-spec |
 | #22 | `labels` ∈ closed `availableLabels` | ⊘ INTENTIONAL — open vocabulary + auto-create |
 | #30/#31/#32 | double escrow.generation / DSL-range-missing / DSL structural | ⊘ N/A — DSL dual-source removed |
-| #12 | hotfix version-format rules | ◻ decide — mostly mitigated by read-only inherited Defaults |
-| #33 | JIRA-delete guard (block deleting a component still in JIRA) | ◻ decide — was build-time only; re-add as delete-time runtime check or leave to CI |
+| #12 | hotfix version-format rules | ⊘ INTENTIONAL — inherited/read-only in Portal; permissive storage preserves imported configs and resolver compatibility |
+| #33 | JIRA-delete guard (block deleting a component still in JIRA) | ⊘ INTENTIONAL — legacy config-snapshot CI guard; v4 delete archives in place and has no runtime JIRA dependency |
 
 ### Already MIGRATED (context — no action)
 
@@ -98,8 +99,8 @@ Legend: ✅ done (this/a merged PR) · ◻ open · ⊘ intentional (to be record
 
 ## Acceptance (whole TD, closed when all rows resolve)
 
-- [ ] Stage 1 person-field validation landed + green (this PR).
-- [ ] Stage 2 lookup endpoints landed + green (this PR).
-- [ ] Stages 4/5 cross-component + cheap-field checks landed.
-- [ ] Stage 6 intentional relaxations recorded in functional-spec; #12/#33 decided.
-- [ ] Portal Stage 3 surfaces the errors + picker + badge.
+- [x] Stage 1 person-field validation landed + green.
+- [x] Stage 2 lookup endpoints landed + green.
+- [x] Stages 4/5 cross-component + cheap-field checks landed.
+- [x] Stage 6 intentional relaxations recorded in functional-spec; #12/#33 decided.
+- [x] Portal Stage 3 surfaces the errors + picker + badge.


### PR DESCRIPTION
## What changed
- require `copyright` for explicit+external components when `components-registry.copyright-path` is configured
- enforce the rule against final create/PATCH state while respecting hidden field config
- document intentional validation relaxations and close the validation-parity ledger

## Why
This closes the last unresolved CRS runtime rule from the pre-publish validation parity audit. The remaining audited differences are intentional and are now recorded in the functional spec.

## Validation
- `./gradlew :components-registry-service-server:test`
- `./gradlew :components-registry-service-server:dbTest`
- `git diff --check`