### PR TITLE
perf: eliminate N+1 in schema-v2 DB resolver batch reads (#321, #249)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.BatchSize
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.Instant
@@ -188,23 +189,30 @@ class ComponentConfigurationEntity(
     //     populated when overridden_attribute is a marker, or part of base) ---
 
     @OneToMany(mappedBy = "componentConfiguration", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var vcsEntries: MutableList<VcsSettingsEntryEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "componentConfiguration", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var mavenArtifacts: MutableList<DistributionMavenArtifactEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "componentConfiguration", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var fileUrlArtifacts: MutableList<DistributionFileUrlArtifactEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "componentConfiguration", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var dockerImages: MutableList<DistributionDockerImageEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "componentConfiguration", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var packages: MutableList<DistributionPackageEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "componentConfiguration", fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var requiredToolJunctions: MutableList<ComponentRequiredToolEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "componentConfiguration", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var buildToolBeans: MutableList<ComponentBuildToolBeanEntity> = mutableListOf(),
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
@@ -11,10 +11,20 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.Version
+import org.hibernate.annotations.BatchSize
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.Instant
 import java.util.UUID
+
+/**
+ * IN-clause batch size for the LAZY associations on the schema-v2 entities. Sized
+ * comfortably above the production component count so the resolver read paths load each
+ * collection role (and lazy to-one proxy) in a single `… IN (…)` select. See the
+ * `@BatchSize` rationale in [ComponentEntity]'s kdoc. File-scoped so both the class-level
+ * (`@ManyToOne` target) and field-level (`@OneToMany`) annotations can reference it.
+ */
+internal const val BATCH_FETCH_SIZE = 100
 
 /**
  * Schema v2 — top-level component entity.
@@ -27,8 +37,15 @@ import java.util.UUID
  *     M:N junctions — those are managed independently of the parent lifecycle.
  *
  *   - **Fetch default:** `FetchType.LAZY` everywhere (both `@ManyToOne` and
- *     `@OneToMany`). Hot-path repository methods opt in to eager loading via
- *     `@EntityGraph` rather than annotating the field.
+ *     `@OneToMany`). A hot-path read that needs a *single* collection eager can
+ *     opt in via `@EntityGraph` on the repository method. But the resolver read
+ *     paths (`find-by-artifacts`, `find-by-docker-images`) walk *several* bag
+ *     (`List`) collections per component, and a single `@EntityGraph`/fetch-join
+ *     cannot eager-fetch more than one bag at once — Hibernate throws
+ *     `MultipleBagFetchException`. Those collections therefore opt into IN-clause
+ *     batch loading via `@BatchSize` instead, which loads each role in its own
+ *     `WHERE parent_id IN (…)` select (immune to the multi-bag restriction) and
+ *     turns the per-component N+1 into a bounded number of batched selects.
  *
  *   - **`@Version`:** only on the top-level aggregate root (`ComponentEntity`).
  *     Sub-entities (`ComponentConfigurationEntity`, child rows, dictionary
@@ -58,6 +75,12 @@ import java.util.UUID
  */
 @Entity
 @Table(name = "components")
+// Class-level @BatchSize governs batched initialization of LAZY `@ManyToOne` proxies that
+// TARGET this entity (e.g. the self-referential `parentComponent`) — Hibernate reads the
+// to-one batch size from the target class, NOT from the referencing field, so a field-level
+// @BatchSize on `parentComponent` would be silently ignored. The `@OneToMany` bags below
+// carry their own field-level @BatchSize (that placement IS honoured for collections).
+@BatchSize(size = BATCH_FETCH_SIZE)
 class ComponentEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -84,6 +107,9 @@ class ComponentEntity(
     @Column(name = "solution")
     var solution: Boolean? = null,
 
+    // Batched via the class-level @BatchSize on the TARGET entities (ComponentEntity for
+    // parentComponent, ComponentGroupEntity for componentGroup) — to-one batch size is read
+    // from the target class, not the field, so no field-level @BatchSize here.
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_component_id")
     var parentComponent: ComponentEntity? = null,
@@ -150,29 +176,37 @@ class ComponentEntity(
     // --- Bidirectional collections (parent-owned children) ---
 
     @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var configurations: MutableList<ComponentConfigurationEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var artifactIds: MutableList<ComponentArtifactIdEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var securityGroups: MutableList<DistributionSecurityGroupEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var teamcityProjects: MutableList<ComponentTeamcityProjectEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var docLinks: MutableList<ComponentDocLinkEntity> = mutableListOf(),
 
     // Ordered multi-value people. No `@OrderBy` — sort by `sortOrder` in the
     // accessors / mappers (matching the artifactIds / docLinks convention).
     @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var releaseManagers: MutableList<ComponentReleaseManagerEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "component", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var securityChampions: MutableList<ComponentSecurityChampionEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "component", fetch = FetchType.LAZY)
+    @BatchSize(size = BATCH_FETCH_SIZE)
     var labelJunctions: MutableList<ComponentLabelEntity> = mutableListOf(),
 ) {
     /** Ordered release-manager usernames (first = primary). */

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentGroupEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentGroupEntity.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.BatchSize
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.Instant
@@ -12,6 +13,9 @@ import java.util.UUID
 
 @Entity
 @Table(name = "component_groups")
+// Class-level @BatchSize so the LAZY `ComponentEntity.componentGroup` to-one is batch-loaded
+// (to-one batch size is read from the target class, not the referencing field).
+@BatchSize(size = BATCH_FETCH_SIZE)
 class ComponentGroupEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ToolEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ToolEntity.kt
@@ -3,12 +3,19 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.BatchSize
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.Instant
 
 @Entity
 @Table(name = "tools")
+// Class-level @BatchSize so the LAZY `ComponentRequiredToolEntity.tool` to-one is batch-loaded
+// when the mapper builds the escrow view. Unlike `parentComponent` (a ComponentEntity co-loaded
+// by the read path's `findAll()`), tools live in a separate table and are NOT pre-loaded, so
+// without this each distinct required tool would issue its own SELECT (a real N+1). To-one batch
+// size is read from the target class, not the referencing field.
+@BatchSize(size = BATCH_FETCH_SIZE)
 class ToolEntity(
     @Id
     @Column(name = "name", length = 100, nullable = false)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentSourceRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentSourceRepository.kt
@@ -11,6 +11,17 @@ import org.springframework.transaction.annotation.Transactional
 interface ComponentSourceRepository : JpaRepository<ComponentSourceEntity, String> {
     fun findBySource(source: String): List<ComponentSourceEntity>
 
+    /**
+     * Projection of [findBySource] returning only the component keys. The routing
+     * layer's `getDbComponentNames()` / `getGitComponentNames()` need just the key
+     * set for membership checks, so this avoids hydrating full `ComponentSourceEntity`
+     * objects for every db-sourced row on each aggregate request (GH #249).
+     */
+    @Query("SELECT c.componentKey FROM ComponentSourceEntity c WHERE c.source = :source")
+    fun findComponentKeysBySource(
+        @Param("source") source: String,
+    ): List<String>
+
     fun countBySource(source: String): Long
 
     /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryImpl.kt
@@ -28,7 +28,7 @@ class ComponentSourceRegistryImpl(
         name: String,
         source: String,
     ) {
-        // Normalize THEN whitelist: `findBySource("db")` is case-sensitive and
+        // Normalize THEN whitelist: `findComponentKeysBySource("db")` is case-sensitive and
         // `ComponentRoutingResolver.resolverFor` checks `== "db"` exactly, so any
         // casing/whitespace variant would route the component to gitResolver and
         // silently exclude it from getDbComponentNames() → 404 blackhole.
@@ -62,9 +62,9 @@ class ComponentSourceRegistryImpl(
         componentSourceRepository.renameComponentKey(oldName, newName)
     }
 
-    override fun getDbComponentNames(): Set<String> = componentSourceRepository.findBySource("db").map { it.componentKey }.toSet()
+    override fun getDbComponentNames(): Set<String> = componentSourceRepository.findComponentKeysBySource("db").toSet()
 
-    override fun getGitComponentNames(): Set<String> = componentSourceRepository.findBySource("git").map { it.componentKey }.toSet()
+    override fun getGitComponentNames(): Set<String> = componentSourceRepository.findComponentKeysBySource("git").toSet()
 
     companion object {
         private val ALLOWED_SOURCES = setOf("git", "db")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -90,6 +90,20 @@ class DatabaseComponentRegistryResolver(
         version: String,
     ): EscrowModuleConfig? {
         val component = componentRepository.findByComponentKey(id) ?: return null
+        return getResolvedComponentDefinition(component, version)
+    }
+
+    /**
+     * Entity-accepting variant of [getResolvedComponentDefinition] — resolves off an
+     * already-loaded [ComponentEntity] so callers that hold the entity (e.g. the
+     * docker-image path) avoid a redundant `findByComponentKey` reload. Semantics are
+     * identical to the `(id, version)` override: null when the version resolves to no
+     * config, distribution-normalisation failures fall back to the raw version string.
+     */
+    private fun getResolvedComponentDefinition(
+        component: ComponentEntity,
+        version: String,
+    ): EscrowModuleConfig? {
         val config =
             component.toResolvedEscrowModuleConfig(
                 version = version,
@@ -107,7 +121,7 @@ class DatabaseComponentRegistryResolver(
         if (config.distribution != null) {
             val normalizedVersion =
                 try {
-                    getJiraComponentVersionToRangeByComponentAndVersion(id, version).first.version
+                    getJiraComponentVersionToRangeByComponentAndVersion(component, version).first.version
                 } catch (_: Exception) {
                     version
                 }
@@ -129,6 +143,27 @@ class DatabaseComponentRegistryResolver(
             1 -> results.first().first
             0 -> throw NotFoundException("Version '$version' for component '$component' is not found")
             else -> error("Found ${results.size} configurations for version '$version' of component '$component'")
+        }
+    }
+
+    /**
+     * Entity-accepting variant of [getJiraComponentVersion] — builds the ranges from an
+     * already-loaded [ComponentEntity] (no `findByComponentKey` reload). Used by the
+     * docker-image path, which holds the entity from [buildImageToComponentMap].
+     */
+    private fun getJiraComponentVersion(
+        component: ComponentEntity,
+        version: String,
+    ): JiraComponentVersion {
+        val jiraVersionRanges = buildJiraVersionRangesForComponent(component)
+        val results = getJiraComponentVersionsToRanges(version, jiraVersionRanges, false)
+        return when (results.size) {
+            1 -> results.first().first
+            0 -> throw NotFoundException("Version '$version' for component '${component.componentKey}' is not found")
+            else ->
+                error(
+                    "Found ${results.size} configurations for version '$version' of component '${component.componentKey}'",
+                )
         }
     }
 
@@ -440,9 +475,9 @@ class DatabaseComponentRegistryResolver(
         val imageNames = images.map { it.name }.toSet()
         return buildImageToComponentMap()
             .filterKeys(imageNames::contains)
-            .mapNotNull { (imgName, compKey) ->
+            .mapNotNull { (imgName, component) ->
                 images.find { it.name == imgName }?.let { requiredImage ->
-                    findConfigurationByDockerImage(imgName, requiredImage.tag, compKey)
+                    findConfigurationByDockerImage(imgName, requiredImage.tag, component)
                 }
             }.toSet()
     }
@@ -530,6 +565,27 @@ class DatabaseComponentRegistryResolver(
             1 -> results.first()
             0 -> throw NotFoundException("Version '$version' for component '$component' is not found")
             else -> error("Found ${results.size} configurations for version '$version' of component '$component'")
+        }
+    }
+
+    /**
+     * Entity-accepting variant of [getJiraComponentVersionToRangeByComponentAndVersion] —
+     * builds the ranges from an already-loaded [ComponentEntity] (no `findByComponentKey`
+     * reload).
+     */
+    private fun getJiraComponentVersionToRangeByComponentAndVersion(
+        component: ComponentEntity,
+        version: String,
+    ): Pair<JiraComponentVersion, JiraComponentVersionRange> {
+        val jiraVersionRanges = buildJiraVersionRangesForComponent(component)
+        val results = getJiraComponentVersionsToRanges(version, jiraVersionRanges, false)
+        return when (results.size) {
+            1 -> results.first()
+            0 -> throw NotFoundException("Version '$version' for component '${component.componentKey}' is not found")
+            else ->
+                error(
+                    "Found ${results.size} configurations for version '$version' of component '${component.componentKey}'",
+                )
         }
     }
 
@@ -635,12 +691,19 @@ class DatabaseComponentRegistryResolver(
                 .containsVersion(numericVersionFactory.create(versionString))
         }.getOrDefault(false)
 
-    private fun buildImageToComponentMap(): Map<String, String> {
-        val result = mutableMapOf<String, String>()
+    /**
+     * Map docker image name → the already-loaded [ComponentEntity] that declares it.
+     * Carrying the entity (not just its key) lets [findConfigurationByDockerImage]
+     * resolve without a per-image `findByComponentKey` reload; with `@BatchSize` on the
+     * walked collections, the single `findAll()` here plus the batched child loads cover
+     * the whole `find-by-docker-images` request in a bounded number of queries.
+     */
+    private fun buildImageToComponentMap(): Map<String, ComponentEntity> {
+        val result = mutableMapOf<String, ComponentEntity>()
         for (component in componentRepository.findAll()) {
             for (configuration in component.configurations) {
                 for (image in configuration.dockerImages) {
-                    result[image.imageName] = component.componentKey
+                    result[image.imageName] = component
                 }
             }
         }
@@ -650,11 +713,11 @@ class DatabaseComponentRegistryResolver(
     private fun findConfigurationByDockerImage(
         imageName: String,
         imageTag: String,
-        componentKey: String,
+        component: ComponentEntity,
     ): ComponentImage? {
         val versionString =
             try {
-                getJiraComponentVersion(componentKey, imageTag).version
+                getJiraComponentVersion(component, imageTag).version
             } catch (_: NotFoundException) {
                 return null
             }
@@ -664,10 +727,10 @@ class DatabaseComponentRegistryResolver(
         // docker() WITHOUT the version tag (e.g. "img" instead of "img:4.0.427"), so the
         // "$imageName:$imageTag" membership check never matched and find-by-docker-images returned
         // empty where the V1 baseline (whose escrow model is version-substituted) returns the image.
-        val config = getResolvedComponentDefinition(componentKey, versionString) ?: return null
+        val config = getResolvedComponentDefinition(component, versionString) ?: return null
         return config.distribution?.let { dist ->
             if (dist.docker()?.split(',')?.contains("$imageName:$imageTag") == true) {
-                ComponentImage(componentKey, versionString, Image(imageName, imageTag))
+                ComponentImage(component.componentKey, versionString, Image(imageName, imageTag))
             } else {
                 null
             }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentSourceRegistryWhitelistTest.kt
@@ -25,7 +25,7 @@ import org.octopusden.octopus.components.registry.server.repository.ComponentSou
  * The Opus adversarial review (P1-C on Group 1 + plan v3 Sonnet review)
  * flagged that the previous implementation persisted any string verbatim.
  * `ComponentRoutingResolver.resolverFor` does an exact `getSource(name) ==
- * "db"` check, and `getDbComponentNames()` calls `findBySource("db")`
+ * "db"` check, and `getDbComponentNames()` calls `findComponentKeysBySource("db")`
  * (case-sensitive query). Storing `"DB"`, `"DB "`, or any whitespace-
  * decorated variant routes the affected component to gitResolver and
  * excludes it from the db-routing set → 404 for any DB-only data.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverQueryCountTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverQueryCountTest.kt
@@ -16,8 +16,12 @@ import org.octopusden.octopus.components.registry.server.ComponentRegistryServic
 import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentRequiredToolEntity
 import org.octopusden.octopus.components.registry.server.entity.DistributionDockerImageEntity
+import org.octopusden.octopus.components.registry.server.entity.ToolEntity
 import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -44,11 +48,18 @@ import java.nio.file.Paths
  * `IN` selects and the docker path resolves off the already-loaded entity — so the
  * count is constant across fixture sizes.
  *
+ * Each fixture component carries one BASE config (artifactId + docker image + Jira
+ * project key), a parent reference (index > 0 → index 0), and a distinct required
+ * tool — so every batched role the mapper walks is exercised, including the two
+ * to-one associations whose batch size is read from the TARGET class (`parentComponent`
+ * → ComponentEntity, `tool` → ToolEntity). The docker fixture fully resolves, so the
+ * test reaches `getResolvedComponentDefinition` (the entity-threaded reload Part B
+ * removes), not just the pre-resolve short-circuit.
+ *
  * NOTE on the strict-equality assertion: it holds only while every per-role owner
  * count stays **below the `@BatchSize(100)` threshold** (a single `IN` batch per
- * role). The fixtures here (K = 2 and K = 8, one config + one artifactId + one
- * docker image each) are deliberately well under that bound. If a fixture is ever
- * grown past 100 owners of any role, switch the assertion to the
+ * role). The fixtures here (K = 2 and K = 8) are deliberately well under that bound.
+ * If a fixture is ever grown past 100 owners of any role, switch the assertion to the
  * `ceil(ownerCount / batchSize)`-shaped expectation instead of strict equality.
  *
  * Integration test: real PostgreSQL via Testcontainers, run under the `dbTest`
@@ -72,6 +83,12 @@ class DatabaseComponentRegistryResolverQueryCountTest {
     private lateinit var componentRepository: ComponentRepository
 
     @Autowired
+    private lateinit var toolRepository: ToolRepository
+
+    @Autowired
+    private lateinit var requiredToolRepository: ComponentRequiredToolRepository
+
+    @Autowired
     private lateinit var entityManagerFactory: EntityManagerFactory
 
     init {
@@ -88,28 +105,41 @@ class DatabaseComponentRegistryResolverQueryCountTest {
     fun cleanDatabase() {
         // Both target methods do componentRepository.findAll(); start from an empty
         // table so a later (larger) measurement is not polluted by earlier rows.
-        // The fixture only attaches CASCADE-ALL children (configurations,
-        // artifactIds, dockerImages), so deleteAll() removes the whole graph — no
-        // orphaned non-cascaded junction rows are created.
+        // Order matters: the component_required_tools junction is NOT cascade-deleted
+        // from the component (its @OneToMany has no cascade) and FKs both the config
+        // and the tool, so delete junctions first, then components (CASCADE-ALL removes
+        // configurations/artifactIds/dockerImages), then the now-unreferenced tools.
+        requiredToolRepository.deleteAll()
         componentRepository.deleteAll()
+        toolRepository.deleteAll()
     }
 
     /**
-     * One component with a single BASE configuration carrying an artifactId and a
-     * docker image — enough to exercise every lazy bag the artifact/docker read
-     * paths walk. Optionally references [parent] so the LAZY `@ManyToOne`
-     * `parentComponent` (read by the mapper) is also exercised. Saved via the
-     * aggregate root: CASCADE-ALL persists the children. Returns the managed entity.
+     * One component with a single BASE configuration carrying an artifactId, a docker
+     * image, a Jira project key (so the version resolves and the docker path reaches
+     * `getResolvedComponentDefinition`), and a distinct required tool (so the LAZY
+     * `ComponentRequiredToolEntity.tool` to-one is exercised). Optionally references
+     * [parent] so the LAZY `@ManyToOne` `parentComponent` is also walked.
+     *
+     * The component + its CASCADE-ALL children (config, artifactId, dockerImage) are
+     * saved via the aggregate root; the tool and the non-cascaded required-tool
+     * junction are persisted separately (the junction keyed by the saved config id).
+     * Returns the managed component entity.
      */
     private fun persistComponent(index: Int, parent: ComponentEntity?): ComponentEntity {
         val component = ComponentEntity(componentKey = "qc-comp-$index", archived = false)
         component.parentComponent = parent
         val base = ComponentConfigurationEntity(
             component = component,
-            versionRange = "[1.0.0,2.0.0)",
+            versionRange = VERSION_RANGE,
             overriddenAttribute = null,
             rowType = "BASE",
             buildSystem = "MAVEN",
+            // Jira project key → buildJiraComponent emits a JiraComponent (default version
+            // formats), so getJiraComponentVersion resolves IMAGE_TAG and the docker path
+            // proceeds into getResolvedComponentDefinition (the entity-threaded reload that
+            // Part B optimises) instead of short-circuiting at the NotFound catch.
+            jiraProjectKey = "QCPROJ$index",
         )
         base.dockerImages.add(
             DistributionDockerImageEntity(
@@ -127,7 +157,21 @@ class DatabaseComponentRegistryResolverQueryCountTest {
                 sortOrder = 0,
             ),
         )
-        return componentRepository.save(component)
+        val saved = componentRepository.save(component)
+
+        // Distinct required tool per component → the mapper's `junction.tool` access
+        // (EntityMappers.toBuildParameters) loads a different ToolEntity per component;
+        // without the class-level @BatchSize on ToolEntity that is a per-tool SELECT
+        // (N+1). The tool and the non-cascaded junction are persisted on their own.
+        val toolName = "qc-tool-$index"
+        toolRepository.save(ToolEntity(name = toolName))
+        requiredToolRepository.save(
+            ComponentRequiredToolEntity(
+                componentConfigurationId = saved.configurations.first().id!!,
+                toolName = toolName,
+            ),
+        )
+        return saved
     }
 
     /**
@@ -181,14 +225,24 @@ class DatabaseComponentRegistryResolverQueryCountTest {
     @DisplayName("find-by-docker-images statement count is independent of component / matched-image count")
     fun findByDockerImagesHasNoNPlusOne() {
         persistComponents(SMALL)
-        val smallImages = (0 until SMALL).map { Image("qc-image-$it", "1.0.0") }.toSet()
+        val smallImages = (0 until SMALL).map { Image("qc-image-$it", IMAGE_TAG) }.toSet()
         val small = measure { resolver.findComponentsByDockerImages(smallImages) }
 
         cleanDatabase()
         persistComponents(LARGE)
-        val largeImages = (0 until LARGE).map { Image("qc-image-$it", "1.0.0") }.toSet()
+        val largeImages = (0 until LARGE).map { Image("qc-image-$it", IMAGE_TAG) }.toSet()
         val large = measure { resolver.findComponentsByDockerImages(largeImages) }
 
+        // Every image must actually resolve — otherwise findConfigurationByDockerImage
+        // short-circuits at the NotFound catch and never reaches getResolvedComponentDefinition,
+        // leaving the entity-threaded reload path (Part B) unmeasured. IMAGE_TAG is a fixed point
+        // of the default `$major.$minor` version format, so calculateDistribution rewrites the
+        // docker entry "qc-image-N" → "qc-image-N:$IMAGE_TAG", matching the requested image.
+        assertEquals(
+            LARGE,
+            resolver.findComponentsByDockerImages(largeImages).size,
+            "every requested docker image must resolve (so the resolve path is actually exercised)",
+        )
         assertEquals(
             small,
             large,
@@ -206,13 +260,19 @@ class DatabaseComponentRegistryResolverQueryCountTest {
         private const val SMALL = 2
         private const val LARGE = 8
 
+        // Version range + tag chosen so IMAGE_TAG is a fixed point of the default
+        // `$major.$minor` Jira release format (normalize("1.2") == "1.2"), in range — so the
+        // docker entry resolves to "qc-image-N:1.2" and matches the requested image exactly.
+        private const val VERSION_RANGE = "[1.0,2.0)"
+        private const val IMAGE_TAG = "1.2"
+
         // Secondary backstops (the cross-size equality above is the primary guard).
-        // Both read paths drive `toEscrowModule`, which walks every child role, so the
-        // post-fix constant is "findAll + one batched IN select per collection role"
-        // (observed 15 for find-by-artifacts) — NOT 3. Calibrated from that observed
-        // post-fix baseline with headroom for Hibernate batch-loader drift.
-        private const val ARTIFACT_STATEMENT_BOUND = 20L
-        private const val DOCKER_STATEMENT_BOUND = 25L
+        // Both read paths drive `toEscrowModule`, which walks every child role (incl. the
+        // required-tool junction + tool to-one), so the post-fix constant is "findAll + one
+        // batched IN select per role". Calibrated from the observed post-fix baseline with
+        // headroom for Hibernate batch-loader drift.
+        private const val ARTIFACT_STATEMENT_BOUND = 25L
+        private const val DOCKER_STATEMENT_BOUND = 35L
 
         @JvmStatic
         val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverQueryCountTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolverQueryCountTest.kt
@@ -1,0 +1,230 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import jakarta.persistence.EntityManagerFactory
+import org.hibernate.SessionFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
+import org.octopusden.octopus.components.registry.core.dto.Image
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentArtifactIdEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionDockerImageEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Paths
+
+/**
+ * Query-count regression guard for the schema-v2 DB read path (GH #321 + #249).
+ *
+ * Asserts the JDBC-statement count of the batch read endpoints is **independent of
+ * the number of components** (and, for docker images, of the number of matched
+ * images) — i.e. there is no N+1. Uses Hibernate's
+ * [org.hibernate.stat.Statistics.getPrepareStatementCount] (every prepared
+ * statement = one round-trip; this is what exposes a lazy-collection N+1, whereas
+ * `queryExecutionCount` ignores collection-init selects and would not).
+ *
+ * Pre-fix (RED): `loadPerComponentArtifactParameters` / `buildImageToComponentMap`
+ * lazily dereference each component's bag collections, and `findConfigurationByDockerImage`
+ * reloads the component by key per matched image — so the count grows with K.
+ * Post-fix (GREEN): `@BatchSize` coalesces the lazy loads into a bounded number of
+ * `IN` selects and the docker path resolves off the already-loaded entity — so the
+ * count is constant across fixture sizes.
+ *
+ * NOTE on the strict-equality assertion: it holds only while every per-role owner
+ * count stays **below the `@BatchSize(100)` threshold** (a single `IN` batch per
+ * role). The fixtures here (K = 2 and K = 8, one config + one artifactId + one
+ * docker image each) are deliberately well under that bound. If a fixture is ever
+ * grown past 100 owners of any role, switch the assertion to the
+ * `ceil(ownerCount / batchSize)`-shaped expectation instead of strict equality.
+ *
+ * Integration test: real PostgreSQL via Testcontainers, run under the `dbTest`
+ * gradle task (`@Tag("integration")`). Scaffold mirrors
+ * `AuditLogRepositoryDeleteBySourceTest`.
+ */
+@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
+@ActiveProfiles("common", "test-db")
+@Timeout(180)
+@Tag("integration")
+class DatabaseComponentRegistryResolverQueryCountTest {
+
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var entityManagerFactory: EntityManagerFactory
+
+    init {
+        val testResourcesPath =
+            Paths.get(
+                DatabaseComponentRegistryResolverQueryCountTest::class.java.getResource("/expected-data")!!.toURI(),
+            ).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private val statistics get() = entityManagerFactory.unwrap(SessionFactory::class.java).statistics
+
+    @BeforeEach
+    fun cleanDatabase() {
+        // Both target methods do componentRepository.findAll(); start from an empty
+        // table so a later (larger) measurement is not polluted by earlier rows.
+        // The fixture only attaches CASCADE-ALL children (configurations,
+        // artifactIds, dockerImages), so deleteAll() removes the whole graph — no
+        // orphaned non-cascaded junction rows are created.
+        componentRepository.deleteAll()
+    }
+
+    /**
+     * One component with a single BASE configuration carrying an artifactId and a
+     * docker image — enough to exercise every lazy bag the artifact/docker read
+     * paths walk. Optionally references [parent] so the LAZY `@ManyToOne`
+     * `parentComponent` (read by the mapper) is also exercised. Saved via the
+     * aggregate root: CASCADE-ALL persists the children. Returns the managed entity.
+     */
+    private fun persistComponent(index: Int, parent: ComponentEntity?): ComponentEntity {
+        val component = ComponentEntity(componentKey = "qc-comp-$index", archived = false)
+        component.parentComponent = parent
+        val base = ComponentConfigurationEntity(
+            component = component,
+            versionRange = "[1.0.0,2.0.0)",
+            overriddenAttribute = null,
+            rowType = "BASE",
+            buildSystem = "MAVEN",
+        )
+        base.dockerImages.add(
+            DistributionDockerImageEntity(
+                componentConfiguration = base,
+                imageName = "qc-image-$index",
+                sortOrder = 0,
+            ),
+        )
+        component.configurations.add(base)
+        component.artifactIds.add(
+            ComponentArtifactIdEntity(
+                component = component,
+                groupPattern = "com.example.qc",
+                artifactPattern = "lib-$index",
+                sortOrder = 0,
+            ),
+        )
+        return componentRepository.save(component)
+    }
+
+    /**
+     * Persist [count] components. Index 0 is a parent; every other component points
+     * its `parentComponent` at it, so the read paths' `parentComponent` access is
+     * exercised for a count that scales with the fixture — this guards the to-one
+     * batch loading (class-level `@BatchSize` on the target entity), which a
+     * field-level annotation would NOT provide.
+     */
+    private fun persistComponents(count: Int) {
+        var parent: ComponentEntity? = null
+        repeat(count) { index ->
+            val saved = persistComponent(index, parent)
+            if (index == 0) parent = saved
+        }
+    }
+
+    /** Statement count of [block], measured in a session with a warm metamodel. */
+    private fun measure(block: () -> Unit): Long {
+        block() // warm-up — exclude one-time costs (metamodel init, etc.)
+        statistics.clear()
+        block()
+        return statistics.prepareStatementCount
+    }
+
+    @Test
+    @DisplayName("find-by-artifacts statement count is independent of component count (no N+1)")
+    fun findByArtifactsHasNoNPlusOne() {
+        val probe = setOf(ArtifactDependency("com.example.probe", "anything", "1.5.0"))
+
+        persistComponents(SMALL)
+        val small = measure { resolver.findComponentsByArtifact(probe) }
+
+        cleanDatabase()
+        persistComponents(LARGE)
+        val large = measure { resolver.findComponentsByArtifact(probe) }
+
+        assertEquals(
+            small,
+            large,
+            "find-by-artifacts must issue the same number of SQL statements for $SMALL and $LARGE " +
+                "components (a difference means a per-component N+1 was reintroduced)",
+        )
+        assertTrue(
+            large <= ARTIFACT_STATEMENT_BOUND,
+            "find-by-artifacts issued $large statements, expected <= $ARTIFACT_STATEMENT_BOUND",
+        )
+    }
+
+    @Test
+    @DisplayName("find-by-docker-images statement count is independent of component / matched-image count")
+    fun findByDockerImagesHasNoNPlusOne() {
+        persistComponents(SMALL)
+        val smallImages = (0 until SMALL).map { Image("qc-image-$it", "1.0.0") }.toSet()
+        val small = measure { resolver.findComponentsByDockerImages(smallImages) }
+
+        cleanDatabase()
+        persistComponents(LARGE)
+        val largeImages = (0 until LARGE).map { Image("qc-image-$it", "1.0.0") }.toSet()
+        val large = measure { resolver.findComponentsByDockerImages(largeImages) }
+
+        assertEquals(
+            small,
+            large,
+            "find-by-docker-images must issue the same number of SQL statements for $SMALL and $LARGE " +
+                "matched images (a difference means the per-image component reload / lazy N+1 was reintroduced)",
+        )
+        assertTrue(
+            large <= DOCKER_STATEMENT_BOUND,
+            "find-by-docker-images issued $large statements, expected <= $DOCKER_STATEMENT_BOUND",
+        )
+    }
+
+    companion object {
+        // Both deliberately below @BatchSize(100) so each role loads in one IN batch.
+        private const val SMALL = 2
+        private const val LARGE = 8
+
+        // Secondary backstops (the cross-size equality above is the primary guard).
+        // Both read paths drive `toEscrowModule`, which walks every child role, so the
+        // post-fix constant is "findAll + one batched IN select per collection role"
+        // (observed 15 for find-by-artifacts) — NOT 3. Calibrated from that observed
+        // post-fix baseline with headroom for Hibernate batch-loader drift.
+        private const val ARTIFACT_STATEMENT_BOUND = 20L
+        private const val DOCKER_STATEMENT_BOUND = 25L
+
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+            // Enable Hibernate statistics only for this test's application context.
+            registry.add("spring.jpa.properties.hibernate.generate_statistics") { "true" }
+        }
+    }
+}

--- a/docs/registry/non-functional-spec.md
+++ b/docs/registry/non-functional-spec.md
@@ -22,6 +22,35 @@
 - TTL: 5 minutes for list queries, 1 minute for individual component lookups
 - Cache-aside pattern: check cache → miss → query DB → populate cache
 
+### Read-path query efficiency (schema-v2 DB resolver)
+
+The batch read endpoints (`find-by-artifacts`, `find-by-docker-images`) and other
+aggregate reads in `DatabaseComponentRegistryResolver` load every component via one
+`findAll()` and then walk each component's child collections through the entity
+mapper. To keep this bounded rather than N+1:
+
+- **IN-clause batch loading via `@BatchSize`.** Every LAZY association on
+  `ComponentEntity` / `ComponentConfigurationEntity` carries `@BatchSize(size = 100)`.
+  After the initial `findAll()` loads all components into the session, the first access
+  to a collection role batch-loads that role for *all* resident components in a single
+  `WHERE parent_id IN (…)` select. A single multi-collection `@EntityGraph`/fetch-join
+  is **not** usable here: the collections are `List` bags and Hibernate rejects
+  fetch-joining more than one bag at once (`MultipleBagFetchException`). Net effect:
+  the per-request statement count is independent of the component count (a bounded set
+  of batched selects — roughly `findAll` + one IN select per collection role).
+- **No redundant per-image reloads.** `find-by-docker-images` threads the
+  already-loaded `ComponentEntity` from the image→component map straight into version
+  and definition resolution (entity-accepting private resolver variants), instead of
+  re-issuing `findByComponentKey` per matched image.
+- **Source-routing projection.** `getDbComponentNames()` / `getGitComponentNames()`
+  use a JPQL projection (`findComponentKeysBySource`) returning only the component-key
+  strings rather than hydrating full `component_source` entity rows on every aggregate
+  request.
+- **Regression guard.** `DatabaseComponentRegistryResolverQueryCountTest` (integration,
+  `dbTest`) asserts via Hibernate statistics that the statement count of these endpoints
+  stays constant as the component / matched-image count grows, failing if an N+1 is
+  reintroduced.
+
 ## 2. Availability
 
 | Metric | Target |

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -422,6 +422,33 @@ class ComponentRoutingResolver(
 }
 ```
 
+### 7.4 DB read-path query efficiency
+
+`DatabaseComponentRegistryResolver`'s aggregate/batch reads load all components via one
+`findAll()` and walk their child collections through `EntityMappers` (`toEscrowModule` /
+`mavenArtifactParametersFor`). Three measures keep that bounded instead of N+1 (GH #321,
+#249):
+
+- **`@BatchSize(100)` on every LAZY association** of `ComponentEntity` /
+  `ComponentConfigurationEntity`. After `findAll()`, the first touch of each collection
+  role batch-loads it for all session-resident components in a single `… IN (…)` select.
+  A single multi-collection `@EntityGraph` is unusable — the collections are `List` bags
+  and Hibernate forbids fetch-joining more than one bag (`MultipleBagFetchException`), so
+  IN-clause batch loading is the chosen mechanism (see the `ComponentEntity` kdoc).
+- **Entity threading on `find-by-docker-images`.** `buildImageToComponentMap` returns the
+  already-loaded `ComponentEntity`; `findConfigurationByDockerImage` resolves the jira
+  version and definition off that entity via private entity-accepting resolver variants,
+  so no `findByComponentKey` reload is issued per matched image.
+- **Source-routing projection.** `ComponentSourceRegistry.getDbComponentNames()` /
+  `getGitComponentNames()` use the `findComponentKeysBySource` JPQL projection (key strings
+  only), avoiding hydration of full `component_source` rows on each aggregate request. The
+  per-request memoization originally proposed in #249 is unnecessary post-#317: each
+  endpoint calls `getDbComponentNames()` at most ~twice and never in a loop.
+
+`DatabaseComponentRegistryResolverQueryCountTest` (integration, `dbTest`) guards this with
+Hibernate statistics: the statement count must stay constant as component / matched-image
+count grows.
+
 ## 8. Testing Strategy & Fitness Functions
 
 ### 8.1 Testing Pyramid


### PR DESCRIPTION
## What

Removes the N+1 query patterns in the schema-v2 DB read path (`find-by-artifacts`, `find-by-docker-images`) and trims the source-routing query cost. Behaviour-preserving — only SQL fetch shape / query routing changes.

Closes #321
Closes #249

## Changes

- **`@BatchSize(100)` on every LAZY association** of `ComponentEntity` / `ComponentConfigurationEntity`. After `findAll()`, the first touch of each collection role batch-loads it for all session-resident components in one `… IN (…)` select. A single multi-collection `@EntityGraph` is impossible here — the collections are `List` bags and Hibernate rejects fetch-joining more than one (`MultipleBagFetchException`). To-one batch size is read from the **target class**, so `parentComponent` / `componentGroup` are covered by class-level `@BatchSize` on `ComponentEntity` / `ComponentGroupEntity`, not a (silently ignored) field-level annotation.
- **Entity threading on `find-by-docker-images`**: `buildImageToComponentMap` returns the already-loaded `ComponentEntity`; jira-version and definition resolution use entity-accepting private resolver variants, eliminating the per-matched-image `findByComponentKey` reloads.
- **Source-routing projection**: `getDbComponentNames` / `getGitComponentNames` use `findComponentKeysBySource` (key strings only) instead of hydrating `component_source` entity rows. #249's per-request memoization is unnecessary post-#317 — each endpoint calls `getDbComponentNames` at most ~twice, never in a loop (measured).
- **Regression guard**: `DatabaseComponentRegistryResolverQueryCountTest` (integration, `dbTest`) asserts via Hibernate statistics that the statement count of both endpoints is constant as component / matched-image count grows. Confirmed RED on baseline, GREEN after the fix.
- **Docs**: `docs/registry/non-functional-spec.md` + `technical-design.md`.

## Verification

- Full `./gradlew build` ✅
- Full `:components-registry-service-server:dbTest` suite ✅
- `:components-registry-service-server:integrationTest` (FatJar boot) ✅
- Independent reviews (Sonnet) → 2 SHOULD-FIX + 2 NIT addressed → **SHIP**
- **Compat gate**: not run locally (CI-gated `[1.7]`/`[1.8]` / `compatibilityReporter`). The change is behaviour-preserving; please confirm `find-by-artifacts` / `find-by-docker-images` stay byte-identical to baseline in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)