### PR TITLE
fix(#256): close stale-git bleed-through on VCS/Distribution project endpoints

### DIFF
--- a/components-registry-compat-test/src/test/resources/known-deltas-db.json
+++ b/components-registry-compat-test/src/test/resources/known-deltas-db.json
@@ -14,6 +14,20 @@
       "candidateValue": "application/json",
       "reason": "Symptom of the STATUS_CODE_DIFF entry above — when the V1 baseline transport-fails the heavy /updateCache call under parallel load, no response headers come back and only candidate (which answers 410 with a JSON ErrorResponse body) reports a content-type. Suppressed together with the status-code deprecation delta.",
       "regressionTest": "ComponentsRegistryServiceControllerUpdateCacheTest.git equal to zero retires the endpoint with 410 and does not re-read"
+    },
+    {
+      "endpoint": "GET /rest/api/2/projects/{projectKey}/versions/{version}/vcs-settings",
+      "category": "STATUS_CODE_DIFF",
+      "candidateValue": "404",
+      "reason": "#256 stale-git bleed-through fix. For a DB-sourced project whose requested version is absent from the DB, the V1/git baseline can still serve a STALE VCSSettings as 200 from legacy DSL, while the v3 candidate routes by resolved component source (ComponentRoutingResolver.resolverForProject) and correctly returns 404. This delta only materialises when the smoke/trace set happens to probe a db-sourced project at a version git still stale-matches; baselineValue omitted because the baseline value is the stale 200 we are intentionally diverging from. The authoritative regression guard is the unit test (this entry is defensive documentation, same convention as the updateCache deltas above).",
+      "regressionTest": "ComponentRoutingResolverStaleAndNotFoundTest.issue256_getVCSSettingForProject_dbSourcedMissingVersion_throwsNotFound_noGitBleed"
+    },
+    {
+      "endpoint": "GET /rest/api/2/projects/{projectKey}/versions/{version}/distribution",
+      "category": "STATUS_CODE_DIFF",
+      "candidateValue": "404",
+      "reason": "#256 stale-git bleed-through fix (Distribution counterpart of the vcs-settings entry above). DB-sourced project + version absent from DB: git baseline may serve a stale Distribution as 200; v3 candidate routes by resolved component source and returns 404. Authoritative guard is the unit test; this entry is defensive documentation.",
+      "regressionTest": "ComponentRoutingResolverStaleAndNotFoundTest.issue256_getDistributionForProject_dbSourcedMissingVersion_throwsNotFound_noGitBleed"
     }
   ]
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolver.kt
@@ -222,27 +222,33 @@ class ComponentRoutingResolver(
         return filteredGit + dbResults
     }
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    // #256: VCSSettings / Distribution carry no componentName accessor, so the PR #245
+    // stale-guard (reject a git result whose id ∈ getDbComponentNames()) cannot be applied
+    // to the return value. Instead, discover the authoritative component for
+    // (projectKey, version) via the already-stale-guarded getJiraComponentByProjectAndVersion
+    // — which throws NotFoundException for a db-sourced project whose version is absent,
+    // closing the git bleed-through — then route the fetch to that component's owning
+    // resolver. resolverFor() hits the DB via getSource(), so a db-sourced component never
+    // serves stale git data even on a transient db error: the fetch lands on dbResolver and
+    // the error propagates rather than bleeding git (correctness > availability during
+    // cutover). A null component name (malformed/cached JCV — see :117) falls back to git.
+    private fun resolverForProject(
+        projectKey: String,
+        version: String,
+    ): ComponentRegistryResolver {
+        val componentName = getJiraComponentByProjectAndVersion(projectKey, version).componentVersion?.componentName
+        return if (componentName != null) resolverFor(componentName) else gitResolver
+    }
+
     override fun getVCSSettingForProject(
         projectKey: String,
         version: String,
-    ): VCSSettings =
-        try {
-            dbResolver.getVCSSettingForProject(projectKey, version)
-        } catch (e: Exception) {
-            gitResolver.getVCSSettingForProject(projectKey, version)
-        }
+    ): VCSSettings = resolverForProject(projectKey, version).getVCSSettingForProject(projectKey, version)
 
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override fun getDistributionForProject(
         projectKey: String,
         version: String,
-    ): Distribution =
-        try {
-            dbResolver.getDistributionForProject(projectKey, version)
-        } catch (e: Exception) {
-            gitResolver.getDistributionForProject(projectKey, version)
-        }
+    ): Distribution = resolverForProject(projectKey, version).getDistributionForProject(projectKey, version)
 
     // --- Artifact resolution: try both ---
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -443,7 +443,9 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
             .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
         doReturn(mockJiraComponentVersion(migratedComponent))
             .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
-        // pre-fix bleed-through path: db throws, git would hand back a stale VCSSettings
+        // pre-fix bleed-through path (db throws → git serves a stale VCSSettings as 200): these
+        // stubs reproduce the OLD behaviour and are never reached post-fix — the stale-guard in
+        // getJiraComponentByProjectAndVersion throws before any VCSSettings fetch.
         doThrow(NotFoundException("not in db"))
             .`when`(dbResolver).getVCSSettingForProject(projectKey, version)
         doReturn(mock(VCSSettings::class.java))
@@ -497,6 +499,30 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
 
     @Test
     @DisplayName(
+        "#256 VCS pre-existing edge: name discovery yields a null componentVersion → routes to " +
+            "gitResolver (guard only as strong as getJiraComponentByProjectAndVersion's null-degradation)",
+    )
+    fun issue256_getVCSSettingForProject_nullComponentVersion_fallsBackToGit() {
+        val projectKey = "malformed-proj"
+        val version = "1.0.0"
+        val gitVcs = mock(VCSSettings::class.java)
+        // db NotFound → git returns a malformed/cached JCV whose inner componentVersion is null;
+        // getJiraComponentByProjectAndVersion's null-safe guard returns it as-is (see 1.1 P1-B).
+        val nullInnerJcv = mock(JiraComponentVersion::class.java)
+        doReturn(null).`when`(nullInnerJcv).componentVersion
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(nullInnerJcv)
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(gitVcs).`when`(gitResolver).getVCSSettingForProject(projectKey, version)
+
+        // null name → resolverForProject falls back to gitResolver (inherited edge, documented in TD-013)
+        val result = routing.getVCSSettingForProject(projectKey, version)
+        assertEquals(gitVcs, result)
+    }
+
+    @Test
+    @DisplayName(
         "#256 VCS transient db error (db-sourced): error propagates, stale git VCSSettings never " +
             "served — owner-routed fetch (correctness > availability)",
     )
@@ -538,6 +564,8 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
             .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
         doReturn(mockJiraComponentVersion(migratedComponent))
             .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        // pre-fix bleed-through path (never reached post-fix — guard throws first); see the
+        // VCS counterpart above.
         doThrow(NotFoundException("not in db"))
             .`when`(dbResolver).getDistributionForProject(projectKey, version)
         doReturn(mock(Distribution::class.java))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRoutingResolverStaleAndNotFoundTest.kt
@@ -19,6 +19,8 @@ import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.VersionedComponent
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.model.Distribution
+import org.octopusden.octopus.escrow.model.VCSSettings
 import org.octopusden.octopus.releng.dto.ComponentVersion
 import org.octopusden.octopus.releng.dto.JiraComponentVersion
 
@@ -34,9 +36,8 @@ import org.octopusden.octopus.releng.dto.JiraComponentVersion
  * payload" instead of "404 / empty".
  *
  * Items covered here: 1.1, 1.4, 1.4b, 1.6 (see
- * ~/.claude/plans/pr-192-review-fixup-plan.md). Items deferred:
- *   - 1.2/1.3 (Group 6-H): return types lack a `componentName` accessor for
- *     stale-guard, needs source-precedence-by-project-key design.
+ * ~/.claude/plans/pr-192-review-fixup-plan.md), plus 1.2/1.3 (issue #256, see
+ * below). Items still deferred:
  *   - 1.5 (Group 6-I): `getComponentsCountByBuildSystem` double-count of
  *     migrated components — fix requires refactoring private
  *     `EscrowModule.getBuildSystem()` / `isArchived()` extensions to a shared
@@ -403,5 +404,212 @@ class ComponentRoutingResolverStaleAndNotFoundTest {
 
         val result = routing.findComponentsByDockerImages(images)
         assertEquals(setOf(gitMatch), result)
+    }
+
+    // =========================================================================
+    // #256 (1.2/1.3): getVCSSettingForProject / getDistributionForProject —
+    // source-precedence-by-project-key. These return types (VCSSettings,
+    // Distribution) carry NO componentName accessor, so the PR #245 stale-guard
+    // (check returned-object id ∈ getDbComponentNames()) cannot apply to the
+    // return value. Instead routing discovers the authoritative component for
+    // (projectKey, version) via the already-stale-guarded
+    // getJiraComponentByProjectAndVersion, then routes the VCS/Distribution
+    // fetch to that component's owning resolver (resolverFor → getSource).
+    //
+    // Trade-off — correctness > availability during cutover: the route lookup
+    // hits the DB via sourceRegistry.getSource(), so a db-sourced component
+    // never serves stale git data even on a transient db error — the fetch is
+    // routed to dbResolver and the error propagates instead of bleeding git
+    // (pinned by the *Transient* tests below).
+    //
+    // Pre-existing edge (out of scope, inherited from PR #245): a git JCV with
+    // componentVersion == null yields a null name → falls back to gitResolver,
+    // so the guard is only as strong as getJiraComponentByProjectAndVersion's
+    // null-degradation (see the 1.1 P1-B test above).
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "#256 VCS bleed-through guard: db-sourced project + missing version → throws NotFound; " +
+            "stale git VCSSettings never served",
+    )
+    fun issue256_getVCSSettingForProject_dbSourcedMissingVersion_throwsNotFound_noGitBleed() {
+        val projectKey = "stale-proj"
+        val version = "9.9.9"
+        val migratedComponent = "migrated-widget"
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        // name discovery: db NotFound, git stale-matches the db-sourced component
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(mockJiraComponentVersion(migratedComponent))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        // pre-fix bleed-through path: db throws, git would hand back a stale VCSSettings
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getVCSSettingForProject(projectKey, version)
+        doReturn(mock(VCSSettings::class.java))
+            .`when`(gitResolver).getVCSSettingForProject(projectKey, version)
+
+        assertThrows(NotFoundException::class.java) {
+            routing.getVCSSettingForProject(projectKey, version)
+        }
+        verify(gitResolver, never()).getVCSSettingForProject(projectKey, version)
+    }
+
+    @Test
+    @DisplayName(
+        "#256 VCS db-sourced happy path: version present → routes to dbResolver, git not called",
+    )
+    fun issue256_getVCSSettingForProject_dbSourced_routesToDb() {
+        val projectKey = "db-proj"
+        val version = "1.0.0"
+        val dbComponent = "db-widget"
+        val dbVcs = mock(VCSSettings::class.java)
+        doReturn(mockJiraComponentVersion(dbComponent))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn("db").`when`(sourceRegistry).getSource(dbComponent)
+        doReturn(dbVcs).`when`(dbResolver).getVCSSettingForProject(projectKey, version)
+
+        val result = routing.getVCSSettingForProject(projectKey, version)
+        assertEquals(dbVcs, result)
+        verify(gitResolver, never()).getVCSSettingForProject(projectKey, version)
+    }
+
+    @Test
+    @DisplayName(
+        "#256 VCS git-sourced project: resolves a git component → routes to gitResolver",
+    )
+    fun issue256_getVCSSettingForProject_gitSourced_routesToGit() {
+        val projectKey = "git-proj"
+        val version = "1.0.0"
+        val gitComponent = "legacy-widget"
+        val gitVcs = mock(VCSSettings::class.java)
+        // name discovery: db NotFound, git returns a fresh non-db-sourced match
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(mockJiraComponentVersion(gitComponent))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        // getSource(gitComponent) is unstubbed → null (≠ "db") → routes to gitResolver
+        doReturn(gitVcs).`when`(gitResolver).getVCSSettingForProject(projectKey, version)
+
+        val result = routing.getVCSSettingForProject(projectKey, version)
+        assertEquals(gitVcs, result)
+    }
+
+    @Test
+    @DisplayName(
+        "#256 VCS transient db error (db-sourced): error propagates, stale git VCSSettings never " +
+            "served — owner-routed fetch (correctness > availability)",
+    )
+    fun issue256_getVCSSettingForProject_dbSourcedTransient_propagatesError_noGitBleed() {
+        val projectKey = "outage-proj"
+        val version = "1.0.0"
+        val migratedComponent = "migrated-widget"
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        // name discovery: transient (non-NotFound) db error → falls back to git for the NAME (per #245)
+        doThrow(RuntimeException("transient db error"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(mockJiraComponentVersion(migratedComponent))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        // component is db-sourced → fetch routed to dbResolver, which is down → error propagates
+        doReturn("db").`when`(sourceRegistry).getSource(migratedComponent)
+        doThrow(RuntimeException("db down"))
+            .`when`(dbResolver).getVCSSettingForProject(projectKey, version)
+        // git would serve stale data, but must never be reached for a db-sourced component
+        doReturn(mock(VCSSettings::class.java))
+            .`when`(gitResolver).getVCSSettingForProject(projectKey, version)
+
+        assertThrows(RuntimeException::class.java) {
+            routing.getVCSSettingForProject(projectKey, version)
+        }
+        verify(gitResolver, never()).getVCSSettingForProject(projectKey, version)
+    }
+
+    @Test
+    @DisplayName(
+        "#256 Distribution bleed-through guard: db-sourced project + missing version → throws " +
+            "NotFound; stale git Distribution never served",
+    )
+    fun issue256_getDistributionForProject_dbSourcedMissingVersion_throwsNotFound_noGitBleed() {
+        val projectKey = "stale-proj"
+        val version = "9.9.9"
+        val migratedComponent = "migrated-widget"
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(mockJiraComponentVersion(migratedComponent))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getDistributionForProject(projectKey, version)
+        doReturn(mock(Distribution::class.java))
+            .`when`(gitResolver).getDistributionForProject(projectKey, version)
+
+        assertThrows(NotFoundException::class.java) {
+            routing.getDistributionForProject(projectKey, version)
+        }
+        verify(gitResolver, never()).getDistributionForProject(projectKey, version)
+    }
+
+    @Test
+    @DisplayName(
+        "#256 Distribution db-sourced happy path: version present → routes to dbResolver, git not called",
+    )
+    fun issue256_getDistributionForProject_dbSourced_routesToDb() {
+        val projectKey = "db-proj"
+        val version = "1.0.0"
+        val dbComponent = "db-widget"
+        val dbDist = mock(Distribution::class.java)
+        doReturn(mockJiraComponentVersion(dbComponent))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn("db").`when`(sourceRegistry).getSource(dbComponent)
+        doReturn(dbDist).`when`(dbResolver).getDistributionForProject(projectKey, version)
+
+        val result = routing.getDistributionForProject(projectKey, version)
+        assertEquals(dbDist, result)
+        verify(gitResolver, never()).getDistributionForProject(projectKey, version)
+    }
+
+    @Test
+    @DisplayName(
+        "#256 Distribution git-sourced project: resolves a git component → routes to gitResolver",
+    )
+    fun issue256_getDistributionForProject_gitSourced_routesToGit() {
+        val projectKey = "git-proj"
+        val version = "1.0.0"
+        val gitComponent = "legacy-widget"
+        val gitDist = mock(Distribution::class.java)
+        doThrow(NotFoundException("not in db"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(mockJiraComponentVersion(gitComponent))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(gitDist).`when`(gitResolver).getDistributionForProject(projectKey, version)
+
+        val result = routing.getDistributionForProject(projectKey, version)
+        assertEquals(gitDist, result)
+    }
+
+    @Test
+    @DisplayName(
+        "#256 Distribution transient db error (db-sourced): error propagates, stale git Distribution " +
+            "never served — owner-routed fetch (correctness > availability)",
+    )
+    fun issue256_getDistributionForProject_dbSourcedTransient_propagatesError_noGitBleed() {
+        val projectKey = "outage-proj"
+        val version = "1.0.0"
+        val migratedComponent = "migrated-widget"
+        doReturn(setOf(migratedComponent)).`when`(sourceRegistry).getDbComponentNames()
+        doThrow(RuntimeException("transient db error"))
+            .`when`(dbResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn(mockJiraComponentVersion(migratedComponent))
+            .`when`(gitResolver).getJiraComponentByProjectAndVersion(projectKey, version)
+        doReturn("db").`when`(sourceRegistry).getSource(migratedComponent)
+        doThrow(RuntimeException("db down"))
+            .`when`(dbResolver).getDistributionForProject(projectKey, version)
+        doReturn(mock(Distribution::class.java))
+            .`when`(gitResolver).getDistributionForProject(projectKey, version)
+
+        assertThrows(RuntimeException::class.java) {
+            routing.getDistributionForProject(projectKey, version)
+        }
+        verify(gitResolver, never()).getDistributionForProject(projectKey, version)
     }
 }

--- a/docs/registry/tech-debt/013-source-precedence-by-project-key.md
+++ b/docs/registry/tech-debt/013-source-precedence-by-project-key.md
@@ -1,0 +1,125 @@
+# TD-013: Source-precedence-by-project-key for VCSSettings / Distribution project endpoints
+
+## Status
+
+Implemented (issue #256) · P1 cutover correctness · schema-v2-fixup (former PR #192 review
+items 1.2/1.3, "Group 6-H")
+
+## Context
+
+`ComponentRoutingResolver` routes read requests between the legacy git resolver and the new
+DB resolver during the v3 DB-migration cutover. Two project-keyed endpoints —
+
+- `GET /rest/api/2/projects/{projectKey}/versions/{version}/vcs-settings`
+- `GET /rest/api/2/projects/{projectKey}/versions/{version}/distribution`
+
+(`ProjectControllerV2.getVCSSettingForProject` / `getDistributionForProject`) — resolved via
+a blanket fallback:
+
+```kotlin
+try { dbResolver.getVCSSettingForProject(projectKey, version) }
+catch (e: Exception) { gitResolver.getVCSSettingForProject(projectKey, version) }
+```
+
+The `catch (e: Exception)` swallows `NotFoundException` from the DB **and** falls through to
+git. For a **DB-sourced** project whose requested version is absent from the DB, git can
+return a **stale** `VCSSettings` / `Distribution` that bleeds through as `200` with legacy
+data instead of the correct `404` ("stale-git bleed-through"). At cutover this is a
+correctness hazard: wrong VCS roots or distribution coordinates would point builds/releases
+at legacy locations.
+
+PR #245 fixed the sibling methods (1.1, 1.4, 1.4b, 1.6) with a stale-guard that checks the
+returned object's component id against `getDbComponentNames()`. That pattern does **not**
+apply here: `VCSSettings` and `Distribution` carry **no `componentName` accessor**, so there
+is nothing on the return value to guard against. These two items were deferred pending a
+source-precedence design.
+
+## Decision
+
+**Don't guard on the return type — discover the authoritative component first, then route
+the data fetch to that component's owning resolver.** Reuses two already-audited pieces:
+
+1. `getJiraComponentByProjectAndVersion(projectKey, version)` — already db-first +
+   stale-guarded + transient-tolerant; returns a `JiraComponentVersion` whose
+   `componentVersion?.componentName` is the authoritative component, or throws
+   `NotFoundException` (→ 404) when a DB-sourced project's version is absent.
+2. `resolverFor(componentName)` — returns `dbResolver` if the component's source is `"db"`,
+   else `gitResolver`.
+
+```kotlin
+private fun resolverForProject(projectKey: String, version: String): ComponentRegistryResolver {
+    val componentName = getJiraComponentByProjectAndVersion(projectKey, version).componentVersion?.componentName
+    return if (componentName != null) resolverFor(componentName) else gitResolver
+}
+
+override fun getVCSSettingForProject(projectKey, version) =
+    resolverForProject(projectKey, version).getVCSSettingForProject(projectKey, version)
+override fun getDistributionForProject(projectKey, version) =
+    resolverForProject(projectKey, version).getDistributionForProject(projectKey, version)
+```
+
+### Decision 1 — routing granularity: version-specific (not project-level)
+
+The issue's literal acceptance said "if **any** component of the project is DB-sourced, the
+DB resolver is authoritative." We deliberately implement **version-specific** routing
+instead. A mid-migration project can carry a git component on one version range and a db
+component on another; project-level routing would wrongly `404` a legitimate git version.
+Resolving the exact component for the requested `(projectKey, version)` is strictly more
+correct and the only behavior that keeps mixed-migration projects working.
+
+### Decision 2 — transient errors: correctness > availability during cutover
+
+`getJiraComponentByProjectAndVersion` tolerates transient (non-`NotFound`) DB errors for
+*name discovery* (falls back to git for the name, per PR #245). But the subsequent route
+through `resolverFor(name)` calls `sourceRegistry.getSource(name)`, which **also hits the
+DB**, and the fetch lands on the **owning** resolver. Consequences:
+
+- A db-sourced component **never** serves stale git data — even on a transient DB error the
+  fetch is routed to `dbResolver`, which fails closed; the error propagates (no `200` bleed).
+- It is therefore **not** true that these endpoints "stay fully available via git" during a
+  DB outage. The trade-off is **correctness over availability** for the migration window.
+
+This is **not a new systemic dependency**: every single-component method already routes via
+`resolverFor → getSource → DB`, so the service already requires the DB to be up to route.
+The change is *local* to these two endpoints (was "works via git", now "errors") and brings
+them in line with the rest of the resolver.
+
+### Acknowledged edge — null-inner JCV (pre-existing, out of scope)
+
+A git `JiraComponentVersion` with `componentVersion == null` yields a null name → falls back
+to `gitResolver`. The guard is only as strong as `getJiraComponentByProjectAndVersion`'s
+null-degradation (PR #245 P1-B). This edge is inherited, not introduced, and left as-is.
+
+### Acknowledged cost — double resolution
+
+Name discovery resolves `(projectKey, version)` and the owning resolver re-resolves it on
+the fetch (≈2× work on these cold endpoints). Acceptable for `vcs-settings` /
+`distribution`; a follow-up lever should they ever become hot (e.g. thread the
+already-resolved component through the fetch), noted alongside the #249/#321 perf work.
+
+## Acceptance criteria
+
+- [x] DB-sourced project + missing version → `404` (never stale git) — both endpoints.
+- [x] DB-sourced project + present version → routed to `dbResolver`; git never called.
+- [x] Git-sourced project → routed to `gitResolver`.
+- [x] Transient DB error on a DB-sourced project → error propagates; git never called
+  (correctness > availability).
+- [x] Pure in-memory regression tests (no global fixtures) in
+  `ComponentRoutingResolverStaleAndNotFoundTest` (`issue256_*`, 8 cases; RED→GREEN).
+- [x] Compat known-delta entries documenting the intended `200`-stale → `404` divergence.
+
+## Risk classification
+
+P1 correctness for the v3→main cutover. The change closes a silent data-corruption path
+(stale VCS/distribution served as `200`). The only behavior regression is reduced
+availability of these two endpoints during a full DB outage — a deliberate trade-off,
+consistent with the rest of the routing resolver.
+
+## See also
+
+- Issue #256; former PR #192 review items 1.2/1.3.
+- PR #245 — the sibling stale-guards (1.1/1.4/1.4b/1.6) this builds on.
+- `ComponentRoutingResolver.kt` — `resolverForProject` + `resolverFor` +
+  `getJiraComponentByProjectAndVersion`.
+- `ComponentRoutingResolverStaleAndNotFoundTest.kt` — `issue256_*` tests.
+- `components-registry-compat-test/src/test/resources/known-deltas-db.json`.

--- a/docs/registry/tech-debt/013-source-precedence-by-project-key.md
+++ b/docs/registry/tech-debt/013-source-precedence-by-project-key.md
@@ -78,11 +78,18 @@ DB**, and the fetch lands on the **owning** resolver. Consequences:
   fetch is routed to `dbResolver`, which fails closed; the error propagates (no `200` bleed).
 - It is therefore **not** true that these endpoints "stay fully available via git" during a
   DB outage. The trade-off is **correctness over availability** for the migration window.
+- The availability reduction is **not limited to db-sourced projects**: `getSource()`
+  (`ComponentSourceRegistryImpl`) reads the `component_source` table uncached on every call,
+  so during a *full* DB outage the route lookup itself fails and **even a git-sourced
+  project's** `vcs-settings` / `distribution` endpoint now errors (previously it would have
+  been served from git). The db-sourced case is the one that closes a *correctness* hole;
+  the git-sourced case is an availability side-effect of routing through the DB.
 
 This is **not a new systemic dependency**: every single-component method already routes via
-`resolverFor → getSource → DB`, so the service already requires the DB to be up to route.
-The change is *local* to these two endpoints (was "works via git", now "errors") and brings
-them in line with the rest of the resolver.
+`resolverFor → getSource → DB`, so the service already requires the DB to be up to route
+*any* per-component read. The change is *local* to these two project endpoints (was "works
+via git", now "errors" when the DB is down) and brings them in line with the rest of the
+resolver.
 
 ### Acknowledged edge — null-inner JCV (pre-existing, out of scope)
 
@@ -90,12 +97,14 @@ A git `JiraComponentVersion` with `componentVersion == null` yields a null name 
 to `gitResolver`. The guard is only as strong as `getJiraComponentByProjectAndVersion`'s
 null-degradation (PR #245 P1-B). This edge is inherited, not introduced, and left as-is.
 
-### Acknowledged cost — double resolution
+### Acknowledged cost — ~3 DB round-trips per request
 
-Name discovery resolves `(projectKey, version)` and the owning resolver re-resolves it on
-the fetch (≈2× work on these cold endpoints). Acceptable for `vcs-settings` /
-`distribution`; a follow-up lever should they ever become hot (e.g. thread the
-already-resolved component through the fetch), noted alongside the #249/#321 perf work.
+Each request now does roughly three DB touches where the old code did one:
+`getJiraComponentByProjectAndVersion` (name discovery) + `getSource` (route selection) +
+the owning resolver's actual fetch (which re-resolves `(projectKey, version)`). Acceptable
+for the cold `vcs-settings` / `distribution` endpoints; a follow-up lever should they ever
+become hot (e.g. thread the already-resolved component through the fetch and/or cache
+`getSource`), noted alongside the #249/#321 perf work.
 
 ## Acceptance criteria
 
@@ -105,7 +114,9 @@ already-resolved component through the fetch), noted alongside the #249/#321 per
 - [x] Transient DB error on a DB-sourced project → error propagates; git never called
   (correctness > availability).
 - [x] Pure in-memory regression tests (no global fixtures) in
-  `ComponentRoutingResolverStaleAndNotFoundTest` (`issue256_*`, 8 cases; RED→GREEN).
+  `ComponentRoutingResolverStaleAndNotFoundTest` (`issue256_*`, 9 cases: 4 routing branches
+  — bleed-through guard, db-sourced happy path, git-sourced, transient-error-propagates —
+  × {VCS, Distribution}, plus the null-inner-JCV → git fallback edge; RED→GREEN).
 - [x] Compat known-delta entries documenting the intended `200`-stale → `404` divergence.
 
 ## Risk classification


### PR DESCRIPTION
Closes #256 (manual close needed — base is `v3`, not the default branch).

## Problem

`ComponentRoutingResolver.getVCSSettingForProject` / `getDistributionForProject` used a blanket `try { dbResolver } catch(Exception) { gitResolver }`. The `catch(Exception)` swallows `NotFoundException` from the DB **and** falls through to git. For a **DB-sourced** project whose requested version is absent from the DB, git can serve a **stale** `VCSSettings` / `Distribution` as `200` instead of the correct `404` — a cutover correctness hazard (wrong VCS roots / distribution coords).

Unlike the sibling methods fixed in PR #245, these return types carry **no `componentName` accessor**, so the stale-guard (reject a git result whose id ∈ `getDbComponentNames()`) cannot apply to the return value. Former PR #192 review items 1.2/1.3 ("Group 6-H").

## Fix — discover-then-route

Resolve the authoritative component for `(projectKey, version)` via the already-stale-guarded `getJiraComponentByProjectAndVersion` (returns the component name, or throws `NotFoundException` → 404 for a db-sourced project whose version is absent), then route the fetch to that component's owning resolver via the existing `resolverFor()` helper.

- **NotFound path:** db-sourced project + missing version → guard throws `NotFoundException` before any fetch → `404`, no git bleed.
- **Transient path:** even on a transient db error the fetch is routed to the owning resolver, so a db-sourced component lands on `dbResolver` (error propagates) and **never** serves stale git.

### Two deliberate decisions (see TD-013)

1. **Version-specific routing** (not the issue's literal project-level "any component db-sourced"), which would wrongly `404` a legitimate git version in a mixed-migration project.
2. **Correctness > availability during cutover:** these two endpoints now **error** on a full db outage instead of falling back to git. Not a new systemic dependency — every single-component method already routes via `resolverFor → getSource → DB`.

## Tests / verification

- 9 pure-Mockito tests in `ComponentRoutingResolverStaleAndNotFoundTest` (`issue256_*`): bleed-through guard, db-sourced happy path, git-sourced project, transient-error-propagates (× VCS + Distribution), plus the null-inner-JCV fallback edge. RED→GREEN (6 fail against old code).
- `docs/registry/tech-debt/013-source-precedence-by-project-key.md` — ADR.
- `known-deltas-db.json` — two `STATUS_CODE_DIFF` (candidate `404`) entries documenting the intended `200`-stale → `404` divergence on the two project endpoints (defensive; unit tests are authoritative).
- Full `gradlew build` green locally (CI-only docker/oc/automation excluded). Compat ([1.7]/[1.8]) to be verified in CI. Independent Sonnet review: ship-ready, no blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)