### PR TITLE
fix(SYS-052): compat-stand candidate boot — resilient employee-service condition + stand off-switch

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/EmployeeServiceConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/EmployeeServiceConfig.kt
@@ -22,7 +22,8 @@ import org.springframework.core.type.AnnotatedTypeMetadata
  *   1. `@ConditionalOnProperty("employee-service.enabled", havingValue="true")`
  *      — the @Bean factory is only considered when the flag is on; and
  *   2. [EmployeeServiceUrlConfiguredCondition] — a half-configured env
- *      (`enabled=true` but no URL) does not register the client bean.
+ *      (`enabled=true` but no URL, or a URL whose placeholder does not resolve
+ *      in this environment — SYS-052) does not register the client bean.
  *
  * When no client bean is registered, `EmployeeDirectoryService`'s
  * `ObjectProvider<EmployeeServiceClient>` resolves empty and the active-employee
@@ -64,5 +65,23 @@ class EmployeeServiceUrlConfiguredCondition : Condition {
     override fun matches(
         context: ConditionContext,
         metadata: AnnotatedTypeMetadata,
-    ): Boolean = !context.environment.getProperty("employee-service.url").isNullOrBlank()
+    ): Boolean =
+        try {
+            !context.environment.getProperty("employee-service.url").isNullOrBlank()
+        } catch (e: IllegalArgumentException) {
+            // SYS-052: the configured URL contains a placeholder that does not
+            // resolve in this environment (e.g. an api-gateway hostname absent
+            // on the local compat stands). That is a half-configured env — per
+            // the contract above it must NOT register the client bean, and it
+            // must not fail context refresh either: degrade to fail-open.
+            log.warn(
+                "employee-service.url is not resolvable in this environment — employee-service client disabled: {}",
+                e.message,
+            )
+            false
+        }
+
+    private companion object {
+        private val log = LoggerFactory.getLogger(EmployeeServiceUrlConfiguredCondition::class.java)
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/EmployeeServiceConfigTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/EmployeeServiceConfigTest.kt
@@ -29,6 +29,27 @@ class EmployeeServiceConfigTest {
     }
 
     @Test
+    @DisplayName("SYS-052: enabled with unresolvable placeholder in url ⇒ context starts without a client bean")
+    fun `SYS-052 unresolvable url placeholder skips bean registration`() {
+        // Mirrors the compat-stand environment: service-config ships
+        // employee-service.url=https://${api-gateway.hostname}/employee-service
+        // while api-gateway.hostname is undefined on the stand. The condition
+        // must treat the unresolvable URL as "not configured" (fail-open, no
+        // client bean) instead of failing the whole context refresh.
+        ApplicationContextRunner()
+            .withUserConfiguration(EmployeeServiceConfig::class.java)
+            .withBean(EmployeeServiceProperties::class.java, { EmployeeServiceProperties(enabled = true, url = "") })
+            .withPropertyValues(
+                "employee-service.enabled=true",
+                "employee-service.url=https://\${api-gateway.hostname}/employee-service",
+            )
+            .run { context ->
+                assertEquals(null, context.startupFailure)
+                assertEquals(false, context.containsBean("employeeServiceClient"))
+            }
+    }
+
+    @Test
     @DisplayName("non-blank url ⇒ a ClassicEmployeeServiceClient is built")
     fun `non-blank url builds client`() {
         val props =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/EmployeeServiceConfigTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/EmployeeServiceConfigTest.kt
@@ -6,7 +6,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.octopusden.employee.client.EmployeeServiceClient
 import org.octopusden.employee.client.impl.ClassicEmployeeServiceClient
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 
 /**
  * Unit tests for the two-gate [EmployeeServiceConfig.employeeServiceClient]
@@ -48,6 +51,31 @@ class EmployeeServiceConfigTest {
                 assertEquals(false, context.containsBean("employeeServiceClient"))
             }
     }
+
+    @Test
+    @DisplayName("SYS-052: binding path — @EnableConfigurationProperties + unresolvable placeholder must not fail boot")
+    fun `SYS-052 unresolvable url placeholder boots through the real binding path`() {
+        // Unlike the case above (which stubs EmployeeServiceProperties via
+        // withBean and so bypasses the Binder), this goes through the real
+        // @EnableConfigurationProperties binding — locking that neither the
+        // condition NOR the properties binding throws on the unresolvable
+        // placeholder (the prod-misconfiguration scenario end-to-end).
+        ApplicationContextRunner()
+            .withUserConfiguration(BindingPathConfig::class.java)
+            .withPropertyValues(
+                "employee-service.enabled=true",
+                "employee-service.url=https://\${api-gateway.hostname}/employee-service",
+            )
+            .run { context ->
+                assertEquals(null, context.startupFailure)
+                assertEquals(false, context.containsBean("employeeServiceClient"))
+            }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(EmployeeServiceProperties::class)
+    @Import(EmployeeServiceConfig::class)
+    open class BindingPathConfig
 
     @Test
     @DisplayName("non-blank url ⇒ a ClassicEmployeeServiceClient is built")

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -60,6 +60,7 @@
 | SYS-049 | Git-history backfill records a component's first appearance with action `MIGRATED` (not `CREATE`); both audit read endpoints hide `MIGRATED` by default and opt back in via `includeMigrated=true`. `/audit/recent` additionally honours an explicit `action=MIGRATED` filter (the entity-history endpoint takes only `includeMigrated`) | High | unit + integration-test | ✅ Tested |
 | SYS-050 | Field-override (version-range) create/update/delete each publish a Component `UPDATE` audit event with an attribute-keyed diff | High | integration-test | ✅ Tested |
 | SYS-051 | TeamCity sync (automated `changedBy=system` reconciliation) does NOT write an audit row — the re-link is traced via an INFO log instead | Medium | unit-test | ✅ Tested |
+| SYS-052 | An `employee-service.url` whose placeholder does not resolve in the current environment is treated as "not configured": the client bean is not registered and context refresh succeeds (fail-open), instead of failing application boot | High | unit-test | ✅ Tested |
 
 ---
 
@@ -1720,3 +1721,37 @@ re-wire point if per-sync auditing is ever wanted).
 `SYS-051 happy path: writes TC row; counts updated; NO audit event`, plus the
 `ambiguousAutoResolved` and `mixed batch` cases assert
 `publisher.events.filterIsInstance<AuditEvent>().isEmpty()`.
+
+### SYS-052: Unresolvable employee-service.url placeholder must not fail boot
+
+**Priority:** High
+**Test layer:** unit-test
+**Status:** ✅ Tested
+
+**Motivation:**
+The shared service configuration ships `employee-service.url` as a value
+containing an environment-specific placeholder (an api-gateway hostname).
+Environments that do not define that placeholder (notably the local
+compatibility stands, where the candidate boots against a plain
+service-config checkout) previously died during context refresh:
+`EmployeeServiceUrlConfiguredCondition` resolved the property eagerly and the
+unresolvable placeholder threw `IllegalArgumentException` out of
+`Condition.matches`, failing the whole application instead of degrading. This
+took down all compat gates ([1.7]/[1.8]/[1.9]) on 2026-06-07.
+
+**Description:**
+`EmployeeServiceUrlConfiguredCondition` treats a URL whose placeholder cannot
+be resolved in the current environment exactly like a missing/blank URL: the
+condition returns `false` (no `employeeServiceClient` bean is registered, the
+active-employee check degrades to DISABLED — the documented fail-open
+behaviour) and a WARN line records why. Context refresh succeeds.
+
+**Acceptance criteria:**
+1. `employee-service.enabled=true` + `employee-service.url` with an unresolvable placeholder ⇒ application context starts.
+2. No `employeeServiceClient` bean is registered in that case.
+3. A resolvable, non-blank URL still registers the client bean (unchanged behaviour).
+4. A blank/missing URL still skips registration (unchanged behaviour).
+
+**Test method:** `EmployeeServiceConfigTest` —
+`SYS-052 unresolvable url placeholder skips bean registration` (plus the
+pre-existing blank-url and non-blank-url cases covering criteria 3–4).

--- a/scripts/local-stands/candidate.sh
+++ b/scripts/local-stands/candidate.sh
@@ -87,6 +87,10 @@ else
   echo ">>> port: $CANDIDATE_PORT,  VCS root: $LOCAL_VCS_ROOT  (work-dir: $WORK_DIR),  DB: none (no-db mode)"
 fi
 echo ">>> config: $SERVICE_CONFIG_DIR (overlaid on dev/)"
+# --employee-service.enabled=false: the active-employee validation is not part
+# of the compat comparison, and service-config may carry an employee-service.url
+# with an environment placeholder the stand cannot resolve (SYS-052) — mirrors
+# teamcity-run.sh's candidate boot. Candidate only; baseline.sh stays untouched.
 exec ./gradlew :components-registry-service-server:bootRun --no-daemon --console=plain \
   --args="--server.port=$CANDIDATE_PORT \
           --spring.profiles.active=$PROFILES \
@@ -94,4 +98,5 @@ exec ./gradlew :components-registry-service-server:bootRun --no-daemon --console
           --components-registry.vcs.root=file://$LOCAL_VCS_ROOT \
           --components-registry.work-dir=$WORK_DIR \
           --components-registry.groovy-path=$WORK_DIR/src/main/resources \
-          --auth-server.disabled=true$NODB_OVERRIDE_ARGS"
+          --auth-server.disabled=true \
+          --employee-service.enabled=false$NODB_OVERRIDE_ARGS"

--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -280,6 +280,10 @@ else
   CANDIDATE_PROFILES="dev,dev-vcs-local,dev-db-automigrate,dev-db-only,local"
 fi
 
+# --employee-service.enabled=false (candidate only): the active-employee
+# validation is not part of the compat comparison (the baseline predates it),
+# and service-config may carry an employee-service.url with an environment
+# placeholder the stand cannot resolve (SYS-052). Deterministically off.
 # shellcheck disable=SC2086  # CANDIDATE_*_ARG are single no-space tokens or empty
 nohup "$JAVA_BIN" -jar "$CANDIDATE_JAR" \
   --server.port="$CANDIDATE_PORT" \
@@ -292,6 +296,7 @@ nohup "$JAVA_BIN" -jar "$CANDIDATE_JAR" \
   --components-registry.version-name.service=serviceCards \
   --components-registry.version-name.minor=minorCards \
   --auth-server.disabled=true \
+  --employee-service.enabled=false \
   $CANDIDATE_AUTOMIGRATE_ARG \
   $CANDIDATE_DEFAULTSOURCE_ARG \
   $CANDIDATE_DATABASE_ARG \


### PR DESCRIPTION
## Problem

All compat gates ([1.7]/[1.8]/[1.9], runs on 2026-06-07) die before tests: the candidate fails context refresh with

`IllegalArgumentException: Could not resolve placeholder 'api-gateway.hostname' in value "https://${api-gateway.hostname}/employee-service"`

thrown from `EmployeeServiceUrlConfiguredCondition.matches`. Trigger: service-config now enables employee-service with a URL whose placeholder only resolves in environments that define the api-gateway hostname — the local stands don't.

## Fix (two slices)

1. **Product (`SYS-052`, RED→GREEN):** the condition treats an unresolvable placeholder exactly like a blank URL — WARN + `false`, context refresh proceeds. This is the class's documented two-gate fail-open contract (half-configured env ⇒ no client bean ⇒ active-employee check degrades to DISABLED), and fail-open is the locked decision per ADR-015 / TD-012. Covered by `EmployeeServiceConfigTest`: condition path (RED on v3 with the exact production stack) + real `@EnableConfigurationProperties` binding path.
2. **Infra:** `--employee-service.enabled=false` unconditionally on the **candidate** boot (`teamcity-run.sh` shared db/git path + `candidate.sh`); baseline untouched. The active-employee check is not part of the compat comparison (verified: compat tests hit only `rest/api/1|2|3`; the single bean gated by this flag is consumed by v4-only endpoints).

## Verification

- RED→GREEN demo: test commit fails on v3 with the production stack; fix commit turns it green (4/4 in `EmployeeServiceConfigTest`).
- Candidate boots healthy locally via `candidate.sh --mode=vcs` against the same service-config checkout that killed the TC runs; no employee-service activity in the boot log.
- Full `gradlew build` (CI-only tasks excluded) green; `:components-registry-service-server:dbTest` green (3m12s); `qualityStatic` green.
- Independent reviews: Sonnet correctness — SHIP; Opus adversarial — SHIP (its one residual, the unverified binding path, is closed by the added binding-path test).

## Watch after merge

Next v3 [1.9]/[1.8]/[1.7] runs must get past candidate boot (no exit 3 before tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)