### PR TITLE
feat: generate OpenAPI v4 spec, gate drift, publish as CI artifact (TD-003)

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -137,6 +137,7 @@ object id10CompileUtAuto : BuildType({
         %ARTIFACT_PATH%
         **/reports
         **/test-results
+        components-registry-service-server/build/openapi/v4.json => openapi
     """.trimIndent()
 
     params {

--- a/components-registry-service-server/build.gradle
+++ b/components-registry-service-server/build.gradle
@@ -165,8 +165,11 @@ processIntegrationTestResources {
 def openApiGateDir = layout.buildDirectory.dir('openapi').get().asFile
 def openApiRefreshDir = layout.buildDirectory.dir('openapi-refresh').get().asFile
 test {
+    // Only set the output dir — the gating `test` run must ALWAYS assert (never refresh), so
+    // `openapi.refresh` is deliberately NOT wired from a -P here. `-Popenapi.refresh=true` would
+    // otherwise make `./gradlew build` silently skip the drift assertion. Refresh is the dedicated
+    // `generateOpenApiDocs`/`generateOpenApiDocsTest` path only.
     systemProperty 'openapi.outputDir', openApiGateDir.absolutePath
-    systemProperty 'openapi.refresh', project.findProperty('openapi.refresh') ?: 'false'
 }
 
 // `./gradlew :components-registry-service-server:generateOpenApiDocs` refreshes the committed

--- a/components-registry-service-server/build.gradle
+++ b/components-registry-service-server/build.gradle
@@ -156,6 +156,50 @@ processIntegrationTestResources {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
+// TD-003: OpenApiV4SpecTest captures GET /v3/api-docs/v4 into build/openapi/v4.json and gates
+// drift vs the committed src/main/resources/openapi/v4.json. The test is UNtagged, so it already
+// runs under `test` -> `check` -> `build` (the [1.0] gate) — no extra gate task. Feed it the
+// output dir and the refresh flag (default false: gate; true: refresh the committed copy).
+// The gating `test` run and the refresh run write to SEPARATE dirs so a `build generateOpenApiDocs
+// --parallel` invocation can never have the two Test tasks race on the same file.
+def openApiGateDir = layout.buildDirectory.dir('openapi').get().asFile
+def openApiRefreshDir = layout.buildDirectory.dir('openapi-refresh').get().asFile
+test {
+    systemProperty 'openapi.outputDir', openApiGateDir.absolutePath
+    systemProperty 'openapi.refresh', project.findProperty('openapi.refresh') ?: 'false'
+}
+
+// `./gradlew :components-registry-service-server:generateOpenApiDocs` refreshes the committed
+// spec after an intended v4 API change. TWO tasks (not a finalizer): the Copy only runs if the
+// regeneration test SUCCEEDS, so a failing test never copies a stale spec over the committed file.
+tasks.register('generateOpenApiDocsTest', Test) {
+    description = 'Regenerates build/openapi-refresh/v4.json from the live v4 controllers (refresh mode).'
+    group = 'documentation'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    // A custom Test task does NOT inherit the root `test {}` block's excludeTags filter — set
+    // an explicit platform + filter so it runs ONLY the spec test.
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching 'org.octopusden.octopus.components.registry.server.openapi.OpenApiV4SpecTest'
+    }
+    systemProperty 'openapi.outputDir', openApiRefreshDir.absolutePath
+    systemProperty 'openapi.refresh', 'true'
+    // InfoControllerV4 needs BuildProperties from build/resources/main/META-INF/build-info.properties
+    // (springBoot { buildInfo() } -> bootBuildInfo), or the context fails to boot on a clean tree.
+    dependsOn 'processResources', 'bootBuildInfo'
+    outputs.upToDateWhen { false }
+}
+
+tasks.register('generateOpenApiDocs', Copy) {
+    description = 'Refreshes the committed src/main/resources/openapi/v4.json from build/openapi-refresh/v4.json.'
+    group = 'documentation'
+    dependsOn 'generateOpenApiDocsTest'
+    from openApiRefreshDir
+    include 'v4.json'
+    into 'src/main/resources/openapi'
+}
+
 jar {
     archiveBaseName = "${project.name}-it"
     enabled = true

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiV4Config.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiV4Config.kt
@@ -1,0 +1,57 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import io.swagger.v3.oas.models.info.Info
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * OpenAPI generation for the **v4** API surface (TD-003 / [ADR-012]).
+ *
+ * v4 is the CRUD + audit + admin contract the Portal SPA binds to; v1/v2/v3 are stable
+ * Feign-client read contracts and are deliberately NOT re-derived here. springdoc serves
+ * this group at `GET /v3/api-docs/v4` (already permitted anonymously by
+ * [WebSecurityConfig] / [AnonymousSecurityConfig]). `OpenApiV4SpecTest` captures that
+ * document into `build/openapi/v4.json` and gates drift against the committed
+ * `src/main/resources/openapi/v4.json`; `./gradlew generateOpenApiDocs` refreshes it.
+ *
+ * `info.version` is a CONSTANT API-major string (`"4"`), NOT the build/project version:
+ * the committed spec must only change when the v4 surface changes, otherwise every release
+ * version bump would churn the spec and fire the drift gate on no real API change.
+ */
+@Configuration
+class OpenApiV4Config {
+    @Bean
+    fun v4OpenApiGroup(): GroupedOpenApi =
+        GroupedOpenApi.builder()
+            .group("v4")
+            .pathsToMatch(
+                "/rest/api/4/components/**",
+                // AuditControllerV4 is mapped at /rest/api/4/audit (NOT /audit-log).
+                "/rest/api/4/audit/**",
+                // Covers AdminControllerV4 and ConfigControllerV4's PUTs under /admin/config/**.
+                "/rest/api/4/admin/**",
+                // ConfigControllerV4 GETs under /config/**.
+                "/rest/api/4/config/**",
+                // InfoControllerV4 (not DB-gated).
+                "/rest/api/4/info",
+                // AuthController at /auth/me — outside /rest/api/4.
+                "/auth/**",
+            )
+            // No pathsToExclude: with pathsToMatch this tight the v1/v2/v3 trees never match.
+            // Scope the info to THIS group only (a global OpenAPI bean would also relabel the
+            // ungrouped /v3/api-docs, which still covers v1/v2/v3). `info.version` is the constant
+            // API-major string "4" — see the class kdoc.
+            .addOpenApiCustomizer { openApi ->
+                openApi.info(
+                    Info()
+                        .title("Components Registry v4 API")
+                        .version("4")
+                        .description(
+                            "CRUD + audit + admin API consumed by the components-management Portal SPA. " +
+                                "Generated from the v4 controllers (TD-003); v1/v2/v3 are separate stable read contracts.",
+                        ),
+                )
+            }
+            .build()
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -289,10 +289,15 @@ class ComponentControllerV4(
             ?.distinct()
             ?.takeIf { it.isNotEmpty() }
 
-    @GetMapping("/{idOrName}")
+    // The path template variable is `{id}` — the SAME name PATCH/DELETE use — so the OpenAPI
+    // generator merges every item-level operation under one `/components/{id}` path. OpenAPI path
+    // identity ignores the variable name, so `{idOrName}` here vs `{id}` on PATCH would emit two
+    // colliding path items. The binding keeps the descriptive `idOrName` name (this GET resolves
+    // by UUID *or* name — SYS-028) via the explicit @PathVariable("id").
+    @GetMapping("/{id}")
     @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
     fun getComponent(
-        @PathVariable idOrName: String,
+        @PathVariable("id") idOrName: String,
     ): ComponentDetailResponse {
         // Prefer UUID lookup when the path parses as one, but fall through to the
         // name lookup ONLY for NotFoundException — the sentinel for "no row with
@@ -321,10 +326,12 @@ class ComponentControllerV4(
      * the view RESOLVED/merged for that concrete version. The component is
      * resolved by UUID or name, identical to [getComponent].
      */
-    @GetMapping("/{idOrName}/as-code", produces = [TEXT_PLAIN_UTF8])
+    // `{id}` (bound to `idOrName`) for the same reason as [getComponent] — keeps the component
+    // identifier path variable consistently named `id` across all item-level paths.
+    @GetMapping("/{id}/as-code", produces = [TEXT_PLAIN_UTF8])
     @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
     fun getComponentAsCode(
-        @PathVariable idOrName: String,
+        @PathVariable("id") idOrName: String,
         @RequestParam(required = false) version: String?,
     ): ResponseEntity<String> {
         val rendered =

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -110,6 +110,12 @@ auth-server:
 # either forces eager OIDC discovery (issuer-uri) or skips issuer validation
 # (jwk-set-uri alone). Instead WebSecurityConfig provides a custom JwtDecoder
 # that is lazy on JWKS fetch AND explicitly enforces the issuer claim.
+# springdoc-openapi: sort keys on serialization so the swagger-ui / api-docs output is
+# stable. The TD-003 drift gate (OpenApiV4SpecTest) additionally re-sorts recursively, but
+# this keeps the live /v3/api-docs/v4 deterministic too. See OpenApiV4Config.
+springdoc:
+  writer-with-order-by-keys: true
+
 spring:
   jpa:
     open-in-view: false

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -1,0 +1,6921 @@
+{
+  "components" : {
+    "schemas" : {
+      "ArtifactIdRequest" : {
+        "properties" : {
+          "artifactPattern" : {
+            "type" : "string"
+          },
+          "groupPattern" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "artifactPattern",
+          "groupPattern"
+        ],
+        "type" : "object"
+      },
+      "ArtifactIdResponse" : {
+        "properties" : {
+          "artifactPattern" : {
+            "type" : "string"
+          },
+          "groupPattern" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "artifactPattern",
+          "groupPattern",
+          "id"
+        ],
+        "type" : "object"
+      },
+      "AuditLogResponse" : {
+        "properties" : {
+          "action" : {
+            "type" : "string"
+          },
+          "changeDiff" : {
+            "additionalProperties" : {
+              "type" : "object"
+            },
+            "type" : "object"
+          },
+          "changedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "changedBy" : {
+            "type" : "string"
+          },
+          "correlationId" : {
+            "type" : "string"
+          },
+          "entityId" : {
+            "type" : "string"
+          },
+          "entityType" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "newValue" : {
+            "additionalProperties" : {
+              "type" : "object"
+            },
+            "type" : "object"
+          },
+          "oldValue" : {
+            "additionalProperties" : {
+              "type" : "object"
+            },
+            "type" : "object"
+          },
+          "source" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "action",
+          "changedAt",
+          "entityId",
+          "entityType",
+          "id",
+          "source"
+        ],
+        "type" : "object"
+      },
+      "BaseConfigurationRequest" : {
+        "properties" : {
+          "build" : {
+            "$ref" : "#/components/schemas/BuildAspectRequest"
+          },
+          "buildToolBeans" : {
+            "items" : {
+              "$ref" : "#/components/schemas/BuildToolBeanRequest"
+            },
+            "type" : "array"
+          },
+          "dockerImages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/DockerImageRequest"
+            },
+            "type" : "array"
+          },
+          "escrow" : {
+            "$ref" : "#/components/schemas/EscrowAspectRequest"
+          },
+          "fileUrlArtifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/FileUrlArtifactRequest"
+            },
+            "type" : "array"
+          },
+          "jira" : {
+            "$ref" : "#/components/schemas/JiraAspectRequest"
+          },
+          "mavenArtifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/MavenArtifactRequest"
+            },
+            "type" : "array"
+          },
+          "packages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/PackageRequest"
+            },
+            "type" : "array"
+          },
+          "requiredTools" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "vcsEntries" : {
+            "items" : {
+              "$ref" : "#/components/schemas/VcsEntryRequest"
+            },
+            "type" : "array"
+          },
+          "versionRange" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "BatchMigrationResult" : {
+        "properties" : {
+          "failed" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "migrated" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "results" : {
+            "items" : {
+              "$ref" : "#/components/schemas/MigrationResult"
+            },
+            "type" : "array"
+          },
+          "skipped" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "total" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "failed",
+          "migrated",
+          "results",
+          "skipped",
+          "total"
+        ],
+        "type" : "object"
+      },
+      "BuildAspectRequest" : {
+        "properties" : {
+          "buildFilePath" : {
+            "type" : "string"
+          },
+          "buildSystem" : {
+            "type" : "string"
+          },
+          "buildTasks" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "gradleVersion" : {
+            "type" : "string"
+          },
+          "javaVersion" : {
+            "type" : "string"
+          },
+          "mavenVersion" : {
+            "type" : "string"
+          },
+          "projectVersion" : {
+            "type" : "string"
+          },
+          "requiredProject" : {
+            "type" : "boolean"
+          },
+          "systemProperties" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "BuildAspectResponse" : {
+        "properties" : {
+          "buildFilePath" : {
+            "type" : "string"
+          },
+          "buildSystem" : {
+            "type" : "string"
+          },
+          "buildTasks" : {
+            "type" : "string"
+          },
+          "deprecated" : {
+            "type" : "boolean"
+          },
+          "gradleVersion" : {
+            "type" : "string"
+          },
+          "javaVersion" : {
+            "type" : "string"
+          },
+          "mavenVersion" : {
+            "type" : "string"
+          },
+          "projectVersion" : {
+            "type" : "string"
+          },
+          "requiredProject" : {
+            "type" : "boolean"
+          },
+          "systemProperties" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "BuildToolBeanRequest" : {
+        "properties" : {
+          "beanType" : {
+            "type" : "string"
+          },
+          "edition" : {
+            "type" : "string"
+          },
+          "settingsProperty" : {
+            "type" : "string"
+          },
+          "toolType" : {
+            "type" : "string"
+          },
+          "versionPattern" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "beanType"
+        ],
+        "type" : "object"
+      },
+      "BuildToolBeanResponse" : {
+        "properties" : {
+          "beanType" : {
+            "type" : "string"
+          },
+          "edition" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "settingsProperty" : {
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "toolType" : {
+            "type" : "string"
+          },
+          "versionPattern" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "beanType",
+          "id",
+          "sortOrder"
+        ],
+        "type" : "object"
+      },
+      "ComponentConfigurationResponse" : {
+        "properties" : {
+          "build" : {
+            "$ref" : "#/components/schemas/BuildAspectResponse"
+          },
+          "buildToolBeans" : {
+            "items" : {
+              "$ref" : "#/components/schemas/BuildToolBeanResponse"
+            },
+            "type" : "array"
+          },
+          "dockerImages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/DockerImageResponse"
+            },
+            "type" : "array"
+          },
+          "escrow" : {
+            "$ref" : "#/components/schemas/EscrowAspectResponse"
+          },
+          "fileUrlArtifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/FileUrlArtifactResponse"
+            },
+            "type" : "array"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "isSyntheticBase" : {
+            "type" : "boolean"
+          },
+          "jira" : {
+            "$ref" : "#/components/schemas/JiraAspectResponse"
+          },
+          "mavenArtifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/MavenArtifactResponse"
+            },
+            "type" : "array"
+          },
+          "overriddenAttribute" : {
+            "type" : "string"
+          },
+          "packages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/PackageResponse"
+            },
+            "type" : "array"
+          },
+          "requiredTools" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "rowType" : {
+            "enum" : [
+              "BASE",
+              "SCALAR_OVERRIDE",
+              "MARKER",
+              "RANGE_PRESENCE"
+            ],
+            "type" : "string"
+          },
+          "vcsEntries" : {
+            "items" : {
+              "$ref" : "#/components/schemas/VcsEntryResponse"
+            },
+            "type" : "array"
+          },
+          "versionRange" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "buildToolBeans",
+          "dockerImages",
+          "fileUrlArtifacts",
+          "id",
+          "isSyntheticBase",
+          "mavenArtifacts",
+          "packages",
+          "requiredTools",
+          "rowType",
+          "vcsEntries",
+          "versionRange"
+        ],
+        "type" : "object"
+      },
+      "ComponentCreateRequest" : {
+        "properties" : {
+          "archived" : {
+            "type" : "boolean"
+          },
+          "artifactIds" : {
+            "items" : {
+              "$ref" : "#/components/schemas/ArtifactIdRequest"
+            },
+            "type" : "array"
+          },
+          "baseConfiguration" : {
+            "$ref" : "#/components/schemas/BaseConfigurationRequest"
+          },
+          "canBeParent" : {
+            "type" : "boolean"
+          },
+          "clientCode" : {
+            "type" : "string"
+          },
+          "componentOwner" : {
+            "type" : "string"
+          },
+          "copyright" : {
+            "type" : "string"
+          },
+          "displayName" : {
+            "type" : "string"
+          },
+          "distributionExplicit" : {
+            "type" : "boolean"
+          },
+          "distributionExternal" : {
+            "type" : "boolean"
+          },
+          "docs" : {
+            "items" : {
+              "$ref" : "#/components/schemas/DocLinkRequest"
+            },
+            "type" : "array"
+          },
+          "group" : {
+            "$ref" : "#/components/schemas/ComponentGroupRequest"
+          },
+          "jiraDisplayName" : {
+            "type" : "string"
+          },
+          "jiraHotfixVersionFormat" : {
+            "type" : "string"
+          },
+          "labels" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "parentComponentName" : {
+            "type" : "string"
+          },
+          "productType" : {
+            "type" : "string"
+          },
+          "releaseManager" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "releasesInDefaultBranch" : {
+            "type" : "boolean"
+          },
+          "securityChampion" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "securityGroups" : {
+            "items" : {
+              "$ref" : "#/components/schemas/SecurityGroupRequest"
+            },
+            "type" : "array"
+          },
+          "solution" : {
+            "type" : "boolean"
+          },
+          "system" : {
+            "type" : "string"
+          },
+          "teamcityProjects" : {
+            "items" : {
+              "$ref" : "#/components/schemas/TeamcityProjectRequest"
+            },
+            "type" : "array"
+          },
+          "vcsExternalRegistry" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "archived",
+          "artifactIds",
+          "canBeParent",
+          "docs",
+          "labels",
+          "name",
+          "releaseManager",
+          "securityChampion",
+          "securityGroups",
+          "teamcityProjects"
+        ],
+        "type" : "object"
+      },
+      "ComponentDetailResponse" : {
+        "properties" : {
+          "archived" : {
+            "type" : "boolean"
+          },
+          "artifactIds" : {
+            "items" : {
+              "$ref" : "#/components/schemas/ArtifactIdResponse"
+            },
+            "type" : "array"
+          },
+          "canBeParent" : {
+            "type" : "boolean"
+          },
+          "canEdit" : {
+            "type" : "boolean"
+          },
+          "clientCode" : {
+            "type" : "string"
+          },
+          "componentOwner" : {
+            "type" : "string"
+          },
+          "configurations" : {
+            "items" : {
+              "$ref" : "#/components/schemas/ComponentConfigurationResponse"
+            },
+            "type" : "array"
+          },
+          "copyright" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "displayName" : {
+            "type" : "string"
+          },
+          "distributionExplicit" : {
+            "type" : "boolean"
+          },
+          "distributionExternal" : {
+            "type" : "boolean"
+          },
+          "docs" : {
+            "items" : {
+              "$ref" : "#/components/schemas/DocLinkResponse"
+            },
+            "type" : "array"
+          },
+          "group" : {
+            "$ref" : "#/components/schemas/ComponentGroupResponse"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "jiraDisplayName" : {
+            "type" : "string"
+          },
+          "jiraHotfixVersionFormat" : {
+            "type" : "string"
+          },
+          "labels" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "parentComponentName" : {
+            "type" : "string"
+          },
+          "productType" : {
+            "type" : "string"
+          },
+          "releaseManager" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "releasesInDefaultBranch" : {
+            "type" : "boolean"
+          },
+          "securityChampion" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "securityGroups" : {
+            "items" : {
+              "$ref" : "#/components/schemas/SecurityGroupResponse"
+            },
+            "type" : "array"
+          },
+          "solution" : {
+            "type" : "boolean"
+          },
+          "system" : {
+            "type" : "string"
+          },
+          "teamcityProjects" : {
+            "items" : {
+              "$ref" : "#/components/schemas/TeamcityProjectResponse"
+            },
+            "type" : "array"
+          },
+          "updatedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "vcsExternalRegistry" : {
+            "type" : "string"
+          },
+          "version" : {
+            "format" : "int64",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "archived",
+          "artifactIds",
+          "canBeParent",
+          "configurations",
+          "docs",
+          "id",
+          "labels",
+          "name",
+          "releaseManager",
+          "securityChampion",
+          "securityGroups",
+          "teamcityProjects",
+          "version"
+        ],
+        "type" : "object"
+      },
+      "ComponentGroupRequest" : {
+        "properties" : {
+          "groupKey" : {
+            "type" : "string"
+          },
+          "isFake" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [
+          "groupKey",
+          "isFake"
+        ],
+        "type" : "object"
+      },
+      "ComponentGroupResponse" : {
+        "properties" : {
+          "groupKey" : {
+            "type" : "string"
+          },
+          "isFake" : {
+            "type" : "boolean"
+          },
+          "role" : {
+            "enum" : [
+              "AGGREGATOR",
+              "MEMBER"
+            ],
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "groupKey",
+          "isFake",
+          "role"
+        ],
+        "type" : "object"
+      },
+      "ComponentSummaryResponse" : {
+        "properties" : {
+          "archived" : {
+            "type" : "boolean"
+          },
+          "buildSystem" : {
+            "type" : "string"
+          },
+          "canBeParent" : {
+            "type" : "boolean"
+          },
+          "componentOwner" : {
+            "type" : "string"
+          },
+          "displayName" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "jiraProjectKey" : {
+            "type" : "string"
+          },
+          "labels" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "productType" : {
+            "type" : "string"
+          },
+          "system" : {
+            "type" : "string"
+          },
+          "teamcityProjectId" : {
+            "type" : "string"
+          },
+          "teamcityProjectUrl" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "vcsPath" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "archived",
+          "canBeParent",
+          "id",
+          "labels",
+          "name"
+        ],
+        "type" : "object"
+      },
+      "ComponentUpdateRequest" : {
+        "properties" : {
+          "archived" : {
+            "type" : "boolean"
+          },
+          "artifactIds" : {
+            "items" : {
+              "$ref" : "#/components/schemas/ArtifactIdRequest"
+            },
+            "type" : "array"
+          },
+          "baseConfiguration" : {
+            "$ref" : "#/components/schemas/BaseConfigurationRequest"
+          },
+          "canBeParent" : {
+            "type" : "boolean"
+          },
+          "clearGroup" : {
+            "type" : "boolean"
+          },
+          "clearParent" : {
+            "type" : "boolean"
+          },
+          "clientCode" : {
+            "type" : "string"
+          },
+          "componentOwner" : {
+            "type" : "string"
+          },
+          "copyright" : {
+            "type" : "string"
+          },
+          "displayName" : {
+            "type" : "string"
+          },
+          "distributionExplicit" : {
+            "type" : "boolean"
+          },
+          "distributionExternal" : {
+            "type" : "boolean"
+          },
+          "docs" : {
+            "items" : {
+              "$ref" : "#/components/schemas/DocLinkRequest"
+            },
+            "type" : "array"
+          },
+          "group" : {
+            "$ref" : "#/components/schemas/ComponentGroupRequest"
+          },
+          "jiraDisplayName" : {
+            "type" : "string"
+          },
+          "jiraHotfixVersionFormat" : {
+            "type" : "string"
+          },
+          "labels" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "parentComponentName" : {
+            "type" : "string"
+          },
+          "productType" : {
+            "type" : "string"
+          },
+          "releaseManager" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "releasesInDefaultBranch" : {
+            "type" : "boolean"
+          },
+          "securityChampion" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "securityGroups" : {
+            "items" : {
+              "$ref" : "#/components/schemas/SecurityGroupRequest"
+            },
+            "type" : "array"
+          },
+          "solution" : {
+            "type" : "boolean"
+          },
+          "system" : {
+            "type" : "string"
+          },
+          "teamcityProjects" : {
+            "items" : {
+              "$ref" : "#/components/schemas/TeamcityProjectRequest"
+            },
+            "type" : "array"
+          },
+          "vcsExternalRegistry" : {
+            "type" : "string"
+          },
+          "version" : {
+            "format" : "int64",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "clearGroup",
+          "clearParent",
+          "version"
+        ],
+        "type" : "object"
+      },
+      "DocLinkRequest" : {
+        "properties" : {
+          "docComponentKey" : {
+            "type" : "string"
+          },
+          "majorVersion" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "docComponentKey"
+        ],
+        "type" : "object"
+      },
+      "DocLinkResponse" : {
+        "properties" : {
+          "docComponentKey" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "majorVersion" : {
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "docComponentKey",
+          "id",
+          "sortOrder"
+        ],
+        "type" : "object"
+      },
+      "DockerImageRequest" : {
+        "properties" : {
+          "flavor" : {
+            "type" : "string"
+          },
+          "imageName" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "imageName"
+        ],
+        "type" : "object"
+      },
+      "DockerImageResponse" : {
+        "properties" : {
+          "flavor" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "imageName" : {
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "id",
+          "imageName",
+          "sortOrder"
+        ],
+        "type" : "object"
+      },
+      "EmployeeMatchResponse" : {
+        "properties" : {
+          "active" : {
+            "type" : "boolean"
+          },
+          "username" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "active",
+          "username"
+        ],
+        "type" : "object"
+      },
+      "ErrorResponse" : {
+        "properties" : {
+          "errorMessage" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "errorMessage"
+        ],
+        "type" : "object"
+      },
+      "EscrowAspectRequest" : {
+        "properties" : {
+          "additionalSources" : {
+            "type" : "string"
+          },
+          "buildTask" : {
+            "type" : "string"
+          },
+          "diskSpace" : {
+            "type" : "string"
+          },
+          "generation" : {
+            "type" : "string"
+          },
+          "gradleExcludeConfigurations" : {
+            "type" : "string"
+          },
+          "gradleIncludeConfigurations" : {
+            "type" : "string"
+          },
+          "gradleIncludeTestConfigurations" : {
+            "type" : "boolean"
+          },
+          "providedDependencies" : {
+            "type" : "string"
+          },
+          "reusable" : {
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "EscrowAspectResponse" : {
+        "properties" : {
+          "additionalSources" : {
+            "type" : "string"
+          },
+          "buildTask" : {
+            "type" : "string"
+          },
+          "diskSpace" : {
+            "type" : "string"
+          },
+          "generation" : {
+            "type" : "string"
+          },
+          "gradleExcludeConfigurations" : {
+            "type" : "string"
+          },
+          "gradleIncludeConfigurations" : {
+            "type" : "string"
+          },
+          "gradleIncludeTestConfigurations" : {
+            "type" : "boolean"
+          },
+          "providedDependencies" : {
+            "type" : "string"
+          },
+          "reusable" : {
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "FieldOverrideCreateRequest" : {
+        "properties" : {
+          "markerChildren" : {
+            "$ref" : "#/components/schemas/MarkerChildrenPayload"
+          },
+          "overriddenAttribute" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "object"
+          },
+          "versionRange" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "overriddenAttribute",
+          "versionRange"
+        ],
+        "type" : "object"
+      },
+      "FieldOverrideResponse" : {
+        "properties" : {
+          "createdAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "markerChildren" : {
+            "$ref" : "#/components/schemas/MarkerChildrenPayload"
+          },
+          "overriddenAttribute" : {
+            "type" : "string"
+          },
+          "rowType" : {
+            "enum" : [
+              "BASE",
+              "SCALAR_OVERRIDE",
+              "MARKER",
+              "RANGE_PRESENCE"
+            ],
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "object"
+          },
+          "versionRange" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "id",
+          "overriddenAttribute",
+          "rowType",
+          "versionRange"
+        ],
+        "type" : "object"
+      },
+      "FieldOverrideUpdateRequest" : {
+        "properties" : {
+          "markerChildren" : {
+            "$ref" : "#/components/schemas/MarkerChildrenPayload"
+          },
+          "value" : {
+            "type" : "object"
+          },
+          "versionRange" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "FileUrlArtifactRequest" : {
+        "properties" : {
+          "artifactId" : {
+            "type" : "string"
+          },
+          "classifier" : {
+            "type" : "string"
+          },
+          "url" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "url"
+        ],
+        "type" : "object"
+      },
+      "FileUrlArtifactResponse" : {
+        "properties" : {
+          "artifactId" : {
+            "type" : "string"
+          },
+          "classifier" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "url" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "id",
+          "sortOrder",
+          "url"
+        ],
+        "type" : "object"
+      },
+      "FullMigrationResult" : {
+        "properties" : {
+          "components" : {
+            "$ref" : "#/components/schemas/BatchMigrationResult"
+          },
+          "defaults" : {
+            "additionalProperties" : {
+              "type" : "object"
+            },
+            "type" : "object"
+          }
+        },
+        "required" : [
+          "components",
+          "defaults"
+        ],
+        "type" : "object"
+      },
+      "HistoryImportResult" : {
+        "properties" : {
+          "auditRecords" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "durationMs" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "processedCommits" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "skippedNoGroovy" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "skippedParseError" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "skippedUnknownNames" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "targetRef" : {
+            "type" : "string"
+          },
+          "targetSha" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "auditRecords",
+          "durationMs",
+          "processedCommits",
+          "skippedNoGroovy",
+          "skippedParseError",
+          "skippedUnknownNames",
+          "targetRef",
+          "targetSha"
+        ],
+        "type" : "object"
+      },
+      "HistoryMigrationJobResponse" : {
+        "properties" : {
+          "auditRecords" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "currentSha" : {
+            "type" : "string"
+          },
+          "errorMessage" : {
+            "type" : "string"
+          },
+          "finishedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "kind" : {
+            "type" : "string"
+          },
+          "processedCommits" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "recoveryAction" : {
+            "type" : "string"
+          },
+          "result" : {
+            "$ref" : "#/components/schemas/HistoryImportResult"
+          },
+          "skippedNoGroovy" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "skippedParseError" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "skippedUnknownNames" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "startedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "state" : {
+            "enum" : [
+              "RUNNING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "type" : "string"
+          },
+          "targetRef" : {
+            "type" : "string"
+          },
+          "totalCommits" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "auditRecords",
+          "id",
+          "kind",
+          "processedCommits",
+          "skippedNoGroovy",
+          "skippedParseError",
+          "skippedUnknownNames",
+          "startedAt",
+          "state",
+          "totalCommits"
+        ],
+        "type" : "object"
+      },
+      "InfoResponse" : {
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "name",
+          "version"
+        ],
+        "type" : "object"
+      },
+      "JiraAspectRequest" : {
+        "properties" : {
+          "buildVersionFormat" : {
+            "type" : "string"
+          },
+          "lineVersionFormat" : {
+            "type" : "string"
+          },
+          "majorVersionFormat" : {
+            "type" : "string"
+          },
+          "projectKey" : {
+            "type" : "string"
+          },
+          "releaseVersionFormat" : {
+            "type" : "string"
+          },
+          "technical" : {
+            "type" : "boolean"
+          },
+          "versionFormat" : {
+            "type" : "string"
+          },
+          "versionPrefix" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "JiraAspectResponse" : {
+        "properties" : {
+          "buildVersionFormat" : {
+            "type" : "string"
+          },
+          "hotfixVersionFormat" : {
+            "type" : "string"
+          },
+          "lineVersionFormat" : {
+            "type" : "string"
+          },
+          "majorVersionFormat" : {
+            "type" : "string"
+          },
+          "projectKey" : {
+            "type" : "string"
+          },
+          "releaseVersionFormat" : {
+            "type" : "string"
+          },
+          "technical" : {
+            "type" : "boolean"
+          },
+          "versionFormat" : {
+            "type" : "string"
+          },
+          "versionPrefix" : {
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "MarkerChildrenPayload" : {
+        "properties" : {
+          "buildToolBeans" : {
+            "items" : {
+              "$ref" : "#/components/schemas/BuildToolBeanRequest"
+            },
+            "type" : "array"
+          },
+          "dockerImages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/DockerImageRequest"
+            },
+            "type" : "array"
+          },
+          "fileUrlArtifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/FileUrlArtifactRequest"
+            },
+            "type" : "array"
+          },
+          "mavenArtifacts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/MavenArtifactRequest"
+            },
+            "type" : "array"
+          },
+          "packages" : {
+            "items" : {
+              "$ref" : "#/components/schemas/PackageRequest"
+            },
+            "type" : "array"
+          },
+          "requiredTools" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "vcsEntries" : {
+            "items" : {
+              "$ref" : "#/components/schemas/VcsEntryRequest"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "MavenArtifactRequest" : {
+        "properties" : {
+          "artifactPattern" : {
+            "type" : "string"
+          },
+          "classifier" : {
+            "type" : "string"
+          },
+          "extension" : {
+            "type" : "string"
+          },
+          "groupPattern" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "artifactPattern",
+          "groupPattern"
+        ],
+        "type" : "object"
+      },
+      "MavenArtifactResponse" : {
+        "properties" : {
+          "artifactPattern" : {
+            "type" : "string"
+          },
+          "classifier" : {
+            "type" : "string"
+          },
+          "extension" : {
+            "type" : "string"
+          },
+          "groupPattern" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "artifactPattern",
+          "groupPattern",
+          "id",
+          "sortOrder"
+        ],
+        "type" : "object"
+      },
+      "MigrationJobResponse" : {
+        "properties" : {
+          "currentComponent" : {
+            "type" : "string"
+          },
+          "errorMessage" : {
+            "type" : "string"
+          },
+          "failed" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "finishedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "kind" : {
+            "type" : "string"
+          },
+          "migrated" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "phase" : {
+            "type" : "string"
+          },
+          "result" : {
+            "$ref" : "#/components/schemas/FullMigrationResult"
+          },
+          "skipped" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "startedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "state" : {
+            "enum" : [
+              "RUNNING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "type" : "string"
+          },
+          "total" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "failed",
+          "id",
+          "kind",
+          "migrated",
+          "skipped",
+          "startedAt",
+          "state",
+          "total"
+        ],
+        "type" : "object"
+      },
+      "MigrationResult" : {
+        "properties" : {
+          "componentName" : {
+            "type" : "string"
+          },
+          "discrepancies" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "dryRun" : {
+            "type" : "boolean"
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "success" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [
+          "componentName",
+          "discrepancies",
+          "dryRun",
+          "message",
+          "success"
+        ],
+        "type" : "object"
+      },
+      "MigrationStatus" : {
+        "properties" : {
+          "db" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "git" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "total" : {
+            "format" : "int64",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "db",
+          "git",
+          "total"
+        ],
+        "type" : "object"
+      },
+      "PackageRequest" : {
+        "properties" : {
+          "packageName" : {
+            "type" : "string"
+          },
+          "packageType" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "packageName",
+          "packageType"
+        ],
+        "type" : "object"
+      },
+      "PackageResponse" : {
+        "properties" : {
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "packageName" : {
+            "type" : "string"
+          },
+          "packageType" : {
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "id",
+          "packageName",
+          "packageType",
+          "sortOrder"
+        ],
+        "type" : "object"
+      },
+      "PageAuditLogResponse" : {
+        "properties" : {
+          "content" : {
+            "items" : {
+              "$ref" : "#/components/schemas/AuditLogResponse"
+            },
+            "type" : "array"
+          },
+          "empty" : {
+            "type" : "boolean"
+          },
+          "first" : {
+            "type" : "boolean"
+          },
+          "last" : {
+            "type" : "boolean"
+          },
+          "number" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "numberOfElements" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "pageable" : {
+            "$ref" : "#/components/schemas/PageableObject"
+          },
+          "size" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "sort" : {
+            "$ref" : "#/components/schemas/SortObject"
+          },
+          "totalElements" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "totalPages" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "PageComponentSummaryResponse" : {
+        "properties" : {
+          "content" : {
+            "items" : {
+              "$ref" : "#/components/schemas/ComponentSummaryResponse"
+            },
+            "type" : "array"
+          },
+          "empty" : {
+            "type" : "boolean"
+          },
+          "first" : {
+            "type" : "boolean"
+          },
+          "last" : {
+            "type" : "boolean"
+          },
+          "number" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "numberOfElements" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "pageable" : {
+            "$ref" : "#/components/schemas/PageableObject"
+          },
+          "size" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "sort" : {
+            "$ref" : "#/components/schemas/SortObject"
+          },
+          "totalElements" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "totalPages" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
+      "Pageable" : {
+        "properties" : {
+          "page" : {
+            "format" : "int32",
+            "minimum" : 0,
+            "type" : "integer"
+          },
+          "size" : {
+            "format" : "int32",
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "sort" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "PageableObject" : {
+        "properties" : {
+          "offset" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "pageNumber" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "pageSize" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "paged" : {
+            "type" : "boolean"
+          },
+          "sort" : {
+            "$ref" : "#/components/schemas/SortObject"
+          },
+          "unpaged" : {
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "Role" : {
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "permissions" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          }
+        },
+        "required" : [
+          "name",
+          "permissions"
+        ],
+        "type" : "object"
+      },
+      "SecurityGroupRequest" : {
+        "properties" : {
+          "groupName" : {
+            "type" : "string"
+          },
+          "groupType" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "groupName",
+          "groupType"
+        ],
+        "type" : "object"
+      },
+      "SecurityGroupResponse" : {
+        "properties" : {
+          "groupName" : {
+            "type" : "string"
+          },
+          "groupType" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "groupName",
+          "groupType",
+          "id"
+        ],
+        "type" : "object"
+      },
+      "SortObject" : {
+        "properties" : {
+          "empty" : {
+            "type" : "boolean"
+          },
+          "sorted" : {
+            "type" : "boolean"
+          },
+          "unsorted" : {
+            "type" : "boolean"
+          }
+        },
+        "type" : "object"
+      },
+      "TeamcityProjectRequest" : {
+        "properties" : {
+          "projectId" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "projectId"
+        ],
+        "type" : "object"
+      },
+      "TeamcityProjectResponse" : {
+        "properties" : {
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "projectId" : {
+            "type" : "string"
+          },
+          "projectUrl" : {
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "id",
+          "projectId",
+          "sortOrder"
+        ],
+        "type" : "object"
+      },
+      "TeamcitySyncJobResponse" : {
+        "properties" : {
+          "errorMessage" : {
+            "type" : "string"
+          },
+          "finishedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "kind" : {
+            "type" : "string"
+          },
+          "result" : {
+            "$ref" : "#/components/schemas/TeamcitySyncResult"
+          },
+          "startedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "state" : {
+            "enum" : [
+              "RUNNING",
+              "COMPLETED",
+              "FAILED"
+            ],
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "id",
+          "kind",
+          "startedAt",
+          "state"
+        ],
+        "type" : "object"
+      },
+      "TeamcitySyncResult" : {
+        "properties" : {
+          "ambiguous_auto_resolved" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "errors" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "scanned" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "skipped_ambiguous" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "skipped_no_match" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "unchanged" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "updated" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [
+          "ambiguous_auto_resolved",
+          "errors",
+          "scanned",
+          "skipped_ambiguous",
+          "skipped_no_match",
+          "unchanged",
+          "updated"
+        ],
+        "type" : "object"
+      },
+      "User" : {
+        "properties" : {
+          "groups" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "roles" : {
+            "items" : {
+              "$ref" : "#/components/schemas/Role"
+            },
+            "type" : "array"
+          },
+          "username" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "groups",
+          "roles",
+          "username"
+        ],
+        "type" : "object"
+      },
+      "ValidationResult" : {
+        "properties" : {
+          "componentName" : {
+            "type" : "string"
+          },
+          "discrepancies" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "valid" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [
+          "componentName",
+          "discrepancies",
+          "valid"
+        ],
+        "type" : "object"
+      },
+      "VcsEntryRequest" : {
+        "properties" : {
+          "branch" : {
+            "type" : "string"
+          },
+          "hotfixBranch" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "repositoryType" : {
+            "type" : "string"
+          },
+          "tag" : {
+            "type" : "string"
+          },
+          "vcsPath" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "vcsPath"
+        ],
+        "type" : "object"
+      },
+      "VcsEntryResponse" : {
+        "properties" : {
+          "branch" : {
+            "type" : "string"
+          },
+          "hotfixBranch" : {
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "repositoryType" : {
+            "type" : "string"
+          },
+          "sortOrder" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "tag" : {
+            "type" : "string"
+          },
+          "vcsPath" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "id",
+          "sortOrder",
+          "vcsPath"
+        ],
+        "type" : "object"
+      }
+    }
+  },
+  "info" : {
+    "description" : "CRUD + audit + admin API consumed by the components-management Portal SPA. Generated from the v4 controllers (TD-003); v1/v2/v3 are separate stable read contracts.",
+    "title" : "Components Registry v4 API",
+    "version" : "4"
+  },
+  "openapi" : "3.0.1",
+  "paths" : {
+    "/auth/me" : {
+      "get" : {
+        "operationId" : "getUserInfo",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "auth-controller"
+        ]
+      }
+    },
+    "/rest/api/4/admin/config/component-defaults" : {
+      "put" : {
+        "operationId" : "updateComponentDefaults",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "additionalProperties" : {
+                  "type" : "object"
+                },
+                "type" : "object"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "object"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "config-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/config/field-config" : {
+      "put" : {
+        "operationId" : "updateFieldConfig",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "additionalProperties" : {
+                  "type" : "object"
+                },
+                "type" : "object"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "object"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "config-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/export" : {
+      "get" : {
+        "operationId" : "exportComponents",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "string"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/import" : {
+      "post" : {
+        "operationId" : "importComponents",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchMigrationResult"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate" : {
+      "post" : {
+        "operationId" : "migrate",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MigrationJobResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate-component/{name}" : {
+      "post" : {
+        "operationId" : "migrateComponent",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "name",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "dryRun",
+            "required" : false,
+            "schema" : {
+              "default" : false,
+              "type" : "boolean"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MigrationResult"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate-components" : {
+      "post" : {
+        "operationId" : "migrateAllComponents",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchMigrationResult"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate-defaults" : {
+      "post" : {
+        "operationId" : "migrateDefaults",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "object"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate-history" : {
+      "post" : {
+        "operationId" : "migrateHistory",
+        "parameters" : [
+          {
+            "in" : "query",
+            "name" : "toRef",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "reset",
+            "required" : false,
+            "schema" : {
+              "default" : false,
+              "type" : "boolean"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/HistoryMigrationJobResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate-history/force-reset" : {
+      "post" : {
+        "operationId" : "forceResetHistory",
+        "parameters" : [
+          {
+            "in" : "query",
+            "name" : "ack-multipod-risk",
+            "required" : false,
+            "schema" : {
+              "default" : false,
+              "type" : "boolean"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate-history/job" : {
+      "get" : {
+        "operationId" : "getHistoryMigrateJob",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/HistoryMigrationJobResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migrate/job" : {
+      "get" : {
+        "operationId" : "getMigrateJob",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MigrationJobResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/migration-status" : {
+      "get" : {
+        "operationId" : "getMigrationStatus",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MigrationStatus"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/reload-config" : {
+      "post" : {
+        "operationId" : "reloadConfig",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "object"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/teamcity-project-ids/sync" : {
+      "post" : {
+        "operationId" : "startTeamcitySync",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TeamcitySyncJobResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/teamcity-project-ids/sync/job" : {
+      "get" : {
+        "operationId" : "getTeamcitySyncJob",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TeamcitySyncJobResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/validate-migration/{name}" : {
+      "post" : {
+        "operationId" : "validateMigration",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "name",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ValidationResult"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/audit/recent" : {
+      "get" : {
+        "operationId" : "getRecentChanges",
+        "parameters" : [
+          {
+            "in" : "query",
+            "name" : "entityType",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "entityId",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "changedBy",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "source",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "action",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "from",
+            "required" : false,
+            "schema" : {
+              "format" : "date-time",
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "to",
+            "required" : false,
+            "schema" : {
+              "format" : "date-time",
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "includeMigrated",
+            "required" : false,
+            "schema" : {
+              "default" : false,
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "pageable",
+            "required" : true,
+            "schema" : {
+              "$ref" : "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageAuditLogResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "audit-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/audit/{entityType}/{entityId}" : {
+      "get" : {
+        "operationId" : "getEntityHistory",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "entityType",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "path",
+            "name" : "entityId",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "includeMigrated",
+            "required" : false,
+            "schema" : {
+              "default" : false,
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "pageable",
+            "required" : true,
+            "schema" : {
+              "$ref" : "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageAuditLogResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "audit-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components" : {
+      "get" : {
+        "operationId" : "listComponents",
+        "parameters" : [
+          {
+            "in" : "query",
+            "name" : "system",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "productType",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "archived",
+            "required" : false,
+            "schema" : {
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "search",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "owner",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "buildSystem",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "labels",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "canBeParent",
+            "required" : false,
+            "schema" : {
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "clientCode",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "solution",
+            "required" : false,
+            "schema" : {
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "jiraProjectKey",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "jiraTechnical",
+            "required" : false,
+            "schema" : {
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "vcsPath",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "productionBranch",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "parentComponentName",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "groupKey",
+            "required" : false,
+            "schema" : {
+              "items" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "distributionExplicit",
+            "required" : false,
+            "schema" : {
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "distributionExternal",
+            "required" : false,
+            "schema" : {
+              "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "pageable",
+            "required" : true,
+            "schema" : {
+              "$ref" : "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageComponentSummaryResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      },
+      "post" : {
+        "operationId" : "createComponent",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ComponentCreateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ComponentDetailResponse"
+                }
+              }
+            },
+            "description" : "Created"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/build-systems" : {
+      "get" : {
+        "operationId" : "getBuildSystems",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/client-codes" : {
+      "get" : {
+        "operationId" : "getDistinctClientCodes",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/employees" : {
+      "get" : {
+        "operationId" : "searchEmployees",
+        "parameters" : [
+          {
+            "in" : "query",
+            "name" : "search",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/EmployeeMatchResponse"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/employees/status" : {
+      "post" : {
+        "operationId" : "employeeStatuses",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "items" : {
+                  "type" : "string"
+                },
+                "type" : "array"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "boolean"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/escrow-generations" : {
+      "get" : {
+        "operationId" : "getEscrowGenerations",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/group-keys" : {
+      "get" : {
+        "operationId" : "getDistinctGroupKeys",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/jira-project-keys" : {
+      "get" : {
+        "operationId" : "getDistinctJiraProjectKeys",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/labels" : {
+      "get" : {
+        "operationId" : "getDistinctLabels",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/labels/dictionary" : {
+      "get" : {
+        "operationId" : "getAllLabels",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/owners" : {
+      "get" : {
+        "operationId" : "getDistinctOwners",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/parent-component-names" : {
+      "get" : {
+        "operationId" : "getDistinctParentComponentNames",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/repository-types" : {
+      "get" : {
+        "operationId" : "getRepositoryTypes",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/systems" : {
+      "get" : {
+        "operationId" : "getDistinctSystems",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/systems/dictionary" : {
+      "get" : {
+        "operationId" : "getAllSystems",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/{idOrName}" : {
+      "get" : {
+        "operationId" : "getComponent",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "idOrName",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ComponentDetailResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/{idOrName}/as-code" : {
+      "get" : {
+        "operationId" : "getComponentAsCode",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "idOrName",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "version",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "text/plain;charset=UTF-8" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/{id}" : {
+      "delete" : {
+        "operationId" : "deleteComponent",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      },
+      "patch" : {
+        "operationId" : "updateComponent",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ComponentUpdateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ComponentDetailResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/{id}/field-overrides" : {
+      "get" : {
+        "operationId" : "listFieldOverrides",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/FieldOverrideResponse"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      },
+      "post" : {
+        "operationId" : "createFieldOverride",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/FieldOverrideCreateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/FieldOverrideResponse"
+                }
+              }
+            },
+            "description" : "Created"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/{id}/field-overrides/{overrideId}" : {
+      "delete" : {
+        "operationId" : "deleteFieldOverride",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "path",
+            "name" : "overrideId",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      },
+      "patch" : {
+        "operationId" : "updateFieldOverride",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "path",
+            "name" : "overrideId",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/FieldOverrideUpdateRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/FieldOverrideResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/config/component-defaults" : {
+      "get" : {
+        "operationId" : "getComponentDefaults",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "object"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "config-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/config/field-config" : {
+      "get" : {
+        "operationId" : "getFieldConfig",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "additionalProperties" : {
+                    "type" : "object"
+                  },
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "config-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/info" : {
+      "get" : {
+        "operationId" : "info",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InfoResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "info-controller-v-4"
+        ]
+      }
+    }
+  },
+  "servers" : [
+    {
+      "description" : "Generated server url",
+      "url" : "http://localhost"
+    }
+  ]
+}

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -5790,214 +5790,6 @@
         ]
       }
     },
-    "/rest/api/4/components/{idOrName}" : {
-      "get" : {
-        "operationId" : "getComponent",
-        "parameters" : [
-          {
-            "in" : "path",
-            "name" : "idOrName",
-            "required" : true,
-            "schema" : {
-              "type" : "string"
-            }
-          }
-        ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ComponentDetailResponse"
-                }
-              }
-            },
-            "description" : "OK"
-          },
-          "400" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Bad Request"
-          },
-          "404" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Not Found"
-          },
-          "409" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Conflict"
-          },
-          "425" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Too Early"
-          },
-          "500" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Internal Server Error"
-          },
-          "501" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Not Implemented"
-          },
-          "502" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Bad Gateway"
-          }
-        },
-        "tags" : [
-          "component-controller-v-4"
-        ]
-      }
-    },
-    "/rest/api/4/components/{idOrName}/as-code" : {
-      "get" : {
-        "operationId" : "getComponentAsCode",
-        "parameters" : [
-          {
-            "in" : "path",
-            "name" : "idOrName",
-            "required" : true,
-            "schema" : {
-              "type" : "string"
-            }
-          },
-          {
-            "in" : "query",
-            "name" : "version",
-            "required" : false,
-            "schema" : {
-              "type" : "string"
-            }
-          }
-        ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "text/plain;charset=UTF-8" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "description" : "OK"
-          },
-          "400" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Bad Request"
-          },
-          "404" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Not Found"
-          },
-          "409" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Conflict"
-          },
-          "425" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Too Early"
-          },
-          "500" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Internal Server Error"
-          },
-          "501" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Not Implemented"
-          },
-          "502" : {
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description" : "Bad Gateway"
-          }
-        },
-        "tags" : [
-          "component-controller-v-4"
-        ]
-      }
-    },
     "/rest/api/4/components/{id}" : {
       "delete" : {
         "operationId" : "deleteComponent",
@@ -6015,6 +5807,104 @@
         "responses" : {
           "204" : {
             "description" : "No Content"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      },
+      "get" : {
+        "operationId" : "getComponent",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ComponentDetailResponse"
+                }
+              }
+            },
+            "description" : "OK"
           },
           "400" : {
             "content" : {
@@ -6120,6 +6010,114 @@
               "*/*" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ComponentDetailResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/{id}/as-code" : {
+      "get" : {
+        "operationId" : "getComponentAsCode",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "version",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "text/plain;charset=UTF-8" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiV4SpecTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiV4SpecTest.kt
@@ -127,6 +127,17 @@ class OpenApiV4SpecTest {
                 "v4 spec must not include legacy `$legacy` paths (got: $pathKeys)",
             )
         }
+        // OpenAPI path identity ignores the parameter NAME, so `/components/{id}` and
+        // `/components/{idOrName}` are the SAME path — emitting both is invalid and breaks
+        // generators (openapi-typescript). Assert no two templates collide after normalizing
+        // every `{param}` to `{}`.
+        val normalizedToOriginals = pathKeys.groupBy { it.replace(Regex("\\{[^}]+}"), "{}") }
+        val collisions = normalizedToOriginals.filterValues { it.size > 1 }
+        Assertions.assertTrue(
+            collisions.isEmpty(),
+            "v4 spec has path templates that collide after parameter-name normalization " +
+                "(same path, different param name): ${collisions.values}",
+        )
 
         if (System.getProperty("openapi.refresh") == "true") return
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiV4SpecTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiV4SpecTest.kt
@@ -1,0 +1,146 @@
+package org.octopusden.octopus.components.registry.server.openapi
+
+import com.fasterxml.jackson.core.util.DefaultIndenter
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.test.BaseComponentsRegistryServiceTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * TD-003: generates the v4 OpenAPI document and gates drift.
+ *
+ * Boots the SAME DB-backed H2 context as [BasicFunctionalitySmokeTest] (profiles
+ * `common` + `smoke`, `auth-server.disabled=true`) so all four `@ConditionalOnDatabaseEnabled`
+ * v4 controllers register and the Spring test-context cache is SHARED with that smoke test
+ * (no extra context boot in the [1.0] gate). The boot signature must stay byte-for-byte
+ * identical to [BasicFunctionalitySmokeTest] or the cache forks — treat that as a hard rule.
+ *
+ * Deliberately UNtagged (no `@Tag("integration")`) so it runs under `test` -> `check` ->
+ * `build` and gates every build.
+ *
+ * Behaviour:
+ *  - hits `GET /v3/api-docs/v4` (served by [OpenApiV4Config]'s GroupedOpenApi),
+ *  - canonicalizes (recursive key sort + fixed 2-space `\n` pretty-print + trailing newline)
+ *    so the bytes are stable regardless of host/JVM map-iteration order,
+ *  - always writes `build/openapi/v4.json` (the AC-1 artifact),
+ *  - in refresh mode (`-Popenapi.refresh=true`) stops there,
+ *  - otherwise asserts byte-equality against the committed classpath resource
+ *    `/openapi/v4.json`, with a message pointing at `generateOpenApiDocs`.
+ */
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    classes = [ComponentRegistryServiceApplication::class],
+    properties = ["auth-server.disabled=true"],
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("common", "smoke")
+class OpenApiV4SpecTest {
+    companion object {
+        init {
+            BaseComponentsRegistryServiceTest.configureSpringAppTestDataDir()
+        }
+
+        private const val COMMITTED_RESOURCE = "/openapi/v4.json"
+        private val MAPPER = ObjectMapper()
+
+        /** Recursively sort object member names; arrays keep element order. */
+        private fun sort(node: JsonNode): JsonNode =
+            when {
+                node.isObject -> JsonNodeFactory.instance.objectNode().also { out ->
+                    node.fieldNames().asSequence().sorted().forEach { name ->
+                        out.set<JsonNode>(name, sort(node.get(name)))
+                    }
+                }
+                node.isArray -> JsonNodeFactory.instance.arrayNode().also { out ->
+                    node.forEach { out.add(sort(it)) }
+                }
+                else -> node
+            }
+
+        private fun canonicalize(rawJson: String): String {
+            val sorted = sort(MAPPER.readTree(rawJson))
+            val indenter = DefaultIndenter("  ", "\n")
+            val printer = DefaultPrettyPrinter().apply {
+                indentObjectsWith(indenter)
+                indentArraysWith(indenter)
+            }
+            return MAPPER.writer(printer).writeValueAsString(sorted) + "\n"
+        }
+    }
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Test
+    @DisplayName("v4 OpenAPI spec is generated, covers the v4 surface, and matches the committed v4.json")
+    fun `v4 openapi spec is generated and matches committed`() {
+        val raw = mvc.perform(get("/v3/api-docs/v4"))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+        val regenerated = canonicalize(raw)
+
+        // AC-1: always emit build/openapi/v4.json.
+        val outDir = System.getProperty("openapi.outputDir") ?: "build/openapi"
+        val outFile = Path.of(outDir, "v4.json")
+        Files.createDirectories(outFile.parent)
+        Files.writeString(outFile, regenerated)
+
+        // Coverage assertions (codified, not manual): the six v4 groups present, no legacy paths.
+        val paths = MAPPER.readTree(regenerated).get("paths")
+        Assertions.assertNotNull(paths, "generated spec has no `paths` object")
+        val pathKeys = paths.fieldNames().asSequence().toList()
+        listOf(
+            "/rest/api/4/components",
+            "/rest/api/4/audit",
+            "/rest/api/4/admin",
+            "/rest/api/4/config",
+            "/rest/api/4/info",
+            "/auth/me",
+        ).forEach { prefix ->
+            Assertions.assertTrue(
+                pathKeys.any { it.startsWith(prefix) },
+                "v4 spec is missing any path under `$prefix` (got: $pathKeys)",
+            )
+        }
+        listOf("/rest/api/1", "/rest/api/2", "/rest/api/3").forEach { legacy ->
+            Assertions.assertTrue(
+                pathKeys.none { it.startsWith(legacy) },
+                "v4 spec must not include legacy `$legacy` paths (got: $pathKeys)",
+            )
+        }
+
+        if (System.getProperty("openapi.refresh") == "true") return
+
+        // AC-3: drift gate.
+        val committed = OpenApiV4SpecTest::class.java.getResource(COMMITTED_RESOURCE)?.readText()
+            ?: Assertions.fail(
+                "committed spec resource $COMMITTED_RESOURCE is missing — run " +
+                    "`./gradlew :components-registry-service-server:generateOpenApiDocs` and commit it",
+            )
+        Assertions.assertEquals(
+            committed,
+            regenerated,
+            "OpenAPI v4 spec drift: the committed src/main/resources/openapi/v4.json is stale. " +
+                "Run `./gradlew :components-registry-service-server:generateOpenApiDocs` and commit the updated v4.json.",
+        )
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiV4SpecTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiV4SpecTest.kt
@@ -91,11 +91,14 @@ class OpenApiV4SpecTest {
     @Test
     @DisplayName("v4 OpenAPI spec is generated, covers the v4 surface, and matches the committed v4.json")
     fun `v4 openapi spec is generated and matches committed`() {
+        // Decode the response bytes as UTF-8 explicitly rather than via contentAsString (which uses
+        // the response's charset) so the gate is not host/charset-sensitive.
         val raw = mvc.perform(get("/v3/api-docs/v4"))
             .andExpect(status().isOk)
             .andReturn()
             .response
-            .contentAsString
+            .contentAsByteArray
+            .toString(Charsets.UTF_8)
         val regenerated = canonicalize(raw)
 
         // AC-1: always emit build/openapi/v4.json.

--- a/docs/registry/README.md
+++ b/docs/registry/README.md
@@ -80,7 +80,7 @@ PRD (why?) ──→ FS (what?) ──→ TDD (how?)
 |----------|----------------|
 | `migration-runbook.md` | Before production migration — step-by-step ops playbook |
 
-> [api-changelog.md](api-changelog.md) — created with the v4 OpenAPI spec generation (TD-003).
+_[api-changelog.md](api-changelog.md) was created with the v4 OpenAPI spec generation (TD-003)._
 
 ## How to Read
 

--- a/docs/registry/README.md
+++ b/docs/registry/README.md
@@ -79,7 +79,8 @@ PRD (why?) ──→ FS (what?) ──→ TDD (how?)
 | Document | When to create |
 |----------|----------------|
 | `migration-runbook.md` | Before production migration — step-by-step ops playbook |
-| `api-changelog.md` | On API v4 release — changelog for consumers |
+
+> [api-changelog.md](api-changelog.md) — created with the v4 OpenAPI spec generation (TD-003).
 
 ## How to Read
 

--- a/docs/registry/api-changelog.md
+++ b/docs/registry/api-changelog.md
@@ -1,0 +1,23 @@
+# API v4 Changelog
+
+Changelog for consumers of the **v4** REST API (CRUD + audit + admin), the contract the
+components-management Portal SPA binds to. v1/v2/v3 are separate stable read contracts and are
+not covered here.
+
+The machine-readable contract is generated from the v4 controllers and committed at
+[`components-registry-service-server/src/main/resources/openapi/v4.json`](../../components-registry-service-server/src/main/resources/openapi/v4.json).
+It is published by the TeamCity `[1.0]` build under the `openapi/` artifact path and consumed by
+the Portal (`frontend/src/lib/api/v4.json` → `schema.d.ts`). A CI drift gate
+(`OpenApiV4SpecTest`) fails the build if the committed spec disagrees with the live regeneration;
+refresh it with `./gradlew :components-registry-service-server:generateOpenApiDocs`. See
+[TD-003](tech-debt/003-openapi-v4-spec-generation.md).
+
+> **How to update:** when a PR changes the v4 surface (a new field, endpoint, enum value, or a
+> rename/removal), run `generateOpenApiDocs`, commit the refreshed `v4.json`, and add a dated
+> entry below describing the consumer-visible change.
+
+## Unreleased
+
+- **OpenAPI spec generation wired (TD-003).** The v4 surface is now published as a machine-readable
+  `v4.json` (OpenAPI 3.0.1) and gated for drift. No behavioural API change — this baselines the
+  contract. `info.version` is the constant `"4"`.

--- a/docs/registry/tech-debt/003-openapi-v4-spec-generation.md
+++ b/docs/registry/tech-debt/003-openapi-v4-spec-generation.md
@@ -2,15 +2,13 @@
 
 ## Status
 
-Open. Mirror of Portal `TD-002` ("Replace hand-written `frontend/src/lib/types.ts` with OpenAPI-generated types"). Either side can drive — the practical work needs both.
+**CRS side: done** (generation + drift gate + CI artifact — see "CRS side" below). **Portal side: open**, tracked as Portal `TD-002` / issue #82 ("Replace hand-written `frontend/src/lib/types.ts` with OpenAPI-generated types"). The CRS build now publishes `v4.json`; the Portal vendors it and regenerates `schema.d.ts`.
 
 ## Context
 
 When the UI was extracted from this repo into `octopus-components-management-portal` (PR #147, [ADR-012](../adr/012-portal-architecture.md), reversed [ADR-009](../adr/009-ui-repository-strategy.md)), we accepted that API + UI changes are no longer atomic across a single PR. The mitigation we agreed to in ADR-012 §"Negative — and how mitigated" is OpenAPI generation, so the SPA can derive its TypeScript types from a machine-readable contract instead of hand-coding them.
 
-That generation is not yet wired. As of `v3` HEAD:
-- The CRS server has no OpenAPI generator dependency in `components-registry-service-server/build.gradle`.
-- The Portal SPA hand-maintains `frontend/src/lib/types.ts` against the Kotlin DTOs in this repo.
+The `springdoc-openapi-starter-webmvc-ui` dependency was already present in `components-registry-service-server/build.gradle`; what was missing — and is now added — is the v4 grouping, the generation/drift task, and the CI artifact. The Portal SPA still hand-maintains `frontend/src/lib/types.ts` against the Kotlin DTOs in this repo; migrating it to the generated `schema.d.ts` is the remaining Portal-side work.
 
 This is fine while a single team owns both repos and the API surface is small. It will not scale.
 
@@ -22,12 +20,12 @@ This is fine while a single team owns both repos and the API surface is small. I
 
 ## Scope
 
-### CRS side (this repo)
+### CRS side (this repo) — DONE
 
-1. Add `springdoc-openapi-starter-webmvc-ui` (or equivalent) to `components-registry-service-server/build.gradle`.
-2. Configure springdoc to scan v4 controllers (and `AuthController` at `/auth/me`, which is outside `/rest/api/4`). Exclude legacy v1/v2/v3 — they are stable Feign-client contracts; not worth re-deriving.
-3. Add a Gradle task `:components-registry-service-server:generateOpenApiDocs` that emits `build/openapi/v4.json`. Wire it to run as part of `./gradlew build` so a hand-edited spec drift fails CI.
-4. Publish `v4.json` as a CI build artifact (TeamCity / GitHub Actions) so the Portal CI can pull it.
+1. `springdoc-openapi-starter-webmvc-ui` was already a dependency in `components-registry-service-server/build.gradle`.
+2. `OpenApiV4Config` registers a `GroupedOpenApi("v4")` matching the v4 controllers + `AuthController` at `/auth/me`; v1/v2/v3 never match the path list. springdoc serves it at `GET /v3/api-docs/v4`. `info.version` is the constant `"4"` (NOT the build version) so the committed spec only changes when the v4 surface changes.
+3. Generation is a `@SpringBootTest`+MockMvc capture (`OpenApiV4SpecTest`, reusing the `BasicFunctionalitySmokeTest` H2/`smoke` context) rather than a `bootRun` plugin — no Keycloak/Postgres needed. The UNtagged test runs under `./gradlew build`, writes `build/openapi/v4.json`, and asserts byte-equality against the committed `components-registry-service-server/src/main/resources/openapi/v4.json` (canonicalized via recursive key-sort). `:components-registry-service-server:generateOpenApiDocs` refreshes the committed copy after an intended change.
+4. The TeamCity `[1.0] Compile & UT [AUTO]` build publishes `components-registry-service-server/build/openapi/v4.json` under the `openapi` artifact path, so Portal CI can pull `openapi/v4.json`.
 
 ### Portal side (mirrors Portal TD-002)
 
@@ -46,7 +44,7 @@ This is fine while a single team owns both repos and the API surface is small. I
 
 1. `./gradlew build` produces `build/openapi/v4.json` covering at least:
    - `/rest/api/4/components/**`
-   - `/rest/api/4/audit-log/**`
+   - `/rest/api/4/audit/**` (the audit controller is mapped at `/audit`, not `/audit-log`)
    - `/rest/api/4/admin/**`
    - `/rest/api/4/config/**`
    - `/rest/api/4/info`


### PR DESCRIPTION
## What & why

CRS **TD-003**. The Portal SPA hand-maintains its v4 wire-contract types; [ADR-012](docs/registry/adr/012-portal-architecture.md) named OpenAPI generation as the mitigation for the API/UI separate-repo split. This wires the **CRS side** (Phase A of a 3-phase plan): generate a machine-readable v4 spec, gate it for drift, and publish it so the Portal can derive `schema.d.ts` from it (Portal issue #82, Phase C).

Scope is the **v4** surface only — v1/v2/v3 stay hand-shaped Feign contracts.

## How

- **`OpenApiV4Config`** — `GroupedOpenApi("v4")` matching the v4 controllers + `/auth/**`, served at `GET /v3/api-docs/v4` (already `permitAll`). `info` is scoped to the group (a global bean would relabel the ungrouped `/v3/api-docs`); `info.version` is the **constant** `"4"`, not the build version, so the committed spec only changes on real API-surface changes.
- **`OpenApiV4SpecTest`** — `@SpringBootTest`+MockMvc reusing the `BasicFunctionalitySmokeTest` H2/`smoke` context (shared test-context cache; no Keycloak/Postgres). Captures the doc, **canonicalizes** (recursive object-key sort + fixed 2-space `\n` pretty-print + trailing newline → byte-stable), writes `build/openapi/v4.json`, and asserts byte-equality vs the committed `src/main/resources/openapi/v4.json`. Also asserts the six v4 groups are present and **no** v1/v2/v3 paths. UNtagged → runs under `test → check → build` (the `[1.0]` gate), no new gate task.
- **`generateOpenApiDocs`** — `./gradlew :components-registry-service-server:generateOpenApiDocs` refreshes the committed spec after an intended change. Two tasks (`generateOpenApiDocsTest` Test → `generateOpenApiDocs` Copy via `dependsOn`) so a failing regeneration never copies a stale spec. Separate output dir from the gate run so the two Test tasks can't race.
- **`application.yml`** — `springdoc.writer-with-order-by-keys: true`.
- **TeamCity `[1.0]`** — publishes `components-registry-service-server/build/openapi/v4.json` under the `openapi` artifact path for Portal CI to pull.
- **docs** — TD-003 status/AC update (fixes the stale `/audit-log` → `/audit` path and the "no springdoc dep" line), new `api-changelog.md`.

## Verification

- Full `./gradlew build` green (drift gate runs in the server `test`).
- `generateOpenApiDocs` run twice → byte-identical `v4.json` (same shasum).
- RED demo: tampering the committed spec fails the gate; `generateOpenApiDocs` restores it green.
- Generated spec covers all six groups, no v1/v2/v3 paths, `info.version="4"`.

## Follow-ups (not in this PR)

- **Phase B** (CRS): structural `@Schema` metadata on the v4 DTOs.
- **Phase C** (Portal #82): vendor the published spec, regenerate `schema.d.ts`, migrate `types.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
