### PR TITLE
feat(config): field-config label/description display overrides

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
@@ -9,7 +9,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *
  * Both subtrees are now declared in `service-config` (Spring Cloud Config) and
  * bound here:
- *  - `components-registry.field-config.<section>.<field>.{visibility,searchable,required,defaultValue}`
+ *  - `components-registry.field-config.<section>.<field>.{visibility,searchable,required,defaultValue,label,description}`
  *  - `components-registry.component-defaults.*`
  *
  * The class is intentionally **mutable** (no constructor binding): Spring Cloud's
@@ -42,6 +42,12 @@ class AdminConfigProperties {
         var searchable: String? = null
         var required: Boolean? = null
         var defaultValue: String? = null
+
+        /** UI display-label override; the Portal falls back to its hardcoded label when absent. */
+        var label: String? = null
+
+        /** Tooltip-description override; the Portal falls back to its hardcoded registry when absent. */
+        var description: String? = null
     }
 
     /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
@@ -125,6 +125,9 @@ class ConfigSyncService(
             }
             entry.required?.let { put("required", it) }
             entry.defaultValue?.let { put("defaultValue", it) }
+            // Free-text display overrides — no validation beyond blank-dropping.
+            entry.label?.takeIf { it.isNotBlank() }?.let { put("label", it.trim()) }
+            entry.description?.takeIf { it.isNotBlank() }?.let { put("description", it.trim()) }
         }
 
     private fun invalid(path: String, value: String, allowed: Set<String>): Nothing =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
@@ -1,0 +1,61 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Characterization of the Spring binding seam for field-config map keys.
+ *
+ * Section field keys are plain map keys, so a key that itself contains a dot
+ * (the distribution section uses "maven.groupPattern"-style keys — the Portal
+ * resolver splits the path on the FIRST dot only) must be written in bracket
+ * notation in service-config YAML:
+ *
+ *   field-config:
+ *     distribution:
+ *       "[maven.groupPattern]": { label: ... }
+ *
+ * Without brackets the binder treats the dot as a path separator and the
+ * trailing segment dies in ignoreUnknownFields — silently. Documented in
+ * ADR-016; this test pins the behavior so a binder upgrade can't change it
+ * unnoticed.
+ */
+class AdminConfigPropertiesBindingTest {
+    @Configuration
+    @EnableConfigurationProperties(AdminConfigProperties::class)
+    open class BindingConfig
+
+    private val runner = ApplicationContextRunner().withUserConfiguration(BindingConfig::class.java)
+
+    @Test
+    fun `bracket notation binds a dotted field key verbatim`() {
+        runner
+            .withPropertyValues(
+                "components-registry.field-config.distribution.[maven.groupPattern].label=Example Label",
+            )
+            .run { ctx ->
+                val props = ctx.getBean(AdminConfigProperties::class.java)
+                val entry = props.fieldConfig["distribution"]?.get("maven.groupPattern")
+                assertEquals("Example Label", entry?.label)
+            }
+    }
+
+    @Test
+    fun `un-bracketed dotted key splits on the dot and loses the leaf`() {
+        runner
+            .withPropertyValues(
+                "components-registry.field-config.distribution.maven.groupPattern.label=Example Label",
+            )
+            .run { ctx ->
+                val props = ctx.getBean(AdminConfigProperties::class.java)
+                // The binder consumes "maven" as the field key; "groupPattern" is
+                // not a FieldEntry property and is dropped by ignoreUnknownFields.
+                assertNull(props.fieldConfig["distribution"]?.get("maven.groupPattern"))
+                assertNull(props.fieldConfig["distribution"]?.get("maven")?.label)
+            }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration
  * unnoticed.
  */
 class AdminConfigPropertiesBindingTest {
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     @EnableConfigurationProperties(AdminConfigProperties::class)
     open class BindingConfig
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
@@ -27,11 +27,15 @@ class ConfigSyncServiceTest {
         searchable: String? = null,
         required: Boolean? = null,
         defaultValue: String? = null,
+        label: String? = null,
+        description: String? = null,
     ) = AdminConfigProperties.FieldEntry().apply {
         this.visibility = visibility
         this.searchable = searchable
         this.required = required
         this.defaultValue = defaultValue
+        this.label = label
+        this.description = description
     }
 
     @Test
@@ -52,6 +56,84 @@ class ConfigSyncServiceTest {
                 "component" to mapOf(
                     "displayName" to mapOf("visibility" to "hidden", "searchable" to "Main", "required" to false),
                     "groupId" to mapOf("visibility" to "editable", "defaultValue" to "com.acme"),
+                ),
+            ),
+            result.fieldConfig,
+        )
+    }
+
+    @Test
+    fun `label and description pass through trimmed`() {
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "build" to mutableMapOf(
+                    "javaVersion" to fieldEntry(
+                        visibility = "editable",
+                        label = " Example Label ",
+                        description = " Example description. ",
+                    ),
+                ),
+            )
+        }
+
+        val result = service(props).syncToCache()
+
+        assertEquals(
+            mapOf(
+                "build" to mapOf(
+                    "javaVersion" to mapOf(
+                        "visibility" to "editable",
+                        "label" to "Example Label",
+                        "description" to "Example description.",
+                    ),
+                ),
+            ),
+            result.fieldConfig,
+        )
+    }
+
+    @Test
+    fun `blank label and description are omitted`() {
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "build" to mutableMapOf(
+                    "javaVersion" to fieldEntry(visibility = "editable", label = "  ", description = ""),
+                ),
+            )
+        }
+
+        val result = service(props).syncToCache()
+
+        assertEquals(
+            mapOf("build" to mapOf("javaVersion" to mapOf("visibility" to "editable"))),
+            result.fieldConfig,
+        )
+    }
+
+    @Test
+    fun `label-only entry serializes without visibility or searchable keys`() {
+        // The production shape for a pure display-rename override: service-config
+        // sets only label/description, leaving the UI policy keys absent.
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "build" to mutableMapOf(
+                    "projectVersion" to fieldEntry(
+                        label = "Example Label",
+                        description = "Example description.",
+                    ),
+                ),
+            )
+        }
+
+        val result = service(props).syncToCache()
+
+        assertEquals(
+            mapOf(
+                "build" to mapOf(
+                    "projectVersion" to mapOf(
+                        "label" to "Example Label",
+                        "description" to "Example description.",
+                    ),
                 ),
             ),
             result.fieldConfig,

--- a/docs/registry/adr/016-admin-config-as-code.md
+++ b/docs/registry/adr/016-admin-config-as-code.md
@@ -69,8 +69,9 @@ components-registry:
   (visibility then defaults to `editable` as usual). When absent, the Portal falls
   back to its hardcoded label and tooltip.
 - **Dotted field keys need bracket notation.** A field key that itself contains a
-  dot (the `distribution` section uses keys like `maven.groupPattern` — the Portal
-  resolver splits the path on the FIRST dot only) must be quoted in brackets, or
+  dot (the `distribution` section uses keys like `maven.groupPattern` — both
+  consumers, CRS `FieldConfigService` and the Portal resolver, split the path on
+  the FIRST dot only) must be quoted in brackets, or
   the Spring binder treats the dot as a path separator and silently drops the leaf
   (pinned by `AdminConfigPropertiesBindingTest`):
 

--- a/docs/registry/adr/016-admin-config-as-code.md
+++ b/docs/registry/adr/016-admin-config-as-code.md
@@ -45,6 +45,9 @@ components-registry:
       clientCode:  { visibility: hidden }     # feature this org does not use
     build:
       javaVersion: { visibility: readonly, searchable: Extended }
+      projectVersion:                       # display-rename override: policy keys may be absent
+        label: Example Label
+        description: Example tooltip text shown next to the field in the Portal.
   component-defaults:
     buildSystem: MAVEN
     build: { javaVersion: "17", requiredProject: true }
@@ -58,6 +61,13 @@ components-registry:
 - `defaultValue` for `component.groupId` replaces the old `FieldConfigSeeder`
   (which derived it from `supportedGroupIds`); it is now an explicit per-installation
   value in the base profile.
+- `label` / `description` are free-text **display overrides**: `label` replaces the
+  Portal's hardcoded field label everywhere in the component editor, `description`
+  replaces the tooltip text from the Portal's `fieldDescriptions` registry. Values are
+  trimmed; blank values are dropped from the cache blob. Both are optional and
+  independent of the policy keys — an entry may carry only `label`/`description`
+  (visibility then defaults to `editable` as usual). When absent, the Portal falls
+  back to its hardcoded label and tooltip.
 
 ### Per-environment (QA vs Prod)
 

--- a/docs/registry/adr/016-admin-config-as-code.md
+++ b/docs/registry/adr/016-admin-config-as-code.md
@@ -68,6 +68,17 @@ components-registry:
   independent of the policy keys — an entry may carry only `label`/`description`
   (visibility then defaults to `editable` as usual). When absent, the Portal falls
   back to its hardcoded label and tooltip.
+- **Dotted field keys need bracket notation.** A field key that itself contains a
+  dot (the `distribution` section uses keys like `maven.groupPattern` — the Portal
+  resolver splits the path on the FIRST dot only) must be quoted in brackets, or
+  the Spring binder treats the dot as a path separator and silently drops the leaf
+  (pinned by `AdminConfigPropertiesBindingTest`):
+
+  ```yaml
+  field-config:
+    distribution:
+      "[maven.groupPattern]": { label: Example Label }
+  ```
 
 ### Per-environment (QA vs Prod)
 


### PR DESCRIPTION
## Summary

Adds two optional free-text display-override keys to the field-config entry schema (`components-registry.field-config.<section>.<field>`):

- **`label`** — replaces the Portal's hardcoded field label everywhere in the component editor;
- **`description`** — replaces the tooltip text from the Portal's `fieldDescriptions` registry.

`ConfigSyncService.serializeFieldEntry` passes both through trimmed, dropping blank values. Entries carrying only `label`/`description` serialize without policy keys — visibility falls back to `editable` exactly as before. No validation beyond blank-dropping (free text by design).

## No API/spec change

`GET /rest/api/4/config/field-config` returns an untyped map; the regenerated `openapi/v4.json` is byte-identical (verified via `generateOpenApiDocs` + `OpenApiV4SpecTest`).

## Docs

ADR-016 documents the new keys, their semantics and the Portal fallback behavior.

## Testing

- `ConfigSyncServiceTest`: passthrough + trim, blank-dropping, and the production label-only shape (all policy keys absent).
- Full `./gradlew build` (automation tests excluded as in CI) and `:components-registry-service-server:integrationTest` pass locally.

Portal counterpart: octopus-components-management-portal PR (label/description consumption with hardcoded fallbacks); actual rename values live in service-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)