### PR TITLE
fix: section-field saves must write an audit row (SYS-053)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -334,7 +334,7 @@ class ComponentManagementServiceImpl(
                 scalarAuditMap(
                     saved,
                     overrideLabels = canonicalizedLabels,
-                ),
+                ) + sectionAuditMap(saved),
         )
 
         return saved.toDetailResponse(teamcityProperties.baseUrl)
@@ -468,7 +468,7 @@ class ComponentManagementServiceImpl(
         // post-write read in `scalarAuditMap` reflects the actual persisted
         // value including the FC-hidden no-op case.
         val originalLabels = entity.labelJunctions.map { it.labelCode }.toSet()
-        val oldValue = scalarAuditMap(entity, originalLabels)
+        val oldValue = scalarAuditMap(entity, originalLabels) + sectionAuditMap(entity)
         // Snapshot parent + canBeParent BEFORE applying the patch — the group is
         // rederived only when one of these actually changes (a no-op update
         // preserves the existing group, incl. grandfathered parent-of-parent rows).
@@ -691,7 +691,7 @@ class ComponentManagementServiceImpl(
                 scalarAuditMap(
                     saved,
                     overrideLabels = canonicalizedLabels ?: originalLabels,
-                ),
+                ) + sectionAuditMap(saved),
         )
 
         return saved.toDetailResponse(teamcityProperties.baseUrl)
@@ -2579,6 +2579,152 @@ class ComponentManagementServiceImpl(
             "distributionExternal" to entity.distributionExternal,
             "labels" to (overrideLabels ?: entity.labelJunctions.map { it.labelCode }.toSet()),
             "system" to entity.systemCode,
+        )
+
+    /**
+     * Snapshot of the component's section fields for the audit trail: the BASE
+     * configuration row's build/escrow/jira scalars + versionRange, its child
+     * collections, and the per-component child collections (artifactIds,
+     * securityGroups, teamcityProjects, docs). SYS-053: these keys must be part
+     * of both audit snapshots — without them a section-only PATCH produces
+     * identical old/new maps and the SYS-048 no-op guard drops the row, so the
+     * save persists but History stays empty.
+     *
+     * Collection entries are content-only — no row ids: a PATCH REPLACE
+     * recreates the child rows, so an id-bearing snapshot would diff on id
+     * churn and turn every re-save of an unchanged form into a fake history
+     * entry. Lists are ordered by sortOrder (requiredTools by tool name,
+     * securityGroups by content — neither carries a sortOrder) so load order
+     * can't leak into the old/new comparison either.
+     *
+     * Version-ranged rows (SCALAR_OVERRIDE / MARKER) are intentionally NOT
+     * captured here — field-override writes publish their own attribute-keyed
+     * audit events (SYS-050).
+     */
+    private fun sectionAuditMap(entity: ComponentEntity): Map<String, Any?> {
+        val base = entity.configurations.firstOrNull { it.rowType == "BASE" }
+        return baseConfigScalarAuditEntries(base) +
+            baseConfigCollectionAuditEntries(base) +
+            componentCollectionAuditEntries(entity)
+    }
+
+    private fun baseConfigScalarAuditEntries(base: ComponentConfigurationEntity?): Map<String, Any?> =
+        mapOf(
+            // Namespaced so the BASE row's range can't be misread as the
+            // range of a version-ranged override row (those audit under
+            // their own fieldOverride[<attr>] key — SYS-050).
+            "baseConfiguration.versionRange" to base?.versionRange,
+            "build.buildSystem" to base?.buildSystem,
+            "build.javaVersion" to base?.javaVersion,
+            "build.mavenVersion" to base?.mavenVersion,
+            "build.gradleVersion" to base?.gradleVersion,
+            "build.buildFilePath" to base?.buildFilePath,
+            "build.deprecated" to base?.deprecated,
+            "build.requiredProject" to base?.requiredProject,
+            "build.projectVersion" to base?.projectVersion,
+            "build.systemProperties" to base?.systemProperties,
+            "build.buildTasks" to base?.buildTasks,
+            "escrow.providedDependencies" to base?.escrowProvidedDependencies,
+            "escrow.reusable" to base?.escrowReusable,
+            "escrow.generation" to base?.escrowGeneration,
+            "escrow.diskSpace" to base?.escrowDiskSpace,
+            "escrow.additionalSources" to base?.escrowAdditionalSources,
+            "escrow.gradleIncludeConfigurations" to base?.escrowGradleIncludeConfigurations,
+            "escrow.gradleExcludeConfigurations" to base?.escrowGradleExcludeConfigurations,
+            "escrow.gradleIncludeTestConfigurations" to base?.escrowGradleIncludeTestConfigurations,
+            "escrow.buildTask" to base?.escrowBuildTask,
+            "jira.projectKey" to base?.jiraProjectKey,
+            "jira.technical" to base?.jiraTechnical,
+            "jira.majorVersionFormat" to base?.jiraMajorVersionFormat,
+            "jira.releaseVersionFormat" to base?.jiraReleaseVersionFormat,
+            "jira.buildVersionFormat" to base?.jiraBuildVersionFormat,
+            "jira.lineVersionFormat" to base?.jiraLineVersionFormat,
+            "jira.versionPrefix" to base?.jiraVersionPrefix,
+            "jira.versionFormat" to base?.jiraVersionFormat,
+            "jira.hotfixVersionFormat" to base?.jiraHotfixVersionFormat,
+        )
+
+    private fun baseConfigCollectionAuditEntries(base: ComponentConfigurationEntity?): Map<String, Any?> =
+        mapOf(
+            "vcsEntries" to
+                base?.vcsEntries.orEmpty().sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "name" to it.name,
+                        "vcsPath" to it.vcsPath,
+                        "branch" to it.branch,
+                        "tag" to it.tag,
+                        "hotfixBranch" to it.hotfixBranch,
+                        "repositoryType" to it.repositoryType,
+                    )
+                },
+            "mavenArtifacts" to
+                base?.mavenArtifacts.orEmpty().sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "groupPattern" to it.groupPattern,
+                        "artifactPattern" to it.artifactPattern,
+                        "extension" to it.extension,
+                        "classifier" to it.classifier,
+                    )
+                },
+            "fileUrlArtifacts" to
+                base?.fileUrlArtifacts.orEmpty().sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "url" to it.url,
+                        "artifactId" to it.artifactId,
+                        "classifier" to it.classifier,
+                    )
+                },
+            "dockerImages" to
+                base?.dockerImages.orEmpty().sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "imageName" to it.imageName,
+                        "flavor" to it.flavor,
+                    )
+                },
+            "packages" to
+                base?.packages.orEmpty().sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "packageType" to it.packageType,
+                        "packageName" to it.packageName,
+                    )
+                },
+            "buildToolBeans" to
+                base?.buildToolBeans.orEmpty().sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "beanType" to it.beanType,
+                        "toolType" to it.toolType,
+                        "settingsProperty" to it.settingsProperty,
+                        "versionPattern" to it.versionPattern,
+                        "edition" to it.edition,
+                    )
+                },
+            "requiredTools" to base?.requiredToolJunctions.orEmpty().map { it.toolName }.sorted(),
+        )
+
+    private fun componentCollectionAuditEntries(entity: ComponentEntity): Map<String, Any?> =
+        mapOf(
+            "artifactIds" to
+                entity.artifactIds.sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "groupPattern" to it.groupPattern,
+                        "artifactPattern" to it.artifactPattern,
+                    )
+                },
+            "securityGroups" to
+                entity.securityGroups.sortedWith(compareBy({ it.groupType }, { it.groupName })).map {
+                    mapOf(
+                        "groupType" to it.groupType,
+                        "groupName" to it.groupName,
+                    )
+                },
+            "teamcityProjects" to entity.teamcityProjects.sortedBy { it.sortOrder }.map { it.projectId },
+            "docs" to
+                entity.docLinks.sortedBy { it.sortOrder }.map {
+                    mapOf(
+                        "docComponentKey" to it.docComponentKey,
+                        "majorVersion" to it.majorVersion,
+                    )
+                },
         )
 
     /**

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentSectionAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentSectionAuditTest.kt
@@ -1,0 +1,244 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Paths
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * SYS-053 — a component PATCH that changes only section fields (base
+ * configuration build/escrow/jira scalars, versionRange, or section child
+ * collections such as vcsEntries) is a real change and must leave an audit
+ * trail, exactly like editing a top-level attribute. Previously the audit
+ * snapshots captured only top-level scalars, so a section-only save produced
+ * identical old/new maps and the SYS-048 no-op guard silently dropped the
+ * row — the value persisted but History stayed empty.
+ *
+ * Integration test (ft-db = H2 + auto-migrate): drives the real V4 PATCH
+ * path end-to-end and reads the resulting audit rows back through the audit
+ * API.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class ComponentSectionAuditTest {
+    private val vcsPayload =
+        """{"baseConfiguration":{"vcsEntries":[""" +
+            """{"name":"main","vcsPath":"ssh://git@vcs.example.com/proj/repo.git","branch":"master"}]}}"""
+
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(ComponentSectionAuditTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("SYS-053: PATCH of build.mavenVersion writes an UPDATE audit row with a field-level diff")
+    fun `SYS-053 build scalar PATCH writes an UPDATE audit row with field-level diff`() {
+        val id = createComponent("sys053b_${UUID.randomUUID().toString().take(8)}", mavenVersion = "3.8")
+        assertEquals(0, updateRowCount(id), "expected no UPDATE rows right after create, got ${historyActions(id)}")
+
+        patchComponent(id, """{"baseConfiguration":{"build":{"mavenVersion":"3.9"}}}""")
+
+        assertEquals(1, updateRowCount(id), "build-section PATCH must write 1 UPDATE row, got ${historyActions(id)}")
+        val change = diffEntry(id, "build.mavenVersion") ?: error("diff must carry key build.mavenVersion: ${diffs(id)}")
+        assertEquals("3.8", change.path("old").asText(), "diff.old must be the pre-PATCH value")
+        assertEquals("3.9", change.path("new").asText(), "diff.new must be the patched value")
+    }
+
+    @Test
+    @DisplayName("SYS-053: PATCH of jira.projectKey writes an UPDATE audit row")
+    fun `SYS-053 jira scalar PATCH writes an UPDATE audit row`() {
+        val id = createComponent("sys053j_${UUID.randomUUID().toString().take(8)}")
+
+        patchComponent(id, """{"baseConfiguration":{"jira":{"projectKey":"PRJX"}}}""")
+
+        assertEquals(1, updateRowCount(id), "jira-section PATCH must write 1 UPDATE row, got ${historyActions(id)}")
+        assertTrue(diffEntry(id, "jira.projectKey") != null, "diff must carry key jira.projectKey: ${diffs(id)}")
+    }
+
+    @Test
+    @DisplayName("SYS-053: PATCH of vcsEntries (section child collection) writes an UPDATE audit row")
+    fun `SYS-053 vcsEntries PATCH writes an UPDATE audit row`() {
+        val id = createComponent("sys053v_${UUID.randomUUID().toString().take(8)}")
+
+        patchComponent(id, vcsPayload)
+
+        assertEquals(1, updateRowCount(id), "vcsEntries PATCH must write 1 UPDATE row, got ${historyActions(id)}")
+        assertTrue(diffEntry(id, "vcsEntries") != null, "diff must carry key vcsEntries: ${diffs(id)}")
+    }
+
+    @Test
+    @DisplayName("SYS-053: PATCH of requiredTools (repo-synced junction collection) audits once; identical re-send is a no-op")
+    fun `SYS-053 requiredTools PATCH writes an UPDATE audit row and identical re-send does not`() {
+        val id = createComponent("sys053t_${UUID.randomUUID().toString().take(8)}")
+        val payload = """{"baseConfiguration":{"requiredTools":["BuildEnv","Oracle"]}}"""
+
+        patchComponent(id, payload)
+        assertEquals(1, updateRowCount(id), "requiredTools PATCH must write 1 UPDATE row, got ${historyActions(id)}")
+        assertTrue(diffEntry(id, "requiredTools") != null, "diff must carry key requiredTools: ${diffs(id)}")
+
+        // The junction is synced via a repo-direct delete+insert — identical
+        // content must still compare equal through the in-memory refresh.
+        patchComponent(id, payload)
+        assertEquals(1, updateRowCount(id), "identical requiredTools re-send must stay a no-op, got ${historyActions(id)}")
+    }
+
+    @Test
+    @DisplayName("SYS-053: PATCH of securityGroups (content-sorted component collection) audits once; identical re-send is a no-op")
+    fun `SYS-053 securityGroups PATCH writes an UPDATE audit row and identical re-send does not`() {
+        val id = createComponent("sys053s_${UUID.randomUUID().toString().take(8)}")
+        val payload = """{"securityGroups":[{"groupType":"read","groupName":"vcs-e2e-group"}]}"""
+
+        patchComponent(id, payload)
+        assertEquals(1, updateRowCount(id), "securityGroups PATCH must write 1 UPDATE row, got ${historyActions(id)}")
+        assertTrue(diffEntry(id, "securityGroups") != null, "diff must carry key securityGroups: ${diffs(id)}")
+
+        // securityGroups is the one snapshot sorted by content (no sortOrder
+        // column) — an identical REPLACE must stay diff-equal.
+        patchComponent(id, payload)
+        assertEquals(1, updateRowCount(id), "identical securityGroups re-send must stay a no-op, got ${historyActions(id)}")
+    }
+
+    @Test
+    @DisplayName("SYS-053: a no-op section PATCH (same scalar, identical collection) writes no audit row — SYS-048 holds")
+    fun `SYS-053 no-op section PATCH writes no audit row`() {
+        val id = createComponent("sys053n_${UUID.randomUUID().toString().take(8)}", mavenVersion = "3.9")
+        patchComponent(id, vcsPayload)
+        val afterRealChange = updateRowCount(id)
+
+        // Same scalar value again — nothing actually changes.
+        patchComponent(id, """{"baseConfiguration":{"build":{"mavenVersion":"3.9"}}}""")
+        // Identical collection again — the REPLACE recreates child rows, but the
+        // content is byte-identical, so no audit row may appear (row-id churn must
+        // not leak into the snapshot).
+        patchComponent(id, vcsPayload)
+
+        assertEquals(
+            afterRealChange,
+            updateRowCount(id),
+            "a no-op section PATCH must not add an audit row, got ${historyActions(id)}",
+        )
+    }
+
+    // ── helpers ──
+
+    private fun createComponent(
+        name: String,
+        mavenVersion: String? = null,
+    ): String {
+        val build =
+            if (mavenVersion != null) {
+                """{"buildSystem":"MAVEN","mavenVersion":"$mavenVersion"}"""
+            } else {
+                """{"buildSystem":"MAVEN"}"""
+            }
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"name":"$name",""" +
+                                """"componentOwner":"owner1",""" +
+                                """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                                """"baseConfiguration":{"build":$build}}""",
+                        ),
+                ).andExpect(status().is2xxSuccessful)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun currentVersion(componentId: String): Long {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components/$componentId").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["version"].asLong()
+    }
+
+    private fun patchComponent(
+        componentId: String,
+        payloadWithoutVersion: String,
+    ) {
+        // Inject the current optimistic-lock version into the caller's payload.
+        val payload = """{"version":${currentVersion(componentId)},${payloadWithoutVersion.removePrefix("{")}"""
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$componentId")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(status().isOk)
+    }
+
+    private fun history(componentId: String): List<JsonNode> {
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/Component/$componentId")
+                        .with(adminJwt())
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["content"].toList()
+    }
+
+    private fun historyActions(componentId: String): List<String> = history(componentId).map { it["action"].asText() }
+
+    private fun updateRowCount(componentId: String): Int = historyActions(componentId).count { it == "UPDATE" }
+
+    private fun diffs(componentId: String): List<JsonNode> =
+        history(componentId)
+            .filter { it["action"].asText() == "UPDATE" }
+            .map { it.path("changeDiff") }
+
+    // The `{ "old": ..., "new": ... }` node for `key` from the newest UPDATE
+    // entry whose structured changeDiff carries that key, or null.
+    private fun diffEntry(
+        componentId: String,
+        key: String,
+    ): JsonNode? = diffs(componentId).firstOrNull { it.isObject && it.has(key) }?.get(key)
+}

--- a/docs/registry/adr/005-audit-log.md
+++ b/docs/registry/adr/005-audit-log.md
@@ -126,6 +126,21 @@ Component `UPDATE` event keyed by the overridden attribute, so version-range edi
 appear in the component history alongside top-level attribute edits — closing the
 "all write paths go through audited service methods" risk for these paths. (SYS-050)
 
+### Coverage: section fields of the component PATCH
+The audit snapshots originally captured only the component's top-level scalars,
+so a PATCH that changed only section data — BASE-configuration build/escrow/jira
+scalars, `versionRange`, section child collections (`vcsEntries`,
+`mavenArtifacts`, `fileUrlArtifacts`, `dockerImages`, `packages`,
+`buildToolBeans`, `requiredTools`) or per-component child collections
+(`artifactIds`, `securityGroups`, `teamcityProjects`, `docs`) — produced
+identical old/new snapshots and was dropped by the SYS-048 no-op guard: the
+value persisted, but History stayed empty. The snapshots now include these
+fields (flat dotted keys for aspect scalars, e.g. `build.mavenVersion`;
+content-only ordered lists for collections — **no row ids**, because a PATCH
+REPLACE recreates child rows and id churn would turn a no-op re-save into a
+fake history entry). Version-ranged rows stay out of this snapshot — they are
+audited by their own field-override events (SYS-050). (SYS-053)
+
 ### Not audited: TeamCity sync
 The automated TeamCity sync (`changedBy = system`) deliberately does NOT write an
 audit row — a per-component re-link row is operational noise, not a user change.

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -61,6 +61,7 @@
 | SYS-050 | Field-override (version-range) create/update/delete each publish a Component `UPDATE` audit event with an attribute-keyed diff | High | integration-test | ✅ Tested |
 | SYS-051 | TeamCity sync (automated `changedBy=system` reconciliation) does NOT write an audit row — the re-link is traced via an INFO log instead | Medium | unit-test | ✅ Tested |
 | SYS-052 | An `employee-service.url` whose placeholder does not resolve in the current environment is treated as "not configured": the client bean is not registered and context refresh succeeds (fail-open), instead of failing application boot | High | unit-test | ✅ Tested |
+| SYS-053 | Component audit snapshots include section fields (BASE-configuration build/escrow/jira scalars, versionRange, section + per-component child collections), so a section-only PATCH writes an UPDATE audit row with a field-level diff instead of being dropped by the SYS-048 no-op guard; collection snapshots are content-only (no row ids) so an identical re-save stays a no-op | High | integration-test | ✅ Tested |
 
 ---
 
@@ -1755,3 +1756,54 @@ behaviour) and a WARN line records why. Context refresh succeeds.
 **Test method:** `EmployeeServiceConfigTest` —
 `SYS-052 unresolvable url placeholder skips bean registration` (plus the
 pre-existing blank-url and non-blank-url cases covering criteria 3–4).
+
+### SYS-053: Section-field PATCH writes an audit row (History no longer empty)
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+Saving a section of the component form (e.g. Build tab → Maven Version 3.9 →
+"Save Build") persisted the value but left the History tab empty. The audit
+snapshots passed to `publishAuditEvent` captured only the component's top-level
+scalars (`scalarAuditMap`), so a PATCH that changed only section data produced
+identical `old_value` / `new_value` maps, `AuditDiff.compute` returned `null`,
+and the SYS-048 no-op guard dropped the row. Component CREATE was unaffected
+(a CREATE row is persisted without a diff), which made the bug read as
+"creation shows in History, edits don't".
+
+**Description:**
+Both audit snapshots of the component CREATE / UPDATE (RENAME) events now
+additionally include (`sectionAuditMap`):
+- BASE-configuration aspect scalars under flat dotted keys — `build.*`
+  (buildSystem, javaVersion, mavenVersion, gradleVersion, buildFilePath,
+  deprecated, requiredProject, projectVersion, systemProperties, buildTasks),
+  `escrow.*`, `jira.*`, plus `baseConfiguration.versionRange`;
+- BASE-configuration child collections — `vcsEntries`, `mavenArtifacts`,
+  `fileUrlArtifacts`, `dockerImages`, `packages`, `buildToolBeans`,
+  `requiredTools`;
+- per-component child collections — `artifactIds`, `securityGroups`,
+  `teamcityProjects`, `docs`.
+
+Collection snapshots are **content-only and deterministically ordered**
+(`sortOrder`, or content where no `sortOrder` exists): a PATCH REPLACE
+recreates child rows, so row ids in the snapshot would diff on id churn and
+turn every re-save of an unchanged form into a fake history entry, violating
+SYS-048. Version-ranged rows (SCALAR_OVERRIDE / MARKER) stay out of this
+snapshot — their writes publish their own attribute-keyed events (SYS-050).
+
+**Acceptance criteria:**
+1. `PATCH /rest/api/4/components/{id}` changing only `baseConfiguration.build.mavenVersion` writes an `UPDATE` audit row whose `change_diff` carries `build.mavenVersion` with the correct old/new values.
+2. A PATCH changing only `baseConfiguration.jira.projectKey` writes an `UPDATE` row keyed `jira.projectKey`.
+3. A PATCH replacing `baseConfiguration.vcsEntries` writes an `UPDATE` row keyed `vcsEntries`.
+4. A no-op section PATCH (same scalar value, or a byte-identical collection REPLACE) writes no audit row (SYS-048 holds — row-id churn must not leak into the diff).
+5. The CREATE audit row's `new_value` includes the section keys.
+
+**Test method:** `ComponentSectionAuditTest` —
+`SYS-053 build scalar PATCH writes an UPDATE audit row with field-level diff`,
+`SYS-053 jira scalar PATCH writes an UPDATE audit row`,
+`SYS-053 vcsEntries PATCH writes an UPDATE audit row`,
+`SYS-053 requiredTools PATCH writes an UPDATE audit row and identical re-send does not`,
+`SYS-053 securityGroups PATCH writes an UPDATE audit row and identical re-send does not`,
+`SYS-053 no-op section PATCH writes no audit row`.


### PR DESCRIPTION
## Problem

Saving a section of the component form (e.g. Build tab → Maven Version → "Save Build") persisted the value but the **History tab stayed empty**. Other section tabs (VCS / Jira / Escrow / Distribution, child collections) were affected the same way. Component **creation showed up in History normally**.

## Root cause

The audit snapshots passed to `publishAuditEvent` (`scalarAuditMap`) captured only top-level component scalars. A PATCH changing only section data produced identical `old_value`/`new_value` maps → `AuditDiff.compute` returned `null` → the SYS-048 no-op guard dropped the row. CREATE rows are persisted without a diff, which is why creation was visible while edits were not.

## Fix (SYS-053)

`sectionAuditMap` joins both snapshots of CREATE/UPDATE/RENAME events:

- BASE-configuration aspect scalars under flat dotted keys (`build.*`, `escrow.*`, `jira.*`, `baseConfiguration.versionRange`) — matching the Portal field-config paths, so the History diff reads `build.mavenVersion: 3.8 → 3.9`;
- section child collections (`vcsEntries`, `mavenArtifacts`, `fileUrlArtifacts`, `dockerImages`, `packages`, `buildToolBeans`, `requiredTools`) and per-component child collections (`artifactIds`, `securityGroups`, `teamcityProjects`, `docs`) as **content-only, deterministically ordered** snapshots — no row ids, because a PATCH REPLACE recreates child rows and id churn would turn a no-op re-save into a fake history entry (SYS-048 must keep holding).

Version-ranged rows (SCALAR_OVERRIDE / MARKER) stay out — they audit via their own field-override events (SYS-050).

## TDD

`ComponentSectionAuditTest` (ft-db integration, `dbTest`) was RED before the fix and is GREEN after: build/jira scalar PATCH, vcsEntries PATCH, requiredTools (repo-synced junction) and securityGroups (content-sorted) each write exactly one UPDATE row with a field-level diff; identical re-sends and a no-op section PATCH write nothing.

## Verification

- Full `gradlew build` green; audit-related suites (`FieldOverrideAuditTest`, `MultiValuePeopleV4Test`, `AuditLogFilterTest`, `AuditMigratedVisibilityTest`) green.
- Two-service e2e (Portal Playwright vs a locally built CRS image with this fix, full testcontainers stack): UI Build-tab edit → History shows the `build.mavenVersion` diff. Spec lands via the Portal PR (merge this one first; the spec self-skips until a CRS image with this fix is pinned).

## Docs

`requirements-common.md` SYS-053 (acceptance criteria + test traceability), `adr/005-audit-log.md` refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)