### PR TITLE
test: pin config-write authorization on POST /admin/reload-config (#250 п.3)

### DIFF
--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.cloud.context.refresh.ContextRefresher
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -80,6 +81,15 @@ class AdminControllerV4SecurityTest {
     private lateinit var teamcitySyncJobService:
         org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
 
+    /**
+     * Mocked so the `/reload-config` positive path does not trigger a real Spring Cloud
+     * Config refresh (which would re-fetch the profile and rebind AdminConfigProperties)
+     * in the test context. The 401/403 cases never reach the controller body — method
+     * security denies first — so `refresh()` must NOT be invoked there.
+     */
+    @MockBean
+    private lateinit var contextRefresher: ContextRefresher
+
     @Autowired
     private lateinit var mvc: MockMvc
 
@@ -115,6 +125,44 @@ class AdminControllerV4SecurityTest {
             .andExpect(status().isAccepted)
 
         verify(migrationJobService, times(1)).startAsync()
+    }
+
+    // #250: config-write guard. Since #343, field-config / component-defaults are
+    // code-as-config — the legacy ConfigControllerV4 PUTs are 410-Gone tombstones and
+    // the real write path is POST /admin/reload-config (re-reads service-config). It
+    // inherits AdminControllerV4's class-level @PreAuthorize("@permissionEvaluator.canImport()").
+    // These cases pin that the config-write capability stays IMPORT_DATA-gated so a
+    // later refactor can't silently move it off the admin gate.
+    @Test
+    @DisplayName("config-write: POST /admin/reload-config without JWT returns 401 and does not refresh")
+    fun `reload-config anonymous returns 401 and does not refresh`() {
+        mvc
+            .perform(post("/rest/api/4/admin/reload-config"))
+            .andExpect(status().isUnauthorized)
+
+        verify(contextRefresher, never()).refresh()
+    }
+
+    @Test
+    @DisplayName("config-write: POST /admin/reload-config with non-IMPORT_DATA JWT returns 403 and does not refresh")
+    fun `reload-config editor JWT returns 403 and does not refresh`() {
+        mvc
+            .perform(post("/rest/api/4/admin/reload-config").with(editorJwt()))
+            .andExpect(status().isForbidden)
+
+        verify(contextRefresher, never()).refresh()
+    }
+
+    @Test
+    @DisplayName("config-write: POST /admin/reload-config with IMPORT_DATA JWT returns 200 and refreshes exactly once")
+    fun `reload-config admin JWT returns 200 and refreshes`() {
+        `when`(contextRefresher.refresh()).thenReturn(emptySet())
+
+        mvc
+            .perform(post("/rest/api/4/admin/reload-config").with(adminJwt()))
+            .andExpect(status().isOk)
+
+        verify(contextRefresher, times(1)).refresh()
     }
 
     companion object {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -31,19 +31,21 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Instant
 
-// MIG-024: pin both gates that protect POST /rest/api/4/admin/migrate:
+// Pins the two gates that protect AdminControllerV4's endpoints, exercised through
+// the full security stack (a slice @WebMvcTest wouldn't load the real WebSecurityConfig):
 //   - URL-level requestMatchers("/rest/api/4/**").authenticated() in
 //     WebSecurityConfig → 401 for anonymous callers.
 //   - Class-level @PreAuthorize("@permissionEvaluator.canImport()") on
 //     AdminControllerV4 → 403 for authenticated callers without IMPORT_DATA.
 //
-// MigrationJobService is mocked so the positive path doesn't actually
-// kick a background migration in the test context. Slice tests
-// (@WebMvcTest) wouldn't load the real WebSecurityConfig, so the only
-// meaningful regression test is a full @SpringBootTest.
-//
-// The endpoint contract changed in this PR: it now returns 202 Accepted
-// with a JobResponse instead of 200 OK with FullMigrationResult.
+// Two surfaces are covered:
+//   - MIG-024: POST /admin/migrate (returns 202 Accepted with a JobResponse).
+//     MigrationJobService is mocked so the positive path doesn't kick a real
+//     background migration in the test context.
+//   - #250: POST /admin/reload-config — the config-write path since #343 made
+//     field-config/component-defaults code-as-config (the legacy ConfigControllerV4
+//     PUTs are now 410-Gone tombstones). ContextRefresher is mocked so the positive
+//     path doesn't trigger a real Spring Cloud Config refresh.
 @AutoConfigureMockMvc
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,


### PR DESCRIPTION
## What

Adds a regression guard pinning the **config-write authorization** on `POST /rest/api/4/admin/reload-config`.

## Why — resolves #250 sub-item 3 (now OBE)

`#250 п.3` flagged that `ConfigControllerV4` PUT `field-config`/`component-defaults` gated only on `canImport()` (no explicit `ACCESS_COMPONENTS`), suspecting an auth gap.

Re-checking against current `v3` HEAD (#343, code-as-config):
- Those two PUT endpoints are now **410-Gone tombstones** — they write nothing. The `@PreAuthorize` on them is moot; passing it just returns a static 410 body. **No vulnerability.**
- The real config-write path moved to **`POST /admin/reload-config`**, which inherits `AdminControllerV4`'s **class-level** `@PreAuthorize("@permissionEvaluator.canImport()")`.
- The implied "IMPORT_DATA without ACCESS_COMPONENTS" concern is **not exploitable**: in the role mapping `IMPORT_DATA` is granted only to `ROLE_ADMIN`, which always carries `ACCESS_COMPONENTS`. So `canImport() ⇒ ACCESS_COMPONENTS` by configuration.

So there is no code fix to make. Instead this locks the protection the review item cared about onto the surface it actually moved to, so a later refactor can't silently drop the gate.

## Change

Three cases added to `AdminControllerV4SecurityTest` (mirroring the existing `/migrate` trio):
| Caller | Expected |
|--------|----------|
| anonymous | 401, `refresh()` never invoked |
| authenticated, no `IMPORT_DATA` (editor) | 403, `refresh()` never invoked |
| `IMPORT_DATA` (admin) | 200, `refresh()` invoked once |

`ContextRefresher` is mocked so the positive path doesn't trigger a real Spring Cloud Config refresh.

**No production code change.** Considered alternative: add an explicit `ACCESS_COMPONENTS` conjunct to `AdminControllerV4`'s class gate — rejected as near-zero value (admin-only `IMPORT_DATA`) and it would alter the shared migrate/import gate.

## Verification

- `./gradlew :components-registry-service-server:dbTest --tests "*AdminControllerV4SecurityTest*"` → 6/6 green
- `./gradlew build` → SUCCESSFUL

Note: #250 п.1 (`FieldOverrideResponse @JsonInclude`) and п.2 (`labels` Set/List) remain open — this PR addresses п.3 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)