### PR TITLE
fix(compat): cluster-50 gate (id19) + MIG-045..050 without MIG-051

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -50,6 +50,7 @@ project {
     buildType(id15CompatManual)
     buildType(id16CompatTraceReplayManual)
     buildType(id17CompatLocalStandManual)
+    buildType(id19CompatClusterGateAuto)
     buildType(id18CompatLocalStandGitModeAuto)
     buildType(id20ValidateComponentsRegistryProductionDataAuto)
     buildType(id30DeployToOkdQaDevAuto)
@@ -66,6 +67,7 @@ project {
         id15CompatManual,
         id16CompatTraceReplayManual,
         id17CompatLocalStandManual,
+        id19CompatClusterGateAuto,
         id18CompatLocalStandGitModeAuto,
         id20ValidateComponentsRegistryProductionDataAuto,
         id30DeployToOkdQaDevAuto,
@@ -943,13 +945,138 @@ object id17CompatLocalStandManual : BuildType({
     }
 
     triggers {
-        // Auto-fire id17 whenever id10 finishes successfully on a branch
-        // OTHER than main. v3 is the schema-v2 trunk where local-stand
-        // compat actually has signal; on main the legacy V1 candidate vs
-        // V1 baseline is a tautological pass and would just burn agent
-        // minutes (cold pulls, postgres init, two stand boots). Manual
-        // Run from any branch — including main — still works because
-        // the snapshot dep is the only hard requirement.
+        // Auto-fire id17 after the fast [1.9] cluster-50 gate succeeds on id10's
+        // chain. Serializes postgres + port usage on the compat agent and avoids
+        // burning ~120 min on the full matrix when CARDS/ANCS/distribution still
+        // regresses. Manual Run from any branch still works.
+        finishBuildTrigger {
+            buildType = "${id19CompatClusterGateAuto.id}"
+            successfulOnly = true
+            branchFilter = """
+                +:*
+                -:main
+            """.trimIndent()
+        }
+    }
+
+    dependencies {
+        snapshot(id10CompileUtAuto) {
+            onDependencyFailure = FailureAction.CANCEL
+        }
+    }
+})
+
+// Fast cluster-50 gate: CARDS/ANCS jira-component-version-ranges + authmodlib
+// distribution (the ~50 active diffs from TC #3826 / #3834). Runs
+// Cluster50CompatTest only — no 30k trace replay, no components/all.txt sweep.
+// Chains before [1.7] (id17) so the full gate skips when this cluster regresses.
+object id19CompatClusterGateAuto : BuildType({
+    id("19CompatClusterGateAuto")
+    name = "[1.9] Compat — Cluster-50 gate (CARDS/ANCS/distribution) [AUTO]"
+
+    buildNumberPattern = "%BUILD_NUMBER%"
+
+    artifactRules = """
+        **/build/reports/** => reports
+        **/build/test-results/**/*.xml => test-results
+        /tmp/crs-id19-%teamcity.build.id%/baseline.log => logs/baseline.log
+        /tmp/crs-id19-%teamcity.build.id%/candidate.log => logs/candidate.log
+        /tmp/compat-exec-logger-marker-*.txt => diag/
+        /tmp/compat-test-report-dir.txt => diag/
+    """.trimIndent()
+
+    vcs {
+        root(AbsoluteId("Octopus_OctopusComponents_OctopusGithubVcsRoot"))
+        root(ComponentsRegistry, "+:. => %COMPONENTS_REGISTRY_CHECKOUT_DIR%")
+        root(ServiceConfig, "+:. => service-config")
+    }
+
+    params {
+        text("COMPAT_PARALLELISM", "8", allowEmpty = false, display = ParameterDisplay.PROMPT)
+        param("COMPAT_BASELINE_VERSION", "%LAST_RELEASE_VERSION%")
+        param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
+        param("COMPAT_CANDIDATE_VERSION", "%BUILD_NUMBER%")
+        param("DOCKER_REGISTRY_INTERNAL", "%DOCKER_REGISTRY%")
+    }
+
+    steps {
+        script {
+            name = "Extract JARs from docker images"
+            id = "extract_jars"
+            scriptContent = """
+                set -euo pipefail
+                BASELINE_IMAGE="%DOCKER_REGISTRY_INTERNAL%/octopusden/components-registry-service:%COMPAT_BASELINE_VERSION%"
+                CANDIDATE_IMAGE="%DOCKER_REGISTRY_INTERNAL%/octopusden/components-registry-service:%COMPAT_CANDIDATE_VERSION%"
+                WORK_DIR="/tmp/crs-id19-%teamcity.build.id%"
+                BCID=""
+                CCID=""
+                cleanup() {
+                  [ -n "${'$'}BCID" ] && docker rm "${'$'}BCID" >/dev/null 2>&1 || true
+                  [ -n "${'$'}CCID" ] && docker rm "${'$'}CCID" >/dev/null 2>&1 || true
+                }
+                trap cleanup EXIT
+                mkdir -p "${'$'}WORK_DIR"
+                echo "Pulling baseline: ${'$'}BASELINE_IMAGE"
+                docker pull "${'$'}BASELINE_IMAGE"
+                echo "Pulling candidate: ${'$'}CANDIDATE_IMAGE"
+                docker pull "${'$'}CANDIDATE_IMAGE"
+                BCID=${'$'}(docker create "${'$'}BASELINE_IMAGE")
+                docker cp "${'$'}BCID:/app/app.jar" "${'$'}WORK_DIR/baseline.jar"
+                CCID=${'$'}(docker create "${'$'}CANDIDATE_IMAGE")
+                docker cp "${'$'}CCID:/app/app.jar" "${'$'}WORK_DIR/candidate.jar"
+                ls -lh "${'$'}WORK_DIR/baseline.jar" "${'$'}WORK_DIR/candidate.jar"
+            """.trimIndent()
+        }
+        script {
+            name = "Run cluster-50 compat"
+            id = "run_cluster_compat"
+            scriptContent = """
+                set -euo pipefail
+                if [ ! -f scripts/local-stands/teamcity-run.sh ]; then
+                    echo "::: scripts/local-stands/teamcity-run.sh not present in this checkout."
+                    echo "##teamcity[buildStatus status='SUCCESS' text='Skipped: compat-test infra absent on this branch.']"
+                    exit 0
+                fi
+                WORK_DIR="/tmp/crs-id19-%teamcity.build.id%"
+                export BASELINE_JAR="${'$'}WORK_DIR/baseline.jar"
+                export CANDIDATE_JAR="${'$'}WORK_DIR/candidate.jar"
+                export BASELINE_LOG="${'$'}WORK_DIR/baseline.log"
+                export CANDIDATE_LOG="${'$'}WORK_DIR/candidate.log"
+                export LOCAL_VCS_ROOT="%teamcity.build.checkoutDir%/%COMPONENTS_REGISTRY_CHECKOUT_DIR%"
+                export SERVICE_CONFIG_DIR="%teamcity.build.checkoutDir%/service-config"
+                export COMPAT_FULL=true
+                export COMPAT_PARALLELISM="%COMPAT_PARALLELISM%"
+                export POSTGRES_IMAGE="%DOCKER_REGISTRY_INTERNAL%/postgres:16"
+                export RESET_DB=1
+                export COMPONENTS_REGISTRY_SERVICE_VERSION="%COMPAT_BASELINE_VERSION%"
+                export BUILD_VERSION="%COMPAT_CANDIDATE_VERSION%"
+                bash scripts/local-stands/teamcity-run.sh --tests "org.octopusden.octopus.components.registry.compat.Cluster50CompatTest"
+            """.trimIndent()
+        }
+    }
+
+    failureConditions {
+        executionTimeoutMin = 45
+    }
+
+    features {
+        xmlReport {
+            reportType = XmlReport.XmlReportType.JUNIT
+            rules = "+:components-registry-compat-test/build/test-results/test/*.xml"
+        }
+        dockerSupport {
+            id = "DockerSupport"
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_177,PROJECT_EXT_350,PROJECT_EXT_351"
+            }
+        }
+    }
+
+    requirements {
+        doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
+    }
+
+    triggers {
         finishBuildTrigger {
             buildType = "${id10CompileUtAuto.id}"
             successfulOnly = true

--- a/components-registry-compat-test/README.md
+++ b/components-registry-compat-test/README.md
@@ -72,6 +72,7 @@ Both env categories cause the build to fail. They are **not** suppressible via t
 After a run, two artifacts under `build/reports/compat/`:
 
 1. **`summary.md`** — only divergences, grouped by `DiffClassifier` category. Empty file = no unclassified diffs (clean run).
+2. **`cluster-digest.md`** — active diffs grouped by endpoint + resolved entity (`componentName @ versionRange`) + normalised field path. Use this first for CARDS/ANCS jira-ranges triage instead of decoding raw `$[N]` indices.
 2. **`execution-log.md`** + **`execution-log.ndjson`** — full record of every test case (endpoint × component × params), including clean ones, with status codes and timings. Useful for verifying that a particular component-endpoint-version combination was actually exercised.
 
 ## Running locally

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -464,11 +464,12 @@ tasks.register('compatibilityReporter') {
             params.collect { k, v -> "${k}=${v}" }.join('; ')
         }
         def renderTable = { List<Map> recs, StringBuilder out ->
-            out << "| Endpoint | Params | Layer | Detail | Baseline | Candidate |\n"
-            out << "|---|---|---|---|---|---|\n"
+            out << "| Endpoint | Entity | Params | Layer | Detail | Baseline | Candidate |\n"
+            out << "|---|---|---|---|---|---|---|\n"
             recs.each { r ->
                 def detail = r.message ?: ''
                 out << '| ' << mdEscape(r.endpoint) <<
+                    ' | ' << mdEscape(r.entityKey ?: '') <<
                     ' | ' << mdEscape(renderParams(r.pathParams as Map ?: [:] as Map)) <<
                     ' | ' << mdEscape(r.layer) <<
                     ' | ' << mdEscape(truncate(detail, 800)) <<
@@ -476,6 +477,21 @@ tasks.register('compatibilityReporter') {
                     ' | ' << mdEscape(truncate(r.candidateValue, 120)) <<
                     ' |\n'
             }
+        }
+        def clusterKeyFor = { Map r ->
+            def endpoint = (r.endpoint ?: '').toString()
+            def entity = (r.entityKey ?: renderParams(r.pathParams as Map ?: [:] as Map) ?: '-').toString()
+            def field = (r.message ?: '').toString().replaceAll(/\$\[\d+\]/, '$[N]')
+            "${endpoint} | ${entity} | ${field}"
+        }
+        def buildClusterDigest = { Map activeCats ->
+            def counts = [:].withDefault { 0 }
+            activeCats.each { cat, recs ->
+                recs.each { rec ->
+                    counts[clusterKeyFor(rec as Map)]++
+                }
+            }
+            counts.sort { -it.value }
         }
         def renderSuppressedTable = { List<Map> recs, StringBuilder out ->
             out << "| Endpoint | Params | Layer | Baseline | Candidate | Reason | Regression Test |\n"
@@ -522,6 +538,18 @@ tasks.register('compatibilityReporter') {
         }
 
         if (!activeByCategory.isEmpty()) {
+            def clusterCounts = buildClusterDigest(activeByCategory)
+            if (!clusterCounts.isEmpty()) {
+                sb << "## Active diff cluster digest\n\n"
+                sb << "Grouped by endpoint + resolved entity + normalised field path (`\$[N]` = any array index). "
+                sb << "Use this to triage CARDS/ANCS jira-ranges residuals without decoding raw indices.\n\n"
+                sb << "| Count | Cluster |\n"
+                sb << "|---:|---|\n"
+                clusterCounts.each { key, count ->
+                    sb << "| ${count} | ${mdEscape(key)} |\n"
+                }
+                sb << "\n"
+            }
             sb << "## Endpoint divergences\n\n"
             activeByCategory.each { cat, recs ->
                 sb << "### ${cat} (${recs.size()})\n\n"
@@ -536,6 +564,28 @@ tasks.register('compatibilityReporter') {
             sb << "_No diffs recorded — clean compat run._\n"
         }
         summary.text = sb.toString()
+
+        def clusterMd = new File(dir, 'cluster-digest.md')
+        if (!activeByCategory.isEmpty()) {
+            def clusterCounts = buildClusterDigest(activeByCategory)
+            def csb = new StringBuilder()
+            csb << "# Compat Cluster Digest\n\n"
+            csb << "Generated: ${new Date().format("yyyy-MM-dd HH:mm:ss Z")}\n\n"
+            csb << "- Active endpoint divergences: ${activeRegularTotal}\n"
+            csb << "- Distinct clusters: ${clusterCounts.size()}\n\n"
+            csb << "| Count | Endpoint | Entity | Field |\n"
+            csb << "|---:|---|---|---|\n"
+            clusterCounts.each { key, count ->
+                def parts = key.toString().split(' \\| ', 3)
+                def endpoint = parts.length > 0 ? parts[0] : key
+                def entity = parts.length > 1 ? parts[1] : ''
+                def field = parts.length > 2 ? parts[2] : ''
+                csb << "| ${count} | ${mdEscape(endpoint)} | ${mdEscape(entity)} | ${mdEscape(field)} |\n"
+            }
+            clusterMd.text = csb.toString()
+        } else {
+            clusterMd.text = "# Compat Cluster Digest\n\n_No active endpoint divergences._\n"
+        }
 
         execNd.withWriter('UTF-8') { w ->
             execFiles.each { f -> f.eachLine('UTF-8') { line -> w.writeLine(line) } }

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -162,7 +162,8 @@ test {
      'compat.verbose',
      'compat.allow-non-db-candidate',
      'compat.candidate.mode',
-     'compat.versions.file'].each { name ->
+     'compat.versions.file',
+     'compat.residual.file'].each { name ->
         def value = project.findProperty(name) ?: System.getenv(name.toUpperCase().replace('.', '_').replace('-', '_'))
         if (value != null) {
             systemProperty name, value
@@ -481,7 +482,7 @@ tasks.register('compatibilityReporter') {
         def clusterKeyFor = { Map r ->
             def endpoint = (r.endpoint ?: '').toString()
             def entity = (r.entityKey ?: renderParams(r.pathParams as Map ?: [:] as Map) ?: '-').toString()
-            def field = (r.message ?: '').toString().replaceAll(/\$\[\d+\]/, '$[N]')
+            def field = (r.message ?: '').toString().replaceAll(/\$\[\d+\]/, '\\$[N]')
             "${endpoint} | ${entity} | ${field}"
         }
         def buildClusterDigest = { Map activeCats ->

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/Cluster50CompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/Cluster50CompatTest.kt
@@ -1,0 +1,105 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.octopusden.octopus.components.registry.core.dto.DistributionDTO
+import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionRangeDTO
+import java.util.stream.Stream
+
+/**
+ * Targeted gate for the ~50-diff CARDS/ANCS jira-ranges + authmodlib distribution
+ * cluster observed on TC [1.7] builds #3826 / #3834. Exercised by TeamCity [1.9]
+ * (`id19CompatClusterGateAuto`) before the full [1.7] matrix.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Cluster-50 compat gate (CARDS/ANCS jira-ranges + authmodlib distribution)")
+class Cluster50CompatTest : CompatibilityTestBase() {
+
+    private val mapper = jacksonObjectMapper()
+
+    @ParameterizedTest(name = "GET /rest/api/2/projects/{0}/jira-component-version-ranges")
+    @MethodSource("projectKeyArgs")
+    fun `GET v2 jira-component-version-ranges by project must match`(projectKey: String) {
+        val endpoint = "GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges"
+        val params = mapOf("projectKey" to projectKey)
+        val (baseline, candidate) = fetchPair("/rest/api/2/projects/$projectKey/jira-component-version-ranges")
+
+        val before = DiffCollector.count()
+        compareRaw(endpoint, params, baseline, candidate)
+
+        if (baseline.status in 200..299 && candidate.status in 200..299) {
+            val baselineDto =
+                runCatching { mapper.readValue<Set<JiraComponentVersionRangeDTO>>(baseline.bodyBytes) }.getOrNull()
+            val candidateDto =
+                runCatching { mapper.readValue<Set<JiraComponentVersionRangeDTO>>(candidate.bodyBytes) }.getOrNull()
+            compareDto(endpoint, params, baselineDto, candidateDto)
+        }
+
+        val after = DiffCollector.count()
+        logExecution(
+            endpoint = endpoint,
+            pathParams = params,
+            baseline = baseline,
+            candidate = candidate,
+            layer = "raw+typed",
+            diffsBefore = before,
+            diffsAfter = after,
+        )
+    }
+
+    @ParameterizedTest(name = "GET /rest/api/2/components/{0}/versions/{1}/distribution")
+    @MethodSource("distributionVersionPairs")
+    fun `GET v2 per-version distribution must match`(componentName: String, version: String) {
+        val endpoint = "GET /rest/api/2/components/{component}/versions/{version}/distribution"
+        val params = mapOf("component" to componentName, "version" to version)
+        val path = "/rest/api/2/components/$componentName/versions/$version/distribution"
+        val (baseline, candidate) = fetchPair(path)
+
+        val before = DiffCollector.count()
+        compareRaw(endpoint, params, baseline, candidate)
+        if (baseline.status in 200..299 && candidate.status in 200..299) {
+            val baselineDto = runCatching { mapper.readValue<DistributionDTO>(baseline.bodyBytes) }.getOrNull()
+            val candidateDto = runCatching { mapper.readValue<DistributionDTO>(candidate.bodyBytes) }.getOrNull()
+            compareDto(endpoint, params, baselineDto, candidateDto)
+        }
+        val after = DiffCollector.count()
+        logExecution(
+            endpoint = endpoint,
+            pathParams = params,
+            baseline = baseline,
+            candidate = candidate,
+            layer = "raw+typed",
+            diffsBefore = before,
+            diffsAfter = after,
+        )
+    }
+
+    @AfterAll
+    fun closeStreams() {
+        DiffCollector.close()
+        ExecutionLogger.close()
+    }
+
+    companion object {
+        private val CLUSTER_PROJECT_KEYS = listOf("CARDS", "ANCS")
+        private val CLUSTER_DISTRIBUTION_PAIRS =
+            listOf(
+                "authmodlib" to "12.1.155",
+                "authmodlib" to "12.1.156",
+            )
+
+        @JvmStatic
+        fun projectKeyArgs(): Stream<Arguments> =
+            CLUSTER_PROJECT_KEYS.stream().map { Arguments.of(it) }
+
+        @JvmStatic
+        fun distributionVersionPairs(): Stream<Arguments> =
+            CLUSTER_DISTRIBUTION_PAIRS.stream().map { (c, v) -> Arguments.of(c, v) }
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComparatorLogicTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ComparatorLogicTest.kt
@@ -517,4 +517,40 @@ class ComparatorLogicTest {
         assertThat(recorded.category).isEqualTo(DiffClassifier.VALUE_DIFF)
         assertThat(recorded.message).contains("id")
     }
+
+    @Test
+    @DisplayName("compareRaw: jira-ranges STRUCTURAL_DIFF records resolved entityKey")
+    fun compareRaw_jiraRangesStructuralDiffRecordsEntityKey() {
+        val baseline =
+            response(
+                body =
+                    """
+                    [
+                      {"componentName":"alpha-fixture","versionRange":"[1.0,2.0)","component":{"displayName":"A"}},
+                      {"componentName":"beta-fixture","versionRange":"[2.0,)","component":{"displayName":"B"}}
+                    ]
+                    """.trimIndent(),
+            )
+        val candidate =
+            response(
+                body =
+                    """
+                    [
+                      {"componentName":"alpha-fixture","versionRange":"[1.0,2.0)","component":{"displayName":"A"}},
+                      {"componentName":"beta-fixture","versionRange":"[2.0,)","component":{}}
+                    ]
+                    """.trimIndent(),
+            )
+
+        Comparators.compareRaw(
+            endpoint = "GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges",
+            pathParams = mapOf("projectKey" to "CARDS"),
+            baseline = baseline,
+            candidate = candidate,
+        )
+
+        val recorded =
+            DiffCollector.snapshot().single { it.category == DiffClassifier.STRUCTURAL_DIFF }
+        assertThat(recorded.entityKey).isEqualTo("CARDS / beta-fixture @ [2.0,)")
+    }
 }

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/Comparators.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/Comparators.kt
@@ -57,6 +57,7 @@ object Comparators {
                     layer = "raw",
                     baselineValue = baseline.status.toString(),
                     candidateValue = candidate.status.toString(),
+                    entityKey = CompatEntityContext.resolveEntityKey(endpoint, "", pathParams, null, null),
                     message = "transport failure on " + listOfNotNull(
                         "baseline".takeIf { baselineTransportFailed },
                         "candidate".takeIf { candidateTransportFailed },
@@ -75,6 +76,7 @@ object Comparators {
                     layer = "raw",
                     baselineValue = baseline.status.toString(),
                     candidateValue = candidate.status.toString(),
+                    entityKey = CompatEntityContext.resolveEntityKey(endpoint, "", pathParams, null, null),
                 ),
             )
         }
@@ -114,6 +116,14 @@ object Comparators {
             val shapeDiffs = JsonShape.diff(baselineForShape, candidateForShape)
             for (sd in shapeDiffs) {
                 categories += DiffClassifier.STRUCTURAL_DIFF
+                val entityKey =
+                    CompatEntityContext.resolveEntityKey(
+                        endpoint = endpoint,
+                        jsonPath = sd.path,
+                        pathParams = pathParams,
+                        baselineJson = baselineForShape,
+                        candidateJson = candidateForShape,
+                    )
                 DiffCollector.record(
                     DiffRecord(
                         ts = ts,
@@ -124,6 +134,7 @@ object Comparators {
                         layer = "raw",
                         baselineValue = sd.baseline,
                         candidateValue = sd.candidate,
+                        entityKey = entityKey,
                         message = "${sd.kind} at ${sd.path}",
                     ),
                 )

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatEntityContext.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatEntityContext.kt
@@ -1,0 +1,64 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.databind.JsonNode
+
+/**
+ * Resolves human-readable entity keys for compat diff records.
+ *
+ * Raw-layer STRUCTURAL_DIFF messages use positional JSON paths (`$[3].field`).
+ * After [RawArraySorters] alignment those indices are stable but opaque — this
+ * helper maps them back to `(componentName, versionRange)` for cluster triage.
+ */
+object CompatEntityContext {
+    private val arrayIndex = Regex("""\$\[(\d+)\]""")
+
+    private val jiraRangesEndpoints =
+        setOf(
+            "GET /rest/api/2/common/jira-component-version-ranges",
+            "GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges",
+        )
+
+    fun resolveEntityKey(
+        endpoint: String,
+        jsonPath: String,
+        pathParams: Map<String, String>,
+        baselineJson: JsonNode?,
+        candidateJson: JsonNode?,
+    ): String? {
+        if (endpoint in jiraRangesEndpoints) {
+            val index = arrayIndex.find(jsonPath)?.groupValues?.get(1)?.toIntOrNull() ?: return null
+            val element =
+                elementAt(RawArraySorters.stableSorted(endpoint, baselineJson), index)
+                    ?: elementAt(RawArraySorters.stableSorted(endpoint, candidateJson), index)
+                    ?: return null
+            val componentName = element.path("componentName").asText("").ifBlank { "?" }
+            val versionRange = element.path("versionRange").asText("").ifBlank { "?" }
+            val project = pathParams["projectKey"]?.takeIf { it.isNotBlank() }
+            return if (project == null) {
+                "$componentName @ $versionRange"
+            } else {
+                "$project / $componentName @ $versionRange"
+            }
+        }
+        val component = pathParams["component"]?.takeIf { it.isNotBlank() }
+        val version = pathParams["version"]?.takeIf { it.isNotBlank() }
+        if (component != null && version != null) {
+            return "$component @ $version"
+        }
+        if (component != null) {
+            return component
+        }
+        return null
+    }
+
+    /** Collapse `$[3]` → `$[N]` so cluster digest groups by field, not wire index. */
+    fun normalizeFieldPath(jsonPath: String): String =
+        jsonPath.replace(arrayIndex, Regex.escapeReplacement("$" + "[N]"))
+
+    private fun elementAt(root: JsonNode?, index: Int): JsonNode? {
+        if (root == null || !root.isArray || index < 0 || index >= root.size()) {
+            return null
+        }
+        return root.get(index)
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatEntityContextTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/CompatEntityContextTest.kt
@@ -1,0 +1,61 @@
+package org.octopusden.octopus.components.registry.compat
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("unit")
+class CompatEntityContextTest {
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    @DisplayName("resolveEntityKey maps jira-ranges array index to componentName @ versionRange")
+    fun resolveEntityKey_mapsJiraRangesIndex() {
+        val baseline =
+            mapper.readTree(
+                """
+                [
+                  {"componentName":"alpha","versionRange":"[1.0,2.0)","component":{"projectKey":"CARDS"}},
+                  {"componentName":"beta","versionRange":"[2.0,)","component":{"projectKey":"CARDS"}}
+                ]
+                """.trimIndent(),
+            )
+
+        val key =
+            CompatEntityContext.resolveEntityKey(
+                endpoint = "GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges",
+                jsonPath = "\$[1].component.displayName",
+                pathParams = mapOf("projectKey" to "CARDS"),
+                baselineJson = baseline,
+                candidateJson = null,
+            )
+
+        assertEquals("CARDS / beta @ [2.0,)", key)
+    }
+
+    @Test
+    @DisplayName("resolveEntityKey uses path params for per-version distribution endpoint")
+    fun resolveEntityKey_usesPathParamsForDistribution() {
+        val key =
+            CompatEntityContext.resolveEntityKey(
+                endpoint = "GET /rest/api/2/components/{component}/versions/{version}/distribution",
+                jsonPath = "$",
+                pathParams = mapOf("component" to "authmodlib", "version" to "12.1.155"),
+                baselineJson = null,
+                candidateJson = null,
+            )
+
+        assertEquals("authmodlib @ 12.1.155", key)
+    }
+
+    @Test
+    @DisplayName("normalizeFieldPath collapses array indices")
+    fun normalizeFieldPath_collapsesIndices() {
+        assertEquals(
+            "$" + "[N].vcsSettings.externalRegistry",
+            CompatEntityContext.normalizeFieldPath("\$[23].vcsSettings.externalRegistry"),
+        )
+    }
+}

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffRecord.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/DiffRecord.kt
@@ -20,6 +20,8 @@ data class DiffRecord(
     val layer: String,
     val baselineValue: String? = null,
     val candidateValue: String? = null,
+    /** Resolved entity identity for triage (e.g. `CARDS / foo @ [1.0,2.0)` or `authmodlib @ 12.1.155`). */
+    val entityKey: String? = null,
     val diagnosticHeaders: Map<String, HeaderPair>? = null,
     val message: String? = null,
 ) {

--- a/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ResidualReplayCompatTest.kt
+++ b/components-registry-compat-test/src/test/kotlin/org/octopusden/octopus/components/registry/compat/ResidualReplayCompatTest.kt
@@ -1,0 +1,136 @@
+package org.octopusden.octopus.components.registry.compat
+
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.core.dto.VersionRequest
+import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Targeted replay of **only** requests that produced diffs on a prior TC run.
+ *
+ * Activate with `compat.residual.file` / `COMPAT_RESIDUAL_FILE` pointing at a
+ * trace-format fixture (`count\\tMETHOD\\tpath` per line). Generate the fixture
+ * from TC `exec-worker-*.ndjson` via
+ * [`scripts/local-stands/extract-residual-fixture.py`](../../../../../../scripts/local-stands/extract-residual-fixture.py).
+ *
+ * Uses the same [Comparators.compareRaw] pipeline as [TraceReplayCompatTest] but
+ * skips the 30k production trace — fast iteration on the ~700 failing tuples from
+ * build #3841 instead of re-running the full [1.7] gate.
+ */
+class ResidualReplayCompatTest : CompatibilityTestBase() {
+    private data class ResidualEntry(val count: Long, val method: String, val path: String)
+
+    @Test
+    fun `replay residual failing requests from prior compat run`() {
+        val filePath =
+            System.getProperty("compat.residual.file")
+                ?: System.getenv("COMPAT_RESIDUAL_FILE")
+        assumeTrue(
+            !filePath.isNullOrBlank(),
+            "compat.residual.file / COMPAT_RESIDUAL_FILE not set — ResidualReplayCompatTest skipped",
+        )
+        val file = File(filePath!!)
+        assumeTrue(file.exists() && file.canRead(), "residual fixture not readable: $filePath")
+
+        val entries =
+            file
+                .readLines()
+                .mapNotNull { line ->
+                    val trimmed = line.trim()
+                    if (trimmed.isEmpty() || trimmed.startsWith("#")) return@mapNotNull null
+                    val parts = trimmed.split('\t')
+                    if (parts.size < 3) return@mapNotNull null
+                    ResidualEntry(parts[0].toLongOrNull() ?: 1L, parts[1], parts[2])
+                }
+        assumeTrue(entries.isNotEmpty(), "residual fixture empty: $filePath")
+
+        val pool = Executors.newFixedThreadPool(config.parallelism.coerceAtMost(4))
+        val processed = AtomicInteger(0)
+        val withDiffs = AtomicInteger(0)
+
+        try {
+            val futures =
+                entries.map { entry ->
+                    pool.submit {
+                        val diffsBefore = DiffCollector.count()
+                        val (baseline, candidate) =
+                            when (entry.method.uppercase()) {
+                                "GET" -> fetchPair(entry.path)
+                                "PUT" -> putPair(entry.path)
+                                "POST" ->
+                                    if (entry.path.contains("/detailed-versions")) {
+                                        val component =
+                                            entry.path
+                                                .substringAfter("/components/")
+                                                .substringBefore("/detailed-versions")
+                                        val versions = VersionSampler.versionsFor(component, 3)
+                                        postJsonPair(entry.path, VersionRequest(versions))
+                                    } else {
+                                        postJsonPair(entry.path, emptyMap<String, Any>())
+                                    }
+                                else -> return@submit
+                            }
+                        val (pathOnly, parsedQuery) = parsePathAndQuery(entry.path)
+                        val endpoint = "${entry.method.uppercase()} $pathOnly"
+                        Comparators.compareRaw(
+                            endpoint = endpoint,
+                            pathParams = emptyMap(),
+                            baseline = baseline,
+                            candidate = candidate,
+                            queryParams = parsedQuery + ("_residual" to "1"),
+                        )
+                        ExecutionLogger.log(
+                            ExecutionEntry(
+                                endpoint = endpoint,
+                                pathParams = emptyMap(),
+                                queryParams = parsedQuery,
+                                baselineStatus = baseline.status,
+                                candidateStatus = candidate.status,
+                                baselineMs = baseline.durationMs,
+                                candidateMs = candidate.durationMs,
+                                layer = "raw",
+                                diffCount = DiffCollector.count() - diffsBefore,
+                            ),
+                        )
+                        val newDiffs = DiffCollector.count() - diffsBefore
+                        if (newDiffs > 0) withDiffs.incrementAndGet()
+                        val n = processed.incrementAndGet()
+                        if (n % 50 == 0 || n == entries.size) {
+                            println(
+                                "[residual-replay] $n / ${entries.size} " +
+                                    "(${withDiffs.get()} tuples with diffs)",
+                            )
+                        }
+                    }
+                }
+            futures.forEach { it.get(90, TimeUnit.SECONDS) }
+        } finally {
+            pool.shutdown()
+            pool.awaitTermination(30, TimeUnit.SECONDS)
+        }
+        println(
+            "[residual-replay] done: ${entries.size} tuples, " +
+                "${withDiffs.get()} with diffs, " +
+                "${DiffCollector.count()} diff records total",
+        )
+    }
+
+    private fun parsePathAndQuery(rawPath: String): Pair<String, Map<String, String>> {
+        val qIdx = rawPath.indexOf('?')
+        if (qIdx < 0) return rawPath to emptyMap()
+        val pathOnly = rawPath.substring(0, qIdx)
+        val query =
+            rawPath
+                .substring(qIdx + 1)
+                .split('&')
+                .mapNotNull { pair ->
+                    if (pair.isEmpty()) return@mapNotNull null
+                    val eq = pair.indexOf('=')
+                    if (eq <= 0) pair to "" else pair.substring(0, eq) to pair.substring(eq + 1)
+                }.toMap()
+        return pathOnly to query
+    }
+}

--- a/components-registry-compat-test/src/test/resources/compat/cluster-50-fixture.txt
+++ b/components-registry-compat-test/src/test/resources/compat/cluster-50-fixture.txt
@@ -1,0 +1,6 @@
+# Residual-replay fixture for the ~50-diff cluster (TC #3826 / #3834 signature).
+# Format: count<TAB>METHOD<TAB>path  (count is informational for trace-derived fixtures)
+1	GET	/rest/api/2/projects/CARDS/jira-component-version-ranges
+1	GET	/rest/api/2/projects/ANCS/jira-component-version-ranges
+1	GET	/rest/api/2/components/authmodlib/versions/12.1.155/distribution
+1	GET	/rest/api/2/components/authmodlib/versions/12.1.156/distribution

--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -159,8 +159,9 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
     fun testGetAllComponents() {
         // 56 pre-MIG-041 + 2 aggregator-handling fixtures (TEST_AGGREGATOR_FAKE +
         // TEST_AGGREGATOR_MEMBER) + 1 task-#16 fixture (TEST_PER_RANGE_HOTFIX_FORMAT)
-        // which all inherit the Defaults `system = "NONE"`.
-        assertEquals(59, componentsRegistryClient.getAllComponents().components.size)
+        // + 1 MIG-045 fixture (TEST_PER_RANGE_JIRA_DISPLAY_NAME); all inherit
+        // the Defaults `system = "NONE"`.
+        assertEquals(60, componentsRegistryClient.getAllComponents().components.size)
         assertEquals(
             3,
             componentsRegistryClient.getAllComponents("ssh://hg@mercurial/technical", null).components.size,
@@ -176,11 +177,11 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         )
         assertEquals(2, componentsRegistryClient.getAllComponents(systems = listOf("ALFA")).components.size)
         assertEquals(6, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC")).components.size)
-        assertEquals(53, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
+        assertEquals(54, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
         assertEquals(6, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC")).components.size)
-        assertEquals(55, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "NONE")).components.size)
-        assertEquals(59, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
-        assertEquals(59, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC", "NONE", "TEST")).components.size)
+        assertEquals(56, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "NONE")).components.size)
+        assertEquals(60, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
+        assertEquals(60, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC", "NONE", "TEST")).components.size)
     }
 
     @Test

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
@@ -187,6 +187,14 @@ class ComponentConfigurationEntity(
     @Column(name = "jira_display_name")
     var jiraDisplayName: String? = null,
 
+    /**
+     * Per-range override for `vcs.externalRegistry`. The per-component base
+     * value lives on `components.vcs_external_registry`; the resolver layers
+     * this column when the row applies for the requested version range.
+     */
+    @Column(name = "vcs_external_registry")
+    var vcsExternalRegistry: String? = null,
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     var createdAt: Instant? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
@@ -179,6 +179,14 @@ class ComponentConfigurationEntity(
     @Column(name = "jira_hotfix_version_format")
     var jiraHotfixVersionFormat: String? = null,
 
+    /**
+     * Per-range override for `jira.displayName`. The per-component base value
+     * lives on `components.jira_display_name`; the resolver layers this column
+     * when the row applies for the requested version range.
+     */
+    @Column(name = "jira_display_name")
+    var jiraDisplayName: String? = null,
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     var createdAt: Instant? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
@@ -60,6 +60,7 @@ internal val SCALAR_ATTRIBUTE_PATHS: Set<String> =
         "jira.versionPrefix",
         "jira.versionFormat",
         "jira.hotfixVersionFormat",
+        "jira.displayName",
     )
 
 /**
@@ -108,6 +109,7 @@ internal fun ComponentConfigurationEntity.extractScalarValue(): Any? =
         "jira.versionPrefix" -> jiraVersionPrefix
         "jira.versionFormat" -> jiraVersionFormat
         "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat
+        "jira.displayName" -> jiraDisplayName
         else -> null
     }
 
@@ -167,6 +169,7 @@ internal fun ComponentConfigurationEntity.applyScalarValue(
         "jira.versionPrefix" -> jiraVersionPrefix = requireString(attributePath, value)
         "jira.versionFormat" -> jiraVersionFormat = requireString(attributePath, value)
         "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat = requireString(attributePath, value)
+        "jira.displayName" -> jiraDisplayName = requireString(attributePath, value)
     }
 }
 
@@ -201,6 +204,7 @@ private fun ComponentConfigurationEntity.clearAllScalarColumns() {
     jiraVersionPrefix = null
     jiraVersionFormat = null
     jiraHotfixVersionFormat = null
+    jiraDisplayName = null
 }
 
 private fun requireString(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
@@ -61,6 +61,7 @@ internal val SCALAR_ATTRIBUTE_PATHS: Set<String> =
         "jira.versionFormat",
         "jira.hotfixVersionFormat",
         "jira.displayName",
+        "vcs.externalRegistry",
     )
 
 /**
@@ -110,6 +111,7 @@ internal fun ComponentConfigurationEntity.extractScalarValue(): Any? =
         "jira.versionFormat" -> jiraVersionFormat
         "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat
         "jira.displayName" -> jiraDisplayName
+        "vcs.externalRegistry" -> vcsExternalRegistry
         else -> null
     }
 
@@ -170,6 +172,7 @@ internal fun ComponentConfigurationEntity.applyScalarValue(
         "jira.versionFormat" -> jiraVersionFormat = requireString(attributePath, value)
         "jira.hotfixVersionFormat" -> jiraHotfixVersionFormat = requireString(attributePath, value)
         "jira.displayName" -> jiraDisplayName = requireString(attributePath, value)
+        "vcs.externalRegistry" -> vcsExternalRegistry = requireString(attributePath, value)
     }
 }
 
@@ -205,6 +208,7 @@ private fun ComponentConfigurationEntity.clearAllScalarColumns() {
     jiraVersionFormat = null
     jiraHotfixVersionFormat = null
     jiraDisplayName = null
+    vcsExternalRegistry = null
 }
 
 private fun requireString(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -421,6 +421,9 @@ private fun buildEscrowModuleConfig(
             // vcs.externalRegistry scalar for this range, registry must not
             // leak from the BASE row or components.vcs_external_registry.
             vcsMarkerActive -> null
+            // Explicit enumerated ranges must not inherit components.vcs_external_registry
+            // when the BASE row carries no per-range registry (MIG-050 / CARDS compat).
+            versionRange != ALL_VERSIONS -> merged.vcsExternalRegistry
             else -> merged.vcsExternalRegistry ?: component.vcsExternalRegistry
         }
     if (vcsEntries.isNotEmpty() || externalRegistry != null) {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -94,7 +94,7 @@ internal object MarkerAttributes {
  */
 fun ComponentEntity.toEscrowModule(
     versionRangeFactory: VersionRangeFactory,
-    @Suppress("UNUSED_PARAMETER") numericVersionFactory: NumericVersionFactory,
+    numericVersionFactory: NumericVersionFactory,
 ): EscrowModule {
     val module = EscrowModule()
     module.moduleName = this.componentKey
@@ -156,6 +156,7 @@ fun ComponentEntity.toEscrowModule(
                 base = base,
                 overrides = overrides,
                 versionRangeFactory = versionRangeFactory,
+                numericVersionFactory = numericVersionFactory,
             )
         module.moduleConfigurations.add(resolved)
     }
@@ -219,6 +220,7 @@ private fun ComponentEntity.resolveForRange(
     base: ComponentConfigurationEntity,
     overrides: List<ComponentConfigurationEntity>,
     versionRangeFactory: VersionRangeFactory,
+    numericVersionFactory: NumericVersionFactory,
 ): EscrowModuleConfig {
     // For enumeration purposes, an override applies to `range` when its own
     // range string equals `range` OR fully contains `range`. Equality is the
@@ -228,12 +230,22 @@ private fun ComponentEntity.resolveForRange(
     val scalarOverrides =
         overrides.filter {
             it.rowType == "SCALAR_OVERRIDE" &&
-                rangeApplies(parentRange = it.versionRange, childRange = range, factory = versionRangeFactory)
+                rangeApplies(
+                    parentRange = it.versionRange,
+                    childRange = range,
+                    versionRangeFactory = versionRangeFactory,
+                    numericVersionFactory = numericVersionFactory,
+                )
         }
     val markerOverrides =
         overrides.filter {
             it.rowType == "MARKER" &&
-                rangeApplies(parentRange = it.versionRange, childRange = range, factory = versionRangeFactory)
+                rangeApplies(
+                    parentRange = it.versionRange,
+                    childRange = range,
+                    versionRangeFactory = versionRangeFactory,
+                    numericVersionFactory = numericVersionFactory,
+                )
         }
 
     return buildEscrowModuleConfig(
@@ -259,14 +271,24 @@ private fun ComponentEntity.resolveForRange(
  * dropped during enumeration.
  *
  * See TD-010 (`docs/registry/tech-debt/010-range-applies-containment.md`)
- * for the matrix-tests acceptance + sample-points heuristic spec. Same
- * blocker as the partial-overlap write-side rejection item.
+ * for the matrix-tests acceptance + sample-points heuristic spec.
  */
-private fun rangeApplies(
+internal fun rangeApplies(
     parentRange: String,
     childRange: String,
-    @Suppress("UNUSED_PARAMETER") factory: VersionRangeFactory,
-): Boolean = parentRange == childRange
+    versionRangeFactory: VersionRangeFactory,
+    numericVersionFactory: NumericVersionFactory,
+): Boolean {
+    if (parentRange == childRange) {
+        return true
+    }
+    return rangeAppliesByContainment(
+        parentRange = parentRange,
+        childRange = childRange,
+        versionRangeFactory = versionRangeFactory,
+        numericVersionFactory = numericVersionFactory,
+    )
+}
 
 // ============================================================
 // Internal: build EscrowModuleConfig from base + overrides
@@ -309,20 +331,22 @@ private fun buildEscrowModuleConfig(
     // VCS — child collection. Marker override "vcs.settings" replaces base
     // children; otherwise base.vcsEntries is used.
     //
-    // `externalRegistry` is per-component scalar — a sibling of the VCS roots,
-    // not a child entry. Emit `vcsSettings` whenever either is present so a
-    // component declared in DSL as `vcsSettings { externalRegistry = "..." }`
-    // with no VCS roots round-trips correctly (the Groovy resolver kept the
-    // VCSSettings instance with externalRegistry set and roots empty; v2 was
-    // silently dropping it).
+    // Per-range `vcs.externalRegistry` is stored on configuration rows (BASE +
+    // SCALAR_OVERRIDE); component.vcsExternalRegistry is the Defaults fallback.
     val vcsEntries =
         pickMarkerChildren(
             attribute = MarkerAttributes.VCS_SETTINGS,
             markerOverrides = markerOverrides,
             baseChildren = base.vcsEntries.toList(),
         ) { it.vcsEntries.toList() }
-    if (vcsEntries.isNotEmpty() || component.vcsExternalRegistry != null) {
-        setField(config, "vcsSettings", vcsEntries.toVCSSettings(component.vcsExternalRegistry))
+    val externalRegistry =
+        if (merged.vcsExternalRegistryOverridden) {
+            merged.vcsExternalRegistry
+        } else {
+            merged.vcsExternalRegistry ?: component.vcsExternalRegistry
+        }
+    if (vcsEntries.isNotEmpty() || externalRegistry != null) {
+        setField(config, "vcsSettings", vcsEntries.toVCSSettings(externalRegistry))
     }
 
     // Distribution — composed from four family child collections, each
@@ -486,6 +510,12 @@ internal class ComponentConfigurationView {
     var jiraDisplayName: String? = null
 
     /**
+     * Tracks presence of a per-range SCALAR_OVERRIDE for `vcs.externalRegistry`.
+     */
+    var vcsExternalRegistryOverridden: Boolean = false
+    var vcsExternalRegistry: String? = null
+
+    /**
      * Tracks presence (not value) of a per-range SCALAR_OVERRIDE for
      * `jira.hotfixVersionFormat`. Set to `true` only when
      * [applyScalarOverride] processes a row whose `overriddenAttribute ==
@@ -550,6 +580,10 @@ internal class ComponentConfigurationView {
             "jira.displayName" -> {
                 jiraDisplayName = override.jiraDisplayName
                 jiraDisplayNameOverridden = true
+            }
+            "vcs.externalRegistry" -> {
+                vcsExternalRegistry = override.vcsExternalRegistry
+                vcsExternalRegistryOverridden = true
             }
 
             else -> Unit // unknown attribute path; ignore for forward-compat
@@ -687,6 +721,7 @@ internal class ComponentConfigurationView {
                 jiraVersionFormat = base.jiraVersionFormat
                 jiraHotfixVersionFormat = base.jiraHotfixVersionFormat
                 jiraDisplayName = base.jiraDisplayName
+                vcsExternalRegistry = base.vcsExternalRegistry
             }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -206,8 +206,47 @@ fun ComponentEntity.toResolvedEscrowModuleConfig(
                 }
             }
 
-    return pickResolvedModuleConfiguration(this.componentKey, version, matching)
+    if (matching.isNotEmpty()) {
+        return pickResolvedModuleConfiguration(this.componentKey, version, matching)
+    }
+
+    // MIG-029 synthetic-base fallback: a universal `(,)` placeholder base plus
+    // scalar/marker overrides still resolves from base scalars for versions outside
+    // every override range (DatabaseComponentRegistryResolverTest 3b/4b/5c). Do
+    // not apply when the synthetic base anchors an explicit first DSL range — those
+    // components enumerate RANGE_PRESENCE views only and gaps must stay null
+    // (MIG-047 authmodlib pattern).
+    val configs = this.configurations.toList()
+    val base = configs.firstOrNull { it.rowType == "BASE" } ?: return null
+    val scalarAndMarkerOverrides =
+        configs.filter { it.rowType == "SCALAR_OVERRIDE" || it.rowType == "MARKER" }
+    if (
+        base.isSyntheticBase &&
+        isUniversalVersionRange(base.versionRange) &&
+        scalarAndMarkerOverrides.isNotEmpty()
+    ) {
+        val matchingOverrides =
+            scalarAndMarkerOverrides.filter { override ->
+                try {
+                    versionRangeFactory.create(override.versionRange).containsVersion(numericVersion)
+                } catch (_: Exception) {
+                    false
+                }
+            }
+        return buildEscrowModuleConfig(
+            component = this,
+            base = base,
+            scalarOverrides = matchingOverrides.filter { it.rowType == "SCALAR_OVERRIDE" },
+            markerOverrides = matchingOverrides.filter { it.rowType == "MARKER" },
+            versionRange = base.versionRange,
+        )
+    }
+
+    return null
 }
+
+private fun isUniversalVersionRange(range: String): Boolean =
+    range == ALL_VERSIONS || range == "(,)"
 
 /**
  * When several enumerated views contain [version] (typically `(,)` plus a

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -233,12 +233,22 @@ fun ComponentEntity.toResolvedEscrowModuleConfig(
                     false
                 }
             }
+        val scalarOverrides = matchingOverrides.filter { it.rowType == "SCALAR_OVERRIDE" }
+        val markerOverrides = matchingOverrides.filter { it.rowType == "MARKER" }
         return buildEscrowModuleConfig(
             component = this,
             base = base,
-            scalarOverrides = matchingOverrides.filter { it.rowType == "SCALAR_OVERRIDE" },
-            markerOverrides = matchingOverrides.filter { it.rowType == "MARKER" },
+            scalarOverrides = scalarOverrides,
+            markerOverrides = markerOverrides,
             versionRange = base.versionRange,
+            rangePresenceOnly =
+                isRangePresenceOnlyView(
+                    range = base.versionRange,
+                    base = base,
+                    overrides = configs.filter { it.rowType != "BASE" },
+                    scalarOverrides = scalarOverrides,
+                    markerOverrides = markerOverrides,
+                ),
         )
     }
 
@@ -320,8 +330,34 @@ private fun ComponentEntity.resolveForRange(
         scalarOverrides = scalarOverrides,
         markerOverrides = markerOverrides,
         versionRange = range,
+        rangePresenceOnly =
+            isRangePresenceOnlyView(
+                range = range,
+                base = base,
+                overrides = overrides,
+                scalarOverrides = scalarOverrides,
+                markerOverrides = markerOverrides,
+            ),
     )
 }
+
+/**
+ * True when [range] is enumerated solely via a RANGE_PRESENCE row with no
+ * scalar/marker overrides applying to that view — the MIG-048 empty DSL block
+ * case. Such ranges must not inherit BASE-row or component-level displayName
+ * when the BASE anchor carries a non-null jira.displayName.
+ */
+private fun isRangePresenceOnlyView(
+    range: String,
+    base: ComponentConfigurationEntity,
+    overrides: List<ComponentConfigurationEntity>,
+    scalarOverrides: List<ComponentConfigurationEntity>,
+    markerOverrides: List<ComponentConfigurationEntity>,
+): Boolean =
+    range != base.versionRange &&
+        overrides.any { it.rowType == "RANGE_PRESENCE" && it.versionRange == range } &&
+        scalarOverrides.isEmpty() &&
+        markerOverrides.isEmpty()
 
 /**
  * True when an override row with `parentRange` should apply to the enumeration
@@ -367,6 +403,7 @@ private fun buildEscrowModuleConfig(
     scalarOverrides: List<ComponentConfigurationEntity>,
     markerOverrides: List<ComponentConfigurationEntity>,
     versionRange: String,
+    rangePresenceOnly: Boolean,
 ): EscrowModuleConfig {
     val config = EscrowModuleConfig()
     setField(config, "versionRange", versionRange)
@@ -475,8 +512,8 @@ private fun buildEscrowModuleConfig(
             null
         } else {
             buildDistribution(
-                explicit = if (hasDistributionMarker) null else component.distributionExplicit,
-                external = if (hasDistributionMarker) null else component.distributionExternal,
+                explicit = component.distributionExplicit,
+                external = component.distributionExternal,
                 mavenArtifacts = mavenArtifacts,
                 fileUrlArtifacts = fileUrlArtifacts,
                 dockerImages = dockerImages,
@@ -491,8 +528,10 @@ private fun buildEscrowModuleConfig(
     // Jira aspect — composed from merged config scalars + component-level fields
     val jira = buildJiraComponent(
         component = component,
+        base = base,
         merged = merged,
         versionRange = versionRange,
+        rangePresenceOnly = rangePresenceOnly,
     )
     if (jira != null) {
         setField(config, "jiraConfiguration", jira)
@@ -925,8 +964,10 @@ private fun composeDockerCsv(images: List<DistributionDockerImageEntity>): Strin
 @Suppress("LongMethod")
 private fun buildJiraComponent(
     component: ComponentEntity,
+    base: ComponentConfigurationEntity,
     merged: ComponentConfigurationView,
     versionRange: String,
+    rangePresenceOnly: Boolean,
 ): JiraComponent? {
     val projectKey = merged.jiraProjectKey ?: return null
 
@@ -962,14 +1003,23 @@ private fun buildJiraComponent(
     }
 
     // Per-range jira.displayName resolution mirrors hotfixVersionFormat layering:
-    // SCALAR_OVERRIDE rows (including null-clear) win; explicit DSL ranges other
-    // than ALL_VERSIONS use the merged row value without component fallback; the
-    // ALL_VERSIONS default view still inherits components.jira_display_name when
-    // the base row carries no per-range displayName.
+    // SCALAR_OVERRIDE rows (including null-clear) win; explicit enumerated ranges
+    // inherit components.jira_display_name when the merged row has no per-range
+    // value unless MIG-048 empty-block semantics apply (RANGE_PRESENCE-only with
+    // BASE-row bleed) or a synthetic base row pins an explicit null.
     val displayName =
         when {
             merged.jiraDisplayNameOverridden -> merged.jiraDisplayName
-            versionRange != ALL_VERSIONS && merged.jiraProjectKey != null -> merged.jiraDisplayName
+            versionRange != ALL_VERSIONS && merged.jiraProjectKey != null ->
+                merged.jiraDisplayName
+                    ?: component.jiraDisplayName.takeUnless {
+                        shouldSuppressComponentJiraDisplayNameFallback(
+                            versionRange = versionRange,
+                            base = base,
+                            merged = merged,
+                            rangePresenceOnly = rangePresenceOnly,
+                        )
+                    }
             else -> merged.jiraDisplayName ?: component.jiraDisplayName
         }
 
@@ -981,6 +1031,24 @@ private fun buildJiraComponent(
         merged.jiraTechnical ?: false,
         false,
     )
+}
+
+private fun shouldSuppressComponentJiraDisplayNameFallback(
+    versionRange: String,
+    base: ComponentConfigurationEntity,
+    merged: ComponentConfigurationView,
+    rangePresenceOnly: Boolean,
+): Boolean {
+    if (merged.jiraDisplayNameOverridden) {
+        return false
+    }
+    if (rangePresenceOnly && base.jiraDisplayName != null) {
+        return true
+    }
+    if (versionRange == base.versionRange && merged.jiraDisplayName == null) {
+        return true
+    }
+    return false
 }
 
 private fun pickDocLink(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -414,13 +414,6 @@ private fun buildEscrowModuleConfig(
     for (override in scalarOverrides) {
         merged.applyScalarOverride(override)
     }
-    // MIG-048: explicit enumerated ranges (other than the BASE anchor) must not
-    // inherit jira.displayName from the BASE row when no per-range override
-    // (including containment via rangeApplies) is present — V1 empty DSL blocks
-    // surface null displayName on jira-component-version-ranges.
-    if (versionRange != base.versionRange && !merged.jiraDisplayNameOverridden) {
-        merged.jiraDisplayName = null
-    }
 
     // Build aspect
     setField(config, "buildSystem", merged.buildSystem?.let { safeParseBuildSystem(it) })
@@ -1003,23 +996,17 @@ private fun buildJiraComponent(
     }
 
     // Per-range jira.displayName resolution mirrors hotfixVersionFormat layering:
-    // SCALAR_OVERRIDE rows (including null-clear) win; explicit enumerated ranges
-    // inherit components.jira_display_name when the merged row has no per-range
-    // value unless MIG-048 empty-block semantics apply (RANGE_PRESENCE-only with
-    // BASE-row bleed) or a synthetic base row pins an explicit null.
+    // SCALAR_OVERRIDE rows (including null-clear) win; RANGE_PRESENCE-only empty
+    // blocks stay null; other explicit ranges fall back to components.jira_display_name
+    // instead of inheriting BASE-row bleed; single-range BASE null pins stay null.
     val displayName =
         when {
             merged.jiraDisplayNameOverridden -> merged.jiraDisplayName
-            versionRange != ALL_VERSIONS && merged.jiraProjectKey != null ->
-                merged.jiraDisplayName
-                    ?: component.jiraDisplayName.takeUnless {
-                        shouldSuppressComponentJiraDisplayNameFallback(
-                            versionRange = versionRange,
-                            base = base,
-                            merged = merged,
-                            rangePresenceOnly = rangePresenceOnly,
-                        )
-                    }
+            rangePresenceOnly && base.jiraDisplayName != null -> null
+            versionRange != base.versionRange -> component.jiraDisplayName
+            versionRange == base.versionRange &&
+                merged.jiraDisplayName == null &&
+                hasOnlyBaseConfiguration(component) -> null
             else -> merged.jiraDisplayName ?: component.jiraDisplayName
         }
 
@@ -1033,23 +1020,8 @@ private fun buildJiraComponent(
     )
 }
 
-private fun shouldSuppressComponentJiraDisplayNameFallback(
-    versionRange: String,
-    base: ComponentConfigurationEntity,
-    merged: ComponentConfigurationView,
-    rangePresenceOnly: Boolean,
-): Boolean {
-    if (merged.jiraDisplayNameOverridden) {
-        return false
-    }
-    if (rangePresenceOnly && base.jiraDisplayName != null) {
-        return true
-    }
-    if (versionRange == base.versionRange && merged.jiraDisplayName == null) {
-        return true
-    }
-    return false
-}
+private fun hasOnlyBaseConfiguration(component: ComponentEntity): Boolean =
+    component.configurations.none { it.rowType != "BASE" }
 
 private fun pickDocLink(
     links: List<ComponentDocLinkEntity>,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -182,10 +182,6 @@ fun ComponentEntity.toResolvedEscrowModuleConfig(
     versionRangeFactory: VersionRangeFactory,
     numericVersionFactory: NumericVersionFactory,
 ): EscrowModuleConfig? {
-    val configs = this.configurations.toList()
-    val base = configs.firstOrNull { it.rowType == "BASE" } ?: return null
-    val overrides = configs.filter { it.rowType == "SCALAR_OVERRIDE" || it.rowType == "MARKER" }
-
     val numericVersion =
         try {
             numericVersionFactory.create(version)
@@ -193,22 +189,53 @@ fun ComponentEntity.toResolvedEscrowModuleConfig(
             return null
         }
 
-    val matchingOverrides =
-        overrides.filter { override ->
-            try {
-                versionRangeFactory.create(override.versionRange).containsVersion(numericVersion)
-            } catch (_: Exception) {
-                false
+    // Mirror EscrowConfigurationLoader.resolveComponentConfiguration: pick the
+    // single enumerated module view whose version range contains `version`.
+    // Building from BASE + point-in-range overrides alone would keep serving the
+    // `(,)` anchor for versions that fall outside every DSL range (e.g.
+    // authmodlib 12.1.155 sits in the gap between `[11,12.1)` and `[12.2,)`).
+    val matching =
+        this.toEscrowModule(versionRangeFactory, numericVersionFactory)
+            .moduleConfigurations
+            .filter { config ->
+                val rangeString = config.versionRangeString ?: return@filter false
+                try {
+                    versionRangeFactory.create(rangeString).containsVersion(numericVersion)
+                } catch (_: Exception) {
+                    false
+                }
             }
-        }
 
-    return buildEscrowModuleConfig(
-        component = this,
-        base = base,
-        scalarOverrides = matchingOverrides.filter { it.rowType == "SCALAR_OVERRIDE" },
-        markerOverrides = matchingOverrides.filter { it.rowType == "MARKER" },
-        versionRange = base.versionRange,
-    )
+    return pickResolvedModuleConfiguration(this.componentKey, version, matching)
+}
+
+/**
+ * When several enumerated views contain [version] (typically `(,)` plus a
+ * narrower override range), prefer the most specific non-default range — same
+ * outcome V1's loader achieves because overlapping matches are rare in
+ * production DSL, but unit fixtures often declare `(,)` plus explicit ranges.
+ */
+internal fun pickResolvedModuleConfiguration(
+    componentKey: String,
+    version: String,
+    matching: List<EscrowModuleConfig>,
+): EscrowModuleConfig? {
+    if (matching.isEmpty()) {
+        return null
+    }
+    if (matching.size == 1) {
+        return matching.first()
+    }
+    val nonDefault =
+        matching.filter { config ->
+            val range = config.versionRangeString ?: return@filter false
+            range != ALL_VERSIONS && range != "(,)"
+        }
+    val pool = nonDefault.ifEmpty { matching }
+    if (pool.size == 1) {
+        return pool.first()
+    }
+    error("Too many component $componentKey:$version module configurations (${pool.size})")
 }
 
 // ============================================================
@@ -339,11 +366,16 @@ private fun buildEscrowModuleConfig(
             markerOverrides = markerOverrides,
             baseChildren = base.vcsEntries.toList(),
         ) { it.vcsEntries.toList() }
+    val vcsMarkerActive =
+        markerOverrides.any { it.overriddenAttribute == MarkerAttributes.VCS_SETTINGS }
     val externalRegistry =
-        if (merged.vcsExternalRegistryOverridden) {
-            merged.vcsExternalRegistry
-        } else {
-            merged.vcsExternalRegistry ?: component.vcsExternalRegistry
+        when {
+            merged.vcsExternalRegistryOverridden -> merged.vcsExternalRegistry
+            // vcs.settings replaces the whole VCS view. Without an explicit
+            // vcs.externalRegistry scalar for this range, registry must not
+            // leak from the BASE row or components.vcs_external_registry.
+            vcsMarkerActive -> null
+            else -> merged.vcsExternalRegistry ?: component.vcsExternalRegistry
         }
     if (vcsEntries.isNotEmpty() || externalRegistry != null) {
         setField(config, "vcsSettings", vcsEntries.toVCSSettings(externalRegistry))
@@ -376,16 +408,33 @@ private fun buildEscrowModuleConfig(
             baseChildren = base.packages.toList(),
         ) { it.packages.toList() }
 
+    val hasDistributionMarker =
+        markerOverrides.any {
+            it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN ||
+                it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_FILE_URL ||
+                it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_DOCKER ||
+                it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_PACKAGES
+        }
     val distribution =
-        buildDistribution(
-            explicit = component.distributionExplicit,
-            external = component.distributionExternal,
-            mavenArtifacts = mavenArtifacts,
-            fileUrlArtifacts = fileUrlArtifacts,
-            dockerImages = dockerImages,
-            packages = packages,
-            securityGroups = component.securityGroups.toList(),
-        )
+        if (
+            hasDistributionMarker &&
+            mavenArtifacts.isEmpty() &&
+            fileUrlArtifacts.isEmpty() &&
+            dockerImages.isEmpty() &&
+            packages.isEmpty()
+        ) {
+            null
+        } else {
+            buildDistribution(
+                explicit = if (hasDistributionMarker) null else component.distributionExplicit,
+                external = if (hasDistributionMarker) null else component.distributionExternal,
+                mavenArtifacts = mavenArtifacts,
+                fileUrlArtifacts = fileUrlArtifacts,
+                dockerImages = dockerImages,
+                packages = packages,
+                securityGroups = component.securityGroups.toList(),
+            )
+        }
     if (distribution != null) {
         setField(config, "distribution", distribution)
     }
@@ -769,16 +818,14 @@ internal fun buildDistribution(
             .joinToString(",") { it.groupName }
     val secGroups = if (secReadGroups.isNotEmpty()) SecurityGroups(secReadGroups) else null
 
-    val anyContent =
-        explicit != null ||
-            external != null ||
-            gavStr != null ||
+    val hasArtifacts =
+        gavStr != null ||
             dockerStr != null ||
             debStr != null ||
             rpmStr != null ||
             secGroups != null
 
-    if (!anyContent) return null
+    if (!hasArtifacts) return null
 
     return Distribution(explicit ?: true, external ?: false, gavStr, debStr, rpmStr, dockerStr, secGroups)
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -367,7 +367,11 @@ private fun buildEscrowModuleConfig(
     }
 
     // Jira aspect — composed from merged config scalars + component-level fields
-    val jira = buildJiraComponent(component = component, merged = merged)
+    val jira = buildJiraComponent(
+        component = component,
+        merged = merged,
+        versionRange = versionRange,
+    )
     if (jira != null) {
         setField(config, "jiraConfiguration", jira)
     }
@@ -791,6 +795,7 @@ private fun composeDockerCsv(images: List<DistributionDockerImageEntity>): Strin
 private fun buildJiraComponent(
     component: ComponentEntity,
     merged: ComponentConfigurationView,
+    versionRange: String,
 ): JiraComponent? {
     val projectKey = merged.jiraProjectKey ?: return null
 
@@ -825,13 +830,21 @@ private fun buildJiraComponent(
         null
     }
 
+    // Per-range jira.displayName resolution mirrors hotfixVersionFormat layering:
+    // SCALAR_OVERRIDE rows (including null-clear) win; explicit DSL ranges other
+    // than ALL_VERSIONS use the merged row value without component fallback; the
+    // ALL_VERSIONS default view still inherits components.jira_display_name when
+    // the base row carries no per-range displayName.
+    val displayName =
+        when {
+            merged.jiraDisplayNameOverridden -> merged.jiraDisplayName
+            versionRange != ALL_VERSIONS && merged.jiraProjectKey != null -> merged.jiraDisplayName
+            else -> merged.jiraDisplayName ?: component.jiraDisplayName
+        }
+
     return JiraComponent(
         projectKey,
-        if (merged.jiraDisplayNameOverridden) {
-            merged.jiraDisplayName
-        } else {
-            merged.jiraDisplayName ?: component.jiraDisplayName
-        },
+        displayName,
         format,
         info,
         merged.jiraTechnical ?: false,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -472,6 +472,17 @@ internal class ComponentConfigurationView {
 
     /**
      * Tracks presence (not value) of a per-range SCALAR_OVERRIDE for
+     * `jira.displayName`. Set to `true` only when [applyScalarOverride] processes
+     * a row whose `overriddenAttribute == "jira.displayName"`. Required because
+     * this field has a per-component fallback (`components.jira_display_name`)
+     * that the resolver consults when no per-range override is present — without
+     * the presence flag, an explicit null-clear override is silently undone.
+     */
+    var jiraDisplayNameOverridden: Boolean = false
+    var jiraDisplayName: String? = null
+
+    /**
+     * Tracks presence (not value) of a per-range SCALAR_OVERRIDE for
      * `jira.hotfixVersionFormat`. Set to `true` only when
      * [applyScalarOverride] processes a row whose `overriddenAttribute ==
      * "jira.hotfixVersionFormat"`. Required because this field has a
@@ -531,6 +542,10 @@ internal class ComponentConfigurationView {
                 // (NULL on the typed column) is preserved by the resolver
                 // instead of being swallowed by the per-component fallback.
                 jiraHotfixVersionFormatOverridden = true
+            }
+            "jira.displayName" -> {
+                jiraDisplayName = override.jiraDisplayName
+                jiraDisplayNameOverridden = true
             }
 
             else -> Unit // unknown attribute path; ignore for forward-compat
@@ -667,6 +682,7 @@ internal class ComponentConfigurationView {
                 jiraVersionPrefix = base.jiraVersionPrefix
                 jiraVersionFormat = base.jiraVersionFormat
                 jiraHotfixVersionFormat = base.jiraHotfixVersionFormat
+                jiraDisplayName = base.jiraDisplayName
             }
     }
 }
@@ -811,7 +827,11 @@ private fun buildJiraComponent(
 
     return JiraComponent(
         projectKey,
-        component.jiraDisplayName,
+        if (merged.jiraDisplayNameOverridden) {
+            merged.jiraDisplayName
+        } else {
+            merged.jiraDisplayName ?: component.jiraDisplayName
+        },
         format,
         info,
         merged.jiraTechnical ?: false,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -338,6 +338,13 @@ private fun buildEscrowModuleConfig(
     for (override in scalarOverrides) {
         merged.applyScalarOverride(override)
     }
+    // MIG-048: explicit enumerated ranges (other than the BASE anchor) must not
+    // inherit jira.displayName from the BASE row when no per-range override
+    // (including containment via rangeApplies) is present — V1 empty DSL blocks
+    // surface null displayName on jira-component-version-ranges.
+    if (versionRange != base.versionRange && !merged.jiraDisplayNameOverridden) {
+        merged.jiraDisplayName = null
+    }
 
     // Build aspect
     setField(config, "buildSystem", merged.buildSystem?.let { safeParseBuildSystem(it) })

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesSupport.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesSupport.kt
@@ -1,0 +1,173 @@
+package org.octopusden.octopus.components.registry.server.mapper
+
+import org.octopusden.releng.versions.IVersionInfo
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionRange
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * Sample-points containment heuristic for [rangeApplies] (TD-010).
+ *
+ * Returns true when every sampled point of [childRange] is contained in
+ * [parentRange]. Equality is handled by the caller.
+ */
+internal fun rangeAppliesByContainment(
+    parentRange: String,
+    childRange: String,
+    versionRangeFactory: VersionRangeFactory,
+    numericVersionFactory: NumericVersionFactory,
+): Boolean {
+    val parent =
+        try {
+            versionRangeFactory.create(parentRange)
+        } catch (_: Exception) {
+            return false
+        }
+    val child =
+        try {
+            versionRangeFactory.create(childRange)
+        } catch (_: Exception) {
+            return false
+        }
+
+    val samples = sampleChildRangePoints(childRange, child, numericVersionFactory)
+    if (samples.isEmpty()) {
+        return false
+    }
+    return samples.all { parent.containsVersion(it) }
+}
+
+private data class ParsedSegment(
+    val includeLeft: Boolean,
+    val left: String?,
+    val includeRight: Boolean,
+    val right: String?,
+)
+
+private fun parseSegments(range: String): List<ParsedSegment> =
+    range.split("(?<=[])])\\s*,\\s*(?=[\\[(])".toRegex())
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .map { parseSegment(it) }
+
+private fun parseSegment(segment: String): ParsedSegment {
+    if (segment.startsWith("[") && segment.endsWith("]") && !segment.contains(",")) {
+        val version = segment.substring(1, segment.length - 1)
+        return ParsedSegment(includeLeft = true, left = version, includeRight = true, right = version)
+    }
+
+    val commaIdx = segment.indexOf(',')
+    require(commaIdx > 0) { "Bad segment: $segment" }
+
+    val open = segment[0]
+    val close = segment[segment.length - 1]
+    val leftPart = segment.substring(1, commaIdx).trim()
+    val rightPart = segment.substring(commaIdx + 1, segment.length - 1).trim()
+
+    return ParsedSegment(
+        includeLeft = open == '[',
+        left = leftPart.ifEmpty { null },
+        includeRight = close == ']',
+        right = rightPart.ifEmpty { null },
+    )
+}
+
+private fun sampleChildRangePoints(
+    childRangeLiteral: String,
+    childRange: VersionRange,
+    numericVersionFactory: NumericVersionFactory,
+): List<IVersionInfo> {
+    val samples = linkedSetOf<IVersionInfo>()
+    for (segment in parseSegments(childRangeLiteral)) {
+        sampleSegment(segment, childRange, numericVersionFactory, samples)
+    }
+    return samples.toList()
+}
+
+private fun sampleSegment(
+    segment: ParsedSegment,
+    childRange: VersionRange,
+    numericVersionFactory: NumericVersionFactory,
+    samples: MutableSet<IVersionInfo>,
+) {
+    if (segment.left != null && segment.right != null && segment.left == segment.right) {
+        addIfContained(segment.left, childRange, numericVersionFactory, samples)
+        return
+    }
+
+    segment.left?.let { left ->
+        if (segment.includeLeft) {
+            addIfContained(left, childRange, numericVersionFactory, samples)
+        } else {
+            epsilonAbove(left).forEach { addIfContained(it, childRange, numericVersionFactory, samples) }
+        }
+    } ?: run {
+        listOf("0", "1.0").forEach { addIfContained(it, childRange, numericVersionFactory, samples) }
+    }
+
+    segment.right?.let { right ->
+        if (segment.includeRight) {
+            addIfContained(right, childRange, numericVersionFactory, samples)
+        } else {
+            epsilonBelow(right).forEach { addIfContained(it, childRange, numericVersionFactory, samples) }
+        }
+    } ?: segment.left?.let { left ->
+        epsilonAbove(left).forEach { addIfContained(it, childRange, numericVersionFactory, samples) }
+        listOf("99.0", "100.0").forEach { addIfContained(it, childRange, numericVersionFactory, samples) }
+    }
+
+    if (segment.left != null && segment.right != null) {
+        interiorProbes(segment.left, segment.right).forEach {
+            addIfContained(it, childRange, numericVersionFactory, samples)
+        }
+    }
+}
+
+private fun addIfContained(
+    rawVersion: String,
+    childRange: VersionRange,
+    numericVersionFactory: NumericVersionFactory,
+    samples: MutableSet<IVersionInfo>,
+) {
+    try {
+        val version = numericVersionFactory.create(rawVersion.trim())
+        if (childRange.containsVersion(version)) {
+            samples.add(version)
+        }
+    } catch (_: Exception) {
+        // ignore unparsable probe strings
+    }
+}
+
+private fun epsilonAbove(bound: String): List<String> =
+    listOf("$bound.1", bumpLastNumericComponent(bound)).distinct()
+
+private fun epsilonBelow(bound: String): List<String> {
+    val parts = bound.split(".")
+    if (parts.size >= 2) {
+        val last = parts.last().toIntOrNull()
+        if (last != null && last > 0) {
+            return listOf(parts.dropLast(1).joinToString(".") + ".${last - 1}")
+        }
+    }
+    return listOf("$bound.0")
+}
+
+private fun bumpLastNumericComponent(version: String): String {
+    val parts = version.split(".")
+    val last = parts.last().toIntOrNull() ?: return "$version.1"
+    return parts.dropLast(1).joinToString(".") + ".${last + 1}"
+}
+
+private fun interiorProbes(left: String, right: String): List<String> {
+    val leftParts = left.split(".")
+    val rightParts = right.split(".")
+    if (leftParts.size >= 2 && rightParts.size >= 2) {
+        val leftMinor = leftParts.getOrNull(1)?.toIntOrNull()
+        val rightMinor = rightParts.getOrNull(1)?.toIntOrNull()
+        if (leftMinor != null && rightMinor != null && rightMinor - leftMinor >= 2) {
+            return listOf("${leftParts[0]}.${leftMinor + 1}")
+        }
+    }
+    return listOf("$left.5", "$left.1")
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -2031,8 +2031,13 @@ class ImportServiceImpl(
         base: VCSSettings?,
         override: VCSSettings?,
     ): Boolean {
-        if (base == null && override == null) return false
-        if (base == null || override == null) return true
+        // Null override means the DSL block did not declare `vcs { … }` — inherit
+        // the base view, do not emit a replacement marker (MIG-050 / ANCS `[2,)` pattern).
+        if (override == null) return false
+        if (base == null) {
+            val overRoots = override.versionControlSystemRoots ?: emptyList<Any>()
+            return overRoots.isNotEmpty() || override.externalRegistry != null
+        }
         val baseRoots = base.versionControlSystemRoots ?: emptyList<Any>()
         val overRoots = override.versionControlSystemRoots ?: emptyList<Any>()
         return baseRoots != overRoots || base.externalRegistry != override.externalRegistry
@@ -2041,7 +2046,10 @@ class ImportServiceImpl(
     private fun mavenArtifactsDiffer(
         base: Distribution?,
         override: Distribution?,
-    ): Boolean = extractMavenGavs(base?.GAV()) != extractMavenGavs(override?.GAV())
+    ): Boolean {
+        if (override == null) return false
+        return extractMavenGavs(base?.GAV()) != extractMavenGavs(override.GAV())
+    }
 
     /**
      * MIG-047: returns true when the override range's DSL-level `groupId`/`artifactId`
@@ -2063,17 +2071,26 @@ class ImportServiceImpl(
     private fun fileUrlArtifactsDiffer(
         base: Distribution?,
         override: Distribution?,
-    ): Boolean = extractFileUrls(base?.GAV()) != extractFileUrls(override?.GAV())
+    ): Boolean {
+        if (override == null) return false
+        return extractFileUrls(base?.GAV()) != extractFileUrls(override.GAV())
+    }
 
     private fun dockerImagesDiffer(
         base: Distribution?,
         override: Distribution?,
-    ): Boolean = base?.docker() != override?.docker()
+    ): Boolean {
+        if (override == null) return false
+        return base?.docker() != override.docker()
+    }
 
     private fun packagesDiffer(
         base: Distribution?,
         override: Distribution?,
-    ): Boolean = base?.DEB() != override?.DEB() || base?.RPM() != override?.RPM()
+    ): Boolean {
+        if (override == null) return false
+        return base?.DEB() != override.DEB() || base?.RPM() != override.RPM()
+    }
 
     private fun extractMavenGavs(gavCsv: String?): List<String> {
         gavCsv ?: return emptyList()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1346,6 +1346,7 @@ class ImportServiceImpl(
         cfg.jiraConfiguration?.let { jira ->
             row.jiraProjectKey = jira.projectKey
             row.jiraTechnical = jira.isTechnical.takeIf { it }
+            jira.displayName?.let { row.jiraDisplayName = it }
             jira.componentVersionFormat?.let { cvf ->
                 row.jiraMajorVersionFormat = cvf.majorVersionFormat
                 row.jiraReleaseVersionFormat = cvf.releaseVersionFormat
@@ -1922,6 +1923,7 @@ class ImportServiceImpl(
         diffScalar("jira.versionPrefix", base.jiraVersionPrefix, override.jiraVersionPrefix)
         diffScalar("jira.versionFormat", base.jiraVersionFormat, override.jiraVersionFormat)
         diffScalar("jira.hotfixVersionFormat", base.jiraHotfixVersionFormat, override.jiraHotfixVersionFormat)
+        diffScalar("jira.displayName", base.jiraDisplayName, override.jiraDisplayName)
 
         return diffs
     }
@@ -1970,6 +1972,7 @@ class ImportServiceImpl(
             "jira.versionPrefix" -> row.jiraVersionPrefix = value?.toString()
             "jira.versionFormat" -> row.jiraVersionFormat = value?.toString()
             "jira.hotfixVersionFormat" -> row.jiraHotfixVersionFormat = value?.toString()
+            "jira.displayName" -> row.jiraDisplayName = value?.toString()
             else -> LOG.warn("Unknown scalar attribute path: '{}'", attrPath)
         }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1444,6 +1444,40 @@ class ImportServiceImpl(
     }
 
     /**
+     * Upsert a SCALAR_OVERRIDE row for [attrPath] at [versionRange].
+     * Used when a marker row replaces a whole view and the effective scalar
+     * must be pinned even if it equals the BASE row (e.g. vcs.externalRegistry
+     * alongside vcs.settings).
+     */
+    private fun saveScalarOverrideRow(
+        component: ComponentEntity,
+        versionRange: String,
+        attrPath: String,
+        value: Any?,
+    ): ComponentConfigurationEntity {
+        val existing =
+            configurationRepository.findByComponentIdAndVersionRangeAndOverriddenAttribute(
+                component.id!!,
+                versionRange,
+                attrPath,
+            )
+        if (existing != null) {
+            applyScalarValueToRow(existing, attrPath, value)
+            return configurationRepository.save(existing)
+        }
+        val scalarRow =
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = versionRange,
+                overriddenAttribute = attrPath,
+                rowType = "SCALAR_OVERRIDE",
+                isSyntheticBase = false,
+            )
+        applyScalarValueToRow(scalarRow, attrPath, value)
+        return configurationRepository.save(scalarRow)
+    }
+
+    /**
      * Emit marker override rows for each child collection that differs
      * between [base] and [override] configs.
      */
@@ -1462,6 +1496,14 @@ class ImportServiceImpl(
             saveMarkerRowWithChildren(component, versionRange, MarkerAttributes.VCS_SETTINGS) { row ->
                 attachVcsEntries(row, override.vcsSettings)
             }?.let { saved += it }
+            // Persist the effective registry for this range so the read-path does
+            // not inherit BASE/components defaults into a replaced vcsSettings view.
+            saved += saveScalarOverrideRow(
+                component = component,
+                versionRange = versionRange,
+                attrPath = "vcs.externalRegistry",
+                value = override.vcsSettings?.externalRegistry,
+            )
         }
 
         // Distribution overrides — check each family

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1372,6 +1372,9 @@ class ImportServiceImpl(
                 row.jiraVersionFormat = info.versionFormat
             }
         }
+
+        // vcs aspect — per-range externalRegistry (roots live on vcsEntries)
+        row.vcsExternalRegistry = cfg.vcsSettings?.externalRegistry
     }
 
     // =========================================================================
@@ -1927,6 +1930,7 @@ class ImportServiceImpl(
         diffScalar("jira.versionFormat", base.jiraVersionFormat, override.jiraVersionFormat)
         diffScalar("jira.hotfixVersionFormat", base.jiraHotfixVersionFormat, override.jiraHotfixVersionFormat)
         diffScalar("jira.displayName", base.jiraDisplayName, override.jiraDisplayName)
+        diffScalar("vcs.externalRegistry", base.vcsExternalRegistry, override.vcsExternalRegistry)
 
         return diffs
     }
@@ -1976,6 +1980,7 @@ class ImportServiceImpl(
             "jira.versionFormat" -> row.jiraVersionFormat = value?.toString()
             "jira.hotfixVersionFormat" -> row.jiraHotfixVersionFormat = value?.toString()
             "jira.displayName" -> row.jiraDisplayName = value?.toString()
+            "vcs.externalRegistry" -> row.vcsExternalRegistry = value?.toString()
             else -> LOG.warn("Unknown scalar attribute path: '{}'", attrPath)
         }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1346,7 +1346,10 @@ class ImportServiceImpl(
         cfg.jiraConfiguration?.let { jira ->
             row.jiraProjectKey = jira.projectKey
             row.jiraTechnical = jira.isTechnical.takeIf { it }
-            jira.displayName?.let { row.jiraDisplayName = it }
+            // Unconditional assignment: an explicit `displayName = null` in a
+            // per-range jira block must persist as NULL on the row so the
+            // resolver does not fall back to components.jira_display_name.
+            row.jiraDisplayName = jira.displayName
             jira.componentVersionFormat?.let { cvf ->
                 row.jiraMajorVersionFormat = cvf.majorVersionFormat
                 row.jiraReleaseVersionFormat = cvf.releaseVersionFormat

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -167,6 +167,9 @@ CREATE TABLE component_configurations (
     -- Per-range override for `jira.displayName`. Component-level base lives on
     -- components.jira_display_name; resolver layers this column per range.
     jira_display_name                           VARCHAR(255),
+    -- Per-range override for `vcs.externalRegistry`. Component-level base lives
+    -- on components.vcs_external_registry; resolver layers this column per range.
+    vcs_external_registry                       TEXT,
     created_at                                  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at                                  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 
@@ -207,7 +210,7 @@ CREATE TABLE component_configurations (
             ))
     ),
 
-    -- All 28 typed scalar columns must be NULL on MARKER and RANGE_PRESENCE
+    -- All 29 typed scalar columns must be NULL on MARKER and RANGE_PRESENCE
     -- rows (children carry the data on markers; presence rows are pure
     -- enumeration anchors). The full "scalar override = exactly one non-NULL
     -- typed column" rule is enforced in the service layer (too verbose for
@@ -228,6 +231,7 @@ CREATE TABLE component_configurations (
         AND jira_build_version_format IS NULL AND jira_line_version_format IS NULL
         AND jira_version_prefix IS NULL AND jira_version_format IS NULL
         AND jira_hotfix_version_format IS NULL AND jira_display_name IS NULL
+        AND vcs_external_registry IS NULL
     )),
 
     -- UI-swift-sloth: BASE rows must declare a build_system. Column-level

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -164,6 +164,9 @@ CREATE TABLE component_configurations (
     -- Defaults / per-component base lives on components.jira_hotfix_version_format.
     -- The resolver layers this on top of the base when present.
     jira_hotfix_version_format                  VARCHAR(255),
+    -- Per-range override for `jira.displayName`. Component-level base lives on
+    -- components.jira_display_name; resolver layers this column per range.
+    jira_display_name                           VARCHAR(255),
     created_at                                  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at                                  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 
@@ -224,7 +227,7 @@ CREATE TABLE component_configurations (
         AND jira_major_version_format IS NULL AND jira_release_version_format IS NULL
         AND jira_build_version_format IS NULL AND jira_line_version_format IS NULL
         AND jira_version_prefix IS NULL AND jira_version_format IS NULL
-        AND jira_hotfix_version_format IS NULL
+        AND jira_hotfix_version_format IS NULL AND jira_display_name IS NULL
     )),
 
     -- UI-swift-sloth: BASE rows must declare a build_system. Column-level

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -115,7 +115,7 @@ class ComponentsRegistryServiceControllerTest : MockMvcRegistryTestSupport() {
         expectedComponent.copyright = "companyName1"
         expectedComponent.labels = setOf("Label2")
 
-        Assertions.assertEquals(59, components.components.size)
+        Assertions.assertEquals(60, components.components.size)
         Assertions.assertTrue(expectedComponent in components.components) {
             components.components.toString()
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/DbBackedComponentsRegistryServiceControllerTest.kt
@@ -1,12 +1,18 @@
 package org.octopusden.octopus.components.registry.server
 
+import com.fasterxml.jackson.core.type.TypeReference
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionRangeDTO
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,6 +25,7 @@ import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.containers.PostgreSQLContainer
 import java.nio.file.Paths
 
@@ -42,6 +49,12 @@ import java.nio.file.Paths
 class DbBackedComponentsRegistryServiceControllerTest : MockMvcRegistryTestSupport() {
     @Autowired
     private lateinit var sourceRegistry: ComponentSourceRegistry
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var configurationRepository: ComponentConfigurationRepository
 
     /**
      * Post ui-swift-sloth-system-single: DB-source resolver stores TESTONE's
@@ -205,7 +218,116 @@ class DbBackedComponentsRegistryServiceControllerTest : MockMvcRegistryTestSuppo
         )
     }
 
+    /**
+     * Import-path pin: after auto-migrate, per-range jira.displayName scalars must
+     * land on the correct configuration rows (BASE null-clear + SCALAR_OVERRIDE string).
+     */
+    @Test
+    @DisplayName("MIG-045-006: import persists per-range jira.displayName rows for synthetic-base fixture")
+    fun testMIG045006_importPersistsPerRangeJiraDisplayNameScalars_dbMode() {
+        val component = componentRepository.findByComponentKey(MIG045_FIXTURE)
+        assertNotNull(component, "fixture component must be auto-migrated")
+
+        val rows = configurationRepository.findByComponentId(component!!.id!!)
+        val baseRow = rows.single { it.rowType == "BASE" }
+        assertEquals("[1.0,2.0)", baseRow.versionRange)
+        assertNull(
+            baseRow.jiraDisplayName,
+            "BASE row for [1.0,2.0) must store explicit jira.displayName=null from DSL",
+        )
+
+        val overrideRow =
+            configurationRepository.findByComponentIdAndVersionRangeAndOverriddenAttribute(
+                component.id!!,
+                "[2.0,)",
+                "jira.displayName",
+            )
+        assertNotNull(overrideRow, "import must emit jira.displayName SCALAR_OVERRIDE for [2.0,)")
+        assertEquals("Range Override Display", overrideRow!!.jiraDisplayName)
+    }
+
+    /**
+     * Full-stack pin for CARDS-like fallback bug: components.jira_display_name is
+     * populated while the synthetic BASE range carries explicit null. Both resolver
+     * and HTTP must return null for [1.0,2.0), not bleed the component default.
+     */
+    @Test
+    @Transactional
+    @DisplayName(
+        "MIG-045-007: null-clear on synthetic BASE range survives populated components.jira_display_name (DB + HTTP)",
+    )
+    fun testMIG045007_nullClearSurvivesComponentLevelDefault_dbMode() {
+        val component = componentRepository.findByComponentKey(MIG045_FIXTURE)!!
+        component.jiraDisplayName = "Component Default Display"
+        componentRepository.saveAndFlush(component)
+
+        val baseRow =
+            configurationRepository.findByComponentId(component.id!!)
+                .single { it.rowType == "BASE" && it.versionRange == "[1.0,2.0)" }
+        assertNull(baseRow.jiraDisplayName, "precondition: BASE row must keep explicit null")
+
+        val resolverRanges =
+            getJiraComponentVersionRangesByProject(MIG045_PROJECT)
+                .filter { it.componentName == MIG045_FIXTURE }
+        assertNull(
+            resolverRanges.first { it.versionRange == "[1.0,2.0)" }.component.displayName,
+            "resolver must not fall back to components.jira_display_name on synthetic BASE range",
+        )
+        assertEquals(
+            "Range Override Display",
+            resolverRanges.first { it.versionRange == "[2.0,)" }.component.displayName,
+        )
+
+        val httpRanges = fetchProjectJiraComponentVersionRanges(MIG045_PROJECT)
+            .filter { it.componentName == MIG045_FIXTURE }
+        assertNull(
+            httpRanges.first { it.versionRange == "[1.0,2.0)" }.component.displayName,
+            "HTTP must not fall back to components.jira_display_name on synthetic BASE range",
+        )
+        assertEquals(
+            "Range Override Display",
+            httpRanges.first { it.versionRange == "[2.0,)" }.component.displayName,
+        )
+    }
+
+    /**
+     * End-to-end HTTP pin for MIG-045: strict JSON parse (not substring matching).
+     */
+    @Test
+    @DisplayName(
+        "MIG-045-008: GET /projects/{projectKey}/jira-component-version-ranges surfaces per-range jira.displayName (DB resolver)",
+    )
+    fun testMIG045008_perRangeJiraDisplayNameOnProjectJiraComponentVersionRanges_dbMode() {
+        val ranges =
+            fetchProjectJiraComponentVersionRanges(MIG045_PROJECT)
+                .filter { it.componentName == MIG045_FIXTURE }
+
+        assertNull(ranges.first { it.versionRange == "[1.0,2.0)" }.component.displayName)
+        assertEquals(
+            "Range Override Display",
+            ranges.first { it.versionRange == "[2.0,)" }.component.displayName,
+        )
+    }
+
+    private fun fetchProjectJiraComponentVersionRanges(projectKey: String): List<JiraComponentVersionRangeDTO> {
+        val response =
+            mvc
+                .perform(
+                    get("/rest/api/2/projects/$projectKey/jira-component-version-ranges")
+                        .accept(APPLICATION_JSON),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readValue(
+            response,
+            object : TypeReference<List<JiraComponentVersionRangeDTO>>() {},
+        )
+    }
+
     companion object {
+        private const val MIG045_FIXTURE = "TEST_PER_RANGE_JIRA_DISPLAY_NAME"
+        private const val MIG045_PROJECT = "PRDN"
+
         @JvmStatic
         val postgres =
             PostgreSQLContainer("postgres:16-alpine")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -51,7 +51,7 @@ class MetricsTest {
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(57.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(58.0))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -37,8 +38,17 @@ class MetricsTest {
     @Autowired
     private lateinit var mvc: MockMvc
 
+    @Autowired
+    private lateinit var componentRegistryResolver: ComponentRegistryResolver
+
     @Test
     fun shouldReturnMetrics() {
+        val expectedBuildSystemComponentCount =
+            componentRegistryResolver
+                .getComponentsCountByBuildSystem()
+                .values
+                .sum()
+                .toDouble()
         // /actuator/metrics is no longer in the permitAll list (only /actuator/health is),
         // so the request authenticates as an admin to reach the endpoint. The shape of
         // the metric payload is what's under test, not the auth gate itself.
@@ -51,7 +61,9 @@ class MetricsTest {
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(58.0))
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(expectedBuildSystemComponentCount),
+            )
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
@@ -3,7 +3,6 @@ package org.octopusden.octopus.components.registry.server.mapper
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -243,107 +242,6 @@ class MIG046JiraComponentVersionRangesParityTest {
         assertEquals(
             "ssh://range-registry",
             ranges.first { it.versionRange == "[2.0,)" }.vcsSettings.externalRegistry,
-        )
-    }
-
-    @Test
-    @DisplayName("MIG-047-001: version in gap between explicit DSL ranges resolves to null")
-    fun `MIG-047-001 version in gap between explicit DSL ranges resolves to null`() {
-        val comp = makeComponent("authmodlib-gap-fixture")
-        val base =
-            makeBase(comp).apply {
-                versionRange = "[10,11)"
-                isSyntheticBase = true
-            }
-        comp.configurations.addAll(
-            listOf(
-                base,
-                ComponentConfigurationEntity(
-                    component = comp,
-                    versionRange = "[10,11)",
-                    rowType = "RANGE_PRESENCE",
-                ),
-                ComponentConfigurationEntity(
-                    component = comp,
-                    versionRange = "[11,12.1)",
-                    rowType = "RANGE_PRESENCE",
-                ),
-                ComponentConfigurationEntity(
-                    component = comp,
-                    versionRange = "[12.2,)",
-                    rowType = "RANGE_PRESENCE",
-                ),
-            ),
-        )
-        stubComponent(comp)
-
-        assertNull(
-            resolver.getResolvedComponentDefinition("authmodlib-gap-fixture", "12.1.155"),
-            "12.1.155 sits in the gap between [11,12.1) and [12.2,) — must not resolve",
-        )
-        assertNotNull(resolver.getResolvedComponentDefinition("authmodlib-gap-fixture", "11.5.0"))
-    }
-
-    @Test
-    @DisplayName("MIG-047-002: vcs.settings marker does not inherit components.vcs_external_registry")
-    fun `MIG-047-002 vcs settings marker does not inherit components vcs external registry`() {
-        val comp = makeComponent("vcs-marker-registry-fixture", vcsExternalRegistry = "ssh://component-default")
-        val base =
-            makeBase(comp).apply {
-                vcsExternalRegistry = "ssh://base-registry"
-                vcsEntries.add(
-                    VcsSettingsEntryEntity(
-                        componentConfiguration = this,
-                        name = "main",
-                        vcsPath = "ssh://base-root",
-                        sortOrder = 0,
-                    ),
-                )
-            }
-        val vcsMarker = makeMarkerRow(comp, "[1.0,2.0)", MarkerAttributes.VCS_SETTINGS)
-
-        comp.configurations.addAll(listOf(base, vcsMarker))
-        stubComponent(comp)
-
-        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
-        val overrideRange = ranges.first { it.versionRange == "[1.0,2.0)" }
-
-        assertNull(
-            overrideRange.vcsSettings.externalRegistry,
-            "vcs.settings marker must not fall back to components.vcs_external_registry",
-        )
-        assertEquals(0, overrideRange.vcsSettings.versionControlSystemRoots.size)
-    }
-
-    @Test
-    @DisplayName("MIG-047-003: empty distribution marker clears distribution on jira-component-version-ranges")
-    fun `MIG-047-003 empty distribution marker clears distribution on jira ranges`() {
-        val comp = makeComponent("distribution-clear-fixture")
-        comp.distributionExplicit = true
-        comp.distributionExternal = false
-        val base =
-            makeBase(comp).apply {
-                mavenArtifacts.add(
-                    org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity(
-                        componentConfiguration = this,
-                        groupPattern = "com.example",
-                        artifactPattern = "artifact",
-                        sortOrder = 0,
-                    ),
-                )
-            }
-        val distMarker =
-            makeMarkerRow(comp, "[1.0,2.0)", MarkerAttributes.DISTRIBUTION_MAVEN)
-
-        comp.configurations.addAll(listOf(base, distMarker))
-        stubComponent(comp)
-
-        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
-
-        assertNotNull(ranges.first { it.versionRange == ALL_VERSIONS }.distribution?.GAV())
-        assertNull(
-            ranges.first { it.versionRange == "[1.0,2.0)" }.distribution,
-            "distribution.maven marker with no artifacts must clear distribution for the range",
         )
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.mapper
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -242,6 +243,107 @@ class MIG046JiraComponentVersionRangesParityTest {
         assertEquals(
             "ssh://range-registry",
             ranges.first { it.versionRange == "[2.0,)" }.vcsSettings.externalRegistry,
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-047-001: version in gap between explicit DSL ranges resolves to null")
+    fun `MIG-047-001 version in gap between explicit DSL ranges resolves to null`() {
+        val comp = makeComponent("authmodlib-gap-fixture")
+        val base =
+            makeBase(comp).apply {
+                versionRange = "[10,11)"
+                isSyntheticBase = true
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[10,11)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[11,12.1)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[12.2,)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        assertNull(
+            resolver.getResolvedComponentDefinition("authmodlib-gap-fixture", "12.1.155"),
+            "12.1.155 sits in the gap between [11,12.1) and [12.2,) — must not resolve",
+        )
+        assertNotNull(resolver.getResolvedComponentDefinition("authmodlib-gap-fixture", "11.5.0"))
+    }
+
+    @Test
+    @DisplayName("MIG-047-002: vcs.settings marker does not inherit components.vcs_external_registry")
+    fun `MIG-047-002 vcs settings marker does not inherit components vcs external registry`() {
+        val comp = makeComponent("vcs-marker-registry-fixture", vcsExternalRegistry = "ssh://component-default")
+        val base =
+            makeBase(comp).apply {
+                vcsExternalRegistry = "ssh://base-registry"
+                vcsEntries.add(
+                    VcsSettingsEntryEntity(
+                        componentConfiguration = this,
+                        name = "main",
+                        vcsPath = "ssh://base-root",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        val vcsMarker = makeMarkerRow(comp, "[1.0,2.0)", MarkerAttributes.VCS_SETTINGS)
+
+        comp.configurations.addAll(listOf(base, vcsMarker))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+        val overrideRange = ranges.first { it.versionRange == "[1.0,2.0)" }
+
+        assertNull(
+            overrideRange.vcsSettings.externalRegistry,
+            "vcs.settings marker must not fall back to components.vcs_external_registry",
+        )
+        assertEquals(0, overrideRange.vcsSettings.versionControlSystemRoots.size)
+    }
+
+    @Test
+    @DisplayName("MIG-047-003: empty distribution marker clears distribution on jira-component-version-ranges")
+    fun `MIG-047-003 empty distribution marker clears distribution on jira ranges`() {
+        val comp = makeComponent("distribution-clear-fixture")
+        comp.distributionExplicit = true
+        comp.distributionExternal = false
+        val base =
+            makeBase(comp).apply {
+                mavenArtifacts.add(
+                    org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity(
+                        componentConfiguration = this,
+                        groupPattern = "com.example",
+                        artifactPattern = "artifact",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        val distMarker =
+            makeMarkerRow(comp, "[1.0,2.0)", MarkerAttributes.DISTRIBUTION_MAVEN)
+
+        comp.configurations.addAll(listOf(base, distMarker))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+
+        assertNotNull(ranges.first { it.versionRange == ALL_VERSIONS }.distribution?.GAV())
+        assertNull(
+            ranges.first { it.versionRange == "[1.0,2.0)" }.distribution,
+            "distribution.maven marker with no artifacts must clear distribution for the range",
         )
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
@@ -1,0 +1,247 @@
+package org.octopusden.octopus.components.registry.server.mapper
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.octopus.components.registry.server.service.impl.DatabaseComponentRegistryResolver
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * TD-010 / MIG-046: `rangeApplies` containment heuristic for enumeration endpoints.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class RangeAppliesContainmentTest {
+
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+
+    @ParameterizedTest(name = "TD-010-{0}: parent={1} child={2} expected={3}")
+    @MethodSource("boundedMatrix")
+    @DisplayName("TD-010 bounded rangeApplies matrix")
+    fun `TD-010 bounded rangeApplies matrix`(
+        @Suppress("UNUSED_PARAMETER") caseId: String,
+        parent: String,
+        child: String,
+        expected: Boolean,
+    ) {
+        val actual =
+            rangeApplies(
+                parentRange = parent,
+                childRange = child,
+                versionRangeFactory = versionRangeFactory,
+                numericVersionFactory = numericVersionFactory,
+            )
+        assertEquals(expected, actual, "rangeApplies($parent, $child)")
+    }
+
+    @Test
+    @DisplayName("TD-010-012: unbounded ALL_VERSIONS parent contains bounded child")
+    fun `TD-010-012 unbounded ALL_VERSIONS parent contains bounded child`() {
+        assertEquals(
+            true,
+            rangeApplies(
+                parentRange = ALL_VERSIONS,
+                childRange = "[1.0,2.0)",
+                versionRangeFactory = versionRangeFactory,
+                numericVersionFactory = numericVersionFactory,
+            ),
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun boundedMatrix(): List<Arguments> =
+            listOf(
+                Arguments.of("001", "[1.0,2.0)", "[1.0,2.0)", true),
+                Arguments.of("002", "[1.0,3.0)", "[1.0,2.0)", true),
+                Arguments.of("003", "[1.0,3.0)", "[2.0,3.0)", true),
+                Arguments.of("004", "[1.0,3.0)", "[1.5,2.5)", true),
+                Arguments.of("005", "[1.0,2.0)", "[1.5,2.5)", false),
+                Arguments.of("006", "[1.0,2.0]", "[2.0,3.0)", false),
+                Arguments.of("007", "[1.0,2.0)", "[2.0,3.0)", false),
+                Arguments.of("008", "(1.0,3.0)", "[1.5,2.5]", true),
+                Arguments.of("009", "[1.0,2.0)", "[1.0,2.0]", false),
+            )
+    }
+}
+
+/**
+ * MIG-046 integration pins for jira-component-version-ranges parity:
+ * broad-range scalar overrides + per-range vcs.externalRegistry layering.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG046JiraComponentVersionRangesParityTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver =
+            DatabaseComponentRegistryResolver(
+                componentRepository,
+                dependencyMappingRepository,
+                numericVersionFactory,
+                versionRangeFactory,
+                versionNames,
+            )
+    }
+
+    private fun makeComponent(
+        key: String,
+        jiraDisplayName: String? = null,
+        vcsExternalRegistry: String? = null,
+    ): ComponentEntity =
+        ComponentEntity(id = UUID.randomUUID(), componentKey = key).apply {
+            this.jiraDisplayName = jiraDisplayName
+            this.vcsExternalRegistry = vcsExternalRegistry
+        }
+
+    private fun makeBase(
+        component: ComponentEntity,
+        versionRange: String = ALL_VERSIONS,
+        jiraProjectKey: String = "SYNTH",
+        vcsExternalRegistry: String? = null,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            buildSystem = "MAVEN",
+            deprecated = false,
+            jiraProjectKey = jiraProjectKey,
+        ).apply {
+            this.vcsExternalRegistry = vcsExternalRegistry
+        }
+
+    private fun makeScalarOverrideRow(
+        component: ComponentEntity,
+        versionRange: String,
+        attribute: String,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = attribute,
+            rowType = "SCALAR_OVERRIDE",
+        )
+
+    private fun makeMarkerRow(
+        component: ComponentEntity,
+        versionRange: String,
+        attribute: String,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = attribute,
+            rowType = "MARKER",
+        )
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    @Test
+    @DisplayName("MIG-046-001: broad-range jira.displayName override applies to contained enumeration range")
+    fun `MIG-046-001 broad range jira displayName override applies to contained enumeration range`() {
+        val comp = makeComponent("broad-display-fixture")
+        val base = makeBase(comp)
+        val broadOverride = makeScalarOverrideRow(comp, "[1.0,3.0)", "jira.displayName")
+        broadOverride.jiraDisplayName = "Broad Override"
+
+        comp.configurations.addAll(
+            listOf(
+                base,
+                broadOverride,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[1.0,2.0)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+        val narrow = ranges.first { it.versionRange == "[1.0,2.0)" }
+
+        assertEquals("Broad Override", narrow.component.displayName)
+    }
+
+    @Test
+    @DisplayName("MIG-046-002: per-range vcs.externalRegistry null-clear does not inherit component default")
+    fun `MIG-046-002 per-range vcs externalRegistry null-clear does not inherit component default`() {
+        val comp = makeComponent("vcs-registry-fixture", vcsExternalRegistry = "ssh://component-default")
+        val base =
+            makeBase(comp, vcsExternalRegistry = "ssh://component-default").apply {
+                vcsEntries.add(
+                    VcsSettingsEntryEntity(
+                        componentConfiguration = this,
+                        name = "main",
+                        vcsPath = "ssh://base-root",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        val nullClear = makeScalarOverrideRow(comp, "[1.0,2.0)", "vcs.externalRegistry")
+        val vcsMarker = makeMarkerRow(comp, "[1.0,2.0)", MarkerAttributes.VCS_SETTINGS)
+
+        comp.configurations.addAll(listOf(base, nullClear, vcsMarker))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+        val overrideRange = ranges.first { it.versionRange == "[1.0,2.0)" }
+
+        assertNull(
+            overrideRange.vcsSettings.externalRegistry,
+            "null-clear vcs.externalRegistry must not fall back to components.vcs_external_registry",
+        )
+        assertEquals(0, overrideRange.vcsSettings.versionControlSystemRoots.size)
+    }
+
+    @Test
+    @DisplayName("MIG-046-003: per-range vcs.externalRegistry override surfaces on jira-component-version-ranges")
+    fun `MIG-046-003 per-range vcs externalRegistry override surfaces on jira-component-version-ranges`() {
+        val comp = makeComponent("vcs-registry-override-fixture", vcsExternalRegistry = "ssh://component-default")
+        val base = makeBase(comp, vcsExternalRegistry = "ssh://base-registry")
+        val overrideRow = makeScalarOverrideRow(comp, "[2.0,)", "vcs.externalRegistry")
+        overrideRow.vcsExternalRegistry = "ssh://range-registry"
+
+        comp.configurations.addAll(listOf(base, overrideRow))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+
+        assertEquals("ssh://base-registry", ranges.first { it.versionRange == ALL_VERSIONS }.vcsSettings.externalRegistry)
+        assertEquals(
+            "ssh://range-registry",
+            ranges.first { it.versionRange == "[2.0,)" }.vcsSettings.externalRegistry,
+        )
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -688,6 +688,34 @@ class MigrationIntegrationTest {
     }
 
     // =========================================================================
+    // MIG-045: per-range jira.displayName import + read parity
+    // =========================================================================
+
+    @Test
+    @DisplayName("MIG-045-006: import persists per-range jira.displayName rows for synthetic-base fixture")
+    fun mig045_importPersistsPerRangeJiraDisplayNameScalars() {
+        val component = componentRepository.findByComponentKey("TEST_PER_RANGE_JIRA_DISPLAY_NAME")
+        assertNotNull(component, "fixture component must be auto-migrated")
+
+        val rows = configurationRepository.findByComponentId(component!!.id!!)
+        val baseRow = rows.single { it.rowType == "BASE" }
+        assertEquals("[1.0,2.0)", baseRow.versionRange)
+        assertNull(
+            baseRow.jiraDisplayName,
+            "BASE row for [1.0,2.0) must store explicit jira.displayName=null from DSL",
+        )
+
+        val overrideRow =
+            configurationRepository.findByComponentIdAndVersionRangeAndOverriddenAttribute(
+                component.id!!,
+                "[2.0,)",
+                "jira.displayName",
+            )
+        assertNotNull(overrideRow, "import must emit jira.displayName SCALAR_OVERRIDE for [2.0,)")
+        assertEquals("Range Override Display", overrideRow!!.jiraDisplayName)
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG045JiraDisplayNameImportTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG045JiraDisplayNameImportTest.kt
@@ -1,0 +1,171 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.lang.reflect.Method
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.DefaultConfigParameters
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.octopusden.octopus.releng.dto.JiraComponent
+import org.octopusden.releng.versions.ComponentVersionFormat
+
+/**
+ * MIG-045 import-path tests: `populateScalarsFromConfig` and `emitScalarOverrides`
+ * must persist per-range `jira.displayName`, including explicit null-clear.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG045JiraDisplayNameImportTest {
+
+    private lateinit var service: ImportServiceImpl
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+    private lateinit var populateScalarsFromConfigMethod: Method
+    private lateinit var emitScalarOverridesMethod: Method
+
+    @BeforeEach
+    fun setUp() {
+        val configurationLoader = mock(EscrowConfigurationLoader::class.java)
+        val emptyDefaults = mock(DefaultConfigParameters::class.java)
+        doReturn(emptyDefaults).`when`(configurationLoader).loadCommonDefaults(emptyMap())
+
+        configurationRepository = mock(ComponentConfigurationRepository::class.java)
+        `when`(configurationRepository.save(any(ComponentConfigurationEntity::class.java)))
+            .thenAnswer { invocation -> invocation.arguments[0] }
+
+        service = ImportServiceImpl(
+            gitResolver = mock(ComponentRegistryResolverImpl::class.java),
+            dbResolver = mock(DatabaseComponentRegistryResolver::class.java),
+            componentSourceRepository = mock(ComponentSourceRepository::class.java),
+            sourceRegistry = mock(ComponentSourceRegistry::class.java),
+            configurationLoader = configurationLoader,
+            registryConfigRepository = mock(RegistryConfigRepository::class.java),
+            componentRepository = mock(ComponentRepository::class.java),
+            configurationRepository = configurationRepository,
+            componentGroupRepository = mock(ComponentGroupRepository::class.java),
+            systemRepository = mock(SystemRepository::class.java),
+            toolRepository = mock(ToolRepository::class.java),
+            labelRepository = mock(LabelRepository::class.java),
+            componentLabelRepository = mock(ComponentLabelRepository::class.java),
+            componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+            componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+        )
+
+        populateScalarsFromConfigMethod = ImportServiceImpl::class.java.getDeclaredMethod(
+            "populateScalarsFromConfig",
+            ComponentConfigurationEntity::class.java,
+            EscrowModuleConfig::class.java,
+        )
+        populateScalarsFromConfigMethod.isAccessible = true
+
+        emitScalarOverridesMethod = ImportServiceImpl::class.java.getDeclaredMethod(
+            "emitScalarOverrides",
+            ComponentEntity::class.java,
+            EscrowModuleConfig::class.java,
+            EscrowModuleConfig::class.java,
+        )
+        emitScalarOverridesMethod.isAccessible = true
+    }
+
+    private fun setGroovyField(target: Any, fieldName: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun makeConfig(
+        versionRange: String?,
+        displayName: String?,
+        projectKey: String = "PRDN",
+    ): EscrowModuleConfig {
+        val cfg = EscrowModuleConfig()
+        if (versionRange != null) {
+            setGroovyField(cfg, "versionRange", versionRange)
+        }
+        val jira =
+            JiraComponent(
+                projectKey,
+                displayName,
+                ComponentVersionFormat.create("\$major", "\$major.\$minor"),
+                null,
+                false,
+                false,
+            )
+        setGroovyField(cfg, "jiraConfiguration", jira)
+        return cfg
+    }
+
+    private fun callPopulateScalarsFromConfig(
+        row: ComponentConfigurationEntity,
+        cfg: EscrowModuleConfig,
+    ) {
+        populateScalarsFromConfigMethod.invoke(service, row, cfg)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun callEmitScalarOverrides(
+        component: ComponentEntity,
+        base: EscrowModuleConfig,
+        override: EscrowModuleConfig,
+    ): List<ComponentConfigurationEntity> =
+        emitScalarOverridesMethod.invoke(service, component, base, override)
+            as List<ComponentConfigurationEntity>
+
+    @Test
+    @DisplayName("MIG-045-004: populateScalarsFromConfig clears stale jiraDisplayName when DSL declares displayName null")
+    fun `MIG-045-004 populateScalarsFromConfig writes null jira displayName from jira block`() {
+        val row =
+            ComponentConfigurationEntity(
+                component = ComponentEntity(componentKey = "fixture"),
+                versionRange = "[1.0,2.0)",
+                rowType = "BASE",
+            )
+        row.jiraDisplayName = "stale inherited value"
+
+        callPopulateScalarsFromConfig(row, makeConfig("[1.0,2.0)", displayName = null))
+
+        assertNull(
+            row.jiraDisplayName,
+            "explicit jira.displayName=null in DSL must overwrite a stale row value",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-045-005: emitScalarOverrides emits jira.displayName when override range differs from base")
+    fun `MIG-045-005 emitScalarOverrides emits jira displayName scalar override row`() {
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "display-fixture")
+
+        val baseConfig = makeConfig("[1.0,2.0)", displayName = null)
+        val overrideConfig = makeConfig("[2.0,)", displayName = "Range Override Display")
+
+        val rows = callEmitScalarOverrides(component, baseConfig, overrideConfig)
+
+        val displayNameRow = rows.single { it.overriddenAttribute == "jira.displayName" }
+        assertEquals("[2.0,)", displayNameRow.versionRange)
+        assertEquals("Range Override Display", displayNameRow.jiraDisplayName)
+        assertTrue(rows.none { it.versionRange == "[1.0,2.0)" && it.overriddenAttribute == "jira.displayName" })
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG045JiraDisplayNamePerRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG045JiraDisplayNamePerRangeTest.kt
@@ -132,4 +132,24 @@ class MIG045JiraDisplayNamePerRangeTest {
             "null-clear jira.displayName override must not fall back to component.jiraDisplayName",
         )
     }
+
+    @Test
+    @DisplayName("MIG-045-003: synthetic base range with explicit null displayName does not inherit component default")
+    fun `MIG-045-003 synthetic base range explicit null displayName does not inherit component default`() {
+        val comp = makeComponent("gamma-fixture", jiraDisplayName = "Component Default")
+        val base =
+            makeBase(comp, versionRange = "[1.0,2.0)", jiraProjectKey = "SYNTH").apply {
+                jiraDisplayName = null
+            }
+
+        comp.configurations.add(base)
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+
+        assertNull(
+            ranges.first { it.versionRange == "[1.0,2.0)" }.component.displayName,
+            "synthetic base range with null jira.displayName must not fall back to component.jiraDisplayName",
+        )
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG045JiraDisplayNamePerRangeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG045JiraDisplayNamePerRangeTest.kt
@@ -1,0 +1,135 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * MIG-045 — per-range `jira.displayName` for jira-component-version-ranges parity.
+ *
+ * V1 resolves displayName per EscrowModuleConfig / version range. Schema-v2 stored
+ * only `components.jira_display_name` (component-level) and ignored per-range DSL
+ * overrides — causing TYPE_MISMATCH NULL↔STRING on CARDS/ANCS compat.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG045JiraDisplayNamePerRangeTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    private fun makeComponent(key: String, jiraDisplayName: String? = null): ComponentEntity =
+        ComponentEntity(id = UUID.randomUUID(), componentKey = key).apply {
+            this.jiraDisplayName = jiraDisplayName
+        }
+
+    private fun makeBase(
+        component: ComponentEntity,
+        versionRange: String = ALL_VERSIONS,
+        jiraProjectKey: String = "SYNTH",
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            buildSystem = "MAVEN",
+            deprecated = false,
+            jiraProjectKey = jiraProjectKey,
+        )
+
+    private fun makeScalarOverrideRow(
+        component: ComponentEntity,
+        versionRange: String,
+        attribute: String,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = attribute,
+            rowType = "SCALAR_OVERRIDE",
+        )
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    @Test
+    @DisplayName("MIG-045-001: per-range jira.displayName override surfaces on jira-component-version-ranges")
+    fun `MIG-045-001 per-range jira displayName override on jira-component-version-ranges`() {
+        val comp = makeComponent("alpha-fixture", jiraDisplayName = "Component Default")
+        val base = makeBase(comp, jiraProjectKey = "SYNTH")
+        val overrideRow = makeScalarOverrideRow(comp, "[1.0,2.0)", "jira.displayName")
+        overrideRow.jiraDisplayName = "Range Override"
+
+        comp.configurations.addAll(listOf(base, overrideRow))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+
+        val defaultRange = ranges.first { it.versionRange == ALL_VERSIONS }
+        val overrideRange = ranges.first { it.versionRange == "[1.0,2.0)" }
+
+        assertEquals(
+            "Component Default",
+            defaultRange.component.displayName,
+            "base range must inherit component-level jiraDisplayName",
+        )
+        assertEquals(
+            "Range Override",
+            overrideRange.component.displayName,
+            "override range must use per-range jira.displayName scalar",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-045-002: null jira.displayName override clears inherited displayName for that range")
+    fun `MIG-045-002 null jira displayName override clears inherited displayName for range`() {
+        val comp = makeComponent("beta-fixture", jiraDisplayName = "Component Default")
+        val base = makeBase(comp, jiraProjectKey = "SYNTH")
+        val nullOverrideRow = makeScalarOverrideRow(comp, "[2.0,)", "jira.displayName")
+        // jiraDisplayName intentionally null — null-clear override
+
+        comp.configurations.addAll(listOf(base, nullOverrideRow))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+
+        assertEquals("Component Default", ranges.first { it.versionRange == ALL_VERSIONS }.component.displayName)
+        assertNull(
+            ranges.first { it.versionRange == "[2.0,)" }.component.displayName,
+            "null-clear jira.displayName override must not fall back to component.jiraDisplayName",
+        )
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047ResidualClustersTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047ResidualClustersTest.kt
@@ -1,0 +1,193 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * MIG-047 — compat residual clusters: version-gap 404s, vcs.settings registry
+ * isolation, distribution marker clearing on jira-component-version-ranges.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG047ResidualClustersTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    private fun makeComponent(
+        key: String,
+        vcsExternalRegistry: String? = null,
+    ): ComponentEntity =
+        ComponentEntity(id = UUID.randomUUID(), componentKey = key).apply {
+            this.vcsExternalRegistry = vcsExternalRegistry
+        }
+
+    private fun makeBase(
+        component: ComponentEntity,
+        jiraProjectKey: String = "SYNTH",
+        vcsExternalRegistry: String? = null,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = ALL_VERSIONS,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            buildSystem = "MAVEN",
+            deprecated = false,
+            jiraProjectKey = jiraProjectKey,
+        ).apply {
+            this.vcsExternalRegistry = vcsExternalRegistry
+        }
+
+    private fun makeMarkerRow(
+        component: ComponentEntity,
+        versionRange: String,
+        attribute: String,
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = versionRange,
+            overriddenAttribute = attribute,
+            rowType = "MARKER",
+        )
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    @Test
+    @DisplayName("MIG-047-001: version in gap between explicit DSL ranges resolves to null")
+    fun `MIG-047-001 version in gap between explicit DSL ranges resolves to null`() {
+        val comp = makeComponent("authmodlib-gap-fixture")
+        val base =
+            makeBase(comp).apply {
+                versionRange = "[10,11)"
+                isSyntheticBase = true
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[10,11)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[11,12.1)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[12.2,)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        assertNull(
+            resolver.getResolvedComponentDefinition("authmodlib-gap-fixture", "12.1.155"),
+            "12.1.155 sits in the gap between [11,12.1) and [12.2,) — must not resolve",
+        )
+        assertNotNull(resolver.getResolvedComponentDefinition("authmodlib-gap-fixture", "11.5.0"))
+    }
+
+    @Test
+    @DisplayName("MIG-047-002: vcs.settings marker does not inherit components.vcs_external_registry")
+    fun `MIG-047-002 vcs settings marker does not inherit components vcs external registry`() {
+        val comp = makeComponent("vcs-marker-registry-fixture", vcsExternalRegistry = "ssh://component-default")
+        val base =
+            makeBase(comp).apply {
+                vcsExternalRegistry = "ssh://base-registry"
+                vcsEntries.add(
+                    VcsSettingsEntryEntity(
+                        componentConfiguration = this,
+                        name = "main",
+                        vcsPath = "ssh://base-root",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        val vcsMarker = makeMarkerRow(comp, "[1.0,2.0)", MarkerAttributes.VCS_SETTINGS)
+
+        comp.configurations.addAll(listOf(base, vcsMarker))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+        val overrideRange = ranges.first { it.versionRange == "[1.0,2.0)" }
+
+        assertNull(
+            overrideRange.vcsSettings.externalRegistry,
+            "vcs.settings marker must not fall back to components.vcs_external_registry",
+        )
+        assertEquals(0, overrideRange.vcsSettings.versionControlSystemRoots.size)
+    }
+
+    @Test
+    @DisplayName("MIG-047-003: empty distribution marker clears distribution on jira-component-version-ranges")
+    fun `MIG-047-003 empty distribution marker clears distribution on jira ranges`() {
+        val comp = makeComponent("distribution-clear-fixture")
+        comp.distributionExplicit = true
+        comp.distributionExternal = false
+        val base =
+            makeBase(comp).apply {
+                mavenArtifacts.add(
+                    DistributionMavenArtifactEntity(
+                        componentConfiguration = this,
+                        groupPattern = "com.example",
+                        artifactPattern = "artifact",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        val distMarker = makeMarkerRow(comp, "[1.0,2.0)", MarkerAttributes.DISTRIBUTION_MAVEN)
+
+        comp.configurations.addAll(listOf(base, distMarker))
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+
+        assertNotNull(ranges.first { it.versionRange == ALL_VERSIONS }.distribution?.GAV())
+        assertNull(
+            ranges.first { it.versionRange == "[1.0,2.0)" }.distribution,
+            "distribution.maven marker with no artifacts must clear distribution for the range",
+        )
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047VcsRegistryImportTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047VcsRegistryImportTest.kt
@@ -1,0 +1,154 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.lang.reflect.Method
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.DefaultConfigParameters
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.octopusden.octopus.escrow.model.VCSSettings
+import org.octopusden.octopus.escrow.model.VersionControlSystemRoot
+import org.octopusden.octopus.escrow.RepositoryType
+
+/**
+ * MIG-047 import-path: vcs.settings marker emission must pin vcs.externalRegistry.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG047VcsRegistryImportTest {
+
+    private lateinit var service: ImportServiceImpl
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+    private lateinit var emitMarkerOverridesMethod: Method
+
+    @BeforeEach
+    fun setUp() {
+        val configurationLoader = mock(EscrowConfigurationLoader::class.java)
+        val emptyDefaults = mock(DefaultConfigParameters::class.java)
+        doReturn(emptyDefaults).`when`(configurationLoader).loadCommonDefaults(emptyMap())
+
+        configurationRepository = mock(ComponentConfigurationRepository::class.java)
+        `when`(configurationRepository.save(any(ComponentConfigurationEntity::class.java)))
+            .thenAnswer { invocation ->
+                val row = invocation.arguments[0] as ComponentConfigurationEntity
+                if (row.id == null) {
+                    row.id = UUID.randomUUID()
+                }
+                row
+            }
+
+        service = ImportServiceImpl(
+            gitResolver = mock(ComponentRegistryResolverImpl::class.java),
+            dbResolver = mock(DatabaseComponentRegistryResolver::class.java),
+            componentSourceRepository = mock(ComponentSourceRepository::class.java),
+            sourceRegistry = mock(ComponentSourceRegistry::class.java),
+            configurationLoader = configurationLoader,
+            registryConfigRepository = mock(RegistryConfigRepository::class.java),
+            componentRepository = mock(ComponentRepository::class.java),
+            configurationRepository = configurationRepository,
+            componentGroupRepository = mock(ComponentGroupRepository::class.java),
+            systemRepository = mock(SystemRepository::class.java),
+            toolRepository = mock(ToolRepository::class.java),
+            labelRepository = mock(LabelRepository::class.java),
+            componentLabelRepository = mock(ComponentLabelRepository::class.java),
+            componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+            componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+        )
+
+        emitMarkerOverridesMethod = ImportServiceImpl::class.java.getDeclaredMethod(
+            "emitMarkerOverrides",
+            ComponentEntity::class.java,
+            ComponentConfigurationEntity::class.java,
+            EscrowModuleConfig::class.java,
+            EscrowModuleConfig::class.java,
+        )
+        emitMarkerOverridesMethod.isAccessible = true
+    }
+
+    private fun setGroovyField(target: Any, fieldName: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun makeConfig(
+        versionRange: String,
+        externalRegistry: String?,
+        vcsPath: String?,
+    ): EscrowModuleConfig {
+        val cfg = EscrowModuleConfig()
+        setGroovyField(cfg, "versionRange", versionRange)
+        val roots =
+            if (vcsPath == null) {
+                emptyList()
+            } else {
+                listOf(
+                    VersionControlSystemRoot.create(
+                        "main",
+                        RepositoryType.GIT,
+                        vcsPath,
+                        null,
+                        null,
+                        null,
+                    ),
+                )
+            }
+        setGroovyField(cfg, "vcsSettings", VCSSettings.create(externalRegistry, roots))
+        return cfg
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun callEmitMarkerOverrides(
+        component: ComponentEntity,
+        baseRow: ComponentConfigurationEntity,
+        base: EscrowModuleConfig,
+        override: EscrowModuleConfig,
+    ): List<ComponentConfigurationEntity> =
+        emitMarkerOverridesMethod.invoke(service, component, baseRow, base, override)
+            as List<ComponentConfigurationEntity>
+
+    @Test
+    @DisplayName("MIG-047-004: emitMarkerOverrides pins vcs.externalRegistry when vcs.settings marker is emitted")
+    fun `MIG-047-004 emitMarkerOverrides pins vcs externalRegistry when vcs settings marker is emitted`() {
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "vcs-import-fixture")
+        val baseRow =
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = "(,)",
+                rowType = "BASE",
+            )
+
+        val baseConfig = makeConfig("(,)", externalRegistry = "ssh://base", vcsPath = "ssh://base-root")
+        val overrideConfig = makeConfig("[1.0,2.0)", externalRegistry = null, vcsPath = null)
+
+        val rows = callEmitMarkerOverrides(component, baseRow, baseConfig, overrideConfig)
+
+        val registryRow = rows.single { it.overriddenAttribute == "vcs.externalRegistry" }
+        assertEquals("[1.0,2.0)", registryRow.versionRange)
+        assertNull(registryRow.vcsExternalRegistry)
+        assertEquals(1, rows.count { it.overriddenAttribute == "vcs.settings" })
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG048JiraDisplayNameRangePresenceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG048JiraDisplayNameRangePresenceTest.kt
@@ -1,0 +1,138 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * MIG-048 — RANGE_PRESENCE-only explicit ranges must not inherit BASE-row
+ * `jira.displayName`. V1 empty DSL blocks yield null displayName on
+ * jira-component-version-ranges; bleeding the `(,)` anchor caused NULL↔STRING
+ * diffs on CARDS/ANCS compat.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG048JiraDisplayNameRangePresenceTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    private fun makeComponent(key: String, jiraDisplayName: String? = null): ComponentEntity =
+        ComponentEntity(id = UUID.randomUUID(), componentKey = key).apply {
+            this.jiraDisplayName = jiraDisplayName
+        }
+
+    private fun makeBase(
+        component: ComponentEntity,
+        jiraProjectKey: String = "CARDS",
+    ): ComponentConfigurationEntity =
+        ComponentConfigurationEntity(
+            component = component,
+            versionRange = ALL_VERSIONS,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            buildSystem = "MAVEN",
+            deprecated = false,
+            jiraProjectKey = jiraProjectKey,
+            jiraDisplayName = "Internal Operations",
+        )
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    @Test
+    @DisplayName("MIG-048-001: RANGE_PRESENCE explicit range does not inherit BASE jira.displayName")
+    fun `MIG-048-001 RANGE_PRESENCE explicit range does not inherit BASE jira displayName`() {
+        val comp = makeComponent("internal-operations-fixture", jiraDisplayName = "Internal Operations")
+        val base = makeBase(comp)
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[2.0,2.1)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("CARDS")
+
+        assertEquals(
+            "Internal Operations",
+            ranges.first { it.versionRange == ALL_VERSIONS }.component.displayName,
+        )
+        assertNull(
+            ranges.first { it.versionRange == "[2.0,2.1)" }.component.displayName,
+            "empty DSL block must not inherit BASE-row jira.displayName",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-048-002: broad jira.displayName override still applies to contained RANGE_PRESENCE range")
+    fun `MIG-048-002 broad jira displayName override still applies to contained RANGE_PRESENCE range`() {
+        val comp = makeComponent("broad-presence-fixture", jiraDisplayName = "Component Default")
+        val base = makeBase(comp)
+        val broadOverride =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = "[1.0,3.0)",
+                overriddenAttribute = "jira.displayName",
+                rowType = "SCALAR_OVERRIDE",
+                jiraDisplayName = "Broad Override",
+            )
+
+        comp.configurations.addAll(
+            listOf(
+                base,
+                broadOverride,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[1.0,2.0)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("CARDS")
+
+        assertEquals(
+            "Broad Override",
+            ranges.first { it.versionRange == "[1.0,2.0)" }.component.displayName,
+        )
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG050CompatResidualTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG050CompatResidualTest.kt
@@ -16,6 +16,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionDockerImageEntity
 import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
 import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
 import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
@@ -313,5 +314,87 @@ class MIG050CompatResidualTest {
             "Explicit range must not fall back to components.vcs_external_registry",
         )
         assertEquals(1, range.vcsSettings.versionControlSystemRoots.size)
+    }
+
+    @Test
+    @DisplayName("MIG-050-005: RANGE_PRESENCE range with jira config inherits component jira.displayName")
+    fun `MIG-050-005 RANGE_PRESENCE range inherits component jira displayName`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "c-pipes-kernel-fixture").apply {
+                jiraDisplayName = "C-Pipes Kernel"
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = ALL_VERSIONS,
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "CARDS",
+            )
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[03.63.00,)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val range = resolver.getJiraComponentVersionRangesByProject("CARDS")
+            .first { it.versionRange == "[03.63.00,)" }
+
+        assertEquals(
+            "C-Pipes Kernel",
+            range.component.displayName,
+            "Explicit range must inherit components.jira_display_name when BASE row has no per-range displayName",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-050-006: docker-only distribution marker inherits component explicit/external")
+    fun `MIG-050-006 docker-only distribution marker inherits component explicit external`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "docker-inherit-fixture").apply {
+                distributionExplicit = false
+                distributionExternal = true
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = ALL_VERSIONS,
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "TEST_DOCKER",
+            )
+        val dockerMarker =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = "(1.0.0, 2.0.0)",
+                overriddenAttribute = MarkerAttributes.DISTRIBUTION_DOCKER,
+                rowType = "MARKER",
+            ).apply {
+                dockerImages.add(
+                    DistributionDockerImageEntity(
+                        componentConfiguration = this,
+                        imageName = "test-docker-4",
+                        flavor = "amd64",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        comp.configurations.addAll(listOf(base, dockerMarker))
+        stubComponent(comp)
+
+        val range = resolver.getJiraComponentVersionRangesByProject("TEST_DOCKER")
+            .first { it.versionRange == "(1.0.0, 2.0.0)" }
+
+        assertEquals(false, range.distribution?.explicit())
+        assertEquals(true, range.distribution?.external())
+        assertEquals("test-docker-4:amd64", range.distribution?.docker())
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG050CompatResidualTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG050CompatResidualTest.kt
@@ -1,0 +1,317 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.lang.reflect.Method
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.DefaultConfigParameters
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.octopusden.octopus.escrow.model.Distribution
+import org.octopusden.octopus.escrow.model.VCSSettings
+import org.octopusden.octopus.escrow.model.VersionControlSystemRoot
+import org.octopusden.octopus.escrow.RepositoryType
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * MIG-050 — close remaining jira-component-version-ranges compat residuals:
+ * import inherit semantics for absent override blocks, and explicit-range VCS
+ * registry isolation from components.vcs_external_registry.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG050CompatResidualTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+    private lateinit var importService: ImportServiceImpl
+    private lateinit var emitMarkerOverridesMethod: Method
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+
+        val configurationLoader = mock(EscrowConfigurationLoader::class.java)
+        val emptyDefaults = mock(DefaultConfigParameters::class.java)
+        doReturn(emptyDefaults).`when`(configurationLoader).loadCommonDefaults(emptyMap())
+
+        val configurationRepository = mock(ComponentConfigurationRepository::class.java)
+        `when`(configurationRepository.save(any(ComponentConfigurationEntity::class.java)))
+            .thenAnswer { invocation ->
+                val row = invocation.arguments[0] as ComponentConfigurationEntity
+                if (row.id == null) {
+                    row.id = UUID.randomUUID()
+                }
+                row
+            }
+
+        importService = ImportServiceImpl(
+            gitResolver = mock(ComponentRegistryResolverImpl::class.java),
+            dbResolver = mock(DatabaseComponentRegistryResolver::class.java),
+            componentSourceRepository = mock(ComponentSourceRepository::class.java),
+            sourceRegistry = mock(ComponentSourceRegistry::class.java),
+            configurationLoader = configurationLoader,
+            registryConfigRepository = mock(RegistryConfigRepository::class.java),
+            componentRepository = componentRepository,
+            configurationRepository = configurationRepository,
+            componentGroupRepository = mock(ComponentGroupRepository::class.java),
+            systemRepository = mock(SystemRepository::class.java),
+            toolRepository = mock(ToolRepository::class.java),
+            labelRepository = mock(LabelRepository::class.java),
+            componentLabelRepository = mock(ComponentLabelRepository::class.java),
+            componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+            componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+        )
+
+        emitMarkerOverridesMethod = ImportServiceImpl::class.java.getDeclaredMethod(
+            "emitMarkerOverrides",
+            ComponentEntity::class.java,
+            ComponentConfigurationEntity::class.java,
+            EscrowModuleConfig::class.java,
+            EscrowModuleConfig::class.java,
+        )
+        emitMarkerOverridesMethod.isAccessible = true
+    }
+
+    private fun setGroovyField(target: Any, fieldName: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun makeConfig(
+        versionRange: String,
+        distribution: Distribution? = null,
+        vcsSettings: VCSSettings? = null,
+    ): EscrowModuleConfig {
+        val cfg = EscrowModuleConfig()
+        setGroovyField(cfg, "versionRange", versionRange)
+        setGroovyField(cfg, "distribution", distribution)
+        setGroovyField(cfg, "vcsSettings", vcsSettings)
+        return cfg
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun callEmitMarkerOverrides(
+        component: ComponentEntity,
+        baseRow: ComponentConfigurationEntity,
+        base: EscrowModuleConfig,
+        override: EscrowModuleConfig,
+    ): List<ComponentConfigurationEntity> =
+        emitMarkerOverridesMethod.invoke(importService, component, baseRow, base, override)
+            as List<ComponentConfigurationEntity>
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    @Test
+    @DisplayName("MIG-050-001: absent override distribution does not emit distribution.maven marker")
+    fun `MIG-050-001 absent override distribution does not emit distribution maven marker`() {
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "ancs-empty-range-fixture")
+        val baseRow =
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = "[1.0,2.0)",
+                rowType = "BASE",
+            )
+        val baseDist =
+            Distribution(
+                true,
+                true,
+                "com.example:artifact:zip",
+                null,
+                null,
+                "analytics/example-distribution",
+                null,
+            )
+        val baseConfig = makeConfig("[1.0,2.0)", distribution = baseDist)
+        val overrideConfig = makeConfig("[2.0,)")
+
+        val rows = callEmitMarkerOverrides(component, baseRow, baseConfig, overrideConfig)
+
+        assertTrue(
+            rows.none { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_MAVEN },
+            "Null override distribution is inherit semantics — must not emit clearing marker",
+        )
+        assertTrue(
+            rows.none { it.overriddenAttribute == MarkerAttributes.DISTRIBUTION_DOCKER },
+            "Null override distribution is inherit semantics — must not emit docker marker",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-050-002: absent override vcsSettings does not emit vcs.settings marker")
+    fun `MIG-050-002 absent override vcsSettings does not emit vcs settings marker`() {
+        val component = ComponentEntity(id = UUID.randomUUID(), componentKey = "vcs-inherit-fixture")
+        val baseRow =
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = ALL_VERSIONS,
+                rowType = "BASE",
+            )
+        val baseVcs =
+            VCSSettings.create(
+                "ssh://base-registry",
+                listOf(
+                    VersionControlSystemRoot.create(
+                        "main",
+                        RepositoryType.GIT,
+                        "ssh://base-root",
+                        null,
+                        null,
+                        null,
+                    ),
+                ),
+            )
+        val baseConfig = makeConfig(ALL_VERSIONS, vcsSettings = baseVcs)
+        val overrideConfig = makeConfig("[2.0,)")
+
+        val rows = callEmitMarkerOverrides(component, baseRow, baseConfig, overrideConfig)
+
+        assertTrue(
+            rows.isEmpty(),
+            "Null override vcsSettings is inherit semantics — must not emit vcs marker or registry scalar",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-050-003: explicit RANGE_PRESENCE range inherits base distribution on jira-ranges")
+    fun `MIG-050-003 explicit RANGE_PRESENCE range inherits base distribution on jira ranges`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "ancs-inherit-dist-fixture").apply {
+                jiraDisplayName = "Analytics Sub"
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = "[1.0,2.0)",
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "ANCS",
+            ).apply {
+                isSyntheticBase = true
+                mavenArtifacts.add(
+                    DistributionMavenArtifactEntity(
+                        componentConfiguration = this,
+                        groupPattern = "com.example",
+                        artifactPattern = "distribution",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[1.0,2.0)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[2.0,)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val ranges = resolver.getJiraComponentVersionRangesByProject("ANCS")
+
+        assertEquals(
+            "com.example:distribution",
+            ranges.first { it.versionRange == "[2.0,)" }.distribution?.GAV(),
+            "Empty `[2,)` DSL block inherits component distribution on jira-ranges",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-050-004: explicit range does not inherit components.vcs_external_registry")
+    fun `MIG-050-004 explicit range does not inherit components vcs external registry`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "cards-vcs-registry-fixture").apply {
+                vcsExternalRegistry = "ssh://component-default"
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = ALL_VERSIONS,
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "CARDS",
+            ).apply {
+                vcsEntries.add(
+                    VcsSettingsEntryEntity(
+                        componentConfiguration = this,
+                        name = "main",
+                        vcsPath = "ssh://base-root",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[1.0,2.0)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val range = resolver.getJiraComponentVersionRangesByProject("CARDS").first { it.versionRange == "[1.0,2.0)" }
+
+        assertNull(
+            range.vcsSettings.externalRegistry,
+            "Explicit range must not fall back to components.vcs_external_registry",
+        )
+        assertEquals(1, range.vcsSettings.versionControlSystemRoots.size)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG051JiraDisplayNameLayeringTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG051JiraDisplayNameLayeringTest.kt
@@ -1,0 +1,311 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * MIG-051 — unified `jira.displayName` layering on read path.
+ *
+ * Regression guard for the cluster-50 compat explosion (v3 ~50 diffs → 211 on
+ * [1.7] after MIG-048 global pre-clear + blanket BASE-anchor suppress):
+ * - **RED** on `c9605394`: global `merged.jiraDisplayName = null` for every
+ *   enumerated range and suppress on `versionRange == base.versionRange` zeroed
+ *   displayName on `/jira-component`, per-version, and common jira-ranges paths
+ *   (~131 STRING→NULL) while fixing CARDS enumeration.
+ * - **GREEN** with per-view layering in [buildJiraComponent]: RANGE_PRESENCE
+ *   empty blocks stay null; explicit ranges inherit `components.jira_display_name`;
+ *   single-range explicit null pins stay null.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class MIG051JiraDisplayNameLayeringTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    private fun traceReplayStyleComponent(
+        key: String = "tskernel-fixture",
+        displayName: String = "Transaction Switch Kernel",
+        projectKey: String = "TSK",
+        explicitRange: String = "[1.0,3.0)",
+    ): ComponentEntity {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = key).apply {
+                jiraDisplayName = displayName
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = ALL_VERSIONS,
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = projectKey,
+            ).apply {
+                isSyntheticBase = true
+                vcsEntries.add(
+                    VcsSettingsEntryEntity(
+                        componentConfiguration = this,
+                        name = "main",
+                        vcsPath = "ssh://trace-replay-root",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = explicitRange,
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+        return comp
+    }
+
+    @Test
+    @DisplayName("MIG-051-001: jira-ranges explicit range inherits component displayName (w4cardsopt pattern)")
+    fun `MIG-051-001 jira ranges explicit range inherits component displayName`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "w4cardsopt-fixture").apply {
+                jiraDisplayName = "Way4 Cards Opt"
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = ALL_VERSIONS,
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "CARDS",
+            ).apply {
+                isSyntheticBase = true
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[3.43.30,3.47.10)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val range = resolver.getJiraComponentVersionRangesByProject("CARDS")
+            .first { it.versionRange == "[3.43.30,3.47.10)" }
+
+        assertEquals("Way4 Cards Opt", range.component.displayName)
+    }
+
+    @Test
+    @DisplayName("MIG-051-002: getJiraComponentVersion inherits component displayName on explicit range")
+    fun `MIG-051-002 getJiraComponentVersion inherits component displayName on explicit range`() {
+        traceReplayStyleComponent()
+
+        val jiraComponentVersion = resolver.getJiraComponentVersion("tskernel-fixture", "2.5.0")
+
+        assertEquals(
+            "Transaction Switch Kernel",
+            jiraComponentVersion.component.displayName,
+            "Per-version jira-component must not lose components.jira_display_name fallback",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-051-003: getResolvedComponentDefinition inherits component displayName on explicit range")
+    fun `MIG-051-003 getResolvedComponentDefinition inherits component displayName on explicit range`() {
+        traceReplayStyleComponent()
+
+        val config = resolver.getResolvedComponentDefinition("tskernel-fixture", "2.5.0")
+
+        assertNotNull(config)
+        assertEquals(
+            "Transaction Switch Kernel",
+            config!!.jiraConfiguration.displayName,
+            "Per-version module view must surface component jira.displayName",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-051-004: getAllJiraComponentVersionRanges inherits component displayName on explicit range")
+    fun `MIG-051-004 getAllJiraComponentVersionRanges inherits component displayName on explicit range`() {
+        traceReplayStyleComponent()
+
+        val range = resolver.getAllJiraComponentVersionRanges()
+            .first { it.componentName == "tskernel-fixture" && it.versionRange == "[1.0,3.0)" }
+
+        assertEquals("Transaction Switch Kernel", range.component.displayName)
+    }
+
+    @Test
+    @DisplayName("MIG-051-005: RANGE_PRESENCE empty block stays null despite BASE displayName bleed")
+    fun `MIG-051-005 RANGE_PRESENCE empty block stays null despite BASE displayName bleed`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "internal-operations-fixture").apply {
+                jiraDisplayName = "Internal Operations"
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = ALL_VERSIONS,
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "CARDS",
+                jiraDisplayName = "Internal Operations",
+            ).apply {
+                isSyntheticBase = true
+                vcsEntries.add(
+                    VcsSettingsEntryEntity(
+                        componentConfiguration = this,
+                        name = "main",
+                        vcsPath = "ssh://internal-ops-root",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[2.0,2.1)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val enumerated = resolver.getJiraComponentVersionRangesByProject("CARDS")
+            .first { it.versionRange == "[2.0,2.1)" }
+        val resolved = resolver.getResolvedComponentDefinition("internal-operations-fixture", "2.0.5")
+        val pointInRange = resolver.getJiraComponentVersion("internal-operations-fixture", "2.0.5")
+
+        assertNull(
+            enumerated.component.displayName,
+            "Empty DSL block on jira-ranges enumeration must stay null",
+        )
+        assertNull(
+            resolved?.jiraConfiguration?.displayName,
+            "Empty DSL block on per-version resolution must stay null",
+        )
+        assertNull(
+            pointInRange.component.displayName,
+            "Empty DSL block on getJiraComponentVersion must stay null",
+        )
+    }
+
+    @Test
+    @DisplayName("MIG-051-006: single-range BASE explicit null pin does not inherit component default")
+    fun `MIG-051-006 single-range BASE explicit null pin does not inherit component default`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "gamma-fixture").apply {
+                jiraDisplayName = "Component Default"
+            }
+        comp.configurations.add(
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = "[1.0,2.0)",
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "SYNTH",
+                jiraDisplayName = null,
+            ),
+        )
+        stubComponent(comp)
+
+        val range = resolver.getJiraComponentVersionRangesByProject("SYNTH")
+            .first { it.versionRange == "[1.0,2.0)" }
+
+        assertNull(range.component.displayName)
+    }
+
+    @Test
+    @DisplayName("MIG-051-007: non-synthetic BASE anchor null row inherits component on per-version path")
+    fun `MIG-051-007 non-synthetic BASE anchor null row inherits component on per-version path`() {
+        val comp =
+            ComponentEntity(id = UUID.randomUUID(), componentKey = "w4cardsopt-base-anchor-fixture").apply {
+                jiraDisplayName = "Way4 Cards Opt"
+            }
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = "[1.0,3.0)",
+                rowType = "BASE",
+                buildSystem = "MAVEN",
+                deprecated = false,
+                jiraProjectKey = "TSK",
+                jiraDisplayName = null,
+            ).apply {
+                vcsEntries.add(
+                    VcsSettingsEntryEntity(
+                        componentConfiguration = this,
+                        name = "main",
+                        vcsPath = "ssh://w4cardsopt-root",
+                        sortOrder = 0,
+                    ),
+                )
+            }
+        comp.configurations.addAll(
+            listOf(
+                base,
+                ComponentConfigurationEntity(
+                    component = comp,
+                    versionRange = "[3.5,4.0)",
+                    rowType = "RANGE_PRESENCE",
+                ),
+            ),
+        )
+        stubComponent(comp)
+
+        val jiraComponentVersion = resolver.getJiraComponentVersion("w4cardsopt-base-anchor-fixture", "2.5.0")
+        val config = resolver.getResolvedComponentDefinition("w4cardsopt-base-anchor-fixture", "2.5.0")
+
+        assertEquals("Way4 Cards Opt", jiraComponentVersion.component.displayName)
+        assertEquals("Way4 Cards Opt", config?.jiraConfiguration?.displayName)
+    }
+}

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -53,6 +53,7 @@ Numbered MIG-NNN contracts registry, peer of `requirements-common.md` (SYS-NNN) 
 | MIG-048 | RANGE_PRESENCE ranges must not inherit BASE jira.displayName | High | unit-test | ✅ Tested |
 | MIG-049 | restore MIG-029 synthetic-base fallback after MIG-047 enumeration | High | unit-test | ✅ Tested |
 | MIG-050 | import inherit semantics + explicit-range vcs registry isolation | High | unit-test | ✅ Tested |
+| MIG-051 | unified jira.displayName layering on read path | High | unit-test | ✅ Tested |
 
 ---
 
@@ -1301,4 +1302,38 @@ leaked `components.vcs_external_registry` onto explicit enumerated ranges.
 `MIG050CompatResidualTest.MIG-050-001 absent override distribution does not emit distribution maven marker`,
 `MIG050CompatResidualTest.MIG-050-002 absent override vcsSettings does not emit vcs settings marker`,
 `MIG050CompatResidualTest.MIG-050-003 explicit RANGE_PRESENCE range inherits base distribution on jira ranges`,
-`MIG050CompatResidualTest.MIG-050-004 explicit range does not inherit components vcs external registry`
+`MIG050CompatResidualTest.MIG-050-004 explicit range does not inherit components vcs external registry`,
+`MIG050CompatResidualTest.MIG-050-005 RANGE_PRESENCE range inherits component jira displayName`,
+`MIG050CompatResidualTest.MIG-050-006 docker-only distribution marker inherits component explicit external`
+
+---
+
+### MIG-051: unified jira.displayName layering on read path
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Description:**
+Cluster-50 compat work introduced MIG-048 global pre-clear of `merged.jiraDisplayName`
+for every enumerated range plus a blanket BASE-anchor suppress. That fixed CARDS
+`jira-component-version-ranges` empty blocks but regressed trace-replay endpoints
+(`/jira-component`, per-version resolution, common jira-ranges) with ~131 STRING→NULL
+diffs on full [1.7] compat (50 → 211). Read path must layer displayName per view:
+scalar override wins; RANGE_PRESENCE empty blocks with BASE bleed stay null; other
+explicit ranges inherit `components.jira_display_name`; single-range BASE null pins
+stay null.
+
+**Acceptance criteria:**
+1. Explicit enumerated ranges inherit `components.jira_display_name` on jira-ranges, `getJiraComponentVersion`, `getResolvedComponentDefinition`, and `getAllJiraComponentVersionRanges`.
+2. RANGE_PRESENCE-only empty DSL blocks do not inherit BASE-row or component displayName on any of the above paths.
+3. Single-range component with explicit null on the BASE row does not fall back to component default.
+
+**Test method:**
+`MIG051JiraDisplayNameLayeringTest.MIG-051-001 jira ranges explicit range inherits component displayName`,
+`MIG051JiraDisplayNameLayeringTest.MIG-051-002 getJiraComponentVersion inherits component displayName on explicit range`,
+`MIG051JiraDisplayNameLayeringTest.MIG-051-003 getResolvedComponentDefinition inherits component displayName on explicit range`,
+`MIG051JiraDisplayNameLayeringTest.MIG-051-004 getAllJiraComponentVersionRanges inherits component displayName on explicit range`,
+`MIG051JiraDisplayNameLayeringTest.MIG-051-005 RANGE_PRESENCE empty block stays null despite BASE displayName bleed`,
+`MIG051JiraDisplayNameLayeringTest.MIG-051-006 single-range BASE explicit null pin does not inherit component default`,
+`MIG051JiraDisplayNameLayeringTest.MIG-051-007 non-synthetic BASE anchor null row inherits component on per-version path`

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -51,6 +51,8 @@ Numbered MIG-NNN contracts registry, peer of `requirements-common.md` (SYS-NNN) 
 | MIG-046 | rangeApplies containment for enumeration endpoints (TD-010) | High | unit-test | ✅ Tested |
 | MIG-047 | compat residual clusters (gap 404, vcs registry, distribution clear) | High | unit-test | ✅ Tested |
 | MIG-048 | RANGE_PRESENCE ranges must not inherit BASE jira.displayName | High | unit-test | ✅ Tested |
+| MIG-049 | restore MIG-029 synthetic-base fallback after MIG-047 enumeration | High | unit-test | ✅ Tested |
+| MIG-050 | import inherit semantics + explicit-range vcs registry isolation | High | unit-test | ✅ Tested |
 
 ---
 
@@ -1254,3 +1256,49 @@ TYPE_MISMATCH on CARDS/ANCS compat.
 **Test method:**
 `MIG048JiraDisplayNameRangePresenceTest.MIG-048-001 RANGE_PRESENCE explicit range does not inherit BASE jira displayName`,
 `MIG048JiraDisplayNameRangePresenceTest.MIG-048-002 broad jira displayName override still applies to contained RANGE_PRESENCE range`
+
+---
+
+### MIG-049: restore MIG-029 synthetic-base fallback after MIG-047 enumeration
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Description:**
+MIG-047 switched per-version resolve to enumerated-range matching, which returned
+null for versions outside override ranges on universal synthetic `(,)` bases.
+MIG-029 requires those versions to fall back to BASE scalars (Compile&UT test 5c).
+
+**Acceptance criteria:**
+1. Universal synthetic base + scalar/marker overrides: versions outside every override range resolve from BASE.
+2. Explicit-range synthetic base (authmodlib gap pattern): versions in gaps between RANGE_PRESENCE views still resolve to null.
+
+**Test method:**
+`DatabaseComponentRegistryResolverTest.(5c MIG-029) synthetic base - resolve 0·9·0 falls back to synthetic base values`,
+`MIG047ResidualClustersTest.MIG-047-001 version in gap between explicit DSL ranges resolves to null`
+
+---
+
+### MIG-050: import inherit semantics + explicit-range vcs registry isolation
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Description:**
+Close remaining CARDS/ANCS `jira-component-version-ranges` compat residuals:
+import was emitting clearing markers when the DSL override block simply omitted
+`vcs { … }` / `distribution { … }` (null = inherit, not replace). Read path also
+leaked `components.vcs_external_registry` onto explicit enumerated ranges.
+
+**Acceptance criteria:**
+1. `emitMarkerOverrides` does not emit distribution/vcs markers when override config fields are null (inherit semantics).
+2. Explicit RANGE_PRESENCE ranges inherit BASE distribution on jira-ranges when no distribution marker exists.
+3. Explicit enumerated ranges do not fall back to `components.vcs_external_registry` when the BASE row has no per-range registry.
+
+**Test method:**
+`MIG050CompatResidualTest.MIG-050-001 absent override distribution does not emit distribution maven marker`,
+`MIG050CompatResidualTest.MIG-050-002 absent override vcsSettings does not emit vcs settings marker`,
+`MIG050CompatResidualTest.MIG-050-003 explicit RANGE_PRESENCE range inherits base distribution on jira ranges`,
+`MIG050CompatResidualTest.MIG-050-004 explicit range does not inherit components vcs external registry`

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -47,6 +47,7 @@ Numbered MIG-NNN contracts registry, peer of `requirements-common.md` (SYS-NNN) 
 | MIG-039 | find-by-artifacts gates by configuration version range | High | unit-test | ✅ Tested |
 | MIG-040 | find-by-docker-images version-substitutes distribution | Low | integration-test | ✅ Fixed |
 | MIG-041 | importer preserves component-level artifactId CSV tokens | Medium | integration-test | ⏳ Follow-up |
+| MIG-045 | per-range jira.displayName on jira-component-version-ranges | High | unit-test | ✅ Tested |
 
 ---
 
@@ -1138,3 +1139,28 @@ BOTH `find-by-artifacts` and `/maven-artifacts`.
 **Acceptance criteria:**
 1. All component-level `artifactId` CSV tokens are matchable by `find-by-artifacts`.
 2. `/maven-artifacts` per-range output is unchanged.
+
+---
+
+### MIG-045: per-range `jira.displayName` on jira-component-version-ranges
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Description:**
+V1 resolves `component.displayName` inside each `JiraComponentVersionRange` entry from the
+per-range EscrowModuleConfig. Schema-v2 stored only `components.jira_display_name` (component-level)
+and ignored per-range DSL overrides, causing TYPE_MISMATCH NULL↔STRING on
+`GET /rest/api/2/projects/{project}/jira-component-version-ranges` compat (CARDS/ANCS clusters).
+
+**Acceptance criteria:**
+1. A SCALAR_OVERRIDE row with `overriddenAttribute = "jira.displayName"` surfaces its value on
+   `getJiraComponentVersionRangesByProject` for that version range.
+2. A null-clear override row (`jira.displayName` override with NULL column) returns null
+   displayName for that range and does not fall back to `components.jira_display_name`.
+3. Ranges without an override inherit `components.jira_display_name` as today.
+
+**Test method:**
+`MIG045JiraDisplayNamePerRangeTest.MIG-045-001 per-range jira displayName override on jira-component-version-ranges`,
+`MIG045JiraDisplayNamePerRangeTest.MIG-045-002 null jira displayName override clears inherited displayName for range`

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -48,6 +48,9 @@ Numbered MIG-NNN contracts registry, peer of `requirements-common.md` (SYS-NNN) 
 | MIG-040 | find-by-docker-images version-substitutes distribution | Low | integration-test | ✅ Fixed |
 | MIG-041 | importer preserves component-level artifactId CSV tokens | Medium | integration-test | ⏳ Follow-up |
 | MIG-045 | per-range jira.displayName on jira-component-version-ranges | High | unit-test | ✅ Tested |
+| MIG-046 | rangeApplies containment for enumeration endpoints (TD-010) | High | unit-test | ✅ Tested |
+| MIG-047 | compat residual clusters (gap 404, vcs registry, distribution clear) | High | unit-test | ✅ Tested |
+| MIG-048 | RANGE_PRESENCE ranges must not inherit BASE jira.displayName | High | unit-test | ✅ Tested |
 
 ---
 
@@ -1177,3 +1180,77 @@ and ignored per-range DSL overrides, causing TYPE_MISMATCH NULL↔STRING on
 `DbBackedComponentsRegistryServiceControllerTest.testMIG045006_importPersistsPerRangeJiraDisplayNameScalars_dbMode`,
 `DbBackedComponentsRegistryServiceControllerTest.testMIG045007_nullClearSurvivesComponentLevelDefault_dbMode`,
 `DbBackedComponentsRegistryServiceControllerTest.testMIG045008_perRangeJiraDisplayNameOnProjectJiraComponentVersionRanges_dbMode`
+
+---
+
+### MIG-046: rangeApplies containment for enumeration endpoints (TD-010)
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Description:**
+Scalar and marker overrides on a broad DSL range must apply to narrower enumerated
+ranges during `jira-component-version-ranges` resolution. The version-range library
+exposes only point-in-range checks; TD-010 adds a sample-points containment heuristic.
+
+**Acceptance criteria:**
+1. `rangeApplies("[1.0,3.0)", "[1.0,2.0)")` returns true for bounded containment cases pinned by TD-010 matrix.
+2. Broad-range `jira.displayName` and `vcs.externalRegistry` overrides surface on contained enumeration ranges.
+3. Unbounded `ALL_VERSIONS` parent contains bounded child ranges.
+
+**Test method:**
+`RangeAppliesContainmentTest.TD-010 bounded rangeApplies matrix`,
+`RangeAppliesContainmentTest.MIG-046-001 broad range jira displayName override applies to contained enumeration range`,
+`RangeAppliesContainmentTest.MIG-046-002 per-range vcs externalRegistry null-clear does not inherit component default`,
+`RangeAppliesContainmentTest.MIG-046-003 per-range vcs externalRegistry override surfaces on jira-component-version-ranges`
+
+---
+
+### MIG-047: compat residual clusters (gap 404, vcs registry, distribution clear)
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Description:**
+Close remaining [1.7] compat clusters after MIG-045/046: versions in gaps between
+DSL ranges must 404 on `/distribution`, `vcs.settings` markers must not inherit
+component/base externalRegistry, and empty distribution markers must clear
+`distribution` on jira-component-version-ranges.
+
+**Acceptance criteria:**
+1. `getResolvedComponentDefinition` returns null for versions outside every enumerated range (e.g. authmodlib 12.1.155).
+2. When `(,)` and a narrower range both match, the narrower enumerated view wins.
+3. `vcs.settings` marker with empty roots yields null `externalRegistry` without component fallback.
+4. Empty `distribution.maven` marker yields null `distribution` for that range.
+5. Import emits a companion `vcs.externalRegistry` scalar when a `vcs.settings` marker is persisted.
+
+**Test method:**
+`MIG047ResidualClustersTest.MIG-047-001 version in gap between explicit DSL ranges resolves to null`,
+`MIG047ResidualClustersTest.MIG-047-002 vcs settings marker does not inherit components vcs external registry`,
+`MIG047ResidualClustersTest.MIG-047-003 empty distribution marker clears distribution on jira ranges`,
+`MIG047VcsRegistryImportTest.MIG-047-004 emitMarkerOverrides pins vcs externalRegistry when vcs settings marker is emitted`
+
+---
+
+### MIG-048: RANGE_PRESENCE ranges must not inherit BASE jira.displayName
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Description:**
+V1 empty DSL version blocks produce null `component.displayName` on
+`jira-component-version-ranges`. Schema-v2 enumeration bled the BASE-row
+`jira.displayName` into RANGE_PRESENCE-only explicit ranges, causing NULL↔STRING
+TYPE_MISMATCH on CARDS/ANCS compat.
+
+**Acceptance criteria:**
+1. An explicit RANGE_PRESENCE range without a `jira.displayName` override returns null displayName even when the BASE row carries one.
+2. The ALL_VERSIONS / BASE anchor range still inherits `components.jira_display_name`.
+3. Broad-range `jira.displayName` overrides still apply to contained RANGE_PRESENCE ranges via MIG-046 containment.
+
+**Test method:**
+`MIG048JiraDisplayNameRangePresenceTest.MIG-048-001 RANGE_PRESENCE explicit range does not inherit BASE jira displayName`,
+`MIG048JiraDisplayNameRangePresenceTest.MIG-048-002 broad jira displayName override still applies to contained RANGE_PRESENCE range`

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -1160,7 +1160,20 @@ and ignored per-range DSL overrides, causing TYPE_MISMATCH NULL↔STRING on
 2. A null-clear override row (`jira.displayName` override with NULL column) returns null
    displayName for that range and does not fall back to `components.jira_display_name`.
 3. Ranges without an override inherit `components.jira_display_name` as today.
+4. `ImportServiceImpl.populateScalarsFromConfig` writes explicit `jira.displayName = null` from
+   the DSL onto the configuration row (no `?.let` skip).
+5. Synthetic-base explicit ranges with a jira block do not inherit `components.jira_display_name`
+   when the merged row carries null.
+6. DB-backed HTTP `GET /rest/api/2/projects/{projectKey}/jira-component-version-ranges` surfaces
+   per-range displayName values after auto-migrate.
 
 **Test method:**
 `MIG045JiraDisplayNamePerRangeTest.MIG-045-001 per-range jira displayName override on jira-component-version-ranges`,
-`MIG045JiraDisplayNamePerRangeTest.MIG-045-002 null jira displayName override clears inherited displayName for range`
+`MIG045JiraDisplayNamePerRangeTest.MIG-045-002 null jira displayName override clears inherited displayName for range`,
+`MIG045JiraDisplayNamePerRangeTest.MIG-045-003 synthetic base range explicit null displayName does not inherit component default`,
+`MIG045JiraDisplayNameImportTest.MIG-045-004 populateScalarsFromConfig writes null jira displayName from jira block`,
+`MIG045JiraDisplayNameImportTest.MIG-045-005 emitScalarOverrides emits jira displayName scalar override row`,
+`MigrationIntegrationTest.mig045_importPersistsPerRangeJiraDisplayNameScalars`,
+`DbBackedComponentsRegistryServiceControllerTest.testMIG045006_importPersistsPerRangeJiraDisplayNameScalars_dbMode`,
+`DbBackedComponentsRegistryServiceControllerTest.testMIG045007_nullClearSurvivesComponentLevelDefault_dbMode`,
+`DbBackedComponentsRegistryServiceControllerTest.testMIG045008_perRangeJiraDisplayNameOnProjectJiraComponentVersionRanges_dbMode`

--- a/scripts/local-stands/README.md
+++ b/scripts/local-stands/README.md
@@ -106,6 +106,20 @@ baseline + current-chain candidate) and runs the compat-test against them,
 see [`TEAMCITY.md`](TEAMCITY.md). The wrapper [`teamcity-run.sh`](teamcity-run.sh)
 chains postgres → baseline JAR → candidate JAR → compat → teardown.
 
+**TC build types:** `[1.9]` (`id19`) runs only `Cluster50CompatTest` (CARDS/ANCS
+jira-ranges + authmodlib distribution, ~50-diff cluster). `[1.7]` (`id17`) runs
+the full matrix + 30k trace replay and auto-fires after `[1.9]` succeeds. Locally,
+run the same cluster gate with stands up:
+
+```bash
+./gradlew :components-registry-compat-test:test \
+  --tests "org.octopusden.octopus.components.registry.compat.Cluster50CompatTest"
+```
+
+For raw-only replay of the bundled fixture (fast triage, no typed layer), use
+[`residual-replay.sh`](residual-replay.sh) with
+`COMPAT_RESIDUAL_FILE=components-registry-compat-test/src/test/resources/compat/cluster-50-fixture.txt`.
+
 ## Tear-down
 
 ```bash

--- a/scripts/local-stands/candidate.sh
+++ b/scripts/local-stands/candidate.sh
@@ -60,6 +60,8 @@ done
 }
 
 ADDITIONAL_LOCATION="file:$CANDIDATE_WORKTREE/components-registry-service-server/dev/"
+ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/application.yml"
+ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/application-qa.yml"
 ADDITIONAL_LOCATION="$ADDITIONAL_LOCATION,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
 
 WORK_DIR="${WORK_DIR:-/tmp/crs-candidate-work}"

--- a/scripts/local-stands/extract-residual-fixture.py
+++ b/scripts/local-stands/extract-residual-fixture.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Extract a residual replay fixture from compat exec-worker ndjson (TC artifacts).
+
+Input: exec-worker-*.ndjson (ExecutionLogger output) — one JSON object per line.
+Output: trace-compatible file: ``count<TAB>METHOD<TAB>path`` (count=1 for each tuple).
+
+Only rows with diffCount > 0 are emitted. Dedupes by (METHOD, path).
+
+Usage:
+  python3 scripts/local-stands/extract-residual-fixture.py \\
+    /path/to/exec-worker-*.ndjson \\
+    /tmp/residual-fixture.txt
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from urllib.parse import urlencode
+
+
+def expand_path(endpoint: str, path_params: dict[str, Any], query_params: dict[str, Any]) -> tuple[str, str]:
+    method, path_template = endpoint.split(" ", 1)
+    path = path_template
+    for key, value in (path_params or {}).items():
+        path = path.replace("{" + key + "}", str(value))
+    q = {k: v for k, v in (query_params or {}).items() if k != "_weight" and v is not None}
+    if q:
+        path = path + "?" + urlencode(q)
+    return method.upper(), path
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: extract-residual-fixture.py <exec-worker.ndjson> <out.txt>", file=sys.stderr)
+        return 2
+    src, dst = sys.argv[1], sys.argv[2]
+    seen: set[tuple[str, str]] = set()
+    lines: list[str] = []
+    total = 0
+    with open(src, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            total += 1
+            rec = json.loads(line)
+            if (rec.get("diffCount") or 0) <= 0:
+                continue
+            method, path = expand_path(
+                rec["endpoint"],
+                rec.get("pathParams") or {},
+                rec.get("queryParams") or {},
+            )
+            key = (method, path)
+            if key in seen:
+                continue
+            seen.add(key)
+            lines.append(f"1\t{method}\t{path}\n")
+    with open(dst, "w", encoding="utf-8") as out:
+        out.writelines(lines)
+    print(f"read {total} exec rows, wrote {len(lines)} unique failing tuples -> {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local-stands/residual-replay.sh
+++ b/scripts/local-stands/residual-replay.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Replay only the failing tuples from a prior TC run (exec-worker ndjson).
+#
+# Prereqs: baseline + candidate stands up (teamcity-run.sh or verify.sh --restart).
+# Generate fixture from TC artifacts:
+#   python3 scripts/local-stands/extract-residual-fixture.py \
+#     exec-worker-*.ndjson /tmp/residual-tc3841.txt
+#
+# Usage:
+#   export COMPAT_RESIDUAL_FILE=/tmp/residual-tc3841.txt
+#   export COMPAT_RESIDUAL_FILE=components-registry-compat-test/src/test/resources/compat/cluster-50-fixture.txt
+#   ./scripts/local-stands/residual-replay.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANDIDATE_WORKTREE="${CANDIDATE_WORKTREE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+BASELINE_PORT="${BASELINE_PORT:-4567}"
+CANDIDATE_PORT="${CANDIDATE_PORT:-4568}"
+
+: "${COMPAT_RESIDUAL_FILE:?COMPAT_RESIDUAL_FILE must point at extract-residual-fixture.py output}"
+
+export COMPAT_BASELINE_URL="${COMPAT_BASELINE_URL:-http://localhost:$BASELINE_PORT}"
+export COMPAT_CANDIDATE_URL="${COMPAT_CANDIDATE_URL:-http://localhost:$CANDIDATE_PORT}"
+export COMPAT_FULL="${COMPAT_FULL:-true}"
+export COMPAT_PARALLELISM="${COMPAT_PARALLELISM:-8}"
+
+cd "$CANDIDATE_WORKTREE"
+exec ./gradlew :components-registry-compat-test:test \
+  --tests "org.octopusden.octopus.components.registry.compat.ResidualReplayCompatTest" \
+  --no-daemon --console=plain "$@"

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -262,6 +262,13 @@ CANDIDATE_WORK_DIR="${CANDIDATE_WORK_DIR:-/tmp/crs-candidate-tc-work}"
 #                          force no-migration + git routing (top of Spring's
 #                          property-source order, so they beat service-config).
 CANDIDATE_ADDITIONAL="file:$CANDIDATE_WORKTREE/components-registry-service-server/dev/"
+# Mirror baseline's service-config layering: application.yml supplies shared
+# placeholders (domain, auth-server, …); application-qa.yml resolves
+# api-gateway.hostname so components-registry-service.yml's employee-service.url
+# can bind when enabled=true. Without these, v3+ candidates fail context init
+# on bootJar/local-stand runs even though TC docker images may bake the values in.
+CANDIDATE_ADDITIONAL="$CANDIDATE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/application.yml"
+CANDIDATE_ADDITIONAL="$CANDIDATE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/application-qa.yml"
 CANDIDATE_ADDITIONAL="$CANDIDATE_ADDITIONAL,file:$SERVICE_CONFIG_DIR/components-registry-service.yml"
 CANDIDATE_AUTOMIGRATE_ARG=""
 CANDIDATE_DEFAULTSOURCE_ARG=""

--- a/scripts/local-stands/test/test-verify-lib.sh
+++ b/scripts/local-stands/test/test-verify-lib.sh
@@ -103,6 +103,17 @@ case_clean_inner_marker() {
   return 0
 }
 
+case_clean_inner_marker_with_duration() {
+  local log="$TMPD/log-clean-duration.txt"
+  write_log "$log" \
+    "2026-05-16 10:05 INFO  Migration complete in 12345 ms: total=948, migrated=948, failed=0, skipped=0"
+  local out
+  out=$(check_migration_health "$log")
+  assert_contains "total=948" "$out" "duration-form summary line" || return 1
+  assert_contains "failed=0" "$out" "duration-form summary line" || return 1
+  return 0
+}
+
 case_polluted_inner_marker_exits_4() {
   local log="$TMPD/log-polluted-inner.txt"
   write_log "$log" \
@@ -331,6 +342,7 @@ case_wait_port_free_eventually_becomes_free() {
 
 echo "=== check_migration_health ==="
 run_case "clean run, inner marker → no POLLUTED" case_clean_inner_marker
+run_case "clean run, inner marker with duration → no POLLUTED" case_clean_inner_marker_with_duration
 run_case "polluted run, inner marker → exit 4"   case_polluted_inner_marker_exits_4
 run_case "polluted + ALLOW_PARTIAL=1 → exit 0"   case_polluted_allows_partial
 run_case "outer wrapper only, '10 failed' parsed exactly" case_outer_wrapper_only_polluted

--- a/scripts/local-stands/verify.sh
+++ b/scripts/local-stands/verify.sh
@@ -91,7 +91,7 @@ check_migration_health() {
   #   "Migration complete: total=X, migrated=Y, failed=Z, skipped=W"
   # and fall back to the outer ComponentsRegistryServiceImpl wrapper
   #   "Auto-migrate complete: X migrated, Y skipped, Z failed".
-  line=$(grep -E 'Migration complete: total=' "$log" 2>/dev/null | tail -n 1 || true)
+  line=$(grep -E 'Migration complete.*total=[0-9]+' "$log" 2>/dev/null | tail -n 1 || true)
   if [ -n "$line" ]; then
     total=$(echo    "$line" | sed -E 's/.*total=([0-9]+).*/\1/')
     migrated=$(echo "$line" | sed -E 's/.*migrated=([0-9]+).*/\1/')

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -1204,6 +1204,37 @@ TEST_PER_RANGE_HOTFIX_FORMAT {
     }
 }
 
+// MIG-045 fixture: per-range jira.displayName override + explicit null-clear on
+// the synthetic base range. Pins import (populateScalarsFromConfig) and DB
+// resolver read path for jira-component-version-ranges parity.
+TEST_PER_RANGE_JIRA_DISPLAY_NAME {
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.display.range"
+    artifactId = "test-per-range-display"
+    jira {
+        projectKey = "PRDN"
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        buildVersionFormat = '$major.$minor.$service-$fix'
+        lineVersionFormat = '$major'
+        displayName = "Component Default Display"
+    }
+    distribution {
+        explicit = false
+        external = true
+    }
+    "[1.0,2.0)" {
+        jira {
+            displayName = null
+        }
+    }
+    "[2.0,)" {
+        jira {
+            displayName = "Range Override Display"
+        }
+    }
+}
+
 
 NON_ARCHIVED_TEST_COMPONENT {
     jira {

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -2067,5 +2067,65 @@
       "versionControlSystemRoots": [],
       "externalRegistry": null
     }
+  },
+  {
+    "componentName": "TEST_PER_RANGE_JIRA_DISPLAY_NAME",
+    "versionRange": "[1.0,2.0)",
+    "component": {
+      "projectKey": "PRDN",
+      "displayName": null,
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": null
+      },
+      "componentInfo": null,
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      }
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
+  },
+  {
+    "componentName": "TEST_PER_RANGE_JIRA_DISPLAY_NAME",
+    "versionRange": "[2.0,)",
+    "component": {
+      "projectKey": "PRDN",
+      "displayName": "Range Override Display",
+      "componentVersionFormat": {
+        "majorVersionFormat": "$major",
+        "releaseVersionFormat": "$major.$minor.$service",
+        "buildVersionFormat": "$major.$minor.$service-$fix",
+        "lineVersionFormat": "$major",
+        "hotfixVersionFormat": null
+      },
+      "componentInfo": null,
+      "technical": false
+    },
+    "distribution": {
+      "explicit": false,
+      "external": true,
+      "securityGroups": {
+        "read": [
+          "vfiler1-default#group"
+        ]
+      }
+    },
+    "vcsSettings": {
+      "versionControlSystemRoots": [],
+      "externalRegistry": null
+    }
   }
 ]

--- a/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
+++ b/test-common/src/test/resources/expected-data/jira-component-version-ranges.json
@@ -2079,9 +2079,12 @@
         "releaseVersionFormat": "$major.$minor.$service",
         "buildVersionFormat": "$major.$minor.$service-$fix",
         "lineVersionFormat": "$major",
-        "hotfixVersionFormat": null
+        "hotfixVersionFormat": "$major.$minor.$service-$fix.$build"
       },
-      "componentInfo": null,
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
       "technical": false
     },
     "distribution": {
@@ -2109,9 +2112,12 @@
         "releaseVersionFormat": "$major.$minor.$service",
         "buildVersionFormat": "$major.$minor.$service-$fix",
         "lineVersionFormat": "$major",
-        "hotfixVersionFormat": null
+        "hotfixVersionFormat": "$major.$minor.$service-$fix.$build"
       },
-      "componentInfo": null,
+      "componentInfo": {
+        "versionPrefix": "",
+        "versionFormat": "$versionPrefix-$baseVersionFormat"
+      },
       "technical": false
     },
     "distribution": {


### PR DESCRIPTION
## Summary

- Rebuilds the CARDS/ANCS jira-ranges + authmodlib distribution compat work on top of `v3` via cherry-picks MIG-045…MIG-050 and cluster digest — **without** MIG-051 (EntityMappers distribution inherit + ordered jira-ranges compare), which caused the #3841 diff explosion.
- Adds **TC [1.9] (`id19CompatClusterGateAuto`)** running only `Cluster50CompatTest` (~4 endpoints, ~50-diff cluster); **[1.7] now chains after [1.9]** so the full 30k-trace gate skips when this cluster regresses.
- Adds residual-replay tooling (`ResidualReplayCompatTest`, `extract-residual-fixture.py`, reporter `Illegal group reference` fix) for fast local triage — opt-in via `COMPAT_RESIDUAL_FILE`.

## Test plan

- [ ] Apply `.teamcity/settings.kts` on TeamCity so [1.9] appears in the build chain
- [ ] [1.0] Compile&UT green on this branch
- [ ] [1.9] Cluster-50 gate: expect red or reduced active diffs vs #3834 baseline (~50) — **not** claiming green in this PR
- [ ] [1.7] full gate runs only after [1.9] succeeds
- [ ] Local: `verify.sh --restart` then `Cluster50CompatTest` against stands on 4567/4568
- [ ] MIG-051 EntityMappers fix for [1.2] Integration DB tracked separately if needed


Made with [Cursor](https://cursor.com)