### PR TITLE
fix(ci): raise dbTest fork heap to 3g to stop heavy-suite OOM on v3

### DIFF
--- a/components-registry-service-server/build.gradle
+++ b/components-registry-service-server/build.gradle
@@ -84,6 +84,24 @@ tasks.withType(Test).configureEach {
     if (registry) environment 'DOCKER_REGISTRY', registry
 }
 
+// CI OOM mitigation. The heavy @Tag("integration") suite runs in `dbTest`: it boots many full
+// Spring Boot contexts (Tomcat + JPA/Hibernate) that the Spring TestContext cache keeps resident,
+// on top of the JaCoCo coverage agent (under `qualityCoverage`) and the Testcontainers client.
+// On the 7 GB GitHub-hosted runner the forked test JVM's default heap (JVM ergonomics ≈ 25% of
+// RAM ≈ 1.75 GB) is exhausted intermittently — the failure surfaced as an OutOfMemoryError in
+// Tomcat `http-nio-*-Poller` threads plus a dropped Postgres connection in
+// MigrateHistoryIntegrationTest (`Connection to localhost:<port> refused`), failing dbTest with
+// no real assertion error. Give this one fork a larger explicit ceiling. `-Xmx` is a CEILING,
+// not a reservation, so this does not by itself raise RAM use: the Gradle daemon (-Xmx2g, see
+// gradle.properties) and the lighter module forks keep their live sets well under 7 GB, and the
+// runner caps concurrency at its 2 vCPUs. Scoped to this module's dbTest (the only heavy one);
+// `test` (fast unit + smoke) and `integrationTest` (offloads to a separate fat-jar process) are
+// left at the default. If this proves insufficient, the next lever is bounding the Spring
+// TestContext cache via `-Dspring.test.context.cache.maxSize`.
+tasks.matching { it.name == 'dbTest' }.configureEach {
+    maxHeapSize = '3g'
+}
+
 sourceSets {
     test {
         resources {


### PR DESCRIPTION
## Problem

The `quality/tests-coverage` job (GH) — and TC `[1.2]` — intermittently fails the `@Tag("integration")` suite in `:components-registry-service-server:dbTest` with a JVM **`OutOfMemoryError`** (in Tomcat `http-nio-*-Poller` threads) plus a dropped Postgres connection (`Connection to localhost:<port> refused`) in `MigrateHistoryIntegrationTest`. There's **no real assertion failure** — it's memory exhaustion. It's blocked recent merges (e.g. #350 needed re-runs; #351 hit it too) and is unrelated to the PRs that tripped it.

## Root cause

The forked `dbTest` JVM has no explicit heap, so it uses the JVM ergonomic default (~25% of the **7 GB** runner ≈ **1.75 GB**). The heavy suite exceeds that intermittently: it boots many full Spring Boot contexts (Tomcat + JPA/Hibernate) that the **Spring TestContext cache** keeps resident, on top of the **JaCoCo** coverage agent (under `qualityCoverage`) and the **Testcontainers** client.

## Fix

Give that one fork an explicit **3 GB** ceiling (`maxHeapSize = '3g'` on the server module's `dbTest`).

- `-Xmx` is a **ceiling, not a reservation** — this doesn't by itself raise RAM use. The Gradle daemon (`-Xmx2g`, gradle.properties) and the lighter module forks keep their live sets well under 7 GB, and the 2-vCPU runner bounds concurrency.
- **Scoped** to this module's `dbTest` (the only heavy one). `test` (fast unit + smoke, runs the `[1.0]` gate) and `integrationTest` (offloads the app boot to a separate fat-jar process) are left at the default, so the `[1.0]` memory profile is unchanged.
- Fallback lever if 3 GB proves insufficient: bound the Spring TestContext cache via `-Dspring.test.context.cache.maxSize`.

## Validation

This PR's own `quality/tests-coverage` run is the real-world test — it exercises the exact job that OOMs. Full local `./gradlew build` is green; `dbTest` config resolves (`--dry-run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
