### PR TITLE
feat(health): employee-service integration health — actuator indicator + v4 endpoint

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -10,6 +10,7 @@ import org.octopusden.octopus.components.registry.server.dto.v4.ComponentEditors
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentSummaryResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.EmployeeIntegrationHealthResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.EmployeeMatchResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideResponse
@@ -101,6 +102,15 @@ class ComponentControllerV4(
     fun searchEmployees(
         @RequestParam search: String,
     ): List<EmployeeMatchResponse> = employeeDirectory.search(search).map(EmployeeMatchResponse::from)
+
+    // Integration health for the Portal admin banner (and any other consumer
+    // that wants a cheap end-to-end check). Always HTTP 200 — UP/DOWN/DISABLED
+    // lives in the body, so a DOWN integration is distinguishable from a failed
+    // request. The same probe backs the `employeeService` actuator indicator.
+    @GetMapping("/meta/employees/health")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun employeeIntegrationHealth(): EmployeeIntegrationHealthResponse =
+        EmployeeIntegrationHealthResponse(employeeDirectory.probe())
 
     // Batch active/inactive status for the component view's "inactive" badge.
     // Body is a list of usernames; response maps each to true (active),

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/EmployeeIntegrationHealthResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/EmployeeIntegrationHealthResponse.kt
@@ -1,0 +1,12 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import org.octopusden.octopus.components.registry.server.service.impl.IntegrationHealth
+
+/**
+ * Wire shape of the employee-service integration health endpoint. Always
+ * delivered with HTTP 200 — the status lives in the body so the Portal can
+ * distinguish "integration is DOWN" from "request itself failed".
+ */
+data class EmployeeIntegrationHealthResponse(
+    val status: IntegrationHealth,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicator.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicator.kt
@@ -1,0 +1,45 @@
+package org.octopusden.octopus.components.registry.server.health
+
+import org.octopusden.octopus.components.registry.server.service.impl.EmployeeDirectoryService
+import org.octopusden.octopus.components.registry.server.service.impl.IntegrationHealth
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+
+/**
+ * Actuator surface of [EmployeeDirectoryService.probe]: component
+ * `employeeService` under `/actuator/health`.
+ *
+ * Deployment safety: the OKD probes hit `/actuator/health/liveness` (the
+ * liveness GROUP), and Spring only places livenessState/readinessState in the
+ * probe groups by default — a custom indicator is never consulted there. So a
+ * DOWN employee-service flips the aggregate `/actuator/health` (HTTP 503, for
+ * monitoring and the Portal-side indicator) without restarting pods or
+ * blocking a rollout. Eureka health propagation is off, so registry routing is
+ * unaffected too.
+ *
+ * DISABLED (no client wired) is intentional configuration, not a failure —
+ * reported as UNKNOWN with `enabled: false` so a dev stand without
+ * employee-service stays green.
+ *
+ * Each health() call fires one real lookup (actuator does not cache by
+ * default) — fine for scrape-style consumers; if the scrape interval ever
+ * drops below a few seconds, configure the health endpoint's time-to-live.
+ */
+@Component("employeeService")
+class EmployeeServiceHealthIndicator(
+    private val employeeDirectory: EmployeeDirectoryService,
+) : HealthIndicator {
+    override fun health(): Health =
+        when (employeeDirectory.probe()) {
+            IntegrationHealth.UP -> Health.up().build()
+            IntegrationHealth.DOWN ->
+                Health.down()
+                    .withDetail(
+                        "reason",
+                        "employee-service lookup failed (credentials / gateway route / directory backend — see logs)",
+                    )
+                    .build()
+            IntegrationHealth.DISABLED -> Health.unknown().withDetail("enabled", false).build()
+        }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryService.kt
@@ -111,7 +111,36 @@ class EmployeeDirectoryService(
         }
     }
 
-    private companion object {
+    /**
+     * Transport-chain health probe for monitoring surfaces (actuator indicator
+     * and the Portal admin banner). Reuses [isActive] on a synthetic username
+     * that must not exist in the directory: a NOT-FOUND answer proves the whole
+     * CRS → api-gateway → employee-service → directory chain end-to-end, while
+     * [ActiveStatus.UNAVAILABLE] (missing/bad credentials, unreachable service)
+     * is the only state reported as [IntegrationHealth.DOWN].
+     *
+     * Unlike the lookup paths this is NOT fail-open — its whole purpose is to
+     * surface the failure — but it still never throws.
+     *
+     * Calls [isActive] directly (same instance, not through the Spring proxy):
+     * if [isActive] ever grows proxy-bound behavior (caching, retry), probe()
+     * will bypass it — route through a self-injection then.
+     */
+    fun probe(): IntegrationHealth =
+        when (isActive(PROBE_USERNAME)) {
+            ActiveStatus.ACTIVE, ActiveStatus.INACTIVE, ActiveStatus.UNKNOWN -> IntegrationHealth.UP
+            ActiveStatus.UNAVAILABLE -> IntegrationHealth.DOWN
+            ActiveStatus.DISABLED -> IntegrationHealth.DISABLED
+        }
+
+    companion object {
+        /**
+         * Synthetic username for [probe]. Deliberately implausible so the
+         * expected directory answer is NOT FOUND (mapped to UP); if someone
+         * ever registers it, ACTIVE/INACTIVE still map to UP.
+         */
+        const val PROBE_USERNAME = "octopus-integration-health-probe"
+
         private val log = LoggerFactory.getLogger(EmployeeDirectoryService::class.java)
     }
 }
@@ -121,3 +150,20 @@ data class EmployeeMatch(
     val username: String,
     val active: Boolean,
 )
+
+/**
+ * Coarse integration health for monitoring surfaces. Unlike [ActiveStatus]
+ * this is about the transport chain, not a particular employee:
+ *
+ * - [UP] — the directory answered (any answer, including "no such employee",
+ *   proves the chain end-to-end);
+ * - [DOWN] — the lookup failed before producing an answer (missing/bad
+ *   credentials, gateway/service unreachable, directory backend down);
+ * - [DISABLED] — no client wired (flag off / blank URL): intentional, not a
+ *   failure.
+ */
+enum class IntegrationHealth {
+    UP,
+    DOWN,
+    DISABLED,
+}

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -109,6 +109,22 @@ employee-service:
   password:
   retry-time-millis: 5000
 
+# The Portal's employeeServiceIntegration indicator mirrors the per-component
+# path /actuator/health/employeeService, which Spring serves only when
+# show-components allows it (default `never` → 404 → the mirror silently
+# degrades to UNKNOWN). Pinned here so the wire contract does not depend on a
+# stand's external service-config. Unlike show-details this exposes only
+# component names and statuses to the (anonymous) health endpoint, no details.
+# The TTL caps real employee-service/directory lookups under scrape
+# amplification: CRS aggregate scrapes + the Portal mirror + admin-tab polling
+# all funnel into EmployeeDirectoryService.probe().
+management:
+  endpoint:
+    health:
+      show-components: always
+      cache:
+        time-to-live: 10s
+
 # auth-server.url and auth-server.realm bind from AUTH_SERVER_URL / AUTH_SERVER_REALM
 # env vars via Spring Boot's relaxed binding. Production and dev profiles must
 # supply them; WebSecurityConfig.jwtDecoder() fails fast if either is missing.

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -971,6 +971,22 @@
         ],
         "type" : "object"
       },
+      "EmployeeIntegrationHealthResponse" : {
+        "properties" : {
+          "status" : {
+            "enum" : [
+              "UP",
+              "DOWN",
+              "DISABLED"
+            ],
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "status"
+        ],
+        "type" : "object"
+      },
       "EmployeeMatchResponse" : {
         "properties" : {
           "active" : {
@@ -4686,6 +4702,96 @@
                     "$ref" : "#/components/schemas/EmployeeMatchResponse"
                   },
                   "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/employees/health" : {
+      "get" : {
+        "operationId" : "employeeIntegrationHealth",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EmployeeIntegrationHealthResponse"
                 }
               }
             },

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/EmployeeLookupEndpointsV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/EmployeeLookupEndpointsV4Test.kt
@@ -10,6 +10,7 @@ import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
 import org.octopusden.octopus.components.registry.server.service.impl.EmployeeDirectoryService
 import org.octopusden.octopus.components.registry.server.service.impl.EmployeeMatch
+import org.octopusden.octopus.components.registry.server.service.impl.IntegrationHealth
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.octopusden.octopus.components.registry.server.support.viewerJwt
 import org.springframework.beans.factory.annotation.Autowired
@@ -111,5 +112,35 @@ class EmployeeLookupEndpointsV4Test {
         `when`(employeeDirectory.search(anyString())).thenReturn(emptyList())
         mvc.perform(get("/rest/api/4/components/meta/employees").param("search", "x").with(adminJwt()))
             .andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("GET /meta/employees/health reports the probe status (UP / DOWN / DISABLED)")
+    fun `health reports probe status`() {
+        `when`(employeeDirectory.probe()).thenReturn(IntegrationHealth.DOWN)
+        mvc.perform(get("/rest/api/4/components/meta/employees/health").with(viewerJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("DOWN"))
+
+        `when`(employeeDirectory.probe()).thenReturn(IntegrationHealth.UP)
+        mvc.perform(get("/rest/api/4/components/meta/employees/health").with(viewerJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("UP"))
+    }
+
+    @Test
+    @DisplayName("GET /meta/employees/health is 200 even when DOWN (status lives in the body, not the code)")
+    fun `health never errors`() {
+        `when`(employeeDirectory.probe()).thenReturn(IntegrationHealth.DISABLED)
+        mvc.perform(get("/rest/api/4/components/meta/employees/health").with(viewerJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("DISABLED"))
+    }
+
+    @Test
+    @DisplayName("GET /meta/employees/health rejects anonymous access (sits under /meta/employees/**)")
+    fun `health requires authentication`() {
+        mvc.perform(get("/rest/api/4/components/meta/employees/health"))
+            .andExpect(status().isUnauthorized)
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicatorTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicatorTest.kt
@@ -1,0 +1,50 @@
+package org.octopusden.octopus.components.registry.server.health
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.service.impl.EmployeeDirectoryService
+import org.octopusden.octopus.components.registry.server.service.impl.IntegrationHealth
+import org.springframework.boot.actuate.health.Status
+
+/**
+ * Unit tests for [EmployeeServiceHealthIndicator] — the actuator surface of
+ * [EmployeeDirectoryService.probe]. The indicator is intentionally NOT part of
+ * the liveness/readiness groups (Spring only puts livenessState/readinessState
+ * there by default), so a DOWN employee-service never blocks deployment; it
+ * only flips the aggregate `/actuator/health` and its own component path.
+ */
+class EmployeeServiceHealthIndicatorTest {
+    private fun indicatorWith(health: IntegrationHealth): EmployeeServiceHealthIndicator {
+        val directory = mock(EmployeeDirectoryService::class.java)
+        `when`(directory.probe()).thenReturn(health)
+        return EmployeeServiceHealthIndicator(directory)
+    }
+
+    @Test
+    @DisplayName("probe UP → actuator UP")
+    fun `up maps to UP`() {
+        assertEquals(Status.UP, indicatorWith(IntegrationHealth.UP).health().status)
+    }
+
+    @Test
+    @DisplayName("probe DOWN → actuator DOWN with a reason detail")
+    fun `down maps to DOWN`() {
+        val health = indicatorWith(IntegrationHealth.DOWN).health()
+        assertEquals(Status.DOWN, health.status)
+        assertEquals(
+            "employee-service lookup failed (credentials / gateway route / directory backend — see logs)",
+            health.details["reason"],
+        )
+    }
+
+    @Test
+    @DisplayName("probe DISABLED → actuator UNKNOWN with enabled=false detail")
+    fun `disabled maps to UNKNOWN`() {
+        val health = indicatorWith(IntegrationHealth.DISABLED).health()
+        assertEquals(Status.UNKNOWN, health.status)
+        assertEquals(false, health.details["enabled"])
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryServiceTest.kt
@@ -95,4 +95,37 @@ class EmployeeDirectoryServiceTest {
         assertEquals(emptyList<EmployeeMatch>(), disabledDirectory().search("alice"))
         assertEquals(emptyList<EmployeeMatch>(), directoryWith(client).search("   "))
     }
+
+    @Test
+    @DisplayName("probe(): NotFound for the synthetic username proves the chain end-to-end → UP")
+    fun `probe notfound is UP`() {
+        val client = mock(EmployeeServiceClient::class.java)
+        `when`(client.getEmployee(EmployeeDirectoryService.PROBE_USERNAME))
+            .thenThrow(NotFoundException("no such employee"))
+        assertEquals(IntegrationHealth.UP, directoryWith(client).probe())
+    }
+
+    @Test
+    @DisplayName("probe(): a real answer (active or not) also proves the chain → UP")
+    fun `probe real answer is UP`() {
+        val client = mock(EmployeeServiceClient::class.java)
+        `when`(client.getEmployee(EmployeeDirectoryService.PROBE_USERNAME))
+            .thenReturn(Employee(EmployeeDirectoryService.PROBE_USERNAME, false))
+        assertEquals(IntegrationHealth.UP, directoryWith(client).probe())
+    }
+
+    @Test
+    @DisplayName("probe(): transport / auth / runtime error → DOWN")
+    fun `probe transport error is DOWN`() {
+        val client = mock(EmployeeServiceClient::class.java)
+        `when`(client.getEmployee(EmployeeDirectoryService.PROBE_USERNAME))
+            .thenThrow(IllegalArgumentException("Bearer token or basic credentials must be provided"))
+        assertEquals(IntegrationHealth.DOWN, directoryWith(client).probe())
+    }
+
+    @Test
+    @DisplayName("probe(): no client bean → DISABLED")
+    fun `probe disabled`() {
+        assertEquals(IntegrationHealth.DISABLED, disabledDirectory().probe())
+    }
 }


### PR DESCRIPTION
## What

Monitoring surfaces for the employee-service integration, so a broken integration (e.g. missing credentials on a stand) is detectable instead of silently degrading person validation in the Portal.

- `EmployeeDirectoryService.probe()` — reuses `isActive()` on a synthetic username; any directory answer (incl. not-found) proves the CRS → api-gateway → employee-service chain end-to-end. Only `UNAVAILABLE` maps to `DOWN`; no client wired stays `DISABLED`.
- Actuator component `employeeService`: `UP` / `DOWN`+reason / `UNKNOWN`+`enabled:false`.
- `GET /rest/api/4/components/meta/employees/health` → `{"status":"UP"|"DOWN"|"DISABLED"}` for the Portal admin banner. Always HTTP 200 (status in the body); authenticated (sits under the `/meta/employees/**` matcher).
- OpenAPI v4.json refreshed — additive only.

## Deployment safety

A DOWN integration must **not** block rollout, and it doesn't:
- OKD probes hit `/actuator/health/liveness` (group); custom indicators are not part of probe groups.
- Eureka health propagation is off (`eureka.client.enabled=false`).
- `DISABLED` (intentionally unconfigured env) maps to `UNKNOWN`, not `DOWN` — dev stands stay green.

## Tests

TDD per layer: `EmployeeDirectoryServiceTest` (probe mapping), `EmployeeServiceHealthIndicatorTest`, `EmployeeLookupEndpointsV4Test` (+4 MockMvc cases incl. anonymous-401). `test` and `dbTest` green; OpenAPI drift gate green.

Portal counterpart PR follows (admin red banner polling this endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)