### PR TITLE
refactor: drop dead buildSystemVersion from v4 API, DB schema and internals

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
@@ -63,7 +63,6 @@ enum class ConfigurationRowType {
 
 data class BuildAspectResponse(
     val buildSystem: String? = null,
-    val buildSystemVersion: String? = null,
     val javaVersion: String? = null,
     val mavenVersion: String? = null,
     val gradleVersion: String? = null,
@@ -176,7 +175,6 @@ data class BaseConfigurationRequest(
 
 data class BuildAspectRequest(
     val buildSystem: String? = null,
-    val buildSystemVersion: String? = null,
     val javaVersion: String? = null,
     val mavenVersion: String? = null,
     val gradleVersion: String? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
@@ -86,9 +86,6 @@ class ComponentConfigurationEntity(
     @Column(name = "build_system", length = 50)
     var buildSystem: String? = null,
 
-    @Column(name = "build_system_version", length = 50)
-    var buildSystemVersion: String? = null,
-
     @Column(name = "java_version", length = 50)
     var javaVersion: String? = null,
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
@@ -32,7 +32,6 @@ import org.octopusden.octopus.components.registry.server.entity.ComponentConfigu
 internal val SCALAR_ATTRIBUTE_PATHS: Set<String> =
     setOf(
         "build.buildSystem",
-        "build.buildSystemVersion",
         "build.javaVersion",
         "build.mavenVersion",
         "build.gradleVersion",
@@ -80,7 +79,6 @@ internal val SCALAR_ATTRIBUTE_PATHS: Set<String> =
 internal fun ComponentConfigurationEntity.extractScalarValue(): Any? =
     when (overriddenAttribute) {
         "build.buildSystem" -> buildSystem
-        "build.buildSystemVersion" -> buildSystemVersion
         "build.javaVersion" -> javaVersion
         "build.mavenVersion" -> mavenVersion
         "build.gradleVersion" -> gradleVersion
@@ -139,7 +137,6 @@ internal fun ComponentConfigurationEntity.applyScalarValue(
 
     when (attributePath) {
         "build.buildSystem" -> buildSystem = requireBuildSystem(attributePath, value)
-        "build.buildSystemVersion" -> buildSystemVersion = requireString(attributePath, value)
         "build.javaVersion" -> javaVersion = requireString(attributePath, value)
         "build.mavenVersion" -> mavenVersion = requireString(attributePath, value)
         "build.gradleVersion" -> gradleVersion = requireString(attributePath, value)
@@ -173,7 +170,6 @@ internal fun ComponentConfigurationEntity.applyScalarValue(
 @Suppress("LongMethod")
 private fun ComponentConfigurationEntity.clearAllScalarColumns() {
     buildSystem = null
-    buildSystemVersion = null
     javaVersion = null
     mavenVersion = null
     gradleVersion = null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -439,7 +439,6 @@ private fun <T> pickMarkerChildren(
  */
 internal class ComponentConfigurationView {
     var buildSystem: String? = null
-    var buildSystemVersion: String? = null
     var javaVersion: String? = null
     var mavenVersion: String? = null
     var gradleVersion: String? = null
@@ -496,7 +495,6 @@ internal class ComponentConfigurationView {
         // through — that was the root cause of bugs F (bug-F-component.buildFilePath) and G (bug-G-component.versionPrefix).
         when (override.overriddenAttribute) {
             "build.buildSystem" -> buildSystem = override.buildSystem
-            "build.buildSystemVersion" -> buildSystemVersion = override.buildSystemVersion
             "build.javaVersion" -> javaVersion = override.javaVersion
             "build.mavenVersion" -> mavenVersion = override.mavenVersion
             "build.gradleVersion" -> gradleVersion = override.gradleVersion
@@ -637,7 +635,6 @@ internal class ComponentConfigurationView {
         fun from(base: ComponentConfigurationEntity): ComponentConfigurationView =
             ComponentConfigurationView().apply {
                 buildSystem = base.buildSystem
-                buildSystemVersion = base.buildSystemVersion
                 javaVersion = base.javaVersion
                 mavenVersion = base.mavenVersion
                 gradleVersion = base.gradleVersion

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -250,7 +250,6 @@ private fun <T> ComponentConfigurationEntity.pickChildRows(
 private fun ComponentConfigurationEntity.buildAspectResponse(): BuildAspectResponse =
     BuildAspectResponse(
         buildSystem = buildSystem,
-        buildSystemVersion = buildSystemVersion,
         javaVersion = javaVersion,
         mavenVersion = mavenVersion,
         gradleVersion = gradleVersion,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1237,7 +1237,6 @@ class ComponentManagementServiceImpl(
         request.versionRange?.let { config.versionRange = it }
         request.build?.let { b ->
             config.buildSystem = b.buildSystem
-            config.buildSystemVersion = b.buildSystemVersion
             config.javaVersion = b.javaVersion
             config.mavenVersion = b.mavenVersion
             config.gradleVersion = b.gradleVersion
@@ -1294,7 +1293,6 @@ class ComponentManagementServiceImpl(
         patch.versionRange?.let { config.versionRange = it }
         patch.build?.let { b ->
             b.buildSystem?.let { config.buildSystem = it }
-            b.buildSystemVersion?.let { config.buildSystemVersion = it }
             b.javaVersion?.let { config.javaVersion = it }
             b.mavenVersion?.let { config.mavenVersion = it }
             b.gradleVersion?.let { config.gradleVersion = it }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1895,7 +1895,6 @@ class ImportServiceImpl(
         }
 
         diffScalar("build.buildSystem", base.buildSystem, override.buildSystem)
-        diffScalar("build.buildSystemVersion", base.buildSystemVersion, override.buildSystemVersion)
         diffScalar("build.javaVersion", base.javaVersion, override.javaVersion)
         diffScalar("build.mavenVersion", base.mavenVersion, override.mavenVersion)
         diffScalar("build.gradleVersion", base.gradleVersion, override.gradleVersion)
@@ -1945,7 +1944,6 @@ class ImportServiceImpl(
     ) {
         when (attrPath) {
             "build.buildSystem" -> row.buildSystem = value?.toString()
-            "build.buildSystemVersion" -> row.buildSystemVersion = value?.toString()
             "build.javaVersion" -> row.javaVersion = value?.toString()
             "build.mavenVersion" -> row.mavenVersion = value?.toString()
             "build.gradleVersion" -> row.gradleVersion = value?.toString()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
@@ -281,14 +281,13 @@ class ComponentCodeRenderer(
     ) {
         val hasContent =
             listOf(
-                s.buildSystem, s.buildSystemVersion, s.javaVersion, s.mavenVersion, s.gradleVersion,
+                s.buildSystem, s.javaVersion, s.mavenVersion, s.gradleVersion,
                 s.buildFilePath, s.projectVersion, s.systemProperties, s.buildTasks,
             ).any { it != null } || s.deprecated != null || s.requiredProject != null ||
                 requiredTools.isNotEmpty() || buildToolBeans.isNotEmpty()
         if (!hasContent) return
         cb.open("build")
         cb.bare("buildSystem", s.buildSystem)
-        cb.str("buildSystemVersion", s.buildSystemVersion)
         cb.str("javaVersion", s.javaVersion)
         cb.str("mavenVersion", s.mavenVersion)
         cb.str("gradleVersion", s.gradleVersion)

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -131,7 +131,6 @@ CREATE TABLE component_configurations (
     is_synthetic_base                           BOOLEAN NOT NULL DEFAULT false, -- true on base row when DSL had no top-level fields
     -- BUILD aspect:
     build_system                                VARCHAR(50),
-    build_system_version                        VARCHAR(50),
     java_version                                VARCHAR(50),
     maven_version                               VARCHAR(50),
     gradle_version                              VARCHAR(50),
@@ -210,7 +209,7 @@ CREATE TABLE component_configurations (
     -- typed column" rule is enforced in the service layer (too verbose for
     -- CHECK with 28 columns).
     CHECK (row_type NOT IN ('MARKER', 'RANGE_PRESENCE') OR (
-        build_system IS NULL AND build_system_version IS NULL AND java_version IS NULL
+        build_system IS NULL AND java_version IS NULL
         AND maven_version IS NULL AND gradle_version IS NULL AND build_file_path IS NULL
         AND deprecated IS NULL AND required_project IS NULL AND project_version IS NULL
         AND system_properties IS NULL AND build_tasks IS NULL AND escrow_build_task IS NULL

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -427,7 +427,7 @@ class MigrationIntegrationTest {
         assertNull(presence.overriddenAttribute, "RANGE_PRESENCE row must have NULL overridden_attribute")
         assertFalse(presence.isSyntheticBase, "RANGE_PRESENCE row must not be marked synthetic")
         // All 28 typed scalar columns must be NULL on a presence row.
-        assertNull(presence.buildSystem); assertNull(presence.buildSystemVersion)
+        assertNull(presence.buildSystem)
         assertNull(presence.javaVersion); assertNull(presence.mavenVersion)
         assertNull(presence.gradleVersion); assertNull(presence.buildFilePath)
         assertNull(presence.deprecated); assertNull(presence.requiredProject)

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -170,7 +170,6 @@ Per-(component, version_range) typed rows; the spine of Model A'.
 | `is_synthetic_base` | BOOLEAN | NOT NULL DEFAULT false | structural flag: no all-versions block + ≥2 ranges (see §3.1); base may still carry real merged values |
 | Build aspect | | | |
 | `build_system` | VARCHAR(50) | | MAVEN/GRADLE/ESCROW_PROVIDED_MANUALLY/PROVIDED/etc. |
-| `build_system_version` | VARCHAR(50) | | |
 | `java_version` | VARCHAR(50) | | |
 | `maven_version` | VARCHAR(50) | | |
 | `gradle_version` | VARCHAR(50) | | |


### PR DESCRIPTION
## Why

`buildSystemVersion` ("Build System Version" in the old Components Registry) never had its own data source:

- No Kotlin DSL component in the real registry uses the `buildSystem { }` block at all (the only `version =` occurrences are Oracle tool versions inside `tools { database { oracle } }`).
- The Groovy DSL has no syntax for a dedicated build-system version.
- Therefore every `component_configurations.build_system_version` row is `NULL`.

**Precision note** (thanks reviewer): legacy v1–v3 `buildSystem.version` is *not* dead on the wire — `BuildParametersConverter` derives it at read time from `buildConfiguration`'s `gradleVersion`/`mavenVersion` (switch on build-system type). That derivation reads the maven/gradle version fields, which stay, so v1–v3 responses are byte-identical after this change. What's removed is the separate v4/DB field that duplicated nothing but NULLs.

## What

Removed from the new system surface:

- **v4 API**: `BuildAspectRequest` / `BuildAspectResponse` field
- **DB**: `build_system_version` column + its term in the consolidated MARKER/RANGE_PRESENCE NULL CHECK (typed scalar count 29 → 28; the old "28" comment was itself off by one — verified by counting the CHECK terms)
- **Internals**: entity, `ConfigurationRowAccessors` (paths/extract/apply/clear), `EntityMappers` (merge view + override apply), `V4Mappers`, `ImportServiceImpl` (diff/apply), `ComponentManagementServiceImpl` (create/patch), `ComponentCodeRenderer` (view-as-code)
- **Docs**: `docs/registry/schema-spec.md`

Kept for compatibility (untouched):

- v1–v3 API bean `ClassicBuildSystem` and its derivation in `BuildParametersConverter`
- Kotlin DSL `BuildSystemDSL.version` (published DSL artifact surface)

Old clients sending the field to v4 are unaffected — Jackson ignores unknown properties (Spring Boot default).

## Verification

- Full `gradlew build` green locally (CI-only docker/oc/automation tasks excluded)
- Independent Sonnet review: SHIP after one comment-count fix (applied)
- Pushed texts and diff scanned for redacted-identifier policy — clean

Portal counterpart PR (UI removal): octopusden/octopus-components-management-portal#80; **this PR merges first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)