### PR TITLE
fix(teamcity): validateConfig authenticates to employee-service via basic creds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1238,7 +1238,8 @@ object id20ValidateComponentsRegistryProductionDataAuto : BuildType({
                 -Pcomponents-registry-service.version=%BUILD_NUMBER%
                 -Puse_dev_repository=all
                 -Pemployee-service.url=%EMPLOYEE_SERVICE_URL%
-                -Pemployee-service.token=%EMPLOYEE_SERVICE_TOKEN%
+                -Pemployee-service.username=%EMPLOYEE_SERVICE_USERNAME%
+                -Pemployee-service.password=%EMPLOYEE_SERVICE_PASSWORD%
             """.trimIndent()
             enableStacktrace = true
             jdkHome = "%env.JAVA_HOME%"


### PR DESCRIPTION
## Problem

`[2.0] Validate Production Data [AUTO]` (the legacy `ComponentRegistryValidationTask` / `validateConfig` CR validation) fails on every **v3**-derived branch with:

```
=== Component Registry Validation Failed === : [401 Unauthorized] during [GET] to
[.../employee-service/employee/<id>] [EmployeeServiceClient#getEmployee(String)]
```

The step passed only `-Pemployee-service.token=%EMPLOYEE_SERVICE_TOKEN%`. `ClassicEmployeeServiceClient`'s request interceptor prefers a non-blank bearer token over basic credentials, so it sent `Authorization: Bearer <token>`. employee-service (`CloudCommonWebSecurityConfig` + `AuthServerClient`) rejects that token → 401.

`master` is green because it has no versioned `.teamcity/settings.kts` and runs on the pre-DSL server config, which authenticates with the `f1-technical-employee-service-user-teamcity` service account over **basic** auth. That is the canonical path (cf. employee-service FT `getSecuredClient()` uses basic; the bearer path there only feeds a fake token to assert a 401). The DSL port (#263) replaced basic with the bearer token, introducing the regression.

## Fix

Pass `username`/`password` instead of the token, so the client falls through to the basic-credentials branch. The token is intentionally dropped — passing both would re-trigger bearer precedence and the 401.

```diff
-                -Pemployee-service.token=%EMPLOYEE_SERVICE_TOKEN%
+                -Pemployee-service.username=%EMPLOYEE_SERVICE_USERNAME%
+                -Pemployee-service.password=%EMPLOYEE_SERVICE_PASSWORD%
```

`%EMPLOYEE_SERVICE_USERNAME%` / `%EMPLOYEE_SERVICE_PASSWORD%` already exist as TC server parameters.

## Validation

- `mvn -f .teamcity/pom.xml teamcity-configs:generate` succeeds; generated XML for the id20 step shows username/password and no token.
- `validateConfig` (Components-Registry `build.gradle`) maps `-Pemployee-service.username/password` → `cr.employeeServiceUsername/Password`; with the token absent, `getBearerToken()` is null and the client authenticates via basic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)