### PR TITLE
feat: crsctl CLI — read-only v4 client + auth/audit scaffolding (gated)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,27 @@ Quality reports index: `build/reports/quality/index.html`
 | `components-registry-service-core` | Core DTOs and exceptions |
 | `components-registry-service-client` | Feign HTTP client |
 | `components-registry-service-server` | Spring Boot REST API (main application) |
+| `components-registry-cli` | `crsctl` — read-only command-line client for the v4 API (Kotlin/JVM fat jar) |
 | `test-common` | Shared test utilities |
+
+### crsctl CLI
+
+`crsctl` (module `components-registry-cli`) is a read-only command-line client for the CRS **v4 API**,
+shipped as a self-contained fat jar (`./gradlew :components-registry-cli:shadowJar`, then
+`java -jar components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT.jar ...`). Anonymous
+read commands (`components`, `component`, `meta`, `whoami`) work without a login; `login` / `audit` /
+`meta employees` need a credential and are currently gated on a pending Keycloak public device-flow
+client. With `-o json` it emits stable JSON (a top-level array for list-shaped commands), structured
+JSON errors on stderr, and pinned exit codes (0 OK, 2 USAGE, 3 NOT_FOUND, 4 AUTH_REQUIRED, 5 SERVER).
+
+```
+crsctl --env dev components list --owner alice --system FOO -o json | jq -r '.[].name'
+crsctl --env dev component get my-component -o json | jq '.componentOwner'
+crsctl --env dev meta owners -o json | jq -r '.[]'
+```
+
+See `components-registry-cli/README.md` for the full command surface and `components-registry-cli/skill/SKILL.md`
+for the agent-facing Skill with copy-pasteable `jq` recipes.
 
 ## Tech Stack
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,12 @@ read commands (`components`, `component`, `meta`, `whoami`) work without a login
 client. With `-o json` it emits stable JSON (a top-level array for list-shaped commands), structured
 JSON errors on stderr, and pinned exit codes (0 OK, 2 USAGE, 3 NOT_FOUND, 4 AUTH_REQUIRED, 5 SERVER).
 
+Global options (`--env`, `--crs-url`, `--token`, `-o`) precede the subcommand:
+
 ```
-crsctl --env dev components list --owner alice --system FOO -o json | jq -r '.[].name'
-crsctl --env dev component get my-component -o json | jq '.componentOwner'
-crsctl --env dev meta owners -o json | jq -r '.[]'
+crsctl --env dev -o json components list --owner alice --system FOO | jq -r '.[].name'
+crsctl --env dev -o json component get my-component | jq '.componentOwner'
+crsctl --env dev -o json meta owners | jq -r '.[]'
 ```
 
 See `components-registry-cli/README.md` for the full command surface and `components-registry-cli/skill/SKILL.md`

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ plugins {
 }
 
 octopusQuality {
-    excludeProjects('components-registry-automation', 'components-registry-compat-test', 'test-common')
+    // TODO(crsctl): enabling the detekt/ktlint quality gate for components-registry-cli is a follow-up;
+    // excluded for the first PR to avoid baseline churn. Keep the module's code clean regardless.
+    excludeProjects('components-registry-automation', 'components-registry-compat-test', 'test-common', 'components-registry-cli')
     java { failOnViolation = true }
     kotlin { failOnViolation = true }
     coverage {

--- a/build.gradle
+++ b/build.gradle
@@ -395,7 +395,10 @@ ${sectionsHtml}
 // task so the shared workflow default command (./gradlew qualityCoverage) remains correct.
 gradle.projectsEvaluated {
     def coverageProjects = subprojects.findAll {
-        !(it.name in ['components-registry-automation', 'components-registry-compat-test', 'test-common'])
+        // components-registry-cli is a standalone CLI tool (like -automation): much of its code is
+        // Clikt wiring / main() / gated interactive auth paths that unit coverage can't meaningfully
+        // reach. Excluded from the aggregate 70% gate, consistent with octopusQuality.excludeProjects.
+        !(it.name in ['components-registry-automation', 'components-registry-compat-test', 'test-common', 'components-registry-cli'])
     }
     def testTargets = coverageProjects.findAll { it.tasks.findByName('test') != null }
 

--- a/components-registry-cli/README.md
+++ b/components-registry-cli/README.md
@@ -201,6 +201,12 @@ Both emit a **JSON array** of audit-log rows under `-o json`.
 
 See "Auth (gated)" below.
 
+### `help`
+
+`crsctl help` prints the top-level help (same as `--help`); `crsctl help <command>` prints help for
+a named, possibly nested command — e.g. `crsctl help components list`, `crsctl help audit recent`.
+`help <unknown>` exits `2` (USAGE). Per-command `--help`/`-h` works everywhere too.
+
 ---
 
 ## Agent contract

--- a/components-registry-cli/README.md
+++ b/components-registry-cli/README.md
@@ -1,0 +1,260 @@
+# crsctl
+
+`crsctl` is a **read-only** command-line client for the Components Registry Service (CRS) **v4 API**.
+It is built from this module (`components-registry-cli`) as a self-contained executable fat jar.
+
+It speaks the v4 REST surface (`/rest/api/4/...` plus `/auth/me`), renders results as JSON or a
+plain table, and is designed to be **scriptable**: stable JSON on stdout, structured JSON errors on
+stderr, and a small, pinned set of process exit codes.
+
+---
+
+## Status
+
+| Capability | Status |
+|------------|--------|
+| Anonymous reads — `components`, `component`, `meta` (except `meta employees`), `whoami` | **Works out of the box.** No login or token required. |
+| `login` / `logout` / `audit` / `meta employees` | **Gated.** These need an authenticated identity. The device-flow `login` depends on a pending Keycloak **public device-flow client** (Part C spike) that does not exist yet, so the auth path is **not usable end-to-end** today. |
+| Release / Homebrew tap / macOS notarization | **Separate follow-up.** Not part of this module yet. |
+
+Anonymous read commands are fully functional now. Everything under the "Auth (gated)" heading below
+is implemented in the CLI but blocked on the OIDC client provisioning.
+
+---
+
+## Build & run
+
+Produce the fat jar:
+
+```
+./gradlew :components-registry-cli:shadowJar
+```
+
+The shadow plugin is configured with an empty archive classifier, so the artifact is:
+
+```
+components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT.jar
+```
+
+Run it:
+
+```
+java -jar components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT.jar --help
+```
+
+Throughout this document `crsctl` is shorthand for `java -jar <path-to-shadow-jar>`. A wrapper
+shell alias is left to the (separate) release/packaging follow-up.
+
+---
+
+## Targeting a registry (env profiles)
+
+`crsctl` never guesses a registry URL. Resolution precedence:
+
+- **URL:** `--crs-url` flag → `CRS_URL` env → named profile (`--env`, else the config `defaultProfile`)
+- **Token:** `--token` flag → `CRS_TOKEN` env → none (anonymous)
+
+If no URL can be resolved from any source the command exits with `USAGE` (2) and a clear message
+rather than defaulting to a possibly-wrong registry.
+
+### Config file
+
+A JSON config file holds named profiles. Location:
+
+- macOS: `~/Library/Application Support/crsctl/config.json`
+- otherwise: `$XDG_CONFIG_HOME/crsctl/config.json`, else `~/.config/crsctl/config.json`
+
+A missing config file is tolerated (you can run entirely off `--crs-url` / `CRS_URL`). Shape:
+
+```json
+{
+  "defaultProfile": "dev",
+  "profiles": {
+    "dev": {
+      "crsUrl": "https://crs.dev.example",
+      "keycloakIssuer": "https://idp.dev.example/realms/registry",
+      "clientId": "crsctl-public"
+    },
+    "prod": {
+      "crsUrl": "https://crs.example"
+    }
+  }
+}
+```
+
+`crsUrl` is the only field required for read commands. `keycloakIssuer` / `clientId` are only
+consumed by the (gated) auth layer; a bare `--crs-url` cannot supply them.
+
+---
+
+## Global options
+
+| Option | Meaning |
+|--------|---------|
+| `--env <name>` | Named config profile to target. |
+| `--crs-url <url>` | CRS base URL. Overrides `--env` and `CRS_URL`. |
+| `--token <token>` | Bearer token. Overrides `CRS_TOKEN`. Anonymous if omitted. |
+| `-o, --output json\|table` | Output format. Default `table`. |
+| `-v, --verbose` | Verbose diagnostics. |
+| `--insecure-token-store` | Store the refresh token in a plaintext file (mode 0600) instead of the system keychain. (Auth path only.) |
+| `--version` | Print the CLI version (`1.0-SNAPSHOT`). |
+| `--help` | Show help for any command or subcommand. |
+
+`CRS_URL` and `CRS_TOKEN` are the recognized environment variables.
+
+---
+
+## Command surface
+
+### `components list`
+
+List components, optionally filtered. Anonymous; no token required.
+
+Filters (repeatable ones may be passed multiple times):
+
+| Option | Repeatable | Notes |
+|--------|:---------:|-------|
+| `--search <text>` | | Free-text across name / displayName. |
+| `--owner <owner>` | yes | Component owner. |
+| `--system <code>` | yes | System code. |
+| `--product-type <type>` | | |
+| `--build-system <bs>` | yes | |
+| `--label <label>` | yes | |
+| `--client-code <code>` | yes | |
+| `--solution <true\|false>` | | |
+| `--jira-project-key <key>` | yes | |
+| `--jira-technical <true\|false>` | | |
+| `--vcs-path <path>` | | |
+| `--production-branch <branch>` | | |
+| `--parent <name>` | yes | Parent component name. |
+| `--group-key <key>` | yes | |
+| `--archived <true\|false>` | | |
+| `--can-be-parent <true\|false>` | | |
+| `--distribution-explicit <true\|false>` | | |
+| `--distribution-external <true\|false>` | | |
+
+Paging:
+
+| Option | Notes |
+|--------|-------|
+| `--page <n>` | Zero-based page number. |
+| `--size <n>` | Page size. |
+| `--sort <spec>` | e.g. `name,asc` (repeatable). |
+| `--all` | Fetch every page (ignores `--page`; loops until the last page, bounded by a safety cap). |
+
+**Output:** with `-o json` the command emits a **JSON array** of component-summary objects (the page
+envelope's `content`, unwrapped). With `-o table` it prints columns `ID  NAME  OWNER  SYSTEM`.
+
+### `component get <ID_OR_NAME>`
+
+Fetch a component's full detail by id (UUID) or name. Anonymous.
+`-o json` emits a single `ComponentDetailResponse` object.
+
+### `component as-code <ID_OR_NAME>`
+
+Print the component's as-code (Groovy-style) source verbatim. Output is raw `text/plain`; the
+`-o` format is not applied.
+
+### `component overrides <ID_OR_NAME>`
+
+List a component's field-overrides. The endpoint requires the component's UUID; if the argument is
+already a UUID it is used directly, otherwise it is resolved to a UUID via a `component get` lookup
+first. `-o json` emits a **JSON array** of field-override objects.
+
+### `meta <subcommand>`
+
+Registry metadata / dictionary lookups. Each returns a **JSON array of strings** under `-o json`:
+
+```
+meta build-systems          meta labels                 meta repository-types
+meta client-codes           meta labels-dictionary      meta systems
+meta escrow-generations     meta maven-versions         meta systems-dictionary
+meta group-keys             meta owners
+meta java-versions          meta parent-component-names
+meta jira-project-keys
+```
+
+`meta employees --search <q>` — **(auth)** search employees. Requires a token; on 401/403 exits
+`AUTH_REQUIRED` (4). Emits a JSON array of `{username, active}` objects.
+
+### `whoami`
+
+Show the current identity. With no resolvable credential it prints a static anonymous line and
+exits 0 **without** any HTTP call. With a token it calls `GET /auth/me` and renders the `User`
+object (`username`, `groups`, `roles[]` with `permissions`).
+
+### `audit` — (auth, gated)
+
+Query the audit log. Every subcommand **requires login and the `ACCESS_AUDIT` permission**; with no
+resolvable credential it fails fast with `AUTH_REQUIRED` (4) before any HTTP call.
+
+- `audit recent` — recent entries, with filters `--entity-type`, `--entity-id`, `--changed-by`,
+  `--action`, `--source`, `--from`, `--to`, `--include-migrated <true|false>`, plus
+  `--page` / `--size` / `--sort`.
+- `audit history <ENTITY_TYPE> <ENTITY_ID>` — history for one entity, with `--include-migrated` plus
+  `--page` / `--size` / `--sort`.
+
+Both emit a **JSON array** of audit-log rows under `-o json`.
+
+### `login` / `logout` — (auth, gated)
+
+See "Auth (gated)" below.
+
+---
+
+## Agent contract
+
+`crsctl` is built to be driven by scripts and AI agents.
+
+- **stdout** carries the result. With `-o json` it is stable, parseable JSON: a JSON **array** for
+  list-shaped commands (`components list`, `component overrides`, `meta *`, `audit *`), a single
+  JSON object for `component get` and `whoami` (with a token), and raw text for `component as-code`.
+- **stderr** carries a structured error object on failure, with a fixed shape:
+
+  ```json
+  {"errorCode": "<code or null>", "message": "<human message>"}
+  ```
+
+  For server (`CrsApiException`) errors the server's `errorCode` / `errorMessage` are surfaced; for
+  local errors `errorCode` is `null`.
+- **exit code** signals the outcome so callers can branch without parsing text.
+
+### Exit codes
+
+| Code | Name | When |
+|:----:|------|------|
+| 0 | `OK` | Success. |
+| 2 | `USAGE` | Bad invocation: unknown flags, missing args, unresolved target (no URL), bad config, HTTP 400. |
+| 3 | `NOT_FOUND` | Resource does not exist (HTTP 404). |
+| 4 | `AUTH_REQUIRED` | Authentication/authorization required or insufficient (HTTP 401/403, or no credential for an auth-required command). |
+| 5 | `SERVER` | Server-side failure or transport problem (HTTP 5xx, I/O error). |
+
+---
+
+## Auth (gated)
+
+> **Gated:** the device-flow login depends on a pending Keycloak **public device-flow client**
+> (Part C spike). Until that client exists, `login` / `audit` / `meta employees` cannot complete
+> end-to-end. The commands are implemented and the contract below is final.
+
+- **Login (device authorization grant, RFC 8628):** `crsctl --env <env> login` resolves the
+  `keycloakIssuer` + `clientId` from the active profile, prints a verification URL and a user code,
+  polls until you authorize in a browser, and stores the resulting refresh token. It deliberately
+  does **not** auto-open a browser.
+- **`--offline`:** `crsctl login --offline` requests the `offline_access` scope so the provider
+  returns a long-lived refresh token for non-interactive refresh between invocations.
+- **Credential storage:** the refresh token is stored in the system keychain by default. Pass the
+  global `--insecure-token-store` to store it in a plaintext file (mode 0600) instead.
+- **Logout (revoke-then-clear):** `crsctl logout` revokes the stored refresh token at the provider
+  (RFC 7009) and then removes it locally. Revocation is best-effort — if it fails, the local token
+  is still cleared and the command exits 0 with a warning.
+- **What needs auth:** anonymous reads need no login. Only `audit *`, `meta employees`, and an
+  authenticated `whoami` consume a credential. `audit` additionally requires the **`ACCESS_AUDIT`**
+  permission on the server.
+
+---
+
+## See also
+
+- `skill/SKILL.md` — a Claude Code Skill describing when and how an agent should reach for `crsctl`,
+  with copy-pasteable `jq` recipes.

--- a/components-registry-cli/README.md
+++ b/components-registry-cli/README.md
@@ -30,16 +30,17 @@ Produce the fat jar:
 ./gradlew :components-registry-cli:shadowJar
 ```
 
-The shadow plugin is configured with an empty archive classifier, so the artifact is:
+The runnable fat jar uses the `all` classifier (the thin `…-<version>.jar` is the plain library
+jar, kept for the repo's release tooling and Maven publication):
 
 ```
-components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT.jar
+components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT-all.jar
 ```
 
 Run it:
 
 ```
-java -jar components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT.jar --help
+java -jar components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT-all.jar --help
 ```
 
 Throughout this document `crsctl` is shorthand for `java -jar <path-to-shadow-jar>`. A wrapper

--- a/components-registry-cli/build.gradle
+++ b/components-registry-cli/build.gradle
@@ -17,13 +17,24 @@ test {
     useJUnitPlatform()
 }
 
+// Runnable fat jar -> components-registry-cli-<version>-all.jar (use this for `java -jar`).
 shadowJar {
-    archiveClassifier = ''
+    archiveClassifier = 'all'
     manifest {
         attributes 'Main-Class': 'org.octopusden.octopus.components.registry.cli.MainKt'
     }
 }
 
-jar.enabled = false
+// Keep the thin `jar` ENABLED: the repo's TeamCity release tooling (extractModuleInfo) requires
+// every module to produce the standard components-registry-cli-<version>.jar, and the maven
+// publication (from components.java) needs it too. Mirrors :components-registry-automation, which
+// also ships a shadowJar while leaving the thin jar in place. (Do NOT set jar.enabled = false here —
+// that broke the [1.0] Compile&UT build: "Artifact components-registry-cli-<version>.jar wasn't
+// produced by this build".)
+jar {
+    manifest {
+        attributes 'Main-Class': 'org.octopusden.octopus.components.registry.cli.MainKt'
+    }
+}
 
 build.dependsOn shadowJar

--- a/components-registry-cli/build.gradle
+++ b/components-registry-cli/build.gradle
@@ -1,0 +1,29 @@
+// crsctl — Components Registry Service command-line client.
+// Kotlin/JVM module producing a self-contained executable fat jar via the shadow plugin.
+// Note: kotlin.jvm, java-library, maven-publish, signing, junit5 test deps, jvmTarget 21
+// and withJavadocJar/withSourcesJar are all applied by the root `configure(subprojects)`
+// block, so they are intentionally NOT re-declared here.
+plugins {
+    id 'com.github.johnrengelman.shadow'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.25'
+}
+
+dependencies {
+    implementation "com.github.ajalt.clikt:clikt:${project['clikt.version']}"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:${project['kotlinx-serialization.version']}"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+shadowJar {
+    archiveClassifier = ''
+    manifest {
+        attributes 'Main-Class': 'org.octopusden.octopus.components.registry.cli.MainKt'
+    }
+}
+
+jar.enabled = false
+
+build.dependsOn shadowJar

--- a/components-registry-cli/skill/SKILL.md
+++ b/components-registry-cli/skill/SKILL.md
@@ -151,12 +151,15 @@ crsctl --env dev audit history COMPONENT my-component -o json | jq '.[].changeDi
 
 ## Branching on results (pseudocode)
 
+JSON results go to stdout; the structured `{"errorCode","message"}` error goes to stderr.
+Capture them separately so you can read the error message on failure:
+
 ```
-out=$(crsctl --env dev component get "$name" -o json); rc=$?
+out=$(crsctl --env dev component get "$name" -o json 2>/tmp/crsctl.err); rc=$?
 case $rc in
   0) echo "$out" | jq .name ;;
   3) echo "no such component: $name" ;;     # NOT_FOUND
   4) echo "need login / permission" ;;      # AUTH_REQUIRED (auth currently gated)
-  *) echo "error: $(echo "$out" | jq -r .message 2>/dev/null)" ;;  # message is on stderr
+  *) echo "error: $(jq -r .message /tmp/crsctl.err 2>/dev/null)" ;;  # message is on stderr
 esac
 ```

--- a/components-registry-cli/skill/SKILL.md
+++ b/components-registry-cli/skill/SKILL.md
@@ -80,6 +80,10 @@ crsctl [GLOBAL OPTS] audit history <ENTITY_TYPE> <ENTITY_ID> [PAGING]   # auth (
 Global opts: `--env <name>` | `--crs-url <url>` | `--token <t>` | `-o json|table` | `-v` |
 `--insecure-token-store`. Env vars: `CRS_URL`, `CRS_TOKEN`.
 
+> **Option order matters:** global options are parsed by the root command, so they must come
+> **before** the subcommand — `crsctl --env dev -o json components list …`, NOT
+> `crsctl components list … -o json` (the latter exits 2 with `no such option -o`).
+
 `components list` filters: `--search`, `--owner`*, `--system`*, `--product-type`, `--build-system`*,
 `--label`*, `--client-code`*, `--solution`, `--jira-project-key`*, `--jira-technical`, `--vcs-path`,
 `--production-branch`, `--parent`*, `--group-key`*, `--archived`, `--can-be-parent`,
@@ -91,19 +95,19 @@ Global opts: `--env <name>` | `--crs-url <url>` | `--token <t>` | `-o json|table
 Find component **names** owned by `alice` in system `FOO` (output is a top-level array):
 
 ```
-crsctl --env dev components list --owner alice --system FOO -o json | jq -r '.[].name'
+crsctl --env dev -o json components list --owner alice --system FOO | jq -r '.[].name'
 ```
 
 All non-archived components, every page, as `id  name`:
 
 ```
-crsctl --env dev components list --archived false --all -o json | jq -r '.[] | "\(.id)\t\(.name)"'
+crsctl --env dev -o json components list --archived false --all | jq -r '.[] | "\(.id)\t\(.name)"'
 ```
 
 Get one component's owner and labels:
 
 ```
-crsctl --env dev component get my-component -o json | jq '{owner: .componentOwner, labels}'
+crsctl --env dev -o json component get my-component | jq '{owner: .componentOwner, labels}'
 ```
 
 View a component as code (raw text — do **not** pipe to jq):
@@ -116,22 +120,22 @@ List a component's field-overrides. The argument may be a UUID (used directly) o
 to its UUID first):
 
 ```
-crsctl --env dev component overrides 123e4567-e89b-12d3-a456-426614174000 -o json \
+crsctl --env dev -o json component overrides 123e4567-e89b-12d3-a456-426614174000 \
   | jq -r '.[] | "\(.overriddenAttribute)\t\(.rowType)\t\(.versionRange)"'
 ```
 
 Meta lookups (each is a JSON array of strings):
 
 ```
-crsctl --env dev meta owners  -o json | jq -r '.[]'
-crsctl --env dev meta systems -o json | jq -r '.[]'
-crsctl --env dev meta labels  -o json | jq -r '.[]'
+crsctl --env dev -o json meta owners  | jq -r '.[]'
+crsctl --env dev -o json meta systems | jq -r '.[]'
+crsctl --env dev -o json meta labels  | jq -r '.[]'
 ```
 
 Who am I (with a token; anonymous prints a static line and makes no call):
 
 ```
-crsctl --env dev --token "$CRS_TOKEN" whoami -o json \
+crsctl --env dev --token "$CRS_TOKEN" -o json whoami \
   | jq '{user: .username, perms: [.roles[].permissions[]] | unique}'
 ```
 
@@ -139,14 +143,14 @@ Recent audit changes for a user — **requires `crsctl login` and the `ACCESS_AU
 (currently gated; expect exit 4 / `AUTH_REQUIRED` until the auth client is provisioned):
 
 ```
-crsctl --env dev audit recent --changed-by alice --action UPDATE -o json \
+crsctl --env dev -o json audit recent --changed-by alice --action UPDATE \
   | jq -r '.[] | "\(.changedAt)\t\(.action)\t\(.entityType)/\(.entityId)"'
 ```
 
 Audit history for a single entity (also auth-gated):
 
 ```
-crsctl --env dev audit history COMPONENT my-component -o json | jq '.[].changeDiff'
+crsctl --env dev -o json audit history COMPONENT my-component | jq '.[].changeDiff'
 ```
 
 ## Branching on results (pseudocode)
@@ -155,7 +159,7 @@ JSON results go to stdout; the structured `{"errorCode","message"}` error goes t
 Capture them separately so you can read the error message on failure:
 
 ```
-out=$(crsctl --env dev component get "$name" -o json 2>/tmp/crsctl.err); rc=$?
+out=$(crsctl --env dev -o json component get "$name" 2>/tmp/crsctl.err); rc=$?
 case $rc in
   0) echo "$out" | jq .name ;;
   3) echo "no such component: $name" ;;     # NOT_FOUND

--- a/components-registry-cli/skill/SKILL.md
+++ b/components-registry-cli/skill/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: crsctl
+description: >-
+  Query a Components Registry Service (CRS) over its v4 API from the command line. Use when an agent
+  needs to look up components, their owners/systems/labels, a component's full detail or as-code
+  source, its field-overrides, registry metadata dictionaries (owners, systems, labels, build
+  systems, ...), or the audit log. Read commands are anonymous (no login). Stable JSON on stdout
+  with -o json, structured JSON errors on stderr, and pinned exit codes for branching.
+---
+
+# crsctl — Components Registry Service CLI
+
+`crsctl` is a **read-only** client for a Components Registry Service v4 API. Prefer it over raw
+`curl` against `/rest/api/4/...`: it resolves the target URL/token consistently, emits stable JSON,
+and uses pinned exit codes so you can branch on the outcome.
+
+In the recipes below, `crsctl` means `java -jar <path-to-shadow-jar>` (build it with
+`./gradlew :components-registry-cli:shadowJar`; the jar is at
+`components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT.jar`). Always pass a target
+with `--env <name>` (or `--crs-url <url>` / `CRS_URL`) and `-o json` for machine output.
+
+## When to use
+
+- "Which components does **alice** own in system **FOO**?" → `components list`
+- "Show me everything about component **X**." → `component get`
+- "What does component **X** look like as code?" → `component as-code`
+- "List the field-overrides on component **X**." → `component overrides`
+- "What owners / systems / labels / build-systems exist?" → `meta <kind>`
+- "Who am I / what permissions do I have?" → `whoami`
+- "What changed recently in the audit log?" → `audit` **(requires login + `ACCESS_AUDIT`)**
+
+## Auth — read this first
+
+- **Anonymous reads need no login:** `components`, `component`, `meta` (except `meta employees`),
+  and `whoami` all work with just a target URL.
+- **Only these need a credential:** `audit *`, `meta employees`, and an authenticated `whoami`.
+- The `login` flow (and therefore `audit` / `meta employees` end-to-end) is currently **gated** on a
+  pending Keycloak public device-flow client. Treat an `AUTH_REQUIRED` (exit 4) from those commands
+  as "auth not available yet," not a bug in your invocation.
+
+## Output shapes (so your jq matches reality)
+
+| Command | `-o json` shape |
+|---------|-----------------|
+| `components list` | JSON **array** of component-summary objects |
+| `component get` | single component-detail **object** |
+| `component as-code` | raw text (not JSON; do not pipe to jq) |
+| `component overrides` | JSON **array** of field-override objects |
+| `meta <kind>` (dictionaries) | JSON **array of strings** |
+| `meta employees` | JSON **array** of `{username, active}` |
+| `whoami` (with token) | single `User` **object** |
+| `audit recent` / `audit history` | JSON **array** of audit-log rows |
+
+## Exit codes (branch on these)
+
+| Code | Meaning |
+|:----:|---------|
+| 0 | OK |
+| 2 | USAGE — bad flags/args, unresolved target, bad config, HTTP 400 |
+| 3 | NOT_FOUND — resource missing (HTTP 404) |
+| 4 | AUTH_REQUIRED — login/permission needed (HTTP 401/403, or no credential) |
+| 5 | SERVER — server failure or transport error (HTTP 5xx, I/O) |
+
+On failure, stderr carries `{"errorCode": <code or null>, "message": <text>}`.
+
+## Commands
+
+```
+crsctl [GLOBAL OPTS] components list [FILTERS] [PAGING]
+crsctl [GLOBAL OPTS] component get|as-code|overrides <ID_OR_NAME>
+crsctl [GLOBAL OPTS] meta <build-systems|client-codes|escrow-generations|group-keys|java-versions|
+                          jira-project-keys|labels|labels-dictionary|maven-versions|owners|
+                          parent-component-names|repository-types|systems|systems-dictionary>
+crsctl [GLOBAL OPTS] meta employees --search <q>          # auth
+crsctl [GLOBAL OPTS] whoami
+crsctl [GLOBAL OPTS] audit recent [FILTERS] [PAGING]      # auth (ACCESS_AUDIT)
+crsctl [GLOBAL OPTS] audit history <ENTITY_TYPE> <ENTITY_ID> [PAGING]   # auth (ACCESS_AUDIT)
+```
+
+Global opts: `--env <name>` | `--crs-url <url>` | `--token <t>` | `-o json|table` | `-v` |
+`--insecure-token-store`. Env vars: `CRS_URL`, `CRS_TOKEN`.
+
+`components list` filters: `--search`, `--owner`*, `--system`*, `--product-type`, `--build-system`*,
+`--label`*, `--client-code`*, `--solution`, `--jira-project-key`*, `--jira-technical`, `--vcs-path`,
+`--production-branch`, `--parent`*, `--group-key`*, `--archived`, `--can-be-parent`,
+`--distribution-explicit`, `--distribution-external` (`*` = repeatable). Paging: `--page`, `--size`,
+`--sort` (e.g. `name,asc`), `--all`.
+
+## Examples
+
+Find component **names** owned by `alice` in system `FOO` (output is a top-level array):
+
+```
+crsctl --env dev components list --owner alice --system FOO -o json | jq -r '.[].name'
+```
+
+All non-archived components, every page, as `id  name`:
+
+```
+crsctl --env dev components list --archived false --all -o json | jq -r '.[] | "\(.id)\t\(.name)"'
+```
+
+Get one component's owner and labels:
+
+```
+crsctl --env dev component get my-component -o json | jq '{owner: .componentOwner, labels}'
+```
+
+View a component as code (raw text — do **not** pipe to jq):
+
+```
+crsctl --env dev component as-code my-component
+```
+
+List a component's field-overrides. The argument may be a UUID (used directly) or a name (resolved
+to its UUID first):
+
+```
+crsctl --env dev component overrides 123e4567-e89b-12d3-a456-426614174000 -o json \
+  | jq -r '.[] | "\(.overriddenAttribute)\t\(.rowType)\t\(.versionRange)"'
+```
+
+Meta lookups (each is a JSON array of strings):
+
+```
+crsctl --env dev meta owners  -o json | jq -r '.[]'
+crsctl --env dev meta systems -o json | jq -r '.[]'
+crsctl --env dev meta labels  -o json | jq -r '.[]'
+```
+
+Who am I (with a token; anonymous prints a static line and makes no call):
+
+```
+crsctl --env dev --token "$CRS_TOKEN" whoami -o json \
+  | jq '{user: .username, perms: [.roles[].permissions[]] | unique}'
+```
+
+Recent audit changes for a user — **requires `crsctl login` and the `ACCESS_AUDIT` permission**
+(currently gated; expect exit 4 / `AUTH_REQUIRED` until the auth client is provisioned):
+
+```
+crsctl --env dev audit recent --changed-by alice --action UPDATE -o json \
+  | jq -r '.[] | "\(.changedAt)\t\(.action)\t\(.entityType)/\(.entityId)"'
+```
+
+Audit history for a single entity (also auth-gated):
+
+```
+crsctl --env dev audit history COMPONENT my-component -o json | jq '.[].changeDiff'
+```
+
+## Branching on results (pseudocode)
+
+```
+out=$(crsctl --env dev component get "$name" -o json); rc=$?
+case $rc in
+  0) echo "$out" | jq .name ;;
+  3) echo "no such component: $name" ;;     # NOT_FOUND
+  4) echo "need login / permission" ;;      # AUTH_REQUIRED (auth currently gated)
+  *) echo "error: $(echo "$out" | jq -r .message 2>/dev/null)" ;;  # message is on stderr
+esac
+```

--- a/components-registry-cli/skill/SKILL.md
+++ b/components-registry-cli/skill/SKILL.md
@@ -84,6 +84,9 @@ Global opts: `--env <name>` | `--crs-url <url>` | `--token <t>` | `-o json|table
 > **before** the subcommand — `crsctl --env dev -o json components list …`, NOT
 > `crsctl components list … -o json` (the latter exits 2 with `no such option -o`).
 
+Help: `crsctl --help` (or `crsctl help`) for the top level; `crsctl help <command>` for any
+(possibly nested) command, e.g. `crsctl help components list`. `help <unknown>` exits 2.
+
 `components list` filters: `--search`, `--owner`*, `--system`*, `--product-type`, `--build-system`*,
 `--label`*, `--client-code`*, `--solution`, `--jira-project-key`*, `--jira-technical`, `--vcs-path`,
 `--production-branch`, `--parent`*, `--group-key`*, `--archived`, `--can-be-parent`,

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
@@ -1,9 +1,17 @@
 package org.octopusden.octopus.components.registry.cli
 
+import org.octopusden.octopus.components.registry.cli.auth.CommandRunner
+import org.octopusden.octopus.components.registry.cli.auth.CredentialStore
+import org.octopusden.octopus.components.registry.cli.auth.DeviceFlowClient
+import org.octopusden.octopus.components.registry.cli.auth.ProcessCommandRunner
+import org.octopusden.octopus.components.registry.cli.auth.TokenManager
+import org.octopusden.octopus.components.registry.cli.auth.credentialStore
+import org.octopusden.octopus.components.registry.cli.client.ConfigResolutionException
 import org.octopusden.octopus.components.registry.cli.client.CrsClient
 import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
 import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
 import org.octopusden.octopus.components.registry.cli.config.EffectiveTarget
+import org.octopusden.octopus.components.registry.cli.config.Profile
 import org.octopusden.octopus.components.registry.cli.config.ResolverInputs
 import org.octopusden.octopus.components.registry.cli.config.TargetResolver
 import org.octopusden.octopus.components.registry.cli.output.OutputFormat
@@ -18,12 +26,22 @@ fun interface CrsClientFactory {
 }
 
 /**
+ * The keycloak issuer + public client id resolved from the active profile, needed by the device-flow
+ * login / logout / refresh paths. Both are SPIKE OUTPUTS (Part C): a profile that predates the auth
+ * layer will not have them.
+ */
+data class OidcConfig(
+    val issuer: String,
+    val clientId: String,
+)
+
+/**
  * Shared state threaded from the root command down to every subcommand via Clikt's
- * `findOrSetObject`. Holds the parsed global options plus the seams (config loader + client factory)
- * that the target-resolution helper needs.
+ * `findOrSetObject`. Holds the parsed global options plus the seams (config loader, client factory,
+ * command runner, device-flow client) that the target-resolution and auth helpers need.
  *
- * The two seams default to production behaviour (load the real config file, build a real
- * [CrsClient]); tests override them so commands can run fully offline.
+ * The seams default to production behaviour (load the real config file, build a real [CrsClient], run
+ * the real `security` CLI, hit the real network); tests override them so commands run fully offline.
  */
 class CliContext(
     val envFlag: String? = null,
@@ -31,10 +49,13 @@ class CliContext(
     val tokenFlag: String? = null,
     val output: OutputFormat = OutputFormat.TABLE,
     val verbose: Boolean = false,
+    val insecureTokenStore: Boolean = false,
     val configLoader: () -> CrsctlConfig = { ConfigLoader.load() },
     val clientFactory: CrsClientFactory = CrsClientFactory { target ->
         CrsClient(baseUrl = target.crsUrl, token = target.token)
     },
+    val commandRunner: CommandRunner = ProcessCommandRunner(),
+    val deviceFlowClient: DeviceFlowClient = DeviceFlowClient(),
     private val getenv: (String) -> String? = System::getenv,
 ) {
     /**
@@ -57,4 +78,50 @@ class CliContext(
 
     /** Resolves the target and builds a [CrsClient] for it. */
     fun client(): CrsClient = clientFactory.create(resolveTarget())
+
+    /** Builds a [CrsClient] for [target] using the configured factory. */
+    fun clientFor(target: EffectiveTarget): CrsClient = clientFactory.create(target)
+
+    /** The selected credential store (keychain by default, plaintext file with `--insecure-token-store`). */
+    fun credentialStore(): CredentialStore = credentialStore(insecureTokenStore, commandRunner)
+
+    /**
+     * Resolves the keycloak issuer + public client id from the active profile, failing clearly when
+     * the profile lacks them. The active profile is the one named by `--env`, else the config
+     * `defaultProfile`. A bare `--crs-url` (no profile) cannot supply OIDC settings.
+     */
+    fun resolveOidcConfig(): OidcConfig {
+        val config = configLoader()
+        val profile = activeProfile(config)
+            ?: throw ConfigResolutionException(
+                "Login requires a configured profile with 'keycloakIssuer' and 'clientId'. " +
+                    "Select one with --env or set a defaultProfile; --crs-url alone cannot provide OIDC settings.",
+            )
+        val issuer = profile.keycloakIssuer
+        val clientId = profile.clientId
+        if (issuer.isNullOrBlank() || clientId.isNullOrBlank()) {
+            throw ConfigResolutionException(
+                "Profile is missing 'keycloakIssuer' and/or 'clientId' (these are outputs of the " +
+                    "Keycloak device-flow client setup). Add them to the profile and retry.",
+            )
+        }
+        return OidcConfig(issuer = issuer, clientId = clientId)
+    }
+
+    /** Builds a [TokenManager] for the active profile's OIDC config + selected credential store. */
+    fun tokenManager(): TokenManager {
+        val oidc = resolveOidcConfig()
+        return TokenManager(
+            issuer = oidc.issuer,
+            clientId = oidc.clientId,
+            store = credentialStore(),
+            deviceFlow = deviceFlowClient,
+        )
+    }
+
+    private fun activeProfile(config: CrsctlConfig): Profile? {
+        val name = sequenceOf(envFlag, config.defaultProfile).firstOrNull { !it.isNullOrBlank() }
+            ?: return null
+        return config.profiles[name]
+    }
 }

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
@@ -1,0 +1,60 @@
+package org.octopusden.octopus.components.registry.cli
+
+import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
+import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
+import org.octopusden.octopus.components.registry.cli.config.EffectiveTarget
+import org.octopusden.octopus.components.registry.cli.config.ResolverInputs
+import org.octopusden.octopus.components.registry.cli.config.TargetResolver
+import org.octopusden.octopus.components.registry.cli.output.OutputFormat
+
+/**
+ * Builds a [CrsClient] for a resolved [EffectiveTarget]. Pulled behind an interface so tests can
+ * inject a client backed by a fake [org.octopusden.octopus.components.registry.cli.client.HttpExchange]
+ * without going through real config / network.
+ */
+fun interface CrsClientFactory {
+    fun create(target: EffectiveTarget): CrsClient
+}
+
+/**
+ * Shared state threaded from the root command down to every subcommand via Clikt's
+ * `findOrSetObject`. Holds the parsed global options plus the seams (config loader + client factory)
+ * that the target-resolution helper needs.
+ *
+ * The two seams default to production behaviour (load the real config file, build a real
+ * [CrsClient]); tests override them so commands can run fully offline.
+ */
+class CliContext(
+    val envFlag: String? = null,
+    val crsUrlFlag: String? = null,
+    val tokenFlag: String? = null,
+    val output: OutputFormat = OutputFormat.TABLE,
+    val verbose: Boolean = false,
+    val configLoader: () -> CrsctlConfig = { ConfigLoader.load() },
+    val clientFactory: CrsClientFactory = CrsClientFactory { target ->
+        CrsClient(baseUrl = target.crsUrl, token = target.token)
+    },
+    private val getenv: (String) -> String? = System::getenv,
+) {
+    /**
+     * Resolves the effective target from flags + `CRS_URL` / `CRS_TOKEN` env vars + the loaded
+     * config (see [TargetResolver] for precedence). Throws
+     * [org.octopusden.octopus.components.registry.cli.client.ConfigResolutionException] when no URL
+     * can be resolved.
+     */
+    fun resolveTarget(): EffectiveTarget =
+        TargetResolver.resolve(
+            ResolverInputs(
+                crsUrlFlag = crsUrlFlag,
+                tokenFlag = tokenFlag,
+                envFlag = envFlag,
+                crsUrlEnv = getenv("CRS_URL"),
+                tokenEnv = getenv("CRS_TOKEN"),
+            ),
+            configLoader(),
+        )
+
+    /** Resolves the target and builds a [CrsClient] for it. */
+    fun client(): CrsClient = clientFactory.create(resolveTarget())
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.cli
 
+import org.octopusden.octopus.components.registry.cli.auth.AuthRequiredException
 import org.octopusden.octopus.components.registry.cli.auth.CommandRunner
 import org.octopusden.octopus.components.registry.cli.auth.CredentialStore
 import org.octopusden.octopus.components.registry.cli.auth.DeviceFlowClient
@@ -79,6 +80,44 @@ class CliContext(
     /** Resolves the target and builds a [CrsClient] for it. */
     fun client(): CrsClient = clientFactory.create(resolveTarget())
 
+    /**
+     * Builds a [CrsClient] guaranteed to carry a bearer token, for endpoints that REQUIRE an
+     * authenticated identity (e.g. the audit API behind ACCESS_AUDIT).
+     *
+     * Token resolution mirrors `whoami`:
+     *   1. An explicit token (`--token` / `CRS_TOKEN`) — used verbatim.
+     *   2. A stored refresh token exchanged for an access token via the [TokenManager].
+     *
+     * Unlike `whoami` (which treats "no credential" as anonymous), this throws
+     * [AuthRequiredException] when neither path yields a token, so the caller never makes a blind
+     * anonymous request that the server would reject with a generic 401. A missing profile-level
+     * OIDC config ([ConfigResolutionException]) is likewise surfaced as [AuthRequiredException]:
+     * from the user's point of view they simply are not logged in for this operation.
+     */
+    fun authedClient(): CrsClient {
+        val target = resolveTarget()
+        val token = resolveBearerToken(target)
+        return clientFactory.create(target.copy(token = token))
+    }
+
+    /**
+     * Returns a usable bearer token for an auth-required operation, or throws [AuthRequiredException]
+     * when none can be resolved. An explicit token wins; otherwise a stored refresh token is
+     * exchanged via the [TokenManager].
+     */
+    private fun resolveBearerToken(target: EffectiveTarget): String {
+        if (!target.token.isNullOrBlank()) {
+            return target.token
+        }
+        return try {
+            tokenManager().accessToken()
+        } catch (e: AuthRequiredException) {
+            throw AuthRequiredException(NOT_AUTHENTICATED_MESSAGE)
+        } catch (e: ConfigResolutionException) {
+            throw AuthRequiredException(NOT_AUTHENTICATED_MESSAGE)
+        }
+    }
+
     /** Builds a [CrsClient] for [target] using the configured factory. */
     fun clientFor(target: EffectiveTarget): CrsClient = clientFactory.create(target)
 
@@ -123,5 +162,11 @@ class CliContext(
         val name = sequenceOf(envFlag, config.defaultProfile).firstOrNull { !it.isNullOrBlank() }
             ?: return null
         return config.profiles[name]
+    }
+
+    companion object {
+        /** Surfaced (exit AUTH_REQUIRED) when an auth-required command has no resolvable credential. */
+        const val NOT_AUTHENTICATED_MESSAGE =
+            "audit requires `crsctl login` and the ACCESS_AUDIT permission"
     }
 }

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/CliContext.kt
@@ -167,6 +167,7 @@ class CliContext(
     companion object {
         /** Surfaced (exit AUTH_REQUIRED) when an auth-required command has no resolvable credential. */
         const val NOT_AUTHENTICATED_MESSAGE =
-            "audit requires `crsctl login` and the ACCESS_AUDIT permission"
+            "this command requires authentication: run `crsctl login` (or pass --token / CRS_TOKEN) " +
+                "and ensure you have the required permission"
     }
 }

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -27,6 +27,7 @@ import org.octopusden.octopus.components.registry.cli.commands.ComponentGetComma
 import org.octopusden.octopus.components.registry.cli.commands.ComponentOverridesCommand
 import org.octopusden.octopus.components.registry.cli.commands.ComponentsCommand
 import org.octopusden.octopus.components.registry.cli.commands.ComponentsListCommand
+import org.octopusden.octopus.components.registry.cli.commands.HelpCommand
 import org.octopusden.octopus.components.registry.cli.commands.LoginCommand
 import org.octopusden.octopus.components.registry.cli.commands.LogoutCommand
 import org.octopusden.octopus.components.registry.cli.commands.WhoamiCommand
@@ -120,7 +121,43 @@ fun crsctl(
     WhoamiCommand(),
     LoginCommand(),
     LogoutCommand(),
+    HelpCommand(),
 )
+
+/** Global options that consume a following value (used to skip their value when scanning args). */
+private val VALUE_OPTIONS = setOf("--env", "--crs-url", "--token", "-o", "--output")
+
+/**
+ * Index of a leading `help` token in the subcommand slot (after any global options), or -1 if the
+ * first positional token is not `help`.
+ */
+private fun helpTokenIndex(args: Array<String>): Int {
+    var i = 0
+    while (i < args.size) {
+        val token = args[i]
+        if (!token.startsWith("-")) {
+            return if (token == "help") i else -1
+        }
+        // Skip an option; also skip its value when given as a separate token (`--env dev`, `-o json`).
+        i += if (token in VALUE_OPTIONS && !token.contains("=")) 2 else 1
+    }
+    return -1
+}
+
+/**
+ * Rewrites a leading `help [<command>...]` invocation into `[<command>...] --help`, so Clikt's own
+ * renderer prints help for the root or the named (possibly nested) subcommand at any depth, with a
+ * clean exit 0. Global options that precede the subcommand are preserved. Returns [args] unchanged
+ * when the first positional token is not `help`.
+ */
+internal fun rewriteHelpArgs(args: Array<String>): Array<String> {
+    val idx = helpTokenIndex(args)
+    if (idx < 0) return args
+    val out = args.toMutableList()
+    out.removeAt(idx)
+    out.add("--help")
+    return out.toTypedArray()
+}
 
 /**
  * Parses and runs [command] over [args], mapping every Clikt outcome onto the crsctl exit-code +
@@ -136,8 +173,21 @@ fun crsctl(
  *     STDERR and exit [ExitCode.USAGE] (2)
  */
 internal fun runCli(args: Array<String>, command: CliktCommand = crsctl()): Int {
+    // `help <unknown-command>` should fail (exit 2) rather than silently show root help (Clikt's
+    // eager --help would otherwise swallow the unknown name). Validate the named top-level command.
+    val helpIdx = helpTokenIndex(args)
+    if (helpIdx >= 0) {
+        val target = args.drop(helpIdx + 1).firstOrNull { !it.startsWith("-") }
+        if (target != null) {
+            val known = command.registeredSubcommands().map { it.commandName }.toSet()
+            if (target !in known) {
+                System.err.println(Renderer.renderError(IllegalArgumentException("no such command: $target")))
+                return ExitCode.USAGE.code
+            }
+        }
+    }
     return try {
-        command.parse(args)
+        command.parse(rewriteHelpArgs(args))
         ExitCode.OK.code
     } catch (e: PrintHelpMessage) {
         if (e.error) {

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -127,9 +127,14 @@ fun crsctl(
 /** Global options that consume a following value (used to skip their value when scanning args). */
 private val VALUE_OPTIONS = setOf("--env", "--crs-url", "--token", "-o", "--output")
 
+/** Global boolean flags (no value). */
+private val FLAG_OPTIONS = setOf("-v", "--verbose", "--insecure-token-store")
+
 /**
- * Index of a leading `help` token in the subcommand slot (after any global options), or -1 if the
- * first positional token is not `help`.
+ * Index of a leading `help` token in the subcommand slot, after only KNOWN global options. Returns
+ * -1 if the first positional token is not `help`, OR if any UNKNOWN option precedes it — in that
+ * case we do NOT enter help mode, so Clikt parses normally and reports the bad option as a usage
+ * error (e.g. `crsctl --bogus help` must fail, not silently print root help).
  */
 private fun helpTokenIndex(args: Array<String>): Int {
     var i = 0
@@ -138,8 +143,13 @@ private fun helpTokenIndex(args: Array<String>): Int {
         if (!token.startsWith("-")) {
             return if (token == "help") i else -1
         }
-        // Skip an option; also skip its value when given as a separate token (`--env dev`, `-o json`).
-        i += if (token in VALUE_OPTIONS && !token.contains("=")) 2 else 1
+        val name = token.substringBefore("=")
+        i += when {
+            name in VALUE_OPTIONS && token.contains("=") -> 1   // --env=dev
+            name in VALUE_OPTIONS -> 2                          // --env dev / -o json
+            name in FLAG_OPTIONS -> 1
+            else -> return -1                                   // unknown option -> not help mode
+        }
     }
     return -1
 }
@@ -173,17 +183,22 @@ internal fun rewriteHelpArgs(args: Array<String>): Array<String> {
  *     STDERR and exit [ExitCode.USAGE] (2)
  */
 internal fun runCli(args: Array<String>, command: CliktCommand = crsctl()): Int {
-    // `help <unknown-command>` should fail (exit 2) rather than silently show root help (Clikt's
-    // eager --help would otherwise swallow the unknown name). Validate the named top-level command.
+    // `help <command-path>` must fail (exit 2) on ANY invalid token rather than let Clikt's eager
+    // --help swallow it. Walk the FULL path against the command tree before rewriting.
     val helpIdx = helpTokenIndex(args)
     if (helpIdx >= 0) {
-        val target = args.drop(helpIdx + 1).firstOrNull { !it.startsWith("-") }
-        if (target != null) {
-            val known = command.registeredSubcommands().map { it.commandName }.toSet()
-            if (target !in known) {
-                System.err.println(Renderer.renderError(IllegalArgumentException("no such command: $target")))
+        val path = args.drop(helpIdx + 1).takeWhile { !it.startsWith("-") }
+        var level = command.registeredSubcommands()
+        val matched = StringBuilder()
+        for (name in path) {
+            val sub = level.find { it.commandName == name }
+            if (sub == null) {
+                val attempted = (matched.toString() + name).trim()
+                System.err.println(Renderer.renderError(IllegalArgumentException("no such command: $attempted")))
                 return ExitCode.USAGE.code
             }
+            matched.append(name).append(' ')
+            level = sub.registeredSubcommands()
         }
     }
     return try {

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -1,23 +1,68 @@
 package org.octopusden.octopus.components.registry.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.findOrSetObject
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
+import com.github.ajalt.clikt.parameters.types.choice
+import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.commands.ComponentAsCodeCommand
+import org.octopusden.octopus.components.registry.cli.commands.ComponentCommand
+import org.octopusden.octopus.components.registry.cli.commands.ComponentGetCommand
+import org.octopusden.octopus.components.registry.cli.commands.ComponentOverridesCommand
+import org.octopusden.octopus.components.registry.cli.commands.ComponentsCommand
+import org.octopusden.octopus.components.registry.cli.commands.ComponentsListCommand
+import org.octopusden.octopus.components.registry.cli.commands.WhoamiCommand
+import org.octopusden.octopus.components.registry.cli.commands.metaCommand
+import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
+import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
+import org.octopusden.octopus.components.registry.cli.output.OutputFormat
 
 /**
- * Root `crsctl` command. Acts as a container for subcommands; on its own it prints help.
- * Subcommands (read/auth operations) are registered in later layers.
+ * Root `crsctl` command. Owns the global options and publishes a [CliContext] (via Clikt's
+ * `findOrSetObject`) for the subcommands to consume.
+ *
+ * The two seams — [configLoader] and [clientFactory] — default to production behaviour but can be
+ * overridden by tests to run the whole command tree offline against a fake
+ * [org.octopusden.octopus.components.registry.cli.client.HttpExchange].
  */
-class Crsctl : CliktCommand(
+class Crsctl(
+    private val configLoader: () -> CrsctlConfig = { ConfigLoader.load() },
+    private val clientFactory: CrsClientFactory = CrsClientFactory { target ->
+        CrsClient(baseUrl = target.crsUrl, token = target.token)
+    },
+) : CliktCommand(
     name = "crsctl",
     help = "Command-line client for the Components Registry Service.",
     invokeWithoutSubcommand = true,
 ) {
+    private val env by option("--env", help = "Named config profile to target.")
+    private val crsUrl by option("--crs-url", help = "CRS base URL (overrides --env and CRS_URL).")
+    private val token by option("--token", help = "Bearer token (overrides CRS_TOKEN). Anonymous if omitted.")
+    private val output by option("-o", "--output", help = "Output format.")
+        .choice("json", "table", ignoreCase = true)
+        .convert { OutputFormat.parse(it) }
+    private val verbose by option("-v", "--verbose", help = "Verbose diagnostics.").flag()
+
     init {
         versionOption(VERSION)
     }
 
     override fun run() {
-        // No-op root: Clikt prints help when invoked without a subcommand.
+        currentContext.findOrSetObject {
+            CliContext(
+                envFlag = env,
+                crsUrlFlag = crsUrl,
+                tokenFlag = token,
+                output = output ?: OutputFormat.TABLE,
+                verbose = verbose,
+                configLoader = configLoader,
+                clientFactory = clientFactory,
+            )
+        }
         if (currentContext.invokedSubcommand == null) {
             echo(getFormattedHelp())
         }
@@ -28,4 +73,23 @@ class Crsctl : CliktCommand(
     }
 }
 
-fun main(args: Array<String>) = Crsctl().main(args)
+/** Builds the full command tree (root + all read subcommands) with the given seams. */
+fun crsctl(
+    configLoader: () -> CrsctlConfig = { ConfigLoader.load() },
+    clientFactory: CrsClientFactory = CrsClientFactory { target ->
+        CrsClient(baseUrl = target.crsUrl, token = target.token)
+    },
+): Crsctl = Crsctl(configLoader, clientFactory).subcommands(
+    ComponentsCommand().subcommands(
+        ComponentsListCommand(),
+    ),
+    ComponentCommand().subcommands(
+        ComponentGetCommand(),
+        ComponentAsCodeCommand(),
+        ComponentOverridesCommand(),
+    ),
+    metaCommand(),
+    WhoamiCommand(),
+)
+
+fun main(args: Array<String>) = crsctl().main(args)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -16,6 +16,9 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.choice
+import org.octopusden.octopus.components.registry.cli.auth.CommandRunner
+import org.octopusden.octopus.components.registry.cli.auth.DeviceFlowClient
+import org.octopusden.octopus.components.registry.cli.auth.ProcessCommandRunner
 import org.octopusden.octopus.components.registry.cli.client.CrsClient
 import org.octopusden.octopus.components.registry.cli.client.ExitCode
 import org.octopusden.octopus.components.registry.cli.commands.ComponentAsCodeCommand
@@ -47,6 +50,8 @@ class Crsctl(
     private val clientFactory: CrsClientFactory = CrsClientFactory { target ->
         CrsClient(baseUrl = target.crsUrl, token = target.token)
     },
+    private val commandRunner: CommandRunner = ProcessCommandRunner(),
+    private val deviceFlowClient: DeviceFlowClient = DeviceFlowClient(),
 ) : CliktCommand(
     name = "crsctl",
     help = "Command-line client for the Components Registry Service.",
@@ -79,6 +84,8 @@ class Crsctl(
                 insecureTokenStore = insecureTokenStore,
                 configLoader = configLoader,
                 clientFactory = clientFactory,
+                commandRunner = commandRunner,
+                deviceFlowClient = deviceFlowClient,
             )
         }
         if (currentContext.invokedSubcommand == null) {
@@ -97,7 +104,9 @@ fun crsctl(
     clientFactory: CrsClientFactory = CrsClientFactory { target ->
         CrsClient(baseUrl = target.crsUrl, token = target.token)
     },
-): Crsctl = Crsctl(configLoader, clientFactory).subcommands(
+    commandRunner: CommandRunner = ProcessCommandRunner(),
+    deviceFlowClient: DeviceFlowClient = DeviceFlowClient(),
+): Crsctl = Crsctl(configLoader, clientFactory, commandRunner, deviceFlowClient).subcommands(
     ComponentsCommand().subcommands(
         ComponentsListCommand(),
     ),

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -1,14 +1,23 @@
 package org.octopusden.octopus.components.registry.cli
 
+import com.github.ajalt.clikt.core.Abort
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.PrintCompletionMessage
+import com.github.ajalt.clikt.core.PrintHelpMessage
+import com.github.ajalt.clikt.core.PrintMessage
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.findOrSetObject
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.output.ParameterFormatter
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.choice
 import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.client.ExitCode
 import org.octopusden.octopus.components.registry.cli.commands.ComponentAsCodeCommand
 import org.octopusden.octopus.components.registry.cli.commands.ComponentCommand
 import org.octopusden.octopus.components.registry.cli.commands.ComponentGetCommand
@@ -23,6 +32,7 @@ import org.octopusden.octopus.components.registry.cli.commands.metaCommand
 import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
 import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
 import org.octopusden.octopus.components.registry.cli.output.OutputFormat
+import org.octopusden.octopus.components.registry.cli.output.Renderer
 
 /**
  * Root `crsctl` command. Owns the global options and publishes a [CliContext] (via Clikt's
@@ -103,4 +113,68 @@ fun crsctl(
     LogoutCommand(),
 )
 
-fun main(args: Array<String>) = crsctl().main(args)
+/**
+ * Parses and runs [command] over [args], mapping every Clikt outcome onto the crsctl exit-code +
+ * structured-error contract instead of Clikt's default human-text-on-stderr behaviour.
+ *
+ * Returns the process exit code (it never calls `exitProcess`, so it is unit-testable):
+ *   - normal completion -> 0
+ *   - --help / no-subcommand help / --version / completion script -> printed to STDOUT, exit 0
+ *   - [ProgramResult] (a command already rendered our structured error to STDERR) -> its status code,
+ *     printing nothing more
+ *   - [Abort] -> 1
+ *   - [UsageError] / any other input-level [CliktError] -> our `{"errorCode","message"}` JSON on
+ *     STDERR and exit [ExitCode.USAGE] (2)
+ */
+internal fun runCli(args: Array<String>, command: CliktCommand = crsctl()): Int {
+    return try {
+        command.parse(args)
+        ExitCode.OK.code
+    } catch (e: PrintHelpMessage) {
+        if (e.error) {
+            // An "error" help (e.g. no subcommand / missing required argument) is a usage failure:
+            // honour the structured-error + USAGE(2) contract rather than printing help to stdout.
+            System.err.println(
+                Renderer.renderError(
+                    IllegalArgumentException("missing or invalid command — run with --help for usage"),
+                ),
+            )
+            ExitCode.USAGE.code
+        } else {
+            println(command.getFormattedHelp(e).orEmpty())
+            ExitCode.OK.code
+        }
+    } catch (e: PrintCompletionMessage) {
+        println(e.message.orEmpty())
+        e.statusCode
+    } catch (e: PrintMessage) {
+        println(e.message.orEmpty())
+        e.statusCode
+    } catch (e: Abort) {
+        1
+    } catch (e: ProgramResult) {
+        // A command already rendered our structured error to STDERR; honour its exit code only.
+        e.statusCode
+    } catch (e: UsageError) {
+        System.err.println(Renderer.renderError(IllegalArgumentException(usageMessage(e, command))))
+        ExitCode.USAGE.code
+    } catch (e: CliktError) {
+        System.err.println(Renderer.renderError(IllegalArgumentException(e.message ?: "usage error")))
+        ExitCode.USAGE.code
+    }
+}
+
+/**
+ * Best-effort human message for a [UsageError]. Subclasses such as `MissingArgument` / `NoSuchOption`
+ * leave [Throwable.message] null and compute it via `formatMessage`, so prefer that (using the error's
+ * own context for localization) and fall back to the raw message.
+ */
+private fun usageMessage(e: UsageError, command: CliktCommand): String {
+    val localization = (e.context ?: command.currentContext).localization
+    val formatted = e.formatMessage(localization, ParameterFormatter.Plain)
+    return formatted.ifBlank { e.message ?: "usage error" }
+}
+
+fun main(args: Array<String>) {
+    kotlin.system.exitProcess(runCli(args))
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -15,6 +15,8 @@ import org.octopusden.octopus.components.registry.cli.commands.ComponentGetComma
 import org.octopusden.octopus.components.registry.cli.commands.ComponentOverridesCommand
 import org.octopusden.octopus.components.registry.cli.commands.ComponentsCommand
 import org.octopusden.octopus.components.registry.cli.commands.ComponentsListCommand
+import org.octopusden.octopus.components.registry.cli.commands.LoginCommand
+import org.octopusden.octopus.components.registry.cli.commands.LogoutCommand
 import org.octopusden.octopus.components.registry.cli.commands.WhoamiCommand
 import org.octopusden.octopus.components.registry.cli.commands.metaCommand
 import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
@@ -46,6 +48,10 @@ class Crsctl(
         .choice("json", "table", ignoreCase = true)
         .convert { OutputFormat.parse(it) }
     private val verbose by option("-v", "--verbose", help = "Verbose diagnostics.").flag()
+    private val insecureTokenStore by option(
+        "--insecure-token-store",
+        help = "Store the refresh token in a plaintext file (0600) instead of the system keychain.",
+    ).flag()
 
     init {
         versionOption(VERSION)
@@ -59,6 +65,7 @@ class Crsctl(
                 tokenFlag = token,
                 output = output ?: OutputFormat.TABLE,
                 verbose = verbose,
+                insecureTokenStore = insecureTokenStore,
                 configLoader = configLoader,
                 clientFactory = clientFactory,
             )
@@ -90,6 +97,8 @@ fun crsctl(
     ),
     metaCommand(),
     WhoamiCommand(),
+    LoginCommand(),
+    LogoutCommand(),
 )
 
 fun main(args: Array<String>) = crsctl().main(args)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -18,6 +18,7 @@ import org.octopusden.octopus.components.registry.cli.commands.ComponentsListCom
 import org.octopusden.octopus.components.registry.cli.commands.LoginCommand
 import org.octopusden.octopus.components.registry.cli.commands.LogoutCommand
 import org.octopusden.octopus.components.registry.cli.commands.WhoamiCommand
+import org.octopusden.octopus.components.registry.cli.commands.auditCommand
 import org.octopusden.octopus.components.registry.cli.commands.metaCommand
 import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
 import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
@@ -96,6 +97,7 @@ fun crsctl(
         ComponentOverridesCommand(),
     ),
     metaCommand(),
+    auditCommand(),
     WhoamiCommand(),
     LoginCommand(),
     LogoutCommand(),

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/Main.kt
@@ -1,0 +1,31 @@
+package org.octopusden.octopus.components.registry.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.versionOption
+
+/**
+ * Root `crsctl` command. Acts as a container for subcommands; on its own it prints help.
+ * Subcommands (read/auth operations) are registered in later layers.
+ */
+class Crsctl : CliktCommand(
+    name = "crsctl",
+    help = "Command-line client for the Components Registry Service.",
+    invokeWithoutSubcommand = true,
+) {
+    init {
+        versionOption(VERSION)
+    }
+
+    override fun run() {
+        // No-op root: Clikt prints help when invoked without a subcommand.
+        if (currentContext.invokedSubcommand == null) {
+            echo(getFormattedHelp())
+        }
+    }
+
+    companion object {
+        const val VERSION = "1.0-SNAPSHOT"
+    }
+}
+
+fun main(args: Array<String>) = Crsctl().main(args)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CommandRunner.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CommandRunner.kt
@@ -1,0 +1,45 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+/**
+ * The outcome of running an external process: its exit code plus captured STDOUT / STDERR.
+ */
+data class CommandResult(
+    val exitCode: Int,
+    val stdout: String,
+    val stderr: String,
+)
+
+/**
+ * Functional seam over launching an external process. Production code uses [ProcessCommandRunner]
+ * (a real [ProcessBuilder]); tests substitute an in-memory fake so the macOS Keychain is never
+ * touched.
+ *
+ * [run] executes [args] (argv-style, no shell) optionally feeding [stdin] to the process's standard
+ * input, and returns a [CommandResult].
+ */
+fun interface CommandRunner {
+    fun run(args: List<String>, stdin: String?): CommandResult
+}
+
+/**
+ * Default [CommandRunner] backed by [ProcessBuilder]. STDOUT and STDERR are captured separately so
+ * the caller can distinguish a printed secret from a diagnostic message.
+ */
+class ProcessCommandRunner : CommandRunner {
+    override fun run(args: List<String>, stdin: String?): CommandResult {
+        val process = ProcessBuilder(args)
+            .redirectInput(ProcessBuilder.Redirect.PIPE)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+        if (stdin != null) {
+            process.outputStream.use { it.write(stdin.toByteArray(Charsets.UTF_8)) }
+        } else {
+            process.outputStream.close()
+        }
+        val out = process.inputStream.readBytes().toString(Charsets.UTF_8)
+        val err = process.errorStream.readBytes().toString(Charsets.UTF_8)
+        val exit = process.waitFor()
+        return CommandResult(exitCode = exit, stdout = out, stderr = err)
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStore.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStore.kt
@@ -33,9 +33,13 @@ class CredentialStoreException(message: String, cause: Throwable? = null) : Runt
 
 /**
  * macOS Keychain-backed [CredentialStore] implemented via the system `security` CLI:
- *   - save  -> `security add-generic-password -U` (-U updates an existing item in place); the secret
- *             is fed via STDIN (a bare `-w` with no value), NOT on the argv, so it never appears in
- *             the process table (`ps`) of other users on the machine.
+ *   - save  -> `security add-generic-password -U -w <secret>` (-U updates an existing item in place).
+ *             The secret is passed as the `-w` argument: a BARE `-w` (no value) makes `security`
+ *             prompt interactively on the tty (with a retype confirmation) and does NOT read from a
+ *             piped stdin, so the only reliable non-interactive path is the `-w <value>` argument.
+ *             Trade-off: the secret is briefly visible in `ps` for the lifetime of the subprocess.
+ *             TODO(spike): replace the `security` CLI with a native Keychain API (Security.framework
+ *             via a small helper / JNA) to store the secret without any `ps` exposure.
  *   - load  -> `security find-generic-password -w` (-w prints just the secret to STDOUT)
  *   - clear -> `security delete-generic-password`
  *
@@ -72,18 +76,19 @@ class KeychainCredentialStore(
     }
 
     override fun save(refreshToken: String) {
-        // The secret is passed via STDIN (bare `-w`), never on argv, to avoid `ps` exposure.
-        // TODO(spike): verify 'security add-generic-password -w' consumes the secret from stdin on the
-        // target macOS; fall back to a temp-file -w @path if not.
+        // `-w <value>` is the only reliable NON-INTERACTIVE write: a bare `-w` makes `security`
+        // prompt + retype on the tty (it does not read a piped stdin), which silently fails to store
+        // anything. The secret is therefore briefly `ps`-visible for the subprocess lifetime.
+        // TODO(spike): replace with a native Keychain API to remove that exposure.
         val result = runner.run(
             listOf(
                 "security", "add-generic-password",
                 "-U",
                 "-s", service,
                 "-a", account,
-                "-w",
+                "-w", refreshToken,
             ),
-            refreshToken,
+            null,
         )
         if (result.exitCode != 0) {
             throw CredentialStoreException(

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStore.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStore.kt
@@ -1,0 +1,181 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+
+/**
+ * Persists the long-lived OIDC refresh token between crsctl invocations.
+ *
+ * Only the refresh token is stored; the short-lived access token lives in memory inside the
+ * [TokenManager] for the duration of a single process and is never written to disk.
+ */
+interface CredentialStore {
+    /** Returns the stored refresh token, or null when none has been saved. */
+    fun load(): String?
+
+    /** Persists (creating or replacing) the refresh token. */
+    fun save(refreshToken: String)
+
+    /** Removes any stored refresh token. A no-op when nothing is stored. */
+    fun clear()
+}
+
+/**
+ * Thrown when the secure (Keychain) credential path fails. Per the security policy a Keychain
+ * failure during save/load is a HARD error: we never silently fall back to a plaintext file, because
+ * doing so would downgrade the user's security posture without their knowledge.
+ */
+class CredentialStoreException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+/**
+ * macOS Keychain-backed [CredentialStore] implemented via the system `security` CLI:
+ *   - save  -> `security add-generic-password -U` (-U updates an existing item in place)
+ *   - load  -> `security find-generic-password -w` (-w prints just the secret to STDOUT)
+ *   - clear -> `security delete-generic-password`
+ *
+ * The `security` process is launched through an injectable [CommandRunner] so tests can fake it
+ * without touching the real Keychain.
+ *
+ * Failure policy:
+ *   - save: a non-zero exit is a hard error -> [CredentialStoreException] (NO silent swallow).
+ *   - load: "item not found" (exit 44) maps to null (a legitimate "not logged in" state); any other
+ *     non-zero exit is a hard error.
+ *   - clear: "item not found" is tolerated (idempotent delete); any other non-zero exit throws.
+ */
+class KeychainCredentialStore(
+    private val runner: CommandRunner,
+    private val service: String = DEFAULT_SERVICE,
+    private val account: String = DEFAULT_ACCOUNT,
+) : CredentialStore {
+
+    override fun load(): String? {
+        val result = runner.run(
+            listOf("security", "find-generic-password", "-s", service, "-a", account, "-w"),
+            null,
+        )
+        if (result.exitCode == 0) {
+            // -w prints the secret followed by a trailing newline.
+            return result.stdout.trimEnd('\n', '\r')
+        }
+        if (result.exitCode == ITEM_NOT_FOUND) {
+            return null
+        }
+        throw CredentialStoreException(
+            "Keychain lookup failed (exit ${result.exitCode}): ${result.stderr.trim()}",
+        )
+    }
+
+    override fun save(refreshToken: String) {
+        val result = runner.run(
+            listOf(
+                "security", "add-generic-password",
+                "-U",
+                "-s", service,
+                "-a", account,
+                "-w", refreshToken,
+            ),
+            null,
+        )
+        if (result.exitCode != 0) {
+            throw CredentialStoreException(
+                "Keychain save failed (exit ${result.exitCode}): ${result.stderr.trim()}",
+            )
+        }
+    }
+
+    override fun clear() {
+        val result = runner.run(
+            listOf("security", "delete-generic-password", "-s", service, "-a", account),
+            null,
+        )
+        if (result.exitCode == 0 || result.exitCode == ITEM_NOT_FOUND) {
+            return
+        }
+        throw CredentialStoreException(
+            "Keychain delete failed (exit ${result.exitCode}): ${result.stderr.trim()}",
+        )
+    }
+
+    companion object {
+        const val DEFAULT_SERVICE = "crsctl"
+        const val DEFAULT_ACCOUNT = "refresh-token"
+
+        /** `security`'s documented "the specified item could not be found in the keychain" exit code. */
+        const val ITEM_NOT_FOUND = 44
+    }
+}
+
+/**
+ * Plaintext-file [CredentialStore] at `<configDir>/credentials`, file mode 0600.
+ *
+ * This is INSECURE and only selected when the user explicitly passes `--insecure-token-store`.
+ * Constructing it emits a one-time warning to STDERR; the file permissions are tightened to
+ * owner-read/write only on every save.
+ */
+class InsecureFileCredentialStore(
+    private val file: Path = ConfigLoader.configDir().resolve(CREDENTIALS_FILE_NAME),
+    private val warn: (String) -> Unit = { System.err.println(it) },
+) : CredentialStore {
+
+    init {
+        warn(
+            "warning: storing the refresh token in plaintext at $file (--insecure-token-store). " +
+                "Prefer the system keychain; this file is readable by your user account only (0600).",
+        )
+    }
+
+    override fun load(): String? {
+        if (!Files.exists(file)) {
+            return null
+        }
+        val text = Files.readString(file).trim()
+        return text.ifBlank { null }
+    }
+
+    override fun save(refreshToken: String) {
+        val dir = file.parent
+        if (dir != null && !Files.exists(dir)) {
+            Files.createDirectories(dir)
+        }
+        if (!Files.exists(file)) {
+            Files.createFile(file)
+        }
+        setOwnerOnlyPermissions(file)
+        Files.writeString(file, refreshToken)
+        // Re-assert perms after write in case the platform reset them on create.
+        setOwnerOnlyPermissions(file)
+    }
+
+    override fun clear() {
+        Files.deleteIfExists(file)
+    }
+
+    private fun setOwnerOnlyPermissions(target: Path) {
+        val view = Files.getFileAttributeView(target, java.nio.file.attribute.PosixFileAttributeView::class.java)
+        if (view != null) {
+            val perms = setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+            Files.setPosixFilePermissions(target, perms)
+        }
+    }
+
+    companion object {
+        const val CREDENTIALS_FILE_NAME = "credentials"
+
+        /** Convenience for callers that want the canonical 0600 permission set. */
+        val OWNER_ONLY: Set<PosixFilePermission> = PosixFilePermissions.fromString("rw-------")
+    }
+}
+
+/**
+ * Selects the credential store. When [insecure] is true the plaintext file store is used (and warns);
+ * otherwise the macOS Keychain store is used, driven by [runner].
+ */
+fun credentialStore(insecure: Boolean, runner: CommandRunner): CredentialStore =
+    if (insecure) {
+        InsecureFileCredentialStore()
+    } else {
+        KeychainCredentialStore(runner)
+    }

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStore.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStore.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.cli.auth
 import org.octopusden.octopus.components.registry.cli.config.ConfigLoader
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermissions
 
@@ -32,7 +33,9 @@ class CredentialStoreException(message: String, cause: Throwable? = null) : Runt
 
 /**
  * macOS Keychain-backed [CredentialStore] implemented via the system `security` CLI:
- *   - save  -> `security add-generic-password -U` (-U updates an existing item in place)
+ *   - save  -> `security add-generic-password -U` (-U updates an existing item in place); the secret
+ *             is fed via STDIN (a bare `-w` with no value), NOT on the argv, so it never appears in
+ *             the process table (`ps`) of other users on the machine.
  *   - load  -> `security find-generic-password -w` (-w prints just the secret to STDOUT)
  *   - clear -> `security delete-generic-password`
  *
@@ -69,15 +72,18 @@ class KeychainCredentialStore(
     }
 
     override fun save(refreshToken: String) {
+        // The secret is passed via STDIN (bare `-w`), never on argv, to avoid `ps` exposure.
+        // TODO(spike): verify 'security add-generic-password -w' consumes the secret from stdin on the
+        // target macOS; fall back to a temp-file -w @path if not.
         val result = runner.run(
             listOf(
                 "security", "add-generic-password",
                 "-U",
                 "-s", service,
                 "-a", account,
-                "-w", refreshToken,
+                "-w",
             ),
-            null,
+            refreshToken,
         )
         if (result.exitCode != 0) {
             throw CredentialStoreException(
@@ -141,11 +147,12 @@ class InsecureFileCredentialStore(
             Files.createDirectories(dir)
         }
         if (!Files.exists(file)) {
-            Files.createFile(file)
+            // Create the file owner-only (0600) ATOMICALLY before any secret is written, closing the
+            // TOCTOU window where a world-readable file could briefly hold the token.
+            Files.createFile(file, PosixFilePermissions.asFileAttribute(OWNER_ONLY))
         }
-        setOwnerOnlyPermissions(file)
-        Files.writeString(file, refreshToken)
-        // Re-assert perms after write in case the platform reset them on create.
+        Files.writeString(file, refreshToken, StandardOpenOption.TRUNCATE_EXISTING)
+        // Re-assert perms after write (covers the overwrite path where the file pre-existed).
         setOwnerOnlyPermissions(file)
     }
 

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/DeviceFlowClient.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/DeviceFlowClient.kt
@@ -1,0 +1,245 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.octopusden.octopus.components.registry.cli.client.HttpExchange
+import org.octopusden.octopus.components.registry.cli.client.JdkHttpExchange
+import org.octopusden.octopus.components.registry.cli.client.Json
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpRequest
+import java.nio.charset.StandardCharsets
+
+/**
+ * Response to the device-authorization request (RFC 8628 section 3.2). `interval` defaults to 5s per
+ * the spec; `verificationUriComplete` is optional (offered by some providers for QR-code shortcuts).
+ */
+@Serializable
+data class DeviceAuthorizationResponse(
+    @SerialName("device_code") val deviceCode: String,
+    @SerialName("user_code") val userCode: String,
+    @SerialName("verification_uri") val verificationUri: String,
+    @SerialName("verification_uri_complete") val verificationUriComplete: String? = null,
+    @SerialName("expires_in") val expiresIn: Long,
+    val interval: Int = 5,
+)
+
+/**
+ * A successful token response (RFC 6749 section 5.1). `refreshToken` is present only when the
+ * `offline_access` scope was granted; `idToken` is present for OIDC.
+ */
+@Serializable
+data class TokenResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("expires_in") val expiresIn: Long,
+    @SerialName("token_type") val tokenType: String,
+    @SerialName("id_token") val idToken: String? = null,
+)
+
+/**
+ * An OAuth error response (RFC 6749 section 5.2 / RFC 8628 section 3.5). During device-flow polling
+ * the `error` field carries the state-machine signals: `authorization_pending`, `slow_down`,
+ * `expired_token`, `access_denied`.
+ */
+@Serializable
+data class TokenErrorResponse(
+    val error: String,
+    @SerialName("error_description") val errorDescription: String? = null,
+)
+
+/** Functional seam over sleeping so the polling loop runs instantly under test. */
+fun interface Sleeper {
+    fun sleep(millis: Long)
+}
+
+/** Default [Sleeper] that really blocks the current thread. */
+class ThreadSleeper : Sleeper {
+    override fun sleep(millis: Long) = Thread.sleep(millis)
+}
+
+/** Thrown when the device-flow grant cannot complete (expired, denied, or a hard transport error). */
+class DeviceFlowException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+/**
+ * OIDC Device Authorization Grant (RFC 8628) client over the injectable [HttpExchange] seam.
+ *
+ * Endpoint paths follow the standard Keycloak realm layout under `<issuer>`:
+ *   - device authorization: `<issuer>/protocol/openid-connect/auth/device`
+ *   - token:                `<issuer>/protocol/openid-connect/token`
+ *   - revocation:           `<issuer>/protocol/openid-connect/revoke`
+ *
+ * The exact paths + the public client id are confirmed by the Keycloak Part C spike; see the
+ * TODO(spike) markers below.
+ */
+class DeviceFlowClient(
+    private val exchange: HttpExchange = JdkHttpExchange(),
+    private val sleeper: Sleeper = ThreadSleeper(),
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+) {
+
+    /**
+     * Starts the grant: POSTs `client_id` + `scope` to the device-authorization endpoint and returns
+     * the parsed [DeviceAuthorizationResponse]. [scope] defaults to "openid"; callers append
+     * "offline_access" (via [scopeFor]) when a refresh token is wanted.
+     */
+    fun requestDeviceAuthorization(
+        issuer: String,
+        clientId: String,
+        scope: String = "openid",
+    ): DeviceAuthorizationResponse {
+        // TODO(spike): confirm device_authorization endpoint path + client_id against Keycloak Part C
+        val form = formBody(
+            "client_id" to clientId,
+            "scope" to scope,
+        )
+        val request = postForm("${issuerBase(issuer)}/protocol/openid-connect/auth/device", form)
+        val response = exchange.send(request)
+        if (response.statusCode() !in 200..299) {
+            throw DeviceFlowException(
+                "Device authorization request failed: HTTP ${response.statusCode()} ${errorDetail(response.body())}",
+            )
+        }
+        return decode(response.body(), DeviceAuthorizationResponse.serializer(), "device authorization response")
+    }
+
+    /**
+     * Polls the token endpoint until the user completes authorization, implementing the RFC 8628
+     * section 3.5 state machine:
+     *   - `authorization_pending` -> wait [interval] seconds and retry.
+     *   - `slow_down`             -> increase the interval by 5s, then wait and retry.
+     *   - `expired_token`         -> abort with a clear error.
+     *   - `access_denied`         -> abort.
+     *   - 2xx success             -> return the [TokenResponse].
+     *
+     * Total wait is capped: once [expiresInSeconds] of wall-clock time has elapsed the loop aborts
+     * even if the server keeps replying `authorization_pending`.
+     */
+    fun pollToken(
+        issuer: String,
+        clientId: String,
+        deviceCode: String,
+        interval: Int,
+        expiresInSeconds: Long,
+    ): TokenResponse {
+        val deadline = nowMillis() + expiresInSeconds * 1000L
+        var currentInterval = if (interval > 0) interval else 5
+        val tokenUri = "${issuerBase(issuer)}/protocol/openid-connect/token"
+        while (true) {
+            if (nowMillis() >= deadline) {
+                throw DeviceFlowException("Device code expired before authorization completed; run `crsctl login` again.")
+            }
+            val form = formBody(
+                "grant_type" to "urn:ietf:params:oauth:grant-type:device_code",
+                "client_id" to clientId,
+                "device_code" to deviceCode,
+            )
+            val response = exchange.send(postForm(tokenUri, form))
+            val status = response.statusCode()
+            if (status in 200..299) {
+                return decode(response.body(), TokenResponse.serializer(), "token response")
+            }
+            val error = parseError(response.body())
+            when (error?.error) {
+                "authorization_pending" -> sleeper.sleep(currentInterval * 1000L)
+                "slow_down" -> {
+                    currentInterval += 5
+                    sleeper.sleep(currentInterval * 1000L)
+                }
+                "expired_token" -> throw DeviceFlowException(
+                    "Device code expired before authorization completed; run `crsctl login` again.",
+                )
+                "access_denied" -> throw DeviceFlowException(
+                    "Authorization was denied. Run `crsctl login` to try again.",
+                )
+                else -> throw DeviceFlowException(
+                    "Token polling failed: HTTP $status ${error?.error ?: errorDetail(response.body())}",
+                )
+            }
+        }
+    }
+
+    /**
+     * Exchanges a refresh token for a fresh [TokenResponse]. Keycloak may rotate the refresh token,
+     * so the caller MUST persist [TokenResponse.refreshToken] when it is present.
+     */
+    fun refresh(issuer: String, clientId: String, refreshToken: String): TokenResponse {
+        val form = formBody(
+            "grant_type" to "refresh_token",
+            "client_id" to clientId,
+            "refresh_token" to refreshToken,
+        )
+        val request = postForm("${issuerBase(issuer)}/protocol/openid-connect/token", form)
+        val response = exchange.send(request)
+        if (response.statusCode() !in 200..299) {
+            val error = parseError(response.body())
+            throw DeviceFlowException(
+                "Token refresh failed: HTTP ${response.statusCode()} ${error?.error ?: errorDetail(response.body())}",
+            )
+        }
+        return decode(response.body(), TokenResponse.serializer(), "token response")
+    }
+
+    /**
+     * Best-effort token revocation (RFC 7009). Returns true when the server accepted the revocation
+     * (2xx); returns false on a non-2xx so the caller can warn-but-continue rather than fail logout.
+     */
+    fun revoke(issuer: String, clientId: String, refreshToken: String): Boolean {
+        val form = formBody(
+            "client_id" to clientId,
+            "token" to refreshToken,
+            "token_type_hint" to "refresh_token",
+        )
+        val request = postForm("${issuerBase(issuer)}/protocol/openid-connect/revoke", form)
+        return exchange.send(request).statusCode() in 200..299
+    }
+
+    private fun issuerBase(issuer: String): String = issuer.trimEnd('/')
+
+    private fun postForm(uri: String, body: String): HttpRequest =
+        HttpRequest.newBuilder()
+            .uri(URI.create(uri))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Accept", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build()
+
+    private fun formBody(vararg pairs: Pair<String, String>): String =
+        pairs.joinToString("&") { (k, v) ->
+            "${urlEncode(k)}=${urlEncode(v)}"
+        }
+
+    private fun urlEncode(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+    private fun parseError(body: String?): TokenErrorResponse? {
+        if (body.isNullOrBlank()) {
+            return null
+        }
+        return try {
+            Json.decodeFromString(TokenErrorResponse.serializer(), body)
+        } catch (e: SerializationException) {
+            null
+        }
+    }
+
+    private fun errorDetail(body: String?): String {
+        val parsed = parseError(body)
+        return parsed?.errorDescription ?: parsed?.error ?: (body?.take(200).orEmpty())
+    }
+
+    private fun <T> decode(body: String?, serializer: kotlinx.serialization.KSerializer<T>, what: String): T {
+        try {
+            return Json.decodeFromString(serializer, body ?: "")
+        } catch (e: SerializationException) {
+            throw DeviceFlowException("Failed to parse $what: ${e.message}", e)
+        }
+    }
+
+    companion object {
+        /** Builds the scope string, appending `offline_access` when a refresh token is wanted. */
+        fun scopeFor(offline: Boolean): String =
+            if (offline) "openid offline_access" else "openid"
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManager.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManager.kt
@@ -1,0 +1,53 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+/**
+ * Thrown when an operation needs an authenticated identity but no usable credential is available
+ * (no stored refresh token). The command layer maps this to
+ * [org.octopusden.octopus.components.registry.cli.client.ExitCode.AUTH_REQUIRED].
+ */
+class AuthRequiredException(
+    message: String = "Not logged in. Run `crsctl login` first.",
+) : RuntimeException(message)
+
+/**
+ * Owns the short-lived access token for a single crsctl process.
+ *
+ * Given an issuer, a public client id, and a [CredentialStore] holding the long-lived refresh token,
+ * [accessToken] returns a currently-valid access token, transparently refreshing (with rotation)
+ * when the cached token is missing or within [refreshSkewSeconds] of expiry. A rotated refresh token
+ * (when the provider returns a new one) is persisted back to the store.
+ *
+ * If the store holds no refresh token, [accessToken] throws [AuthRequiredException] rather than
+ * attempting an interactive login — login is an explicit user action (`crsctl login`).
+ */
+class TokenManager(
+    private val issuer: String,
+    private val clientId: String,
+    private val store: CredentialStore,
+    private val deviceFlow: DeviceFlowClient = DeviceFlowClient(),
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+    private val refreshSkewSeconds: Long = 30,
+) {
+    private var cachedAccessToken: String? = null
+    private var expiresAtMillis: Long = 0
+
+    /** Returns a valid access token, refreshing-with-rotation when needed. */
+    fun accessToken(): String {
+        val cached = cachedAccessToken
+        if (cached != null && nowMillis() < expiresAtMillis - refreshSkewSeconds * 1000L) {
+            return cached
+        }
+        val refreshToken = store.load()
+            ?: throw AuthRequiredException()
+        val response = deviceFlow.refresh(issuer, clientId, refreshToken)
+        // Rotation: persist the new refresh token when the provider returned one.
+        response.refreshToken?.let { rotated ->
+            if (rotated != refreshToken) {
+                store.save(rotated)
+            }
+        }
+        cachedAccessToken = response.accessToken
+        expiresAtMillis = nowMillis() + response.expiresIn * 1000L
+        return response.accessToken
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManager.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManager.kt
@@ -40,12 +40,9 @@ class TokenManager(
         val refreshToken = store.load()
             ?: throw AuthRequiredException()
         val response = deviceFlow.refresh(issuer, clientId, refreshToken)
-        // Rotation: persist the new refresh token when the provider returned one.
-        response.refreshToken?.let { rotated ->
-            if (rotated != refreshToken) {
-                store.save(rotated)
-            }
-        }
+        // Rotation: persist the refresh token whenever the provider returned one (save is idempotent).
+        // Never save/wipe when the response omits a refresh token.
+        response.refreshToken?.let { store.save(it) }
         cachedAccessToken = response.accessToken
         expiresAtMillis = nowMillis() + response.expiresIn * 1000L
         return response.accessToken

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ConfigResolutionException.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ConfigResolutionException.kt
@@ -1,0 +1,7 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+/**
+ * Thrown when the effective CRS target cannot be determined (no flag, env var, or resolvable
+ * profile). Maps to [ExitCode.USAGE] — we never silently default to a wrong registry.
+ */
+class ConfigResolutionException(message: String) : RuntimeException(message)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsApiException.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsApiException.kt
@@ -1,0 +1,13 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+/**
+ * Thrown when the CRS responds with a non-2xx status. Carries the HTTP status plus the parsed
+ * `ErrorResponse` fields (errorCode is optional per the contract; errorMessage is required).
+ *
+ * The command layer maps this to an [ExitCode] via [ExitCodes.fromThrowable].
+ */
+class CrsApiException(
+    val httpStatus: Int,
+    val errorCode: String?,
+    val errorMessage: String,
+) : RuntimeException("HTTP $httpStatus: $errorMessage")

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClient.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClient.kt
@@ -1,0 +1,106 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import org.octopusden.octopus.components.registry.cli.model.ErrorResponse
+import java.net.URI
+import java.net.http.HttpRequest
+
+/**
+ * Thin read-only client over the CRS REST API.
+ *
+ * Construction takes a base URL, an optional bearer token, and an injectable [HttpExchange] seam so
+ * tests can run without a network. The default seam is [JdkHttpExchange].
+ *
+ * Responses:
+ * - 2xx with `application/json` -> deserialized into the requested type via [getJson].
+ * - 2xx with `text/plain` (the as-code endpoints) -> raw String via [getText].
+ * - non-2xx -> body parsed as [ErrorResponse] and re-thrown as [CrsApiException] (including 401/403,
+ *   so the command layer can map to AUTH_REQUIRED).
+ */
+class CrsClient(
+    baseUrl: String,
+    private val token: String? = null,
+    private val exchange: HttpExchange = JdkHttpExchange(),
+) {
+    /** Base URL with any trailing slash stripped so path joining is unambiguous. */
+    private val baseUrl: String = baseUrl.trimEnd('/')
+
+    /**
+     * GET [path] (+ optional [query]) and deserialize a 2xx JSON body into [T] using [serializer].
+     * Sends `Accept: application/json`.
+     */
+    fun <T> getJson(
+        path: String,
+        serializer: KSerializer<T>,
+        query: QueryParams? = null,
+    ): T {
+        val response = get(path, query, "application/json")
+        return try {
+            Json.decodeFromString(serializer, response.body() ?: "")
+        } catch (e: SerializationException) {
+            throw CrsApiException(
+                httpStatus = response.statusCode(),
+                errorCode = null,
+                errorMessage = "Failed to parse response body: ${e.message}",
+            )
+        }
+    }
+
+    /**
+     * GET [path] (+ optional [query]) and return the raw 2xx body verbatim (for the as-code /
+     * text/plain endpoints). Sends `Accept: text/plain`.
+     */
+    fun getText(path: String, query: QueryParams? = null): String {
+        val response = get(path, query, "text/plain")
+        return response.body() ?: ""
+    }
+
+    private fun get(
+        path: String,
+        query: QueryParams?,
+        accept: String,
+    ): java.net.http.HttpResponse<String> {
+        val request = buildGet(path, query, accept)
+        val response = exchange.send(request)
+        if (response.statusCode() in 200..299) {
+            return response
+        }
+        throw toApiException(response)
+    }
+
+    private fun buildGet(path: String, query: QueryParams?, accept: String): HttpRequest {
+        val builder = HttpRequest.newBuilder()
+            .uri(buildUri(path, query))
+            .GET()
+            .header("Accept", accept)
+        if (!token.isNullOrBlank()) {
+            builder.header("Authorization", "Bearer $token")
+        }
+        return builder.build()
+    }
+
+    private fun buildUri(path: String, query: QueryParams?): URI {
+        val normalizedPath = if (path.startsWith("/")) path else "/$path"
+        val suffix = if (query != null && !query.isEmpty()) "?${query.encode()}" else ""
+        return URI.create("$baseUrl$normalizedPath$suffix")
+    }
+
+    private fun toApiException(response: java.net.http.HttpResponse<String>): CrsApiException {
+        val body = response.body()
+        val parsed = if (body.isNullOrBlank()) {
+            null
+        } else {
+            try {
+                Json.decodeFromString(ErrorResponse.serializer(), body)
+            } catch (e: SerializationException) {
+                null
+            }
+        }
+        return CrsApiException(
+            httpStatus = response.statusCode(),
+            errorCode = parsed?.errorCode,
+            errorMessage = parsed?.errorMessage ?: "HTTP ${response.statusCode()}",
+        )
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClient.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClient.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.SerializationException
 import org.octopusden.octopus.components.registry.cli.model.ErrorResponse
 import java.net.URI
 import java.net.http.HttpRequest
+import java.time.Duration
 
 /**
  * Thin read-only client over the CRS REST API.
@@ -72,6 +73,7 @@ class CrsClient(
     private fun buildGet(path: String, query: QueryParams?, accept: String): HttpRequest {
         val builder = HttpRequest.newBuilder()
             .uri(buildUri(path, query))
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
             .GET()
             .header("Accept", accept)
         if (!token.isNullOrBlank()) {
@@ -102,5 +104,10 @@ class CrsClient(
             errorCode = parsed?.errorCode,
             errorMessage = parsed?.errorMessage ?: "HTTP ${response.statusCode()}",
         )
+    }
+
+    companion object {
+        /** Per-request timeout (seconds); a slow/stalled response surfaces as a SERVER exit. */
+        private const val REQUEST_TIMEOUT_SECONDS = 30L
     }
 }

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
@@ -39,6 +39,7 @@ object ExitCodes {
     }
 
     fun fromHttpStatus(status: Int): ExitCode = when (status) {
+        400 -> ExitCode.USAGE
         404 -> ExitCode.NOT_FOUND
         401, 403 -> ExitCode.AUTH_REQUIRED
         in 500..599 -> ExitCode.SERVER

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
@@ -1,0 +1,43 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import java.io.IOException
+
+/**
+ * Process exit codes for crsctl. The numeric values are part of the CLI contract (scripts depend on
+ * them), so they are pinned explicitly.
+ */
+enum class ExitCode(val code: Int) {
+    /** Successful completion. */
+    OK(0),
+
+    /** Bad invocation — unknown flags, missing required args, unresolved target, etc. */
+    USAGE(2),
+
+    /** The requested resource does not exist (HTTP 404). */
+    NOT_FOUND(3),
+
+    /** Authentication or authorization is required/insufficient (HTTP 401/403). */
+    AUTH_REQUIRED(4),
+
+    /** Server-side failure or a transport problem (HTTP 5xx, IOException). */
+    SERVER(5),
+}
+
+/**
+ * Maps thrown errors to an [ExitCode].
+ */
+object ExitCodes {
+    fun fromThrowable(t: Throwable): ExitCode = when (t) {
+        is CrsApiException -> fromHttpStatus(t.httpStatus)
+        is IOException -> ExitCode.SERVER
+        is ConfigResolutionException -> ExitCode.USAGE
+        else -> ExitCode.SERVER
+    }
+
+    fun fromHttpStatus(status: Int): ExitCode = when (status) {
+        404 -> ExitCode.NOT_FOUND
+        401, 403 -> ExitCode.AUTH_REQUIRED
+        in 500..599 -> ExitCode.SERVER
+        else -> ExitCode.SERVER
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.cli.client
 
+import org.octopusden.octopus.components.registry.cli.config.ConfigLoadException
 import java.io.IOException
 
 /**
@@ -31,6 +32,7 @@ object ExitCodes {
         is CrsApiException -> fromHttpStatus(t.httpStatus)
         is IOException -> ExitCode.SERVER
         is ConfigResolutionException -> ExitCode.USAGE
+        is ConfigLoadException -> ExitCode.USAGE
         else -> ExitCode.SERVER
     }
 

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCode.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.cli.client
 
+import org.octopusden.octopus.components.registry.cli.auth.AuthRequiredException
 import org.octopusden.octopus.components.registry.cli.config.ConfigLoadException
 import java.io.IOException
 
@@ -30,6 +31,7 @@ enum class ExitCode(val code: Int) {
 object ExitCodes {
     fun fromThrowable(t: Throwable): ExitCode = when (t) {
         is CrsApiException -> fromHttpStatus(t.httpStatus)
+        is AuthRequiredException -> ExitCode.AUTH_REQUIRED
         is IOException -> ExitCode.SERVER
         is ConfigResolutionException -> ExitCode.USAGE
         is ConfigLoadException -> ExitCode.USAGE

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/HttpExchange.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/HttpExchange.kt
@@ -3,6 +3,10 @@ package org.octopusden.octopus.components.registry.cli.client
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.time.Duration
+
+/** Default TCP connect timeout for the production HTTP client (seconds). */
+private const val CONNECT_TIMEOUT_SECONDS = 10L
 
 /**
  * Small functional seam over the JDK HTTP client so tests can substitute a fake without touching the
@@ -14,10 +18,13 @@ fun interface HttpExchange {
 
 /**
  * Default [HttpExchange] backed by [java.net.http.HttpClient], always reading the body as a UTF-8
- * String.
+ * String. The default client carries a connect timeout so a dead host fails fast rather than
+ * hanging; the per-request read timeout is set by [CrsClient].
  */
 class JdkHttpExchange(
-    private val httpClient: HttpClient = HttpClient.newHttpClient(),
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+        .build(),
 ) : HttpExchange {
     override fun send(request: HttpRequest): HttpResponse<String> =
         httpClient.send(request, HttpResponse.BodyHandlers.ofString())

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/HttpExchange.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/HttpExchange.kt
@@ -1,0 +1,24 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * Small functional seam over the JDK HTTP client so tests can substitute a fake without touching the
+ * network. Production code uses [JdkHttpExchange]; tests provide an in-memory implementation.
+ */
+fun interface HttpExchange {
+    fun send(request: HttpRequest): HttpResponse<String>
+}
+
+/**
+ * Default [HttpExchange] backed by [java.net.http.HttpClient], always reading the body as a UTF-8
+ * String.
+ */
+class JdkHttpExchange(
+    private val httpClient: HttpClient = HttpClient.newHttpClient(),
+) : HttpExchange {
+    override fun send(request: HttpRequest): HttpResponse<String> =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/QueryParams.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/QueryParams.kt
@@ -1,0 +1,66 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Builds an URL query string from a sequence of name/value pairs, omitting any pair whose value is
+ * null. Multi-valued params (e.g. Spring's repeated `sort`) are expressed as multiple pairs sharing
+ * the same name and are emitted in insertion order.
+ *
+ * Both names and values are percent-encoded. The returned string has NO leading `?`; callers join it
+ * onto a path themselves (see [CrsClient]).
+ */
+class QueryParams private constructor(private val pairs: List<Pair<String, String>>) {
+
+    fun isEmpty(): Boolean = pairs.isEmpty()
+
+    /** Renders the query string without a leading `?`, or an empty string when there are no params. */
+    fun encode(): String = pairs.joinToString("&") { (name, value) ->
+        "${enc(name)}=${enc(value)}"
+    }
+
+    private fun enc(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
+
+    class Builder {
+        private val pairs = mutableListOf<Pair<String, String>>()
+
+        /** Adds a single param unless [value] is null. Non-String values use their `toString()`. */
+        fun add(name: String, value: Any?): Builder {
+            if (value != null) {
+                pairs += name to value.toString()
+            }
+            return this
+        }
+
+        /** Adds one entry per non-null element of [values]; a null list is skipped entirely. */
+        fun addAll(name: String, values: List<String>?): Builder {
+            values?.forEach { pairs += name to it }
+            return this
+        }
+
+        /**
+         * Adds the standard Spring pageable params. `page`/`size` are added only when non-null;
+         * each entry of `sort` becomes its own `sort=` param (Spring's repeated-param convention).
+         */
+        fun pageable(page: Int? = null, size: Int? = null, sort: List<String>? = null): Builder {
+            add("page", page)
+            add("size", size)
+            addAll("sort", sort)
+            return this
+        }
+
+        /** Adds arbitrary filter params, skipping null values. */
+        fun filters(filters: Map<String, Any?>): Builder {
+            filters.forEach { (name, value) -> add(name, value) }
+            return this
+        }
+
+        fun build(): QueryParams = QueryParams(pairs.toList())
+    }
+
+    companion object {
+        fun builder(): Builder = Builder()
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/Serialization.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/client/Serialization.kt
@@ -1,0 +1,30 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import kotlinx.serialization.json.Json
+
+/**
+ * The single kotlinx Json instance owned by the core layer.
+ *
+ * - `ignoreUnknownKeys = true`: the DTO mirror in `model/` intentionally does not enumerate every
+ *   server field, so unknown keys must be tolerated rather than fail deserialization.
+ * - `encodeDefaults = false`: keeps rendered output compact — properties left at their default
+ *   (notably the many nullable `= null` fields) are omitted.
+ * - `isLenient = false`: the server emits strict RFC-8259 JSON; we reject anything that is not.
+ */
+val Json: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+    isLenient = false
+}
+
+/**
+ * A separate pretty-printing instance for human-facing STDOUT rendering. Shares the lenient/unknown
+ * settings of [Json] but turns on indentation. `encodeDefaults` stays false so null fields are
+ * omitted from rendered output.
+ */
+val PrettyJson: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+    isLenient = false
+    prettyPrint = true
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/AuditCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/AuditCommand.kt
@@ -1,0 +1,155 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.boolean
+import com.github.ajalt.clikt.parameters.types.int
+import kotlinx.serialization.builtins.ListSerializer
+import org.octopusden.octopus.components.registry.cli.CliContext
+import org.octopusden.octopus.components.registry.cli.client.QueryParams
+import org.octopusden.octopus.components.registry.cli.model.AuditLogResponse
+import org.octopusden.octopus.components.registry.cli.model.PageAuditLogResponse
+import org.octopusden.octopus.components.registry.cli.output.Renderer
+
+/**
+ * `crsctl audit` — parent for the audit-log queries.
+ *
+ * Every audit subcommand REQUIRES a bearer token (the server gates these behind ACCESS_AUDIT). The
+ * token is resolved through [CliContext.authedClient], which mirrors `whoami` (explicit `--token` /
+ * `CRS_TOKEN`, else a stored refresh token exchanged for an access token). When no credential can be
+ * resolved it throws [org.octopusden.octopus.components.registry.cli.auth.AuthRequiredException]
+ * BEFORE any HTTP call, so a missing login surfaces as a clear AUTH_REQUIRED (exit 4) rather than a
+ * generic server 401.
+ */
+class AuditCommand : CliktCommand(
+    name = "audit",
+    help = "Query the audit log (requires login and the ACCESS_AUDIT permission).",
+    invokeWithoutSubcommand = false,
+) {
+    override fun run() = Unit
+}
+
+/**
+ * `crsctl audit recent` — GET /rest/api/4/audit/recent with the full filter set.
+ *
+ * CLI kebab option -> v4.json query param: --entity-type=entityType, --entity-id=entityId,
+ * --changed-by=changedBy, --action=action, --source=source, --from=from, --to=to,
+ * --include-migrated=includeMigrated, plus the standard pageable (--page/--size/--sort).
+ *
+ * `--include-migrated` is tri-state: omitted -> not sent (server default applies); `true`/`false`
+ * -> sent verbatim.
+ */
+class AuditRecentCommand : CliktCommand(
+    name = "recent",
+    help = "List recent audit-log entries, optionally filtered. Requires login (ACCESS_AUDIT).",
+) {
+    private val ctx by requireObject<CliContext>()
+
+    // --- filters (CLI kebab-case -> v4.json getRecentChanges query param) ---
+    private val entityType by option("--entity-type", help = "Filter by entity type (spec: entityType).")
+    private val entityId by option("--entity-id", help = "Filter by entity id (spec: entityId).")
+    private val changedBy by option("--changed-by", help = "Filter by the user who made the change (spec: changedBy).")
+    private val action by option("--action", help = "Filter by action (spec: action).")
+    private val source by option("--source", help = "Filter by change source (spec: source).")
+    private val from by option("--from", help = "Lower bound (inclusive), ISO-8601 date-time (spec: from).")
+    private val to by option("--to", help = "Upper bound (exclusive), ISO-8601 date-time (spec: to).")
+    private val includeMigrated by option(
+        "--include-migrated",
+        help = "Include migrated entries (true|false). Omitted means the server default.",
+    ).boolean()
+
+    // --- paging ---
+    private val page by option("--page", help = "Zero-based page number.").int()
+    private val size by option("--size", help = "Page size.").int()
+    private val sort by option("--sort", help = "Sort spec, e.g. changedAt,desc (repeatable).").multiple()
+
+    override fun run() = runCommand {
+        val client = ctx.authedClient()
+        val query = QueryParams.builder()
+            .add("entityType", entityType)
+            .add("entityId", entityId)
+            .add("changedBy", changedBy)
+            .add("action", action)
+            .add("source", source)
+            .add("from", from)
+            .add("to", to)
+            .add("includeMigrated", includeMigrated)
+            .pageable(page = page, size = size, sort = sort.ifEmpty { null })
+            .build()
+        val response = client.getJson(AUDIT_RECENT_PATH, PageAuditLogResponse.serializer(), query)
+        renderAuditPage(ctx, response)
+    }
+
+    companion object {
+        const val AUDIT_RECENT_PATH = "/rest/api/4/audit/recent"
+    }
+}
+
+/**
+ * `crsctl audit <entityType> <entityId>` — GET /rest/api/4/audit/{entityType}/{entityId}.
+ *
+ * Both path segments are percent-encoded via [encodePathSegment]. Supports `--include-migrated` plus
+ * the standard pageable (--page/--size/--sort). Requires login (ACCESS_AUDIT).
+ */
+class AuditHistoryCommand : CliktCommand(
+    name = "history",
+    help = "Show the audit history for a single entity. Requires login (ACCESS_AUDIT).",
+) {
+    private val ctx by requireObject<CliContext>()
+
+    private val entityType by argument("entity-type", help = "Entity type (e.g. COMPONENT).")
+    private val entityId by argument("entity-id", help = "Entity id.")
+
+    private val includeMigrated by option(
+        "--include-migrated",
+        help = "Include migrated entries (true|false). Omitted means the server default.",
+    ).boolean()
+
+    private val page by option("--page", help = "Zero-based page number.").int()
+    private val size by option("--size", help = "Page size.").int()
+    private val sort by option("--sort", help = "Sort spec, e.g. changedAt,desc (repeatable).").multiple()
+
+    override fun run() = runCommand {
+        val client = ctx.authedClient()
+        val path = "/rest/api/4/audit/${encodePathSegment(entityType)}/${encodePathSegment(entityId)}"
+        val query = QueryParams.builder()
+            .add("includeMigrated", includeMigrated)
+            .pageable(page = page, size = size, sort = sort.ifEmpty { null })
+            .build()
+        val response = client.getJson(path, PageAuditLogResponse.serializer(), query)
+        renderAuditPage(ctx, response)
+    }
+}
+
+/** Shared rendering of a [PageAuditLogResponse] as either JSON (the rows) or a table. */
+private fun CliktCommand.renderAuditPage(ctx: CliContext, response: PageAuditLogResponse) {
+    val rows = response.content.orEmpty()
+    render(
+        ctx,
+        json = { Renderer.renderJson(rows, ListSerializer(AuditLogResponse.serializer())) },
+        table = {
+            Renderer.renderTable(
+                headers = listOf("CHANGED_AT", "ACTION", "ENTITY_TYPE", "ENTITY_ID", "CHANGED_BY"),
+                rows = rows.map {
+                    listOf(it.changedAt, it.action, it.entityType, it.entityId, it.changedBy)
+                },
+            )
+        },
+    )
+}
+
+/**
+ * Builds the `audit` command tree (parent + subcommands).
+ *
+ * `recent` and `history` are sibling subcommands because Clikt cannot mix free-standing positional
+ * arguments on a parent with subcommand dispatch (a bare `audit COMPONENT 123` would be read as a
+ * subcommand named "COMPONENT"). `audit history <entityType> <entityId>` is the per-entity form.
+ */
+fun auditCommand(): AuditCommand = AuditCommand().subcommands(
+    AuditRecentCommand(),
+    AuditHistoryCommand(),
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandSupport.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandSupport.kt
@@ -1,0 +1,48 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.ProgramResult
+import org.octopusden.octopus.components.registry.cli.CliContext
+import org.octopusden.octopus.components.registry.cli.client.ExitCodes
+import org.octopusden.octopus.components.registry.cli.output.OutputFormat
+import org.octopusden.octopus.components.registry.cli.output.Renderer
+
+/**
+ * Runs [block], catching any thrown error, writing a structured error to STDERR via
+ * [Renderer.renderError], and aborting with the mapped process exit code
+ * ([ExitCodes.fromThrowable]).
+ *
+ * On success the command simply returns; a non-zero exit is signalled by throwing Clikt's
+ * [ProgramResult], which Clikt translates into `System.exit` (and which the testing harness reports
+ * as `statusCode`). [ProgramResult] itself is re-thrown untouched so an inner helper can short-circuit
+ * with an explicit code.
+ */
+internal fun CliktCommand.runCommand(block: () -> Unit) {
+    try {
+        block()
+    } catch (pr: ProgramResult) {
+        throw pr
+    } catch (t: Throwable) {
+        echo(Renderer.renderError(t), err = true)
+        throw ProgramResult(ExitCodes.fromThrowable(t).code)
+    }
+}
+
+/** Writes [text] to STDOUT (no trailing extra newline beyond [echo]'s own). */
+internal fun CliktCommand.emit(text: String) = echo(text)
+
+/**
+ * Emits either [json] or [table], honouring the resolved [OutputFormat] from [ctx]. Both are passed
+ * as thunks so only the selected renderer runs.
+ */
+internal fun CliktCommand.render(
+    ctx: CliContext,
+    json: () -> String,
+    table: () -> String,
+) {
+    val rendered = when (ctx.output) {
+        OutputFormat.JSON -> json()
+        OutputFormat.TABLE -> table()
+    }
+    emit(rendered)
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandSupport.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandSupport.kt
@@ -6,6 +6,19 @@ import org.octopusden.octopus.components.registry.cli.CliContext
 import org.octopusden.octopus.components.registry.cli.client.ExitCodes
 import org.octopusden.octopus.components.registry.cli.output.OutputFormat
 import org.octopusden.octopus.components.registry.cli.output.Renderer
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Percent-encodes a single URL path segment so user-supplied ids/names/uuids can be safely
+ * interpolated into a request path. A raw name with a space makes `URI.create` throw, and a raw
+ * `/` would mis-route into a different path segment; encoding here prevents both.
+ *
+ * [URLEncoder.encode] is form/application-x-www-form-urlencoded oriented (it emits `+` for a space),
+ * so the result is post-processed to turn `+` into `%20` which is the correct path-segment encoding.
+ */
+internal fun encodePathSegment(s: String): String =
+    URLEncoder.encode(s, StandardCharsets.UTF_8).replace("+", "%20")
 
 /**
  * Runs [block], catching any thrown error, writing a structured error to STDERR via

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentCommand.kt
@@ -1,0 +1,119 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.arguments.argument
+import kotlinx.serialization.builtins.ListSerializer
+import org.octopusden.octopus.components.registry.cli.CliContext
+import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.model.ComponentDetailResponse
+import org.octopusden.octopus.components.registry.cli.model.FieldOverrideResponse
+import org.octopusden.octopus.components.registry.cli.output.Renderer
+import java.util.UUID
+
+/** `crsctl component` — parent for single-component operations (get / as-code / overrides). */
+class ComponentCommand : CliktCommand(
+    name = "component",
+    help = "Inspect a single component (get / as-code / overrides).",
+    invokeWithoutSubcommand = false,
+) {
+    override fun run() = Unit
+}
+
+/** `crsctl component get <idOrName>` — fetch the full component detail. */
+class ComponentGetCommand : CliktCommand(
+    name = "get",
+    help = "Get a component's full detail by id (UUID) or name. Read is anonymous.",
+) {
+    private val ctx by requireObject<CliContext>()
+    private val idOrName by argument(name = "ID_OR_NAME", help = "Component id (UUID) or name.")
+
+    override fun run() = runCommand {
+        val client = ctx.client()
+        val detail = fetchDetail(client, idOrName)
+        render(
+            ctx,
+            json = { Renderer.renderJson(detail, ComponentDetailResponse.serializer()) },
+            table = { detailTable(detail) },
+        )
+    }
+}
+
+/** `crsctl component as-code <idOrName>` — print the Groovy-style component source verbatim. */
+class ComponentAsCodeCommand : CliktCommand(
+    name = "as-code",
+    help = "Print a component's as-code (Groovy-style) source by id or name. Output is raw text/plain.",
+) {
+    private val ctx by requireObject<CliContext>()
+    private val idOrName by argument(name = "ID_OR_NAME", help = "Component id (UUID) or name.")
+
+    override fun run() = runCommand {
+        val client = ctx.client()
+        // text/plain endpoint: print exactly what the server returns, no JSON/table shaping.
+        emit(client.getText("/rest/api/4/components/$idOrName/as-code"))
+    }
+}
+
+/**
+ * `crsctl component overrides <idOrUuidOrName>` — list a component's field-overrides.
+ *
+ * The field-overrides endpoint requires the component's UUID in the path. If the argument already is
+ * a valid UUID it is used directly; otherwise it is treated as a name and resolved to a UUID via a
+ * `component get` lookup (reading the detail's `id`) before the field-overrides call.
+ */
+class ComponentOverridesCommand : CliktCommand(
+    name = "overrides",
+    help = "List a component's field-overrides. A UUID is used directly; a name is first resolved " +
+        "to its UUID via a component lookup.",
+) {
+    private val ctx by requireObject<CliContext>()
+    private val idOrUuidOrName by argument(name = "ID_OR_NAME", help = "Component UUID or name.")
+
+    override fun run() = runCommand {
+        val client = ctx.client()
+        val uuid = if (isUuid(idOrUuidOrName)) {
+            idOrUuidOrName
+        } else {
+            fetchDetail(client, idOrUuidOrName).id
+        }
+        val overrides = client.getJson(
+            "/rest/api/4/components/$uuid/field-overrides",
+            ListSerializer(FieldOverrideResponse.serializer()),
+        )
+        render(
+            ctx,
+            json = { Renderer.renderJson(overrides, ListSerializer(FieldOverrideResponse.serializer())) },
+            table = { overridesTable(overrides) },
+        )
+    }
+}
+
+/** Shared: GET /rest/api/4/components/{idOrName} (no resolve — server accepts id or name). */
+private fun fetchDetail(client: CrsClient, idOrName: String): ComponentDetailResponse =
+    client.getJson("/rest/api/4/components/$idOrName", ComponentDetailResponse.serializer())
+
+/** True when [value] parses as a canonical UUID. */
+private fun isUuid(value: String): Boolean =
+    runCatching { UUID.fromString(value) }.isSuccess
+
+private fun detailTable(detail: ComponentDetailResponse): String =
+    Renderer.renderTable(
+        headers = listOf("FIELD", "VALUE"),
+        rows = listOf(
+            listOf("id", detail.id),
+            listOf("name", detail.name),
+            listOf("displayName", detail.displayName),
+            listOf("owner", detail.componentOwner),
+            listOf("system", detail.system),
+            listOf("productType", detail.productType),
+            listOf("archived", detail.archived.toString()),
+            listOf("canBeParent", detail.canBeParent.toString()),
+            listOf("labels", detail.labels.joinToString(", ")),
+        ),
+    )
+
+private fun overridesTable(overrides: List<FieldOverrideResponse>): String =
+    Renderer.renderTable(
+        headers = listOf("ID", "ATTRIBUTE", "ROW_TYPE", "VERSION_RANGE"),
+        rows = overrides.map { listOf(it.id, it.overriddenAttribute, it.rowType, it.versionRange) },
+    )

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentCommand.kt
@@ -50,7 +50,7 @@ class ComponentAsCodeCommand : CliktCommand(
     override fun run() = runCommand {
         val client = ctx.client()
         // text/plain endpoint: print exactly what the server returns, no JSON/table shaping.
-        emit(client.getText("/rest/api/4/components/$idOrName/as-code"))
+        emit(client.getText("/rest/api/4/components/${encodePathSegment(idOrName)}/as-code"))
     }
 }
 
@@ -77,7 +77,7 @@ class ComponentOverridesCommand : CliktCommand(
             fetchDetail(client, idOrUuidOrName).id
         }
         val overrides = client.getJson(
-            "/rest/api/4/components/$uuid/field-overrides",
+            "/rest/api/4/components/${encodePathSegment(uuid)}/field-overrides",
             ListSerializer(FieldOverrideResponse.serializer()),
         )
         render(
@@ -90,7 +90,7 @@ class ComponentOverridesCommand : CliktCommand(
 
 /** Shared: GET /rest/api/4/components/{idOrName} (no resolve — server accepts id or name). */
 private fun fetchDetail(client: CrsClient, idOrName: String): ComponentDetailResponse =
-    client.getJson("/rest/api/4/components/$idOrName", ComponentDetailResponse.serializer())
+    client.getJson("/rest/api/4/components/${encodePathSegment(idOrName)}", ComponentDetailResponse.serializer())
 
 /** True when [value] parses as a canonical UUID. */
 private fun isUuid(value: String): Boolean =

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentsCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentsCommand.kt
@@ -112,7 +112,13 @@ class ComponentsListCommand : CliktCommand(
         return response.content.orEmpty()
     }
 
-    /** Walks pages starting at 0 (or the configured size), accumulating content until `last == true`. */
+    /**
+     * Walks pages starting at 0 (or the configured size), accumulating content until `last == true`.
+     *
+     * A misbehaving server that never sets `last` must not loop forever, so two extra guards apply:
+     *  - if the response carries a non-null `totalPages`, stop once the next index would reach it;
+     *  - an absolute [MAX_PAGES] safety cap, which (if hit) warns on STDERR and breaks.
+     */
     private fun fetchAll(client: CrsClient): List<ComponentSummaryResponse> {
         val accumulated = mutableListOf<ComponentSummaryResponse>()
         var current = 0
@@ -125,6 +131,16 @@ class ComponentsListCommand : CliktCommand(
             }
             // Defensive stop: a server that never reports `last` (or returns an empty page) must not loop forever.
             if (response.content.isNullOrEmpty()) {
+                break
+            }
+            // Page-count bound: stop when the next page index would reach/exceed the reported total.
+            val totalPages = response.totalPages
+            if (totalPages != null && current + 1 >= totalPages) {
+                break
+            }
+            // Absolute safety cap: never loop past MAX_PAGES even if the server keeps lying.
+            if (current + 1 >= MAX_PAGES) {
+                System.err.println("warning: --all stopped at the $MAX_PAGES-page safety cap")
                 break
             }
             current++
@@ -140,5 +156,8 @@ class ComponentsListCommand : CliktCommand(
 
     companion object {
         const val COMPONENTS_PATH = "/rest/api/4/components"
+
+        /** Absolute upper bound on `--all` page fetches, guarding against a server that never sets `last`. */
+        const val MAX_PAGES = 10_000
     }
 }

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentsCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentsCommand.kt
@@ -140,7 +140,7 @@ class ComponentsListCommand : CliktCommand(
             }
             // Absolute safety cap: never loop past MAX_PAGES even if the server keeps lying.
             if (current + 1 >= MAX_PAGES) {
-                System.err.println("warning: --all stopped at the $MAX_PAGES-page safety cap")
+                echo("warning: --all stopped at the $MAX_PAGES-page safety cap", err = true)
                 break
             }
             current++

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentsCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/ComponentsCommand.kt
@@ -1,0 +1,144 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.boolean
+import com.github.ajalt.clikt.parameters.types.int
+import kotlinx.serialization.builtins.ListSerializer
+import org.octopusden.octopus.components.registry.cli.CliContext
+import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.client.QueryParams
+import org.octopusden.octopus.components.registry.cli.model.ComponentSummaryResponse
+import org.octopusden.octopus.components.registry.cli.model.PageComponentSummaryResponse
+import org.octopusden.octopus.components.registry.cli.output.Renderer
+
+/** `crsctl components` — parent for component-list operations. */
+class ComponentsCommand : CliktCommand(
+    name = "components",
+    help = "List components in the registry.",
+    invokeWithoutSubcommand = false,
+) {
+    override fun run() = Unit
+}
+
+/**
+ * `crsctl components list` — query the components list with the full filter set, paging, and an
+ * optional `--all` auto-paginate that walks every page until the server reports `last == true`.
+ */
+class ComponentsListCommand : CliktCommand(
+    name = "list",
+    help = "List components, optionally filtered. Reads are anonymous; no token is required.",
+) {
+    private val ctx by requireObject<CliContext>()
+
+    // --- filters (CLI kebab-case -> v4.json listComponents query param) ---
+    private val search by option("--search", help = "Free-text search across name/displayName.")
+    private val owner by option("--owner", help = "Filter by component owner (repeatable).").multiple()
+    private val system by option("--system", help = "Filter by system code (repeatable).").multiple()
+    private val productType by option("--product-type", help = "Filter by product type.")
+    private val buildSystem by option("--build-system", help = "Filter by build system (repeatable).").multiple()
+    private val label by option("--label", help = "Filter by label (repeatable).").multiple()
+    private val clientCode by option("--client-code", help = "Filter by client code (repeatable).").multiple()
+    private val solution by option("--solution", help = "Filter solutions (true|false).").boolean()
+    private val jiraProjectKey by option(
+        "--jira-project-key",
+        help = "Filter by Jira project key (repeatable).",
+    ).multiple()
+    private val jiraTechnical by option("--jira-technical", help = "Filter technical Jira projects (true|false).").boolean()
+    private val vcsPath by option("--vcs-path", help = "Filter by VCS path.")
+    private val productionBranch by option("--production-branch", help = "Filter by production branch.")
+    private val parent by option(
+        "--parent",
+        help = "Filter by parent component name (repeatable).",
+    ).multiple()
+    private val groupKey by option("--group-key", help = "Filter by group key (repeatable).").multiple()
+    private val archived by option("--archived", help = "Filter archived components (true|false).").boolean()
+    private val canBeParent by option("--can-be-parent", help = "Filter components that can be parents (true|false).").boolean()
+    private val distributionExplicit by option(
+        "--distribution-explicit",
+        help = "Filter by explicit distribution (true|false).",
+    ).boolean()
+    private val distributionExternal by option(
+        "--distribution-external",
+        help = "Filter by external distribution (true|false).",
+    ).boolean()
+
+    // --- paging ---
+    private val page by option("--page", help = "Zero-based page number.").int()
+    private val size by option("--size", help = "Page size.").int()
+    private val sort by option("--sort", help = "Sort spec, e.g. name,asc (repeatable).").multiple()
+    private val all by option(
+        "--all",
+        help = "Fetch every page (ignores --page; loops until the last page).",
+    ).flag()
+
+    override fun run() = runCommand {
+        val client = ctx.client()
+        val rows = if (all) fetchAll(client) else fetchOnePage(client)
+        render(
+            ctx,
+            json = { Renderer.renderJson(rows, ListSerializer(ComponentSummaryResponse.serializer())) },
+            table = { renderTable(rows) },
+        )
+    }
+
+    private fun baseFilters(): QueryParams.Builder =
+        QueryParams.builder()
+            .add("search", search)
+            .addAll("owner", owner.ifEmpty { null })
+            .addAll("system", system.ifEmpty { null })
+            .add("productType", productType)
+            .addAll("buildSystem", buildSystem.ifEmpty { null })
+            .addAll("labels", label.ifEmpty { null })
+            .addAll("clientCode", clientCode.ifEmpty { null })
+            .add("solution", solution)
+            .addAll("jiraProjectKey", jiraProjectKey.ifEmpty { null })
+            .add("jiraTechnical", jiraTechnical)
+            .add("vcsPath", vcsPath)
+            .add("productionBranch", productionBranch)
+            .addAll("parentComponentName", parent.ifEmpty { null })
+            .addAll("groupKey", groupKey.ifEmpty { null })
+            .add("archived", archived)
+            .add("canBeParent", canBeParent)
+            .add("distributionExplicit", distributionExplicit)
+            .add("distributionExternal", distributionExternal)
+
+    private fun fetchOnePage(client: CrsClient): List<ComponentSummaryResponse> {
+        val query = baseFilters().pageable(page = page, size = size, sort = sort.ifEmpty { null }).build()
+        val response = client.getJson(COMPONENTS_PATH, PageComponentSummaryResponse.serializer(), query)
+        return response.content.orEmpty()
+    }
+
+    /** Walks pages starting at 0 (or the configured size), accumulating content until `last == true`. */
+    private fun fetchAll(client: CrsClient): List<ComponentSummaryResponse> {
+        val accumulated = mutableListOf<ComponentSummaryResponse>()
+        var current = 0
+        while (true) {
+            val query = baseFilters().pageable(page = current, size = size, sort = sort.ifEmpty { null }).build()
+            val response = client.getJson(COMPONENTS_PATH, PageComponentSummaryResponse.serializer(), query)
+            accumulated += response.content.orEmpty()
+            if (response.last == true) {
+                break
+            }
+            // Defensive stop: a server that never reports `last` (or returns an empty page) must not loop forever.
+            if (response.content.isNullOrEmpty()) {
+                break
+            }
+            current++
+        }
+        return accumulated
+    }
+
+    private fun renderTable(rows: List<ComponentSummaryResponse>): String =
+        Renderer.renderTable(
+            headers = listOf("ID", "NAME", "OWNER", "SYSTEM"),
+            rows = rows.map { listOf(it.id, it.name, it.componentOwner, it.system) },
+        )
+
+    companion object {
+        const val COMPONENTS_PATH = "/rest/api/4/components"
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/HelpCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/HelpCommand.kt
@@ -1,0 +1,32 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.PrintHelpMessage
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+
+/**
+ * `crsctl help [<command>...]` — print help for crsctl or a named (possibly nested) subcommand,
+ * e.g. `crsctl help`, `crsctl help components list`.
+ *
+ * Dispatch is actually handled in `runCli` (Main.kt), which rewrites a leading `help <command>...`
+ * into `<command>... --help` BEFORE parsing — that reuses Clikt's own help renderer for any depth
+ * and keeps exit codes consistent (0 for help). This class exists so `help` is listed under
+ * Commands and has its own usage line; its [run] is a safety net that is normally never reached.
+ */
+class HelpCommand : CliktCommand(
+    name = "help",
+    help = "Show help for crsctl or a specific command (e.g. `help components list`).",
+) {
+    private val command by argument(
+        name = "command",
+        help = "Command path to show help for; omit for top-level help.",
+    ).multiple()
+
+    override fun run() {
+        // Safety net: runCli normally rewrites `help ...` before this runs. If reached, show the
+        // root help (the parent context), ignoring any command path.
+        command.let { /* registered for usage display; dispatch happens in runCli */ }
+        throw PrintHelpMessage(currentContext.parent ?: currentContext)
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/LoginCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/LoginCommand.kt
@@ -1,0 +1,60 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import org.octopusden.octopus.components.registry.cli.CliContext
+import org.octopusden.octopus.components.registry.cli.auth.DeviceFlowClient
+
+/**
+ * `crsctl login [--offline]` — authenticate via the OIDC Device Authorization Grant (RFC 8628).
+ *
+ * Resolves the keycloak issuer + public client id from the active profile (clear error if absent),
+ * starts the device flow, prints the verification URI + user code to STDOUT (it deliberately does
+ * NOT shell out to mac `open`), polls until the user completes authorization, and persists the
+ * resulting refresh token via the selected [org.octopusden.octopus.components.registry.cli.auth.CredentialStore].
+ *
+ * `--offline` requests the `offline_access` scope so the provider returns a refresh token (needed for
+ * non-interactive token refresh between invocations).
+ */
+class LoginCommand : CliktCommand(
+    name = "login",
+    help = "Log in via the OIDC device authorization grant and store the refresh token.",
+) {
+    private val ctx by requireObject<CliContext>()
+    private val offline by option(
+        "--offline",
+        help = "Request the offline_access scope so a long-lived refresh token is issued.",
+    ).flag()
+
+    override fun run() = runCommand {
+        val oidc = ctx.resolveOidcConfig()
+        val deviceFlow = ctx.deviceFlowClient
+        val scope = DeviceFlowClient.scopeFor(offline)
+
+        val authorization = deviceFlow.requestDeviceAuthorization(oidc.issuer, oidc.clientId, scope)
+
+        emit("To sign in, open ${authorization.verificationUri} and enter code ${authorization.userCode}")
+        authorization.verificationUriComplete?.let { complete ->
+            emit("Or open this URL directly (code prefilled): $complete")
+        }
+        emit("Waiting for authorization...")
+
+        val token = deviceFlow.pollToken(
+            issuer = oidc.issuer,
+            clientId = oidc.clientId,
+            deviceCode = authorization.deviceCode,
+            interval = authorization.interval,
+            expiresInSeconds = authorization.expiresIn,
+        )
+
+        val refreshToken = token.refreshToken
+            ?: error(
+                "Login succeeded but the provider returned no refresh token; pass --offline to " +
+                    "request the offline_access scope.",
+            )
+        ctx.credentialStore().save(refreshToken)
+        emit("Login successful. Credentials stored.")
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/LogoutCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/LogoutCommand.kt
@@ -1,0 +1,44 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import org.octopusden.octopus.components.registry.cli.CliContext
+
+/**
+ * `crsctl logout` — revoke-then-clear.
+ *
+ * If a refresh token is stored it is first revoked at the provider (RFC 7009) and then removed from
+ * the credential store. Revocation is best-effort: if it fails, the local token is STILL cleared and
+ * the command exits 0 with a warning (a stale server-side session is preferable to a token lingering
+ * on disk). When no token is stored the command is a no-op success.
+ */
+class LogoutCommand : CliktCommand(
+    name = "logout",
+    help = "Revoke and remove the stored refresh token.",
+) {
+    private val ctx by requireObject<CliContext>()
+
+    override fun run() = runCommand {
+        val store = ctx.credentialStore()
+        val refreshToken = store.load()
+        if (refreshToken == null) {
+            emit("Already logged out.")
+            return@runCommand
+        }
+
+        val oidc = ctx.resolveOidcConfig()
+        // Revoke FIRST, then clear. Revocation is best-effort: any failure is recoverable — we warn
+        // and still clear the local token (exit 0).
+        try {
+            val revoked = ctx.deviceFlowClient.revoke(oidc.issuer, oidc.clientId, refreshToken)
+            if (!revoked) {
+                echo("warning: provider did not confirm revocation; clearing local credentials anyway.", err = true)
+            }
+        } catch (e: Exception) {
+            echo("warning: token revocation failed (${e.message}); clearing local credentials anyway.", err = true)
+        }
+
+        store.clear()
+        emit("Logged out.")
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/LogoutCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/LogoutCommand.kt
@@ -26,16 +26,17 @@ class LogoutCommand : CliktCommand(
             return@runCommand
         }
 
-        val oidc = ctx.resolveOidcConfig()
-        // Revoke FIRST, then clear. Revocation is best-effort: any failure is recoverable — we warn
-        // and still clear the local token (exit 0).
+        // Revoke FIRST (best-effort), then ALWAYS clear. Any failure is recoverable — including a
+        // missing/broken OIDC profile that prevents us from even attempting revocation: we warn and
+        // still clear the local token (exit 0), so a stale server session never strands a token on disk.
         try {
+            val oidc = ctx.resolveOidcConfig()
             val revoked = ctx.deviceFlowClient.revoke(oidc.issuer, oidc.clientId, refreshToken)
             if (!revoked) {
                 echo("warning: provider did not confirm revocation; clearing local credentials anyway.", err = true)
             }
         } catch (e: Exception) {
-            echo("warning: token revocation failed (${e.message}); clearing local credentials anyway.", err = true)
+            echo("warning: could not revoke the token (${e.message}); clearing local credentials anyway.", err = true)
         }
 
         store.clear()

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/MetaCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/MetaCommand.kt
@@ -1,0 +1,103 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import org.octopusden.octopus.components.registry.cli.CliContext
+import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.client.QueryParams
+import org.octopusden.octopus.components.registry.cli.model.EmployeeMatchResponse
+import org.octopusden.octopus.components.registry.cli.output.Renderer
+
+/** `crsctl meta` — parent for the registry metadata / dictionary lookups. */
+class MetaCommand : CliktCommand(
+    name = "meta",
+    help = "Registry metadata lookups (owners, systems, labels, build-systems, ...).",
+    invokeWithoutSubcommand = false,
+) {
+    override fun run() = Unit
+}
+
+/**
+ * A meta endpoint that returns a bare JSON array of strings. Each instance maps a CLI subcommand
+ * name to its `/rest/api/4/components/meta/<name>` path.
+ */
+class MetaListCommand(
+    name: String,
+    private val path: String,
+    help: String,
+) : CliktCommand(name = name, help = help) {
+    private val ctx by requireObject<CliContext>()
+
+    override fun run() = runCommand {
+        val client = ctx.client()
+        val values = client.getJson(path, ListSerializer(String.serializer()))
+        render(
+            ctx,
+            json = { Renderer.renderJson(values, ListSerializer(String.serializer())) },
+            table = { Renderer.renderTable(listOf("VALUE"), values.map { listOf(it) }) },
+        )
+    }
+}
+
+/**
+ * `crsctl meta employees --search <q>` — the authenticated employee lookup. Requires a token; a
+ * 401/403 from the server surfaces (via the shared error handler) as exit code AUTH_REQUIRED.
+ */
+class MetaEmployeesCommand : CliktCommand(
+    name = "employees",
+    help = "Search employees (requires login). On 401/403 exits with AUTH_REQUIRED.",
+) {
+    private val ctx by requireObject<CliContext>()
+    private val search by option("--search", help = "Required search term (username / name fragment).").required()
+
+    override fun run() = runCommand {
+        val client: CrsClient = ctx.client()
+        val query = QueryParams.builder().add("search", search).build()
+        val matches = client.getJson(
+            "/rest/api/4/components/meta/employees",
+            ListSerializer(EmployeeMatchResponse.serializer()),
+            query,
+        )
+        render(
+            ctx,
+            json = { Renderer.renderJson(matches, ListSerializer(EmployeeMatchResponse.serializer())) },
+            table = {
+                Renderer.renderTable(
+                    headers = listOf("USERNAME", "ACTIVE"),
+                    rows = matches.map { listOf(it.username, it.active.toString()) },
+                )
+            },
+        )
+    }
+}
+
+/**
+ * Registers all meta subcommands on a fresh [MetaCommand]. Centralised so the CLI option -> spec path
+ * mapping lives in exactly one place.
+ */
+fun metaCommand(): MetaCommand = MetaCommand().subcommands(
+    MetaListCommand("build-systems", "/rest/api/4/components/meta/build-systems", "List build systems in use."),
+    MetaListCommand("client-codes", "/rest/api/4/components/meta/client-codes", "List client codes in use."),
+    MetaListCommand("escrow-generations", "/rest/api/4/components/meta/escrow-generations", "List escrow generations."),
+    MetaListCommand("group-keys", "/rest/api/4/components/meta/group-keys", "List group keys in use."),
+    MetaListCommand("java-versions", "/rest/api/4/components/meta/java-versions", "List Java versions in use."),
+    MetaListCommand("jira-project-keys", "/rest/api/4/components/meta/jira-project-keys", "List Jira project keys."),
+    MetaListCommand("labels", "/rest/api/4/components/meta/labels", "List labels currently in use."),
+    MetaListCommand("labels-dictionary", "/rest/api/4/components/meta/labels/dictionary", "List all known labels (dictionary)."),
+    MetaListCommand("maven-versions", "/rest/api/4/components/meta/maven-versions", "List Maven versions in use."),
+    MetaListCommand("owners", "/rest/api/4/components/meta/owners", "List component owners in use."),
+    MetaListCommand(
+        "parent-component-names",
+        "/rest/api/4/components/meta/parent-component-names",
+        "List parent component names.",
+    ),
+    MetaListCommand("repository-types", "/rest/api/4/components/meta/repository-types", "List repository types."),
+    MetaListCommand("systems", "/rest/api/4/components/meta/systems", "List systems currently in use."),
+    MetaListCommand("systems-dictionary", "/rest/api/4/components/meta/systems/dictionary", "List all known systems (dictionary)."),
+    MetaEmployeesCommand(),
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/MetaCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/MetaCommand.kt
@@ -56,7 +56,7 @@ class MetaEmployeesCommand : CliktCommand(
     private val search by option("--search", help = "Required search term (username / name fragment).").required()
 
     override fun run() = runCommand {
-        val client: CrsClient = ctx.client()
+        val client: CrsClient = ctx.authedClient()
         val query = QueryParams.builder().add("search", search).build()
         val matches = client.getJson(
             "/rest/api/4/components/meta/employees",

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/WhoamiCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/WhoamiCommand.kt
@@ -1,0 +1,31 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import org.octopusden.octopus.components.registry.cli.CliContext
+
+/**
+ * `crsctl whoami` — report the current identity.
+ *
+ * Without a resolved token there is nothing to ask the server: `/auth/me` is authenticated-only, and
+ * for current CRS versions anonymous callers implicitly have ACCESS_COMPONENTS. So the no-token branch
+ * prints a static line and exits 0 — it deliberately makes NO HTTP call.
+ */
+class WhoamiCommand : CliktCommand(
+    name = "whoami",
+    help = "Show the current identity. Anonymous (no token) reports a static line without calling the server.",
+) {
+    private val ctx by requireObject<CliContext>()
+
+    override fun run() = runCommand {
+        val target = ctx.resolveTarget()
+        if (target.token.isNullOrBlank()) {
+            emit("anonymous; for current CRS versions ACCESS_COMPONENTS is implied")
+            return@runCommand
+        }
+        // TODO(auth-layer): with a resolved token, call GET /auth/me and render the User
+        //  (username / groups / roles). Added in the auth layer; until then we cannot describe a
+        //  token-bearing identity, so fall back to the anonymous-style note.
+        emit("authenticated (token present); /auth/me lookup is implemented in the auth layer")
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/WhoamiCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/WhoamiCommand.kt
@@ -3,29 +3,80 @@ package org.octopusden.octopus.components.registry.cli.commands
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.requireObject
 import org.octopusden.octopus.components.registry.cli.CliContext
+import org.octopusden.octopus.components.registry.cli.auth.AuthRequiredException
+import org.octopusden.octopus.components.registry.cli.client.ConfigResolutionException
+import org.octopusden.octopus.components.registry.cli.config.EffectiveTarget
+import org.octopusden.octopus.components.registry.cli.model.User
+import org.octopusden.octopus.components.registry.cli.output.Renderer
 
 /**
  * `crsctl whoami` — report the current identity.
  *
- * Without a resolved token there is nothing to ask the server: `/auth/me` is authenticated-only, and
- * for current CRS versions anonymous callers implicitly have ACCESS_COMPONENTS. So the no-token branch
- * prints a static line and exits 0 — it deliberately makes NO HTTP call.
+ * Credential resolution order:
+ *   1. An explicit token (`--token` / `CRS_TOKEN`) — used verbatim.
+ *   2. A stored refresh token — exchanged for an access token via the
+ *      [org.octopusden.octopus.components.registry.cli.auth.TokenManager].
+ *   3. Neither — print the static anonymous line and exit 0, making NO HTTP call (`/auth/me` is
+ *      authenticated-only and anonymous callers implicitly have ACCESS_COMPONENTS on current CRS).
+ *
+ * With a resolvable token it calls GET /auth/me and renders the [User] (username + roles) honouring
+ * `-o json|table`.
  */
 class WhoamiCommand : CliktCommand(
     name = "whoami",
-    help = "Show the current identity. Anonymous (no token) reports a static line without calling the server.",
+    help = "Show the current identity. Anonymous (no credential) reports a static line without calling the server.",
 ) {
     private val ctx by requireObject<CliContext>()
 
     override fun run() = runCommand {
         val target = ctx.resolveTarget()
-        if (target.token.isNullOrBlank()) {
+        val token = resolveToken(target)
+        if (token == null) {
             emit("anonymous; for current CRS versions ACCESS_COMPONENTS is implied")
             return@runCommand
         }
-        // TODO(auth-layer): with a resolved token, call GET /auth/me and render the User
-        //  (username / groups / roles). Added in the auth layer; until then we cannot describe a
-        //  token-bearing identity, so fall back to the anonymous-style note.
-        emit("authenticated (token present); /auth/me lookup is implemented in the auth layer")
+
+        val client = ctx.clientFor(target.copy(token = token))
+        val user = client.getJson("/auth/me", User.serializer())
+        render(
+            ctx,
+            json = { Renderer.renderJson(user, User.serializer()) },
+            table = { userTable(user) },
+        )
     }
+
+    /**
+     * Returns a usable bearer token, or null when the caller is anonymous.
+     *
+     * An explicit token wins. Otherwise, if a refresh token is stored AND the active profile carries
+     * OIDC settings, the refresh token is exchanged for an access token. With no stored credential
+     * ([AuthRequiredException]) or no profile-level OIDC config ([ConfigResolutionException]) the
+     * caller is treated as anonymous rather than failing — `whoami` must work on a bare `--crs-url`.
+     */
+    private fun resolveToken(target: EffectiveTarget): String? {
+        if (!target.token.isNullOrBlank()) {
+            return target.token
+        }
+        return try {
+            ctx.tokenManager().accessToken()
+        } catch (e: AuthRequiredException) {
+            null
+        } catch (e: ConfigResolutionException) {
+            null
+        }
+    }
+}
+
+private fun userTable(user: User): String {
+    val roleNames = user.roles.joinToString(", ") { it.name }
+    val authorities = user.roles.flatMap { it.permissions }.distinct().joinToString(", ")
+    return Renderer.renderTable(
+        headers = listOf("FIELD", "VALUE"),
+        rows = listOf(
+            listOf("username", user.username),
+            listOf("groups", user.groups.joinToString(", ")),
+            listOf("roles", roleNames),
+            listOf("authorities", authorities),
+        ),
+    )
 }

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/WhoamiCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/WhoamiCommand.kt
@@ -29,7 +29,16 @@ class WhoamiCommand : CliktCommand(
     private val ctx by requireObject<CliContext>()
 
     override fun run() = runCommand {
-        val target = ctx.resolveTarget()
+        // whoami must answer "anonymous" out of the box, even with no profile/URL configured —
+        // the anonymous branch makes no server call. Only surface a missing-URL error when the
+        // user supplied a token (they clearly intended an authenticated /auth/me lookup).
+        val target = try {
+            ctx.resolveTarget()
+        } catch (e: ConfigResolutionException) {
+            if (!ctx.tokenFlag.isNullOrBlank()) throw e
+            emit("anonymous; for current CRS versions ACCESS_COMPONENTS is implied")
+            return@runCommand
+        }
         val token = resolveToken(target)
         if (token == null) {
             emit("anonymous; for current CRS versions ACCESS_COMPONENTS is implied")

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/config/Config.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/config/Config.kt
@@ -1,0 +1,93 @@
+package org.octopusden.octopus.components.registry.cli.config
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializable
+import org.octopusden.octopus.components.registry.cli.client.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * A single named target profile. Only [crsUrl] is required to make a profile usable for read
+ * commands; [keycloakIssuer] / [clientId] are present for the (later) device-flow login layer.
+ */
+@Serializable
+data class Profile(
+    val crsUrl: String,
+    val keycloakIssuer: String? = null,
+    val clientId: String? = null,
+)
+
+/**
+ * Top-level config-file model.
+ *
+ * `defaultProfile` names the profile to use when neither `--env` nor an explicit `--crs-url` is
+ * given. `profiles` maps a profile name to its [Profile].
+ */
+@Serializable
+data class CrsctlConfig(
+    val defaultProfile: String? = null,
+    val profiles: Map<String, Profile> = emptyMap(),
+) {
+    companion object {
+        val EMPTY = CrsctlConfig()
+    }
+}
+
+/**
+ * Loads (and centralizes the location of) the crsctl config file.
+ *
+ * Config-dir resolution lives in exactly ONE place ([configDir]) so adding Windows/Linux variants
+ * later is purely additive. The chosen layout:
+ *   - macOS:  ~/Library/Application Support/crsctl/config.json
+ *   - other:  $XDG_CONFIG_HOME/crsctl/config.json, else ~/.config/crsctl/config.json
+ *
+ * A missing config file is tolerated and yields [CrsctlConfig.EMPTY].
+ */
+object ConfigLoader {
+
+    private const val CONFIG_FILE_NAME = "config.json"
+
+    /** The single source of truth for the per-OS config directory. */
+    fun configDir(): Path {
+        val osName = System.getProperty("os.name").orEmpty().lowercase()
+        val home = System.getProperty("user.home").orEmpty()
+        return when {
+            osName.contains("mac") || osName.contains("darwin") ->
+                Paths.get(home, "Library", "Application Support", "crsctl")
+
+            else -> {
+                val xdg = System.getenv("XDG_CONFIG_HOME")
+                if (!xdg.isNullOrBlank()) {
+                    Paths.get(xdg, "crsctl")
+                } else {
+                    Paths.get(home, ".config", "crsctl")
+                }
+            }
+        }
+    }
+
+    fun configFile(): Path = configDir().resolve(CONFIG_FILE_NAME)
+
+    /** Loads the config from the default location, tolerating absence. */
+    fun load(): CrsctlConfig = load(configFile())
+
+    /** Loads the config from [file], returning [CrsctlConfig.EMPTY] when the file is absent. */
+    fun load(file: Path): CrsctlConfig {
+        if (!Files.exists(file)) {
+            return CrsctlConfig.EMPTY
+        }
+        val text = Files.readString(file)
+        if (text.isBlank()) {
+            return CrsctlConfig.EMPTY
+        }
+        return try {
+            Json.decodeFromString(CrsctlConfig.serializer(), text)
+        } catch (e: SerializationException) {
+            throw ConfigLoadException("Config file $file is not valid crsctl config JSON: ${e.message}", e)
+        }
+    }
+}
+
+/** Thrown when a present config file cannot be parsed. */
+class ConfigLoadException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolver.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolver.kt
@@ -1,6 +1,8 @@
 package org.octopusden.octopus.components.registry.cli.config
 
 import org.octopusden.octopus.components.registry.cli.client.ConfigResolutionException
+import java.net.URI
+import java.net.URISyntaxException
 
 /**
  * The resolved CRS target a command will talk to. [token] may be null (anonymous read); [envName] is
@@ -40,11 +42,11 @@ object TargetResolver {
         val token = firstNonBlank(inputs.tokenFlag, inputs.tokenEnv)
 
         firstNonBlank(inputs.crsUrlFlag)?.let { url ->
-            return EffectiveTarget(crsUrl = url, token = token, envName = null)
+            return EffectiveTarget(crsUrl = validate(url), token = token, envName = null)
         }
 
         firstNonBlank(inputs.crsUrlEnv)?.let { url ->
-            return EffectiveTarget(crsUrl = url, token = token, envName = null)
+            return EffectiveTarget(crsUrl = validate(url), token = token, envName = null)
         }
 
         // Profile path: explicit --env wins; otherwise fall back to config defaultProfile.
@@ -57,13 +59,40 @@ object TargetResolver {
                     "No profile named '$profileName' in config. Known profiles: " +
                         knownProfiles(config),
                 )
-            return EffectiveTarget(crsUrl = profile.crsUrl, token = token, envName = profileName)
+            return EffectiveTarget(crsUrl = validate(profile.crsUrl), token = token, envName = profileName)
         }
 
         throw ConfigResolutionException(
             "No CRS URL resolved. Provide --crs-url, set CRS_URL, or configure a profile " +
                 "(--env / defaultProfile). Known profiles: ${knownProfiles(config)}",
         )
+    }
+
+    /**
+     * Validates the resolved CRS URL and strips a single trailing slash so base+path joins stay
+     * clean. The URL must be a syntactically valid absolute URI with an http/https scheme and a
+     * non-empty host; anything else is a [ConfigResolutionException] (which maps to USAGE/exit 2)
+     * rather than a confusing transport-level failure later on.
+     */
+    private fun validate(rawUrl: String): String {
+        val trimmed = rawUrl.trim()
+        val uri = try {
+            URI(trimmed)
+        } catch (e: URISyntaxException) {
+            throw ConfigResolutionException("Invalid CRS URL '$rawUrl': ${e.message}")
+        } catch (e: IllegalArgumentException) {
+            throw ConfigResolutionException("Invalid CRS URL '$rawUrl': ${e.message}")
+        }
+        val scheme = uri.scheme?.lowercase()
+        if (scheme != "http" && scheme != "https") {
+            throw ConfigResolutionException(
+                "Invalid CRS URL '$rawUrl': scheme must be http or https.",
+            )
+        }
+        if (uri.host.isNullOrBlank()) {
+            throw ConfigResolutionException("Invalid CRS URL '$rawUrl': missing host.")
+        }
+        return trimmed.trimEnd('/')
     }
 
     private fun knownProfiles(config: CrsctlConfig): String =

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolver.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolver.kt
@@ -1,0 +1,74 @@
+package org.octopusden.octopus.components.registry.cli.config
+
+import org.octopusden.octopus.components.registry.cli.client.ConfigResolutionException
+
+/**
+ * The resolved CRS target a command will talk to. [token] may be null (anonymous read); [envName] is
+ * the profile name when the URL came from a profile, otherwise null.
+ */
+data class EffectiveTarget(
+    val crsUrl: String,
+    val token: String? = null,
+    val envName: String? = null,
+)
+
+/**
+ * Inputs the resolver considers, lowest-friction first. The command layer fills these from Clikt
+ * options / the environment; the resolver applies a fixed precedence and never guesses a URL.
+ */
+data class ResolverInputs(
+    val crsUrlFlag: String? = null,
+    val tokenFlag: String? = null,
+    val envFlag: String? = null,
+    val crsUrlEnv: String? = null,
+    val tokenEnv: String? = null,
+)
+
+/**
+ * Resolves the effective CRS URL and token with explicit precedence:
+ *
+ *   URL:    --crs-url flag  >  CRS_URL env  >  named profile (--env, else config defaultProfile)
+ *   token:  --token flag    >  CRS_TOKEN env  >  (no token — anonymous)
+ *
+ * If no URL can be resolved from any source, a [ConfigResolutionException] is thrown rather than
+ * silently defaulting to a possibly wrong registry. An explicit `--env` that names a profile absent
+ * from the config is also an error.
+ */
+object TargetResolver {
+
+    fun resolve(inputs: ResolverInputs, config: CrsctlConfig): EffectiveTarget {
+        val token = firstNonBlank(inputs.tokenFlag, inputs.tokenEnv)
+
+        firstNonBlank(inputs.crsUrlFlag)?.let { url ->
+            return EffectiveTarget(crsUrl = url, token = token, envName = null)
+        }
+
+        firstNonBlank(inputs.crsUrlEnv)?.let { url ->
+            return EffectiveTarget(crsUrl = url, token = token, envName = null)
+        }
+
+        // Profile path: explicit --env wins; otherwise fall back to config defaultProfile.
+        val requestedEnv = firstNonBlank(inputs.envFlag)
+        val profileName = requestedEnv ?: firstNonBlank(config.defaultProfile)
+
+        if (profileName != null) {
+            val profile = config.profiles[profileName]
+                ?: throw ConfigResolutionException(
+                    "No profile named '$profileName' in config. Known profiles: " +
+                        knownProfiles(config),
+                )
+            return EffectiveTarget(crsUrl = profile.crsUrl, token = token, envName = profileName)
+        }
+
+        throw ConfigResolutionException(
+            "No CRS URL resolved. Provide --crs-url, set CRS_URL, or configure a profile " +
+                "(--env / defaultProfile). Known profiles: ${knownProfiles(config)}",
+        )
+    }
+
+    private fun knownProfiles(config: CrsctlConfig): String =
+        if (config.profiles.isEmpty()) "(none)" else config.profiles.keys.sorted().joinToString(", ")
+
+    private fun firstNonBlank(vararg values: String?): String? =
+        values.firstOrNull { !it.isNullOrBlank() }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Audit.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Audit.kt
@@ -1,0 +1,29 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Mirror of v4.json `AuditLogResponse` — a single audit row returned (paged) by
+ * GET /rest/api/4/audit/recent and GET /rest/api/4/audit/{entityType}/{entityId}.
+ *
+ * `changeDiff`, `newValue` and `oldValue` are spec `object` maps with free-form `object` values,
+ * modelled here as Map<String, JsonElement>. `changedAt` is an ISO-8601 date-time string (kept as
+ * String to avoid pulling a date dependency into the DTO layer).
+ *
+ * Required per spec: action, changedAt, entityId, entityType, id, source.
+ */
+@Serializable
+data class AuditLogResponse(
+    val id: Long,
+    val action: String,
+    val entityType: String,
+    val entityId: String,
+    val changedAt: String,
+    val source: String,
+    val changedBy: String? = null,
+    val correlationId: String? = null,
+    val changeDiff: Map<String, JsonElement>? = null,
+    val newValue: Map<String, JsonElement>? = null,
+    val oldValue: Map<String, JsonElement>? = null,
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Auth.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Auth.kt
@@ -1,0 +1,25 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Mirror of v4.json `Role`.
+ */
+@Serializable
+data class Role(
+    val name: String,
+    val permissions: List<String>,
+)
+
+/**
+ * Mirror of v4.json `User` — the body returned by GET /auth/me.
+ *
+ * Note: in the canon `roles` is an array of [Role] objects (not plain strings); `groups` is an
+ * array of strings. All three properties are required.
+ */
+@Serializable
+data class User(
+    val username: String,
+    val groups: List<String>,
+    val roles: List<Role>,
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Component.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Component.kt
@@ -1,0 +1,275 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Mirror of v4.json `ComponentSummaryResponse` — one row of the components list page.
+ *
+ * Required per spec: archived, canBeParent, id, labels, name.
+ */
+@Serializable
+data class ComponentSummaryResponse(
+    val id: String,
+    val name: String,
+    val archived: Boolean,
+    val canBeParent: Boolean,
+    val labels: List<String>,
+    val displayName: String? = null,
+    val system: String? = null,
+    val productType: String? = null,
+    val componentOwner: String? = null,
+    val buildSystem: String? = null,
+    val jiraProjectKey: String? = null,
+    val vcsPath: String? = null,
+    val teamcityProjectId: String? = null,
+    val teamcityProjectUrl: String? = null,
+    val updatedAt: String? = null,
+)
+
+/**
+ * Mirror of v4.json `ComponentGroupResponse`. `role` is the enum AGGREGATOR|MEMBER (kept as String).
+ *
+ * Required per spec: groupKey, isFake, role.
+ */
+@Serializable
+data class ComponentGroupResponse(
+    val groupKey: String,
+    val isFake: Boolean,
+    val role: String,
+)
+
+/**
+ * Mirror of v4.json `ArtifactIdResponse`. Required: artifactPattern, groupPattern, id.
+ */
+@Serializable
+data class ArtifactIdResponse(
+    val artifactPattern: String,
+    val groupPattern: String,
+    val id: String,
+)
+
+/**
+ * Mirror of v4.json `DocLinkResponse`. Required: docComponentKey, id, sortOrder.
+ */
+@Serializable
+data class DocLinkResponse(
+    val docComponentKey: String,
+    val id: String,
+    val sortOrder: Int,
+    val majorVersion: String? = null,
+)
+
+/**
+ * Mirror of v4.json `SecurityGroupResponse`. Required: groupName, groupType, id.
+ */
+@Serializable
+data class SecurityGroupResponse(
+    val groupName: String,
+    val groupType: String,
+    val id: String,
+)
+
+/**
+ * Mirror of v4.json `TeamcityProjectResponse`. Required: id, projectId, sortOrder.
+ */
+@Serializable
+data class TeamcityProjectResponse(
+    val id: String,
+    val projectId: String,
+    val sortOrder: Int,
+    val projectUrl: String? = null,
+)
+
+/**
+ * Mirror of v4.json `BuildAspectResponse`. No required fields per spec; all-nullable.
+ */
+@Serializable
+data class BuildAspectResponse(
+    val buildFilePath: String? = null,
+    val buildSystem: String? = null,
+    val buildTasks: String? = null,
+    val deprecated: Boolean? = null,
+    val gradleVersion: String? = null,
+    val javaVersion: String? = null,
+    val mavenVersion: String? = null,
+    val projectVersion: String? = null,
+    val requiredProject: Boolean? = null,
+    val systemProperties: String? = null,
+)
+
+/**
+ * Mirror of v4.json `EscrowAspectResponse`. No required fields per spec; all-nullable.
+ */
+@Serializable
+data class EscrowAspectResponse(
+    val additionalSources: String? = null,
+    val buildTask: String? = null,
+    val diskSpace: String? = null,
+    val generation: String? = null,
+    val gradleExcludeConfigurations: String? = null,
+    val gradleIncludeConfigurations: String? = null,
+    val gradleIncludeTestConfigurations: Boolean? = null,
+    val providedDependencies: String? = null,
+    val reusable: Boolean? = null,
+)
+
+/**
+ * Mirror of v4.json `JiraAspectResponse`. No required fields per spec; all-nullable.
+ */
+@Serializable
+data class JiraAspectResponse(
+    val buildVersionFormat: String? = null,
+    val hotfixVersionFormat: String? = null,
+    val lineVersionFormat: String? = null,
+    val majorVersionFormat: String? = null,
+    val projectKey: String? = null,
+    val releaseVersionFormat: String? = null,
+    val technical: Boolean? = null,
+    val versionFormat: String? = null,
+    val versionPrefix: String? = null,
+)
+
+/**
+ * Mirror of v4.json `BuildToolBeanResponse`. Required: beanType, id, sortOrder.
+ */
+@Serializable
+data class BuildToolBeanResponse(
+    val beanType: String,
+    val id: String,
+    val sortOrder: Int,
+    val edition: String? = null,
+    val settingsProperty: String? = null,
+    val toolType: String? = null,
+    val versionPattern: String? = null,
+)
+
+/**
+ * Mirror of v4.json `DockerImageResponse`. Required: id, imageName, sortOrder.
+ */
+@Serializable
+data class DockerImageResponse(
+    val id: String,
+    val imageName: String,
+    val sortOrder: Int,
+    val flavor: String? = null,
+)
+
+/**
+ * Mirror of v4.json `FileUrlArtifactResponse`. Required: id, sortOrder, url.
+ */
+@Serializable
+data class FileUrlArtifactResponse(
+    val id: String,
+    val sortOrder: Int,
+    val url: String,
+    val artifactId: String? = null,
+    val classifier: String? = null,
+)
+
+/**
+ * Mirror of v4.json `MavenArtifactResponse`. Required: artifactPattern, groupPattern, id, sortOrder.
+ */
+@Serializable
+data class MavenArtifactResponse(
+    val artifactPattern: String,
+    val groupPattern: String,
+    val id: String,
+    val sortOrder: Int,
+    val classifier: String? = null,
+    val extension: String? = null,
+)
+
+/**
+ * Mirror of v4.json `PackageResponse`. Required: id, packageName, packageType, sortOrder.
+ */
+@Serializable
+data class PackageResponse(
+    val id: String,
+    val packageName: String,
+    val packageType: String,
+    val sortOrder: Int,
+)
+
+/**
+ * Mirror of v4.json `VcsEntryResponse`. Required: id, sortOrder, vcsPath.
+ */
+@Serializable
+data class VcsEntryResponse(
+    val id: String,
+    val sortOrder: Int,
+    val vcsPath: String,
+    val name: String? = null,
+    val repositoryType: String? = null,
+    val branch: String? = null,
+    val tag: String? = null,
+    val hotfixBranch: String? = null,
+)
+
+/**
+ * Mirror of v4.json `ComponentConfigurationResponse` — one configuration row (BASE/override/marker)
+ * of a component detail. `rowType` is the enum BASE|SCALAR_OVERRIDE|MARKER|RANGE_PRESENCE (String).
+ *
+ * Required per spec: buildToolBeans, dockerImages, fileUrlArtifacts, id, isSyntheticBase,
+ * mavenArtifacts, packages, requiredTools, rowType, vcsEntries, versionRange.
+ */
+@Serializable
+data class ComponentConfigurationResponse(
+    val id: String,
+    val isSyntheticBase: Boolean,
+    val rowType: String,
+    val versionRange: String,
+    val requiredTools: List<String>,
+    val buildToolBeans: List<BuildToolBeanResponse>,
+    val dockerImages: List<DockerImageResponse>,
+    val fileUrlArtifacts: List<FileUrlArtifactResponse>,
+    val mavenArtifacts: List<MavenArtifactResponse>,
+    val packages: List<PackageResponse>,
+    val vcsEntries: List<VcsEntryResponse>,
+    val build: BuildAspectResponse? = null,
+    val escrow: EscrowAspectResponse? = null,
+    val jira: JiraAspectResponse? = null,
+    val overriddenAttribute: String? = null,
+)
+
+/**
+ * Mirror of v4.json `ComponentDetailResponse` — the body returned by GET /rest/api/4/components/{id}
+ * (and on create). `createdAt`/`updatedAt` are ISO-8601 date-time strings; `version` is the optimistic
+ * lock counter (int64).
+ *
+ * Required per spec: archived, artifactIds, canBeParent, configurations, docs, id, labels, name,
+ * releaseManager, securityChampion, securityGroups, teamcityProjects, version.
+ */
+@Serializable
+data class ComponentDetailResponse(
+    val id: String,
+    val name: String,
+    val archived: Boolean,
+    val canBeParent: Boolean,
+    val version: Long,
+    val labels: List<String>,
+    val artifactIds: List<ArtifactIdResponse>,
+    val configurations: List<ComponentConfigurationResponse>,
+    val docs: List<DocLinkResponse>,
+    val releaseManager: List<String>,
+    val securityChampion: List<String>,
+    val securityGroups: List<SecurityGroupResponse>,
+    val teamcityProjects: List<TeamcityProjectResponse>,
+    val canEdit: Boolean? = null,
+    val clientCode: String? = null,
+    val componentOwner: String? = null,
+    val copyright: String? = null,
+    val createdAt: String? = null,
+    val displayName: String? = null,
+    val distributionExplicit: Boolean? = null,
+    val distributionExternal: Boolean? = null,
+    val group: ComponentGroupResponse? = null,
+    val jiraDisplayName: String? = null,
+    val jiraHotfixVersionFormat: String? = null,
+    val parentComponentName: String? = null,
+    val productType: String? = null,
+    val releasesInDefaultBranch: Boolean? = null,
+    val solution: Boolean? = null,
+    val system: String? = null,
+    val updatedAt: String? = null,
+    val vcsExternalRegistry: String? = null,
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Error.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Error.kt
@@ -1,0 +1,15 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Mirror of v4.json `ErrorResponse` — the structured error body returned on every non-2xx status.
+ *
+ * The spec marks only `errorMessage` as required; `errorCode` is optional. Both are surfaced so the
+ * core layer can render structured stderr errors.
+ */
+@Serializable
+data class ErrorResponse(
+    val errorMessage: String,
+    val errorCode: String? = null,
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/FieldOverride.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/FieldOverride.kt
@@ -1,0 +1,108 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Mirror of v4.json `MarkerChildrenPayload`.
+ *
+ * In the canon the nested item types are the *Request* shapes (the payload is symmetric for
+ * read/write), so this mirror reuses [BuildAspectResponse]-style request fields directly where they
+ * are structurally identical. Items below mirror the request item schemas faithfully. All optional.
+ */
+@Serializable
+data class MarkerChildrenPayload(
+    val buildToolBeans: List<BuildToolBeanItem>? = null,
+    val dockerImages: List<DockerImageItem>? = null,
+    val fileUrlArtifacts: List<FileUrlArtifactItem>? = null,
+    val mavenArtifacts: List<MavenArtifactItem>? = null,
+    val packages: List<PackageItem>? = null,
+    val requiredTools: List<String>? = null,
+    val vcsEntries: List<VcsEntryItem>? = null,
+)
+
+/**
+ * Mirror of v4.json `BuildToolBeanRequest` (used inside [MarkerChildrenPayload]). `beanType` required.
+ */
+@Serializable
+data class BuildToolBeanItem(
+    val beanType: String,
+    val edition: String? = null,
+    val settingsProperty: String? = null,
+    val toolType: String? = null,
+    val versionPattern: String? = null,
+)
+
+/**
+ * Mirror of v4.json `DockerImageRequest` (used inside [MarkerChildrenPayload]). `imageName` required.
+ */
+@Serializable
+data class DockerImageItem(
+    val imageName: String,
+    val flavor: String? = null,
+)
+
+/**
+ * Mirror of v4.json `FileUrlArtifactRequest` (used inside [MarkerChildrenPayload]). `url` required.
+ */
+@Serializable
+data class FileUrlArtifactItem(
+    val url: String,
+    val artifactId: String? = null,
+    val classifier: String? = null,
+)
+
+/**
+ * Mirror of v4.json `MavenArtifactRequest` (used inside [MarkerChildrenPayload]).
+ */
+@Serializable
+data class MavenArtifactItem(
+    val artifactPattern: String,
+    val groupPattern: String,
+    val classifier: String? = null,
+    val extension: String? = null,
+)
+
+/**
+ * Mirror of v4.json `PackageRequest` (used inside [MarkerChildrenPayload]).
+ */
+@Serializable
+data class PackageItem(
+    val packageName: String,
+    val packageType: String,
+)
+
+/**
+ * Mirror of v4.json `VcsEntryRequest` (used inside [MarkerChildrenPayload]). No required fields per
+ * the request schema; modelled all-nullable.
+ */
+@Serializable
+data class VcsEntryItem(
+    val name: String? = null,
+    val vcsPath: String? = null,
+    val repositoryType: String? = null,
+    val branch: String? = null,
+    val tag: String? = null,
+    val hotfixBranch: String? = null,
+)
+
+/**
+ * Mirror of v4.json `FieldOverrideResponse` — a single element of the array returned by
+ * GET /rest/api/4/components/{id}/field-overrides.
+ *
+ * `value` is a free-form spec `object`, modelled as a nullable [JsonElement]. `createdAt`/`updatedAt`
+ * are ISO-8601 date-time strings.
+ *
+ * Required per spec: id, overriddenAttribute, rowType, versionRange.
+ */
+@Serializable
+data class FieldOverrideResponse(
+    val id: String,
+    val overriddenAttribute: String,
+    val rowType: String,
+    val versionRange: String,
+    val value: JsonElement? = null,
+    val markerChildren: MarkerChildrenPayload? = null,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/FieldOverride.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/FieldOverride.kt
@@ -73,13 +73,13 @@ data class PackageItem(
 )
 
 /**
- * Mirror of v4.json `VcsEntryRequest` (used inside [MarkerChildrenPayload]). No required fields per
- * the request schema; modelled all-nullable.
+ * Mirror of v4.json `VcsEntryRequest` (used inside [MarkerChildrenPayload]). The canon marks
+ * `vcsPath` as required; the rest are optional.
  */
 @Serializable
 data class VcsEntryItem(
     val name: String? = null,
-    val vcsPath: String? = null,
+    val vcsPath: String,
     val repositoryType: String? = null,
     val branch: String? = null,
     val tag: String? = null,

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Meta.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Meta.kt
@@ -1,0 +1,43 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.Serializable
+
+// Meta endpoints under /rest/api/4/components/meta/*.
+//
+// Most meta + dictionary endpoints (build-systems, client-codes, escrow-generations, group-keys,
+// java-versions, jira-project-keys, labels, labels/dictionary, maven-versions, owners,
+// parent-component-names, repository-types, systems, systems/dictionary) return a bare JSON array of
+// strings and therefore decode directly to List<String> — no dedicated DTO is needed for those.
+//
+// The endpoints below return object schemas and so are mirrored as data classes.
+
+/**
+ * Mirror of v4.json `EmployeeMatchResponse` — one element of the array returned by
+ * GET /rest/api/4/components/meta/employees. Required: active, username.
+ */
+@Serializable
+data class EmployeeMatchResponse(
+    val username: String,
+    val active: Boolean,
+)
+
+/**
+ * Mirror of v4.json `EmployeeIntegrationHealthResponse` — body of
+ * GET /rest/api/4/components/meta/employees/health. `status` is the enum UP|DOWN|DISABLED (String).
+ * Required: status.
+ */
+@Serializable
+data class EmployeeIntegrationHealthResponse(
+    val status: String,
+)
+
+/**
+ * Mirror of v4.json `ComponentEditorsResponse` — body of
+ * GET /rest/api/4/components/{idOrName}/editors. Required: releaseManagers, securityChampions.
+ */
+@Serializable
+data class ComponentEditorsResponse(
+    val releaseManagers: List<String>,
+    val securityChampions: List<String>,
+    val componentOwner: String? = null,
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Models.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Models.kt
@@ -1,0 +1,14 @@
+// Mirror of v4.json — verify/regenerate against the canon on any contract change.
+//
+// All @Serializable data classes in this package are a faithful, hand-written mirror of the
+// schemas declared in:
+//   components-registry-service-server/src/main/resources/openapi/v4.json
+//
+// Conventions:
+//   - Required spec fields are non-nullable Kotlin properties.
+//   - Optional spec fields are nullable with a `= null` default.
+//   - @SerialName is applied only where the JSON key differs from the idiomatic Kotlin name.
+//   - Free-form JSON `object` values are modelled as kotlinx JsonElement / Map<String, JsonElement>.
+//   - The core layer owns the Json instance and MUST set ignoreUnknownKeys = true; these classes
+//     intentionally do not enumerate every server field (e.g. request-only schemas are omitted).
+package org.octopusden.octopus.components.registry.cli.model

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Page.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Page.kt
@@ -1,0 +1,65 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Mirror of v4.json `SortObject`.
+ */
+@Serializable
+data class SortObject(
+    val empty: Boolean? = null,
+    val sorted: Boolean? = null,
+    val unsorted: Boolean? = null,
+)
+
+/**
+ * Mirror of v4.json `PageableObject` (the resolved pageable echoed back in page responses).
+ */
+@Serializable
+data class PageableObject(
+    val offset: Long? = null,
+    val pageNumber: Int? = null,
+    val pageSize: Int? = null,
+    val paged: Boolean? = null,
+    val sort: SortObject? = null,
+    val unpaged: Boolean? = null,
+)
+
+/**
+ * Mirror of v4.json `PageComponentSummaryResponse` — the page envelope returned by
+ * GET /rest/api/4/components.
+ *
+ * The spec marks no property as required, so every field is nullable.
+ */
+@Serializable
+data class PageComponentSummaryResponse(
+    val content: List<ComponentSummaryResponse>? = null,
+    val empty: Boolean? = null,
+    val first: Boolean? = null,
+    val last: Boolean? = null,
+    val number: Int? = null,
+    val numberOfElements: Int? = null,
+    val pageable: PageableObject? = null,
+    val size: Int? = null,
+    val sort: SortObject? = null,
+    val totalElements: Long? = null,
+    val totalPages: Int? = null,
+)
+
+/**
+ * Mirror of v4.json `PageAuditLogResponse` — the page envelope returned by the audit endpoints.
+ */
+@Serializable
+data class PageAuditLogResponse(
+    val content: List<AuditLogResponse>? = null,
+    val empty: Boolean? = null,
+    val first: Boolean? = null,
+    val last: Boolean? = null,
+    val number: Int? = null,
+    val numberOfElements: Int? = null,
+    val pageable: PageableObject? = null,
+    val size: Int? = null,
+    val sort: SortObject? = null,
+    val totalElements: Long? = null,
+    val totalPages: Int? = null,
+)

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/output/OutputFormat.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/output/OutputFormat.kt
@@ -1,0 +1,21 @@
+package org.octopusden.octopus.components.registry.cli.output
+
+/**
+ * Output format selected via `-o` / `--output`. JSON is the machine-readable default; TABLE is a
+ * compact human view for list-shaped data.
+ */
+enum class OutputFormat {
+    JSON,
+    TABLE,
+    ;
+
+    companion object {
+        /** Parses a `-o` value case-insensitively; throws [IllegalArgumentException] on unknown. */
+        fun parse(value: String): OutputFormat =
+            when (value.trim().lowercase()) {
+                "json" -> JSON
+                "table" -> TABLE
+                else -> throw IllegalArgumentException("Unknown output format '$value' (expected: json, table)")
+            }
+    }
+}

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/output/Renderer.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/output/Renderer.kt
@@ -1,0 +1,68 @@
+package org.octopusden.octopus.components.registry.cli.output
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.octopusden.octopus.components.registry.cli.client.CrsApiException
+import org.octopusden.octopus.components.registry.cli.client.Json
+import org.octopusden.octopus.components.registry.cli.client.PrettyJson
+
+/**
+ * Renders command results to strings. The caller is responsible for the actual write to STDOUT /
+ * STDERR; keeping the rendering pure makes it trivially testable.
+ */
+object Renderer {
+
+    /** Pretty JSON for STDOUT. */
+    fun <T> renderJson(value: T, serializer: KSerializer<T>): String =
+        PrettyJson.encodeToString(serializer, value)
+
+    /**
+     * A simple fixed-width table for list-shaped data. [headers] names the columns; [rows] supplies
+     * one cell per column per row. Null cells render as an empty string. Columns are padded to the
+     * widest cell so output lines up. An empty [rows] renders just the header line.
+     */
+    fun renderTable(headers: List<String>, rows: List<List<String?>>): String {
+        val widths = IntArray(headers.size) { headers[it].length }
+        for (row in rows) {
+            for (i in headers.indices) {
+                val cell = row.getOrNull(i).orEmpty()
+                if (cell.length > widths[i]) {
+                    widths[i] = cell.length
+                }
+            }
+        }
+        val sb = StringBuilder()
+        appendRow(sb, headers, widths)
+        for (row in rows) {
+            val cells = headers.indices.map { row.getOrNull(it).orEmpty() }
+            appendRow(sb, cells, widths)
+        }
+        return sb.toString().trimEnd('\n')
+    }
+
+    private fun appendRow(sb: StringBuilder, cells: List<String>, widths: IntArray) {
+        val line = cells.indices.joinToString("  ") { i ->
+            cells[i].padEnd(widths[i])
+        }
+        sb.append(line.trimEnd()).append('\n')
+    }
+
+    /**
+     * Structured error JSON for STDERR. Shape is fixed: {"errorCode": <code or null>, "message": <msg>}.
+     * For [CrsApiException] the parsed errorCode/errorMessage are surfaced; for anything else the
+     * errorCode is null and the message is the throwable's message (or its class name as a fallback).
+     */
+    fun renderError(throwable: Throwable): String {
+        val (errorCode, message) = when (throwable) {
+            is CrsApiException -> throwable.errorCode to throwable.errorMessage
+            else -> null to (throwable.message ?: throwable::class.simpleName ?: "Unknown error")
+        }
+        val obj: JsonObject = buildJsonObject {
+            put("errorCode", if (errorCode == null) JsonPrimitive(null as String?) else JsonPrimitive(errorCode))
+            put("message", JsonPrimitive(message))
+        }
+        return Json.encodeToString(JsonObject.serializer(), obj)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/CrsctlTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/CrsctlTest.kt
@@ -1,0 +1,22 @@
+package org.octopusden.octopus.components.registry.cli
+
+import com.github.ajalt.clikt.testing.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CrsctlTest {
+    @Test
+    fun `help runs without throwing and prints the command name`() {
+        val result = Crsctl().test("--help")
+        assertEquals(0, result.statusCode)
+        assertTrue(result.output.contains("crsctl"), "help output should mention the command name")
+    }
+
+    @Test
+    fun `version flag reports the version`() {
+        val result = Crsctl().test("--version")
+        assertEquals(0, result.statusCode)
+        assertTrue(result.output.contains(Crsctl.VERSION), "version output should contain ${Crsctl.VERSION}")
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/AuthTestSupport.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/AuthTestSupport.kt
@@ -1,0 +1,103 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+import org.octopusden.octopus.components.registry.cli.client.HttpExchange
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Optional
+import javax.net.ssl.SSLSession
+
+/** Minimal in-memory HttpResponse<String> for the auth-layer fakes. */
+internal class FakeResponse(
+    private val status: Int,
+    private val body: String?,
+    private val req: HttpRequest,
+) : HttpResponse<String> {
+    override fun statusCode(): Int = status
+    override fun request(): HttpRequest = req
+    override fun previousResponse(): Optional<HttpResponse<String>> = Optional.empty()
+    override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+    override fun body(): String? = body
+    override fun sslSession(): Optional<SSLSession> = Optional.empty()
+    override fun uri(): java.net.URI = req.uri()
+    override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+}
+
+/** Replays the next queued (status, body) per call and records every request. */
+internal class QueueExchange(
+    private val replies: List<Pair<Int, String?>>,
+) : HttpExchange {
+    val requests = mutableListOf<HttpRequest>()
+    override fun send(request: HttpRequest): HttpResponse<String> {
+        requests += request
+        val (status, body) = replies[requests.size - 1]
+        return FakeResponse(status, body, request)
+    }
+
+    fun bodyOf(index: Int): String =
+        requests[index].bodyPublisher()
+            .map { publisher ->
+                val sub = StringBodySubscriber()
+                publisher.subscribe(sub)
+                sub.text
+            }
+            .orElse("")
+}
+
+/** Records every sleep so tests can assert the polling intervals without real waiting. */
+internal class RecordingSleeper : Sleeper {
+    val slept = mutableListOf<Long>()
+    override fun sleep(millis: Long) {
+        slept += millis
+    }
+}
+
+/** Records calls to a [CredentialStore] and holds an in-memory value. */
+internal class RecordingStore(initial: String? = null) : CredentialStore {
+    var value: String? = initial
+    val calls = mutableListOf<String>()
+    override fun load(): String? {
+        calls += "load"
+        return value
+    }
+
+    override fun save(refreshToken: String) {
+        calls += "save"
+        value = refreshToken
+    }
+
+    override fun clear() {
+        calls += "clear"
+        value = null
+    }
+}
+
+/** Records each `security` invocation and replies from a queue of canned [CommandResult]s. */
+internal class FakeCommandRunner(
+    private val results: List<CommandResult>,
+) : CommandRunner {
+    val invocations = mutableListOf<List<String>>()
+    override fun run(args: List<String>, stdin: String?): CommandResult {
+        invocations += args
+        return results[invocations.size - 1]
+    }
+}
+
+/** Drains an HTTP body publisher into a String so request form bodies can be asserted. */
+private class StringBodySubscriber : java.util.concurrent.Flow.Subscriber<java.nio.ByteBuffer> {
+    private val sb = StringBuilder()
+    val text: String get() = sb.toString()
+    override fun onSubscribe(subscription: java.util.concurrent.Flow.Subscription) {
+        subscription.request(Long.MAX_VALUE)
+    }
+
+    override fun onNext(item: java.nio.ByteBuffer) {
+        val bytes = ByteArray(item.remaining())
+        item.get(bytes)
+        sb.append(String(bytes, Charsets.UTF_8))
+    }
+
+    override fun onError(throwable: Throwable) = Unit
+    override fun onComplete() = Unit
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStoreTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStoreTest.kt
@@ -3,14 +3,13 @@ package org.octopusden.octopus.components.registry.cli.auth
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
  * Focused coverage of [KeychainCredentialStore]'s `security` CLI wiring: the hard-fail-on-nonzero
- * policy, the "item not found" (exit 44) special-casing, and — critically — that the secret travels
- * via STDIN and never on the argv (no `ps` exposure).
+ * policy, the "item not found" (exit 44) special-casing, and that the secret is written via the
+ * `-w <value>` argument (the only reliable non-interactive path; a bare `-w` would prompt on the tty).
  */
 class CredentialStoreTest {
 
@@ -32,15 +31,18 @@ class CredentialStoreTest {
     private fun fail() = CommandResult(1, "", "boom")
 
     @Test
-    fun `save passes the secret via stdin and never on the argv`() {
+    fun `save writes the secret as the -w argument non-interactively`() {
         val secret = "super-secret-refresh-token"
         val runner = RecordingRunner(listOf(ok()))
         KeychainCredentialStore(runner).save(secret)
 
         val argv = runner.argvs.single()
-        assertFalse(argv.contains(secret), "refresh token must NOT appear on the argv: $argv")
-        assertTrue(argv.contains("-w"), "a bare -w flag is expected so the secret is read from stdin")
-        assertEquals(secret, runner.stdins.single(), "the refresh token must be fed via stdin")
+        // `-w <value>` is required: a bare `-w` would prompt+retype on the tty and store nothing.
+        val wIndex = argv.indexOf("-w")
+        assertTrue(wIndex >= 0, "a -w flag is expected: $argv")
+        assertEquals(secret, argv.getOrNull(wIndex + 1), "the secret must be the value after -w")
+        assertTrue(argv.contains("-U"), "must update-in-place with -U")
+        assertNull(runner.stdins.single(), "no interactive stdin is used")
     }
 
     @Test

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStoreTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/CredentialStoreTest.kt
@@ -1,0 +1,81 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Focused coverage of [KeychainCredentialStore]'s `security` CLI wiring: the hard-fail-on-nonzero
+ * policy, the "item not found" (exit 44) special-casing, and — critically — that the secret travels
+ * via STDIN and never on the argv (no `ps` exposure).
+ */
+class CredentialStoreTest {
+
+    /** Records both argv and stdin per call so the secret's transport channel can be asserted. */
+    private class RecordingRunner(
+        private val results: List<CommandResult>,
+    ) : CommandRunner {
+        val argvs = mutableListOf<List<String>>()
+        val stdins = mutableListOf<String?>()
+        override fun run(args: List<String>, stdin: String?): CommandResult {
+            argvs += args
+            stdins += stdin
+            return results[argvs.size - 1]
+        }
+    }
+
+    private fun ok() = CommandResult(0, "", "")
+    private fun notFound() = CommandResult(KeychainCredentialStore.ITEM_NOT_FOUND, "", "not found")
+    private fun fail() = CommandResult(1, "", "boom")
+
+    @Test
+    fun `save passes the secret via stdin and never on the argv`() {
+        val secret = "super-secret-refresh-token"
+        val runner = RecordingRunner(listOf(ok()))
+        KeychainCredentialStore(runner).save(secret)
+
+        val argv = runner.argvs.single()
+        assertFalse(argv.contains(secret), "refresh token must NOT appear on the argv: $argv")
+        assertTrue(argv.contains("-w"), "a bare -w flag is expected so the secret is read from stdin")
+        assertEquals(secret, runner.stdins.single(), "the refresh token must be fed via stdin")
+    }
+
+    @Test
+    fun `save hard-fails on a non-zero exit`() {
+        val runner = RecordingRunner(listOf(fail()))
+        assertFailsWith<CredentialStoreException> { KeychainCredentialStore(runner).save("x") }
+    }
+
+    @Test
+    fun `load returns the trimmed secret on exit 0`() {
+        val runner = RecordingRunner(listOf(CommandResult(0, "the-token\n", "")))
+        assertEquals("the-token", KeychainCredentialStore(runner).load())
+    }
+
+    @Test
+    fun `load returns null on exit 44`() {
+        val runner = RecordingRunner(listOf(notFound()))
+        assertNull(KeychainCredentialStore(runner).load())
+    }
+
+    @Test
+    fun `load hard-fails on any other non-zero exit`() {
+        val runner = RecordingRunner(listOf(fail()))
+        assertFailsWith<CredentialStoreException> { KeychainCredentialStore(runner).load() }
+    }
+
+    @Test
+    fun `clear is idempotent on exit 0 and exit 44`() {
+        KeychainCredentialStore(RecordingRunner(listOf(ok()))).clear()
+        KeychainCredentialStore(RecordingRunner(listOf(notFound()))).clear()
+    }
+
+    @Test
+    fun `clear hard-fails on any other non-zero exit`() {
+        val runner = RecordingRunner(listOf(fail()))
+        assertFailsWith<CredentialStoreException> { KeychainCredentialStore(runner).clear() }
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/DeviceFlowClientTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/DeviceFlowClientTest.kt
@@ -1,0 +1,124 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class DeviceFlowClientTest {
+
+    private val issuer = "https://kc.example/realms/crs"
+    private val clientId = "crsctl-public"
+
+    @Test
+    fun `requestDeviceAuthorization parses response and posts client_id and scope`() {
+        val body = """
+            {"device_code":"DC","user_code":"WXYZ-1234","verification_uri":"https://kc.example/device",
+             "verification_uri_complete":"https://kc.example/device?user_code=WXYZ-1234",
+             "expires_in":600,"interval":5}
+        """.trimIndent()
+        val ex = QueueExchange(listOf(200 to body))
+        val client = DeviceFlowClient(exchange = ex, sleeper = RecordingSleeper())
+
+        val auth = client.requestDeviceAuthorization(issuer, clientId, "openid offline_access")
+
+        assertEquals("DC", auth.deviceCode)
+        assertEquals("WXYZ-1234", auth.userCode)
+        assertEquals("https://kc.example/device", auth.verificationUri)
+        assertEquals("https://kc.example/device?user_code=WXYZ-1234", auth.verificationUriComplete)
+        assertEquals(600, auth.expiresIn)
+        assertEquals(5, auth.interval)
+
+        val req = ex.requests.single()
+        assertTrue(req.uri().toString().endsWith("/protocol/openid-connect/auth/device"))
+        val form = ex.bodyOf(0)
+        assertTrue(form.contains("client_id=crsctl-public"), form)
+        assertTrue(form.contains("scope=openid+offline_access") || form.contains("scope=openid%20offline_access"), form)
+    }
+
+    @Test
+    fun `pollToken returns token after authorization_pending then success`() {
+        val pending = """{"error":"authorization_pending"}"""
+        val success = """{"access_token":"AT","refresh_token":"RT","expires_in":300,"token_type":"Bearer"}"""
+        val ex = QueueExchange(listOf(400 to pending, 200 to success))
+        val sleeper = RecordingSleeper()
+        val client = DeviceFlowClient(exchange = ex, sleeper = sleeper)
+
+        val token = client.pollToken(issuer, clientId, "DC", interval = 5, expiresInSeconds = 600)
+
+        assertEquals("AT", token.accessToken)
+        assertEquals("RT", token.refreshToken)
+        assertEquals(listOf(5000L), sleeper.slept, "one 5s wait between the pending and success polls")
+        assertEquals(2, ex.requests.size)
+        val form = ex.bodyOf(0)
+        assertTrue(form.contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"), form)
+        assertTrue(form.contains("device_code=DC"), form)
+    }
+
+    @Test
+    fun `pollToken increases interval by 5s on slow_down`() {
+        val slowDown = """{"error":"slow_down"}"""
+        val success = """{"access_token":"AT","refresh_token":"RT","expires_in":300,"token_type":"Bearer"}"""
+        val ex = QueueExchange(listOf(400 to slowDown, 200 to success))
+        val sleeper = RecordingSleeper()
+        val client = DeviceFlowClient(exchange = ex, sleeper = sleeper)
+
+        client.pollToken(issuer, clientId, "DC", interval = 5, expiresInSeconds = 600)
+
+        // 5s base + 5s slow_down bump = 10s wait.
+        assertEquals(listOf(10000L), sleeper.slept)
+    }
+
+    @Test
+    fun `pollToken aborts on expired_token`() {
+        val ex = QueueExchange(listOf(400 to """{"error":"expired_token"}"""))
+        val client = DeviceFlowClient(exchange = ex, sleeper = RecordingSleeper())
+        val e = assertFailsWith<DeviceFlowException> {
+            client.pollToken(issuer, clientId, "DC", interval = 5, expiresInSeconds = 600)
+        }
+        assertTrue(e.message!!.contains("expired"), e.message!!)
+    }
+
+    @Test
+    fun `pollToken aborts on access_denied`() {
+        val ex = QueueExchange(listOf(400 to """{"error":"access_denied"}"""))
+        val client = DeviceFlowClient(exchange = ex, sleeper = RecordingSleeper())
+        val e = assertFailsWith<DeviceFlowException> {
+            client.pollToken(issuer, clientId, "DC", interval = 5, expiresInSeconds = 600)
+        }
+        assertTrue(e.message!!.contains("denied"), e.message!!)
+    }
+
+    @Test
+    fun `refresh returns rotated refresh token`() {
+        val body = """{"access_token":"AT2","refresh_token":"RT2","expires_in":300,"token_type":"Bearer"}"""
+        val ex = QueueExchange(listOf(200 to body))
+        val client = DeviceFlowClient(exchange = ex, sleeper = RecordingSleeper())
+
+        val token = client.refresh(issuer, clientId, "RT1")
+
+        assertEquals("AT2", token.accessToken)
+        assertEquals("RT2", token.refreshToken)
+        val form = ex.bodyOf(0)
+        assertTrue(form.contains("grant_type=refresh_token"), form)
+        assertTrue(form.contains("refresh_token=RT1"), form)
+    }
+
+    @Test
+    fun `revoke returns true on 2xx and false on non-2xx`() {
+        val okEx = QueueExchange(listOf(200 to ""))
+        assertTrue(DeviceFlowClient(exchange = okEx, sleeper = RecordingSleeper()).revoke(issuer, clientId, "RT"))
+        val req = okEx.requests.single()
+        assertTrue(req.uri().toString().endsWith("/protocol/openid-connect/revoke"))
+        assertTrue(okEx.bodyOf(0).contains("token_type_hint=refresh_token"))
+
+        val failEx = QueueExchange(listOf(503 to ""))
+        assertEquals(false, DeviceFlowClient(exchange = failEx, sleeper = RecordingSleeper()).revoke(issuer, clientId, "RT"))
+    }
+
+    @Test
+    fun `scopeFor appends offline_access only when offline`() {
+        assertEquals("openid", DeviceFlowClient.scopeFor(false))
+        assertEquals("openid offline_access", DeviceFlowClient.scopeFor(true))
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/KeycloakIntegrationTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/KeycloakIntegrationTest.kt
@@ -1,0 +1,17 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+import org.junit.jupiter.api.Disabled
+import kotlin.test.Test
+
+/**
+ * Gated, end-to-end device-flow login against a real Keycloak issuer. Kept as a placeholder until the
+ * public device-flow client exists; the single method stays [Disabled] so the suite is green meanwhile.
+ */
+class KeycloakIntegrationTest {
+
+    @Test
+    @Disabled("gated on Keycloak Part C spike: needs the public device-flow client components-registry-cli")
+    fun deviceFlowLoginAgainstRealKeycloak() {
+        // TODO(spike): drive login against a real Keycloak issuer once the public client exists
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManagerTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManagerTest.kt
@@ -1,0 +1,52 @@
+package org.octopusden.octopus.components.registry.cli.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TokenManagerTest {
+
+    private val issuer = "https://kc.example/realms/crs"
+    private val clientId = "crsctl-public"
+
+    @Test
+    fun `empty store throws AuthRequiredException`() {
+        val store = RecordingStore(initial = null)
+        val tm = TokenManager(issuer, clientId, store, DeviceFlowClient(QueueExchange(emptyList()), RecordingSleeper()))
+        assertFailsWith<AuthRequiredException> { tm.accessToken() }
+        assertEquals(listOf("load"), store.calls, "must consult the store and stop, never hit the network")
+    }
+
+    @Test
+    fun `accessToken refreshes and persists the rotated refresh token`() {
+        val store = RecordingStore(initial = "RT1")
+        val body = """{"access_token":"AT","refresh_token":"RT2","expires_in":300,"token_type":"Bearer"}"""
+        val ex = QueueExchange(listOf(200 to body))
+        val tm = TokenManager(issuer, clientId, store, DeviceFlowClient(ex, RecordingSleeper()))
+
+        val at = tm.accessToken()
+
+        assertEquals("AT", at)
+        assertEquals("RT2", store.value, "rotated refresh token persisted")
+        assertEquals(listOf("load", "save"), store.calls)
+    }
+
+    @Test
+    fun `accessToken caches the token until near expiry`() {
+        val store = RecordingStore(initial = "RT1")
+        val body = """{"access_token":"AT","refresh_token":"RT1","expires_in":300,"token_type":"Bearer"}"""
+        // Only ONE reply queued: a second refresh would throw on the empty queue.
+        val ex = QueueExchange(listOf(200 to body))
+        var now = 0L
+        val tm = TokenManager(issuer, clientId, store, DeviceFlowClient(ex, RecordingSleeper()), nowMillis = { now })
+
+        val first = tm.accessToken()
+        now = 100_000 // well inside the 300s validity (minus 30s skew)
+        val second = tm.accessToken()
+
+        assertEquals(first, second)
+        assertEquals(1, ex.requests.size, "second call served from cache, no extra refresh")
+        // Same refresh token -> no save call.
+        assertEquals(listOf("load"), store.calls)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManagerTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/auth/TokenManagerTest.kt
@@ -46,7 +46,8 @@ class TokenManagerTest {
 
         assertEquals(first, second)
         assertEquals(1, ex.requests.size, "second call served from cache, no extra refresh")
-        // Same refresh token -> no save call.
-        assertEquals(listOf("load"), store.calls)
+        // A present refresh token is always persisted (save is idempotent); the cached second call
+        // does not refresh, so exactly one load+save pair is expected.
+        assertEquals(listOf("load", "save"), store.calls)
     }
 }

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClientTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClientTest.kt
@@ -78,6 +78,14 @@ class CrsClientTest {
     }
 
     @Test
+    fun `request carries a non-null timeout`() {
+        val exchange = CapturingExchange(200, "{}")
+        CrsClient("https://crs.example", exchange = exchange)
+            .getJson("/x", PageComponentSummaryResponse.serializer())
+        assertTrue(exchange.lastRequest!!.timeout().isPresent, "per-request timeout must be set")
+    }
+
+    @Test
     fun `non-2xx with ErrorResponse body throws CrsApiException with parsed fields`() {
         val errBody = """{"errorCode":"COMPONENT_NOT_FOUND","errorMessage":"No such component: zzz"}"""
         val exchange = CapturingExchange(404, errBody)

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClientTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/CrsClientTest.kt
@@ -1,0 +1,124 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import org.octopusden.octopus.components.registry.cli.model.ComponentSummaryResponse
+import org.octopusden.octopus.components.registry.cli.model.PageComponentSummaryResponse
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Optional
+import javax.net.ssl.SSLSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Minimal in-memory HttpResponse<String> for the fake seam. */
+private class FakeResponse(
+    private val status: Int,
+    private val body: String?,
+    private val req: HttpRequest,
+) : HttpResponse<String> {
+    override fun statusCode(): Int = status
+    override fun request(): HttpRequest = req
+    override fun previousResponse(): Optional<HttpResponse<String>> = Optional.empty()
+    override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+    override fun body(): String? = body
+    override fun sslSession(): Optional<SSLSession> = Optional.empty()
+    override fun uri(): java.net.URI = req.uri()
+    override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+}
+
+private class CapturingExchange(
+    private val status: Int,
+    private val body: String?,
+) : HttpExchange {
+    var lastRequest: HttpRequest? = null
+    override fun send(request: HttpRequest): HttpResponse<String> {
+        lastRequest = request
+        return FakeResponse(status, body, request)
+    }
+}
+
+class CrsClientTest {
+
+    @Test
+    fun `2xx json body is deserialized`() {
+        val json = """{"content":[{"id":"a","name":"A","archived":false,"canBeParent":true,"labels":[]}],"totalElements":1}"""
+        val exchange = CapturingExchange(200, json)
+        val client = CrsClient("https://crs.example/", token = null, exchange = exchange)
+
+        val page = client.getJson("/rest/api/4/components", PageComponentSummaryResponse.serializer())
+
+        assertEquals(1L, page.totalElements)
+        assertEquals(listOf(ComponentSummaryResponse("a", "A", false, true, emptyList())), page.content)
+    }
+
+    @Test
+    fun `bearer header set only when token present`() {
+        val withToken = CapturingExchange(200, "{}")
+        CrsClient("https://crs.example", token = "tok-123", exchange = withToken)
+            .getJson("/x", PageComponentSummaryResponse.serializer())
+        assertEquals("Bearer tok-123", withToken.lastRequest!!.headers().firstValue("Authorization").get())
+
+        val noToken = CapturingExchange(200, "{}")
+        CrsClient("https://crs.example", token = null, exchange = noToken)
+            .getJson("/x", PageComponentSummaryResponse.serializer())
+        assertTrue(noToken.lastRequest!!.headers().firstValue("Authorization").isEmpty)
+    }
+
+    @Test
+    fun `uri is built from base path and query`() {
+        val exchange = CapturingExchange(200, "{}")
+        val client = CrsClient("https://crs.example/", exchange = exchange)
+        val q = QueryParams.builder().pageable(page = 1, size = 10).build()
+        client.getJson("/rest/api/4/components", PageComponentSummaryResponse.serializer(), q)
+        assertEquals("https://crs.example/rest/api/4/components?page=1&size=10", exchange.lastRequest!!.uri().toString())
+    }
+
+    @Test
+    fun `non-2xx with ErrorResponse body throws CrsApiException with parsed fields`() {
+        val errBody = """{"errorCode":"COMPONENT_NOT_FOUND","errorMessage":"No such component: zzz"}"""
+        val exchange = CapturingExchange(404, errBody)
+        val client = CrsClient("https://crs.example", exchange = exchange)
+
+        val ex = assertFailsWith<CrsApiException> {
+            client.getJson("/rest/api/4/components/zzz", PageComponentSummaryResponse.serializer())
+        }
+        assertEquals(404, ex.httpStatus)
+        assertEquals("COMPONENT_NOT_FOUND", ex.errorCode)
+        assertEquals("No such component: zzz", ex.errorMessage)
+        assertEquals(ExitCode.NOT_FOUND, ExitCodes.fromThrowable(ex))
+    }
+
+    @Test
+    fun `401 throws so command layer can map to AUTH_REQUIRED`() {
+        val exchange = CapturingExchange(401, """{"errorMessage":"Authentication required"}""")
+        val client = CrsClient("https://crs.example", exchange = exchange)
+        val ex = assertFailsWith<CrsApiException> {
+            client.getJson("/auth/me", PageComponentSummaryResponse.serializer())
+        }
+        assertNull(ex.errorCode)
+        assertEquals(ExitCode.AUTH_REQUIRED, ExitCodes.fromThrowable(ex))
+    }
+
+    @Test
+    fun `non-2xx with non-json body still throws with fallback message`() {
+        val exchange = CapturingExchange(503, "<html>gateway down</html>")
+        val client = CrsClient("https://crs.example", exchange = exchange)
+        val ex = assertFailsWith<CrsApiException> {
+            client.getJson("/x", PageComponentSummaryResponse.serializer())
+        }
+        assertEquals(503, ex.httpStatus)
+        assertEquals("HTTP 503", ex.errorMessage)
+    }
+
+    @Test
+    fun `text endpoint returns raw body`() {
+        val exchange = CapturingExchange(200, "Component('x') { }")
+        val client = CrsClient("https://crs.example", exchange = exchange)
+        assertEquals("Component('x') { }", client.getText("/rest/api/4/components/x/as-code"))
+        assertEquals("text/plain", exchange.lastRequest!!.headers().firstValue("Accept").get())
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCodeTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCodeTest.kt
@@ -1,0 +1,44 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExitCodeTest {
+
+    @Test
+    fun `404 maps to NOT_FOUND`() {
+        assertEquals(ExitCode.NOT_FOUND, ExitCodes.fromThrowable(CrsApiException(404, null, "x")))
+    }
+
+    @Test
+    fun `401 and 403 map to AUTH_REQUIRED`() {
+        assertEquals(ExitCode.AUTH_REQUIRED, ExitCodes.fromThrowable(CrsApiException(401, null, "x")))
+        assertEquals(ExitCode.AUTH_REQUIRED, ExitCodes.fromThrowable(CrsApiException(403, null, "x")))
+    }
+
+    @Test
+    fun `5xx maps to SERVER`() {
+        assertEquals(ExitCode.SERVER, ExitCodes.fromThrowable(CrsApiException(500, null, "x")))
+        assertEquals(ExitCode.SERVER, ExitCodes.fromThrowable(CrsApiException(503, null, "x")))
+    }
+
+    @Test
+    fun `IOException maps to SERVER`() {
+        assertEquals(ExitCode.SERVER, ExitCodes.fromThrowable(IOException("connection refused")))
+    }
+
+    @Test
+    fun `config resolution failure maps to USAGE`() {
+        assertEquals(ExitCode.USAGE, ExitCodes.fromThrowable(ConfigResolutionException("no url")))
+    }
+
+    @Test
+    fun `numeric exit codes are pinned`() {
+        assertEquals(0, ExitCode.OK.code)
+        assertEquals(2, ExitCode.USAGE.code)
+        assertEquals(3, ExitCode.NOT_FOUND.code)
+        assertEquals(4, ExitCode.AUTH_REQUIRED.code)
+        assertEquals(5, ExitCode.SERVER.code)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCodeTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCodeTest.kt
@@ -8,6 +8,11 @@ import kotlin.test.assertEquals
 class ExitCodeTest {
 
     @Test
+    fun `400 maps to USAGE`() {
+        assertEquals(ExitCode.USAGE, ExitCodes.fromHttpStatus(400))
+    }
+
+    @Test
     fun `404 maps to NOT_FOUND`() {
         assertEquals(ExitCode.NOT_FOUND, ExitCodes.fromThrowable(CrsApiException(404, null, "x")))
     }

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCodeTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/ExitCodeTest.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.cli.client
 
+import org.octopusden.octopus.components.registry.cli.config.ConfigLoadException
 import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -31,6 +32,11 @@ class ExitCodeTest {
     @Test
     fun `config resolution failure maps to USAGE`() {
         assertEquals(ExitCode.USAGE, ExitCodes.fromThrowable(ConfigResolutionException("no url")))
+    }
+
+    @Test
+    fun `malformed config file maps to USAGE`() {
+        assertEquals(ExitCode.USAGE, ExitCodes.fromThrowable(ConfigLoadException("bad json")))
     }
 
     @Test

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/QueryParamsTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/client/QueryParamsTest.kt
@@ -1,0 +1,48 @@
+package org.octopusden.octopus.components.registry.cli.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class QueryParamsTest {
+
+    @Test
+    fun `omits null values`() {
+        val q = QueryParams.builder()
+            .add("present", "yes")
+            .add("absent", null)
+            .build()
+        assertEquals("present=yes", q.encode())
+    }
+
+    @Test
+    fun `empty builder produces empty query`() {
+        val q = QueryParams.builder().build()
+        assertTrue(q.isEmpty())
+        assertEquals("", q.encode())
+    }
+
+    @Test
+    fun `serializes page and size and repeats sort`() {
+        val q = QueryParams.builder()
+            .pageable(page = 2, size = 50, sort = listOf("name,asc", "id,desc"))
+            .build()
+        assertEquals("page=2&size=50&sort=name%2Casc&sort=id%2Cdesc", q.encode())
+    }
+
+    @Test
+    fun `pageable omits null page and size and skips null sort`() {
+        val q = QueryParams.builder()
+            .pageable(page = null, size = null, sort = null)
+            .build()
+        assertTrue(q.isEmpty())
+    }
+
+    @Test
+    fun `filters skip null values and encode spaces`() {
+        val q = QueryParams.builder()
+            .filters(mapOf("system" to "core service", "owner" to null, "archived" to false))
+            .build()
+        assertEquals("system=core%20service&archived=false", q.encode())
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CliMainTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CliMainTest.kt
@@ -1,0 +1,94 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import org.octopusden.octopus.components.registry.cli.CrsClientFactory
+import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.client.HttpExchange
+import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
+import org.octopusden.octopus.components.registry.cli.crsctl
+import org.octopusden.octopus.components.registry.cli.runCli
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers FIX 1: parse-time Clikt outcomes (--help / --version / usage errors) are mapped onto the
+ * crsctl exit-code contract instead of Clikt's own status codes / human-text behaviour.
+ */
+class CliMainTest {
+
+    private val neverExchange = HttpExchange { error("no HTTP call expected during parse-time tests") }
+
+    private fun cli() = crsctl(
+        configLoader = { CrsctlConfig.EMPTY },
+        clientFactory = CrsClientFactory { target -> CrsClient(target.crsUrl, target.token, neverExchange) },
+    )
+
+    /** Runs [block] with STDOUT captured; restores the original stream in a finally. */
+    private fun captureStdout(block: () -> Int): Pair<Int, String> {
+        val original = System.out
+        val buffer = ByteArrayOutputStream()
+        System.setOut(PrintStream(buffer, true, "UTF-8"))
+        return try {
+            val code = block()
+            code to buffer.toString("UTF-8")
+        } finally {
+            System.setOut(original)
+        }
+    }
+
+    /** Runs [block] with STDERR captured; restores the original stream in a finally. */
+    private fun captureStderr(block: () -> Int): Pair<Int, String> {
+        val original = System.err
+        val buffer = ByteArrayOutputStream()
+        System.setErr(PrintStream(buffer, true, "UTF-8"))
+        return try {
+            val code = block()
+            code to buffer.toString("UTF-8")
+        } finally {
+            System.setErr(original)
+        }
+    }
+
+    @Test
+    fun `--help exits 0 and prints usage to stdout`() {
+        val (code, out) = captureStdout { runCli(arrayOf("--help"), cli()) }
+        assertEquals(0, code)
+        assertTrue(out.contains("crsctl"), "help should name the program: $out")
+    }
+
+    @Test
+    fun `no subcommand exits 0`() {
+        // The root command renders help via its own echo and returns normally (no exception).
+        val (code, _) = captureStdout { runCli(arrayOf(), cli()) }
+        assertEquals(0, code)
+    }
+
+    @Test
+    fun `--version exits 0`() {
+        val (code, _) = captureStdout { runCli(arrayOf("--version"), cli()) }
+        assertEquals(0, code)
+    }
+
+    @Test
+    fun `missing required subcommand argument exits USAGE`() {
+        val (code, err) = captureStderr { runCli(arrayOf("component"), cli()) }
+        assertEquals(2, code)
+        assertTrue(err.contains("\"message\""), "structured error JSON expected on stderr: $err")
+    }
+
+    @Test
+    fun `invalid output choice exits USAGE`() {
+        val (code, _) = captureStderr {
+            runCli(arrayOf("components", "list", "-o", "bogus", "--crs-url=https://crs.example"), cli())
+        }
+        assertEquals(2, code)
+    }
+
+    @Test
+    fun `unknown command exits USAGE`() {
+        val (code, _) = captureStderr { runCli(arrayOf("totallyunknowncommand"), cli()) }
+        assertEquals(2, code)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CliMainTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CliMainTest.kt
@@ -5,6 +5,7 @@ import org.octopusden.octopus.components.registry.cli.client.CrsClient
 import org.octopusden.octopus.components.registry.cli.client.HttpExchange
 import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
 import org.octopusden.octopus.components.registry.cli.crsctl
+import org.octopusden.octopus.components.registry.cli.rewriteHelpArgs
 import org.octopusden.octopus.components.registry.cli.runCli
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
@@ -90,5 +91,55 @@ class CliMainTest {
     fun `unknown command exits USAGE`() {
         val (code, _) = captureStderr { runCli(arrayOf("totallyunknowncommand"), cli()) }
         assertEquals(2, code)
+    }
+
+    @Test
+    fun `bare help prints root help to stdout exit 0`() {
+        val (code, out) = captureStdout { runCli(arrayOf("help"), cli()) }
+        assertEquals(0, code)
+        assertTrue(out.contains("Commands:") && out.contains("components"), "root help expected: $out")
+    }
+
+    @Test
+    fun `help with a nested command prints that command's help exit 0`() {
+        val (code, out) = captureStdout { runCli(arrayOf("help", "components", "list"), cli()) }
+        assertEquals(0, code)
+        assertTrue(out.contains("components list") && out.contains("--archived"), "list help expected: $out")
+    }
+
+    @Test
+    fun `help preserves preceding global options`() {
+        val (code, out) = captureStdout { runCli(arrayOf("--env", "dev", "help", "meta"), cli()) }
+        assertEquals(0, code)
+        assertTrue(out.contains("employees"), "meta help expected: $out")
+    }
+
+    @Test
+    fun `help for an unknown command exits USAGE`() {
+        val (code, _) = captureStderr { runCli(arrayOf("help", "bogus"), cli()) }
+        assertEquals(2, code)
+    }
+
+    @Test
+    fun `help is listed in root help`() {
+        val (_, out) = captureStdout { runCli(arrayOf("--help"), cli()) }
+        assertTrue(Regex("(?m)^\\s*help\\b").containsMatchIn(out), "help command should be listed: $out")
+    }
+
+    @Test
+    fun `rewriteHelpArgs maps leading help onto --help at each depth`() {
+        assertEquals(listOf("--help"), rewriteHelpArgs(arrayOf("help")).toList())
+        assertEquals(listOf("components", "list", "--help"), rewriteHelpArgs(arrayOf("help", "components", "list")).toList())
+        // global options before the subcommand are preserved (both --opt value and --opt=value forms)
+        assertEquals(listOf("--env", "dev", "meta", "--help"), rewriteHelpArgs(arrayOf("--env", "dev", "help", "meta")).toList())
+        assertEquals(listOf("-o", "json", "--help"), rewriteHelpArgs(arrayOf("-o", "json", "help")).toList())
+        assertEquals(listOf("--crs-url=https://x", "--help"), rewriteHelpArgs(arrayOf("--crs-url=https://x", "help")).toList())
+    }
+
+    @Test
+    fun `rewriteHelpArgs leaves non-leading help untouched`() {
+        // `help` as an argument to a subcommand (not the subcommand slot) must NOT become help mode.
+        val args = arrayOf("component", "get", "help")
+        assertEquals(args.toList(), rewriteHelpArgs(args).toList())
     }
 }

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CliMainTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CliMainTest.kt
@@ -121,6 +121,28 @@ class CliMainTest {
     }
 
     @Test
+    fun `help for an unknown nested command exits USAGE`() {
+        val (code, err) = captureStderr { runCli(arrayOf("help", "components", "bogus"), cli()) }
+        assertEquals(2, code)
+        assertTrue(err.contains("no such command: components bogus"), "full path expected in error: $err")
+    }
+
+    @Test
+    fun `unknown global option before help is a usage error not help mode`() {
+        val (code, err) = captureStderr { runCli(arrayOf("--bogus", "help"), cli()) }
+        assertEquals(2, code)
+        assertTrue(err.contains("\"message\""), "structured error JSON expected on stderr: $err")
+    }
+
+    @Test
+    fun `helpTokenIndex ignores unknown options`() {
+        // unknown option before `help` -> not help mode (-1), so Clikt reports the bad option.
+        assertEquals(listOf("--bogus", "help"), rewriteHelpArgs(arrayOf("--bogus", "help")).toList())
+        // known flags/value-opts before `help` are still recognized.
+        assertEquals(listOf("-v", "meta", "--help"), rewriteHelpArgs(arrayOf("-v", "help", "meta")).toList())
+    }
+
+    @Test
     fun `help is listed in root help`() {
         val (_, out) = captureStdout { runCli(arrayOf("--help"), cli()) }
         assertTrue(Regex("(?m)^\\s*help\\b").containsMatchIn(out), "help command should be listed: $out")

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
@@ -173,6 +173,67 @@ class CommandsTest {
     }
 
     @Test
+    fun `component get happy path hits the components id path and renders`() {
+        val uuid = "33333333-3333-3333-3333-333333333333"
+        val detail = """{"id":"$uuid","name":"my-comp","archived":false,"canBeParent":false,"version":1,""" +
+            """"labels":[],"artifactIds":[],"configurations":[],"docs":[],"releaseManager":[],""" +
+            """"securityChampion":[],"securityGroups":[],"teamcityProjects":[],"componentOwner":"alice","system":"SYS"}"""
+        // Table render.
+        val tableEx = QueueExchange(listOf(200 to detail))
+        val table = cli(tableEx).test(listOf(URL, "component", "get", uuid))
+        assertEquals(0, table.statusCode, table.stderr)
+        assertEquals("/rest/api/4/components/$uuid", tableEx.requests.single().uri().path)
+        assertTrue(table.stdout.contains("FIELD"), "detail table header expected")
+        assertTrue(table.stdout.contains("my-comp"))
+
+        // JSON render.
+        val jsonEx = QueueExchange(listOf(200 to detail))
+        val json = cli(jsonEx).test(listOf(URL, "-o", "json", "component", "get", uuid))
+        assertEquals(0, json.statusCode, json.stderr)
+        assertTrue(json.stdout.contains("\"id\""))
+        assertTrue(json.stdout.contains(uuid))
+    }
+
+    @Test
+    fun `component as-code uses text-plain Accept and passes the body through verbatim`() {
+        val raw = "component(\"my-comp\") {\n    owner \"alice\"\n}\n"
+        val ex = QueueExchange(listOf(200 to raw))
+        val result = cli(ex).test(listOf(URL, "component", "as-code", "my-comp"))
+        assertEquals(0, result.statusCode, result.stderr)
+        val request = ex.requests.single()
+        assertTrue(request.uri().path.endsWith("/components/my-comp/as-code"))
+        assertEquals("text/plain", request.headers().firstValue("Accept").orElse(""))
+        assertTrue(result.stdout.contains("component(\"my-comp\")"), "raw body must pass through: ${result.stdout}")
+        assertTrue(result.stdout.contains("owner \"alice\""))
+    }
+
+    @Test
+    fun `component get percent-encodes a name with a space in the path`() {
+        val detail = """{"id":"x","name":"my comp","archived":false,"canBeParent":false,"version":1,""" +
+            """"labels":[],"artifactIds":[],"configurations":[],"docs":[],"releaseManager":[],""" +
+            """"securityChampion":[],"securityGroups":[],"teamcityProjects":[]}"""
+        val ex = QueueExchange(listOf(200 to detail))
+        // A raw space would make URI.create throw; if encoding works the call succeeds (exit 0).
+        val result = cli(ex).test(listOf(URL, "component", "get", "my comp"))
+        assertEquals(0, result.statusCode, result.stderr)
+        val uri = ex.requests.single().uri()
+        assertTrue(uri.rawPath.contains("%20"), "space must be percent-encoded in the path: ${uri.rawPath}")
+        assertTrue(uri.rawPath.endsWith("/components/my%20comp"))
+    }
+
+    @Test
+    fun `components list --all stops after totalPages even when last is never true`() {
+        // A misbehaving server: always last=false, but reports totalPages=2. The single reply is
+        // reused for every call, so without the totalPages guard this would loop forever.
+        val page = """{"content":[{"id":"1","name":"A","archived":false,"canBeParent":false,"labels":[]}],""" +
+            """"last":false,"totalPages":2}"""
+        val ex = QueueExchange(listOf(200 to page))
+        val result = cli(ex).test(listOf(URL, "components", "list", "--all"))
+        assertEquals(0, result.statusCode, result.stderr)
+        assertEquals(2, ex.requests.size, "must stop after totalPages=2 fetches")
+    }
+
+    @Test
     fun `meta employees 401 maps to AUTH_REQUIRED`() {
         val ex = QueueExchange(listOf(401 to """{"errorMessage":"login required"}"""))
         val result = cli(ex).test(listOf(URL, "meta", "employees", "--search", "ali"))

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
@@ -1,0 +1,201 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.testing.test
+import org.octopusden.octopus.components.registry.cli.CrsClientFactory
+import org.octopusden.octopus.components.registry.cli.client.CrsClient
+import org.octopusden.octopus.components.registry.cli.client.HttpExchange
+import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
+import org.octopusden.octopus.components.registry.cli.crsctl
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Optional
+import javax.net.ssl.SSLSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Minimal in-memory HttpResponse<String>. */
+private class FakeResponse(
+    private val status: Int,
+    private val body: String?,
+    private val req: HttpRequest,
+) : HttpResponse<String> {
+    override fun statusCode(): Int = status
+    override fun request(): HttpRequest = req
+    override fun previousResponse(): Optional<HttpResponse<String>> = Optional.empty()
+    override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+    override fun body(): String? = body
+    override fun sslSession(): Optional<SSLSession> = Optional.empty()
+    override fun uri(): java.net.URI = req.uri()
+    override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+}
+
+/**
+ * Fake exchange that replies with the next queued (status, body) per call and records every request.
+ * A single queued reply is reused for all calls (handy for the "one canned response" cases).
+ */
+private class QueueExchange(
+    private val replies: List<Pair<Int, String?>>,
+) : HttpExchange {
+    val requests = mutableListOf<HttpRequest>()
+    override fun send(request: HttpRequest): HttpResponse<String> {
+        requests += request
+        val (status, body) = if (replies.size == 1) replies[0] else replies[requests.size - 1]
+        return FakeResponse(status, body, request)
+    }
+}
+
+/** Builds the CLI wired to [exchange], with an empty config and a fixed CRS URL flag in args. */
+private fun cli(exchange: QueueExchange) =
+    crsctl(
+        configLoader = { CrsctlConfig.EMPTY },
+        clientFactory = CrsClientFactory { target -> CrsClient(target.crsUrl, target.token, exchange) },
+    )
+
+private const val URL = "--crs-url=https://crs.example"
+
+class CommandsTest {
+
+    @Test
+    fun `components list maps filter options to spec query params`() {
+        val page = """{"content":[],"last":true}"""
+        val ex = QueueExchange(listOf(200 to page))
+        val result = cli(ex).test(
+            listOf(
+                URL, "components", "list",
+                "--search", "foo",
+                "--owner", "alice", "--owner", "bob",
+                "--system", "SYS",
+                "--product-type", "LIB",
+                "--build-system", "GRADLE",
+                "--label", "core",
+                "--client-code", "C1",
+                "--solution", "true",
+                "--jira-project-key", "ABC",
+                "--jira-technical", "false",
+                "--vcs-path", "/git/x",
+                "--production-branch", "main",
+                "--parent", "root",
+                "--group-key", "g1",
+                "--archived", "false",
+                "--can-be-parent", "true",
+                "--distribution-explicit", "true",
+                "--distribution-external", "false",
+                "--page", "2", "--size", "50", "--sort", "name,asc",
+            ),
+        )
+        assertEquals(0, result.statusCode, result.stderr)
+        // rawQuery preserves percent-encoding; uri().query would decode %2F/%2C back to /,
+        // hiding the wire-format the server actually receives.
+        val q = ex.requests.single().uri().rawQuery
+        // CLI kebab -> spec param-name mapping.
+        assertTrue(q.contains("search=foo"))
+        assertTrue(q.contains("owner=alice"))
+        assertTrue(q.contains("owner=bob"))
+        assertTrue(q.contains("system=SYS"))
+        assertTrue(q.contains("productType=LIB"))
+        assertTrue(q.contains("buildSystem=GRADLE"))
+        assertTrue(q.contains("labels=core"), "label option must map to spec 'labels': $q")
+        assertTrue(q.contains("clientCode=C1"))
+        assertTrue(q.contains("solution=true"))
+        assertTrue(q.contains("jiraProjectKey=ABC"))
+        assertTrue(q.contains("jiraTechnical=false"))
+        assertTrue(q.contains("vcsPath=%2Fgit%2Fx"))
+        assertTrue(q.contains("productionBranch=main"))
+        assertTrue(q.contains("parentComponentName=root"), "parent must map to spec 'parentComponentName': $q")
+        assertTrue(q.contains("groupKey=g1"))
+        assertTrue(q.contains("archived=false"))
+        assertTrue(q.contains("canBeParent=true"))
+        assertTrue(q.contains("distributionExplicit=true"))
+        assertTrue(q.contains("distributionExternal=false"))
+        assertTrue(q.contains("page=2"))
+        assertTrue(q.contains("size=50"))
+        assertTrue(q.contains("sort=name%2Casc"))
+    }
+
+    @Test
+    fun `components list --all paginates until last and accumulates`() {
+        val p0 = """{"content":[{"id":"1","name":"A","archived":false,"canBeParent":false,"labels":[]}],"last":false}"""
+        val p1 = """{"content":[{"id":"2","name":"B","archived":false,"canBeParent":false,"labels":[]}],"last":true}"""
+        val ex = QueueExchange(listOf(200 to p0, 200 to p1))
+        val result = cli(ex).test(listOf(URL, "components", "list", "--all"))
+        assertEquals(0, result.statusCode, result.stderr)
+        assertEquals(2, ex.requests.size, "exactly two page fetches expected")
+        assertEquals("page=0", ex.requests[0].uri().query)
+        assertEquals("page=1", ex.requests[1].uri().query)
+        assertTrue(result.stdout.contains("1"))
+        assertTrue(result.stdout.contains("2"))
+    }
+
+    @Test
+    fun `components list renders table by default and json on -o json`() {
+        val page = """{"content":[{"id":"1","name":"A","archived":false,"canBeParent":false,""" +
+            """"labels":[],"componentOwner":"alice","system":"SYS"}],"last":true}"""
+        val tableEx = QueueExchange(listOf(200 to page))
+        val table = cli(tableEx).test(listOf(URL, "components", "list"))
+        assertEquals(0, table.statusCode, table.stderr)
+        assertTrue(table.stdout.contains("ID"), "table header expected")
+        assertTrue(table.stdout.contains("alice"))
+
+        val jsonEx = QueueExchange(listOf(200 to page))
+        val json = cli(jsonEx).test(listOf(URL, "-o", "json", "components", "list"))
+        assertEquals(0, json.statusCode, json.stderr)
+        assertTrue(json.stdout.trimStart().startsWith("["), "json array expected: ${json.stdout}")
+        assertTrue(json.stdout.contains("\"id\""))
+    }
+
+    @Test
+    fun `component overrides resolves name to uuid then calls field-overrides`() {
+        val uuid = "11111111-1111-1111-1111-111111111111"
+        val detail = """{"id":"$uuid","name":"my-comp","archived":false,"canBeParent":false,"version":1,""" +
+            """"labels":[],"artifactIds":[],"configurations":[],"docs":[],"releaseManager":[],""" +
+            """"securityChampion":[],"securityGroups":[],"teamcityProjects":[]}"""
+        val overrides = """[{"id":"o1","overriddenAttribute":"build","rowType":"SCALAR_OVERRIDE","versionRange":"[1,2)"}]"""
+        val ex = QueueExchange(listOf(200 to detail, 200 to overrides))
+        val result = cli(ex).test(listOf(URL, "component", "overrides", "my-comp"))
+        assertEquals(0, result.statusCode, result.stderr)
+        assertEquals(2, ex.requests.size)
+        assertTrue(ex.requests[0].uri().path.endsWith("/components/my-comp"))
+        assertTrue(ex.requests[1].uri().path.endsWith("/components/$uuid/field-overrides"))
+    }
+
+    @Test
+    fun `component overrides with uuid skips resolve`() {
+        val uuid = "22222222-2222-2222-2222-222222222222"
+        val overrides = """[]"""
+        val ex = QueueExchange(listOf(200 to overrides))
+        val result = cli(ex).test(listOf(URL, "component", "overrides", uuid))
+        assertEquals(0, result.statusCode, result.stderr)
+        assertEquals(1, ex.requests.size, "no resolve lookup expected for a UUID arg")
+        assertTrue(ex.requests.single().uri().path.endsWith("/components/$uuid/field-overrides"))
+    }
+
+    @Test
+    fun `meta employees 401 maps to AUTH_REQUIRED`() {
+        val ex = QueueExchange(listOf(401 to """{"errorMessage":"login required"}"""))
+        val result = cli(ex).test(listOf(URL, "meta", "employees", "--search", "ali"))
+        assertEquals(4, result.statusCode, "AUTH_REQUIRED exit code expected")
+        assertTrue(ex.requests.single().uri().query.contains("search=ali"))
+    }
+
+    @Test
+    fun `whoami without token prints static line and makes no http call`() {
+        val ex = QueueExchange(listOf(500 to "should not be called"))
+        val result = cli(ex).test(listOf(URL, "whoami"))
+        assertEquals(0, result.statusCode, result.stderr)
+        assertEquals(0, ex.requests.size, "whoami without token must not hit the network")
+        assertTrue(result.stdout.contains("anonymous; for current CRS versions ACCESS_COMPONENTS is implied"))
+    }
+
+    @Test
+    fun `meta owners returns string list as table`() {
+        val ex = QueueExchange(listOf(200 to """["alice","bob"]"""))
+        val result = cli(ex).test(listOf(URL, "meta", "owners"))
+        assertEquals(0, result.statusCode, result.stderr)
+        assertTrue(ex.requests.single().uri().path.endsWith("/components/meta/owners"))
+        assertTrue(result.stdout.contains("alice"))
+        assertTrue(result.stdout.contains("bob"))
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
@@ -251,6 +251,122 @@ class CommandsTest {
     }
 
     @Test
+    fun `audit recent maps filter options to spec query params and pageable`() {
+        val page = """{"content":[],"last":true}"""
+        val ex = QueueExchange(listOf(200 to page))
+        val result = cli(ex).test(
+            listOf(
+                URL, "--token=tok", "audit", "recent",
+                "--entity-type", "COMPONENT",
+                "--entity-id", "abc",
+                "--changed-by", "alice",
+                "--action", "UPDATE",
+                "--source", "PORTAL",
+                "--from", "2026-06-01T00:00:00Z",
+                "--to", "2026-06-14T00:00:00Z",
+                "--include-migrated", "true",
+                "--page", "1", "--size", "25", "--sort", "changedAt,desc",
+            ),
+        )
+        assertEquals(0, result.statusCode, result.stderr)
+        val request = ex.requests.single()
+        assertTrue(request.uri().path.endsWith("/rest/api/4/audit/recent"))
+        // rawQuery preserves percent-encoding for the wire-format the server receives.
+        val q = request.uri().rawQuery
+        assertTrue(q.contains("entityType=COMPONENT"), "entity-type must map to spec 'entityType': $q")
+        assertTrue(q.contains("entityId=abc"), "entity-id must map to spec 'entityId': $q")
+        assertTrue(q.contains("changedBy=alice"), "changed-by must map to spec 'changedBy': $q")
+        assertTrue(q.contains("action=UPDATE"))
+        assertTrue(q.contains("source=PORTAL"))
+        assertTrue(q.contains("from=2026-06-01T00%3A00%3A00Z"), "from must be sent percent-encoded: $q")
+        assertTrue(q.contains("to=2026-06-14T00%3A00%3A00Z"))
+        assertTrue(q.contains("includeMigrated=true"), "include-migrated must map to spec 'includeMigrated': $q")
+        assertTrue(q.contains("page=1"))
+        assertTrue(q.contains("size=25"))
+        assertTrue(q.contains("sort=changedAt%2Cdesc"))
+    }
+
+    @Test
+    fun `audit recent omits include-migrated when not given`() {
+        val ex = QueueExchange(listOf(200 to """{"content":[],"last":true}"""))
+        val result = cli(ex).test(listOf(URL, "--token=tok", "audit", "recent"))
+        assertEquals(0, result.statusCode, result.stderr)
+        val q = ex.requests.single().uri().rawQuery ?: ""
+        assertTrue(!q.contains("includeMigrated"), "include-migrated must be omitted when not passed: $q")
+    }
+
+    @Test
+    fun `audit history builds the entityType entityId path with encoded segments and pageable`() {
+        val ex = QueueExchange(listOf(200 to """{"content":[],"last":true}"""))
+        val result = cli(ex).test(
+            listOf(
+                URL, "--token=tok", "audit", "history", "COMPONENT TYPE", "id/with slash",
+                "--include-migrated", "false", "--page", "0", "--size", "10", "--sort", "changedAt,asc",
+            ),
+        )
+        assertEquals(0, result.statusCode, result.stderr)
+        val uri = ex.requests.single().uri()
+        // Both path segments must be percent-encoded (space -> %20, slash -> %2F) so they stay single segments.
+        assertTrue(
+            uri.rawPath.endsWith("/rest/api/4/audit/COMPONENT%20TYPE/id%2Fwith%20slash"),
+            "encoded entity path expected: ${uri.rawPath}",
+        )
+        val q = uri.rawQuery
+        assertTrue(q.contains("includeMigrated=false"))
+        assertTrue(q.contains("page=0"))
+        assertTrue(q.contains("size=10"))
+        assertTrue(q.contains("sort=changedAt%2Casc"))
+    }
+
+    @Test
+    fun `audit recent renders table by default and json on -o json`() {
+        val page = """{"content":[{"id":1,"action":"UPDATE","entityType":"COMPONENT",""" +
+            """"entityId":"abc","changedAt":"2026-06-14T00:00:00Z","source":"PORTAL","changedBy":"alice"}],""" +
+            """"last":true}"""
+        val tableEx = QueueExchange(listOf(200 to page))
+        val table = cli(tableEx).test(listOf(URL, "--token=tok", "audit", "recent"))
+        assertEquals(0, table.statusCode, table.stderr)
+        assertTrue(table.stdout.contains("CHANGED_AT"), "table header expected: ${table.stdout}")
+        assertTrue(table.stdout.contains("UPDATE"))
+        assertTrue(table.stdout.contains("alice"))
+
+        val jsonEx = QueueExchange(listOf(200 to page))
+        val json = cli(jsonEx).test(listOf(URL, "--token=tok", "-o", "json", "audit", "recent"))
+        assertEquals(0, json.statusCode, json.stderr)
+        assertTrue(json.stdout.trimStart().startsWith("["), "json array expected: ${json.stdout}")
+        assertTrue(json.stdout.contains("\"action\""))
+    }
+
+    @Test
+    fun `audit recent attaches a bearer token on the outgoing request`() {
+        val ex = QueueExchange(listOf(200 to """{"content":[],"last":true}"""))
+        val result = cli(ex).test(listOf(URL, "--token=secret-tok", "audit", "recent"))
+        assertEquals(0, result.statusCode, result.stderr)
+        val auth = ex.requests.single().headers().firstValue("Authorization").orElse("")
+        assertEquals("Bearer secret-tok", auth, "audit must send the bearer token")
+    }
+
+    @Test
+    fun `audit recent without any credential exits AUTH_REQUIRED and makes no http call`() {
+        val ex = QueueExchange(listOf(500 to "should not be called"))
+        val result = cli(ex).test(listOf(URL, "audit", "recent"))
+        assertEquals(4, result.statusCode, "AUTH_REQUIRED exit code expected: ${result.stderr}")
+        assertEquals(0, ex.requests.size, "no HTTP call must be made when there is no credential")
+        assertTrue(
+            result.stderr.contains("audit requires `crsctl login` and the ACCESS_AUDIT permission"),
+            "clear no-credential message expected: ${result.stderr}",
+        )
+    }
+
+    @Test
+    fun `audit history without any credential exits AUTH_REQUIRED and makes no http call`() {
+        val ex = QueueExchange(listOf(500 to "should not be called"))
+        val result = cli(ex).test(listOf(URL, "audit", "history", "COMPONENT", "abc"))
+        assertEquals(4, result.statusCode, "AUTH_REQUIRED exit code expected: ${result.stderr}")
+        assertEquals(0, ex.requests.size, "no HTTP call must be made when there is no credential")
+    }
+
+    @Test
     fun `meta owners returns string list as table`() {
         val ex = QueueExchange(listOf(200 to """["alice","bob"]"""))
         val result = cli(ex).test(listOf(URL, "meta", "owners"))

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
@@ -236,9 +236,30 @@ class CommandsTest {
     @Test
     fun `meta employees 401 maps to AUTH_REQUIRED`() {
         val ex = QueueExchange(listOf(401 to """{"errorMessage":"login required"}"""))
-        val result = cli(ex).test(listOf(URL, "meta", "employees", "--search", "ali"))
+        val result = cli(ex).test(listOf(URL, "--token=tok", "meta", "employees", "--search", "ali"))
         assertEquals(4, result.statusCode, "AUTH_REQUIRED exit code expected")
         assertTrue(ex.requests.single().uri().query.contains("search=ali"))
+    }
+
+    @Test
+    fun `meta employees without any credential exits AUTH_REQUIRED and makes no http call`() {
+        val ex = QueueExchange(listOf(500 to "should not be called"))
+        val result = cli(ex).test(listOf(URL, "meta", "employees", "--search", "x"))
+        assertEquals(4, result.statusCode, "AUTH_REQUIRED exit code expected: ${result.stderr}")
+        assertEquals(0, ex.requests.size, "no HTTP call must be made when there is no credential")
+        assertTrue(
+            result.stderr.contains("this command requires authentication"),
+            "clear no-credential message expected: ${result.stderr}",
+        )
+    }
+
+    @Test
+    fun `meta employees attaches a bearer token on the outgoing request`() {
+        val ex = QueueExchange(listOf(200 to "[]"))
+        val result = cli(ex).test(listOf(URL, "--token=tok", "meta", "employees", "--search", "x"))
+        assertEquals(0, result.statusCode, result.stderr)
+        val auth = ex.requests.single().headers().firstValue("Authorization").orElse("")
+        assertEquals("Bearer tok", auth, "meta employees must send the bearer token")
     }
 
     @Test
@@ -362,7 +383,7 @@ class CommandsTest {
         assertEquals(4, result.statusCode, "AUTH_REQUIRED exit code expected: ${result.stderr}")
         assertEquals(0, ex.requests.size, "no HTTP call must be made when there is no credential")
         assertTrue(
-            result.stderr.contains("audit requires `crsctl login` and the ACCESS_AUDIT permission"),
+            result.stderr.contains("this command requires authentication"),
             "clear no-credential message expected: ${result.stderr}",
         )
     }

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
@@ -251,6 +251,15 @@ class CommandsTest {
     }
 
     @Test
+    fun `whoami with no url configured still reports anonymous out of the box`() {
+        val ex = QueueExchange(listOf(500 to "should not be called"))
+        val result = cli(ex).test(listOf("whoami"))
+        assertEquals(0, result.statusCode, result.stderr)
+        assertEquals(0, ex.requests.size, "anonymous whoami must not hit the network")
+        assertTrue(result.stdout.contains("anonymous; for current CRS versions ACCESS_COMPONENTS is implied"))
+    }
+
+    @Test
     fun `audit recent maps filter options to spec query params and pageable`() {
         val page = """{"content":[],"last":true}"""
         val ex = QueueExchange(listOf(200 to page))

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/LogoutTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/LogoutTest.kt
@@ -1,0 +1,59 @@
+package org.octopusden.octopus.components.registry.cli.commands
+
+import com.github.ajalt.clikt.testing.test
+import org.octopusden.octopus.components.registry.cli.auth.CommandResult
+import org.octopusden.octopus.components.registry.cli.auth.CommandRunner
+import org.octopusden.octopus.components.registry.cli.config.CrsctlConfig
+import org.octopusden.octopus.components.registry.cli.crsctl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `crsctl logout` must ALWAYS clear the locally stored refresh token, even when the OIDC config
+ * needed for server-side revocation is missing/broken (otherwise deleting the config would strand a
+ * token on disk forever). Driven through the full command tree with a fake `security` runner and an
+ * EMPTY config (so OIDC resolution fails).
+ */
+class LogoutTest {
+
+    /** Fakes the `security` CLI: load returns a stored token; records whether delete was invoked. */
+    private class KeychainRunner : CommandRunner {
+        var deleteCalled = false
+        override fun run(args: List<String>, stdin: String?): CommandResult = when {
+            args.contains("find-generic-password") -> CommandResult(0, "stored-refresh-token\n", "")
+            args.contains("delete-generic-password") -> {
+                deleteCalled = true
+                CommandResult(0, "", "")
+            }
+            else -> CommandResult(0, "", "")
+        }
+    }
+
+    @Test
+    fun `logout clears the local token even when OIDC config is missing`() {
+        val runner = KeychainRunner()
+        // EMPTY config + no --env -> resolveOidcConfig() throws; the token must still be cleared.
+        val result = crsctl(configLoader = { CrsctlConfig.EMPTY }, commandRunner = runner).test(listOf("logout"))
+
+        assertEquals(0, result.statusCode, result.stderr)
+        assertTrue(runner.deleteCalled, "the stored refresh token must be cleared even without OIDC config")
+        assertTrue(
+            result.stderr.contains("clearing local credentials anyway"),
+            "a best-effort warning is expected on stderr: ${result.stderr}",
+        )
+    }
+
+    @Test
+    fun `logout with no stored token is a clean no-op`() {
+        val runner = object : CommandRunner {
+            override fun run(args: List<String>, stdin: String?): CommandResult =
+                // exit 44 = item-not-found -> store.load() returns null.
+                CommandResult(44, "", "not found")
+        }
+        val result = crsctl(configLoader = { CrsctlConfig.EMPTY }, commandRunner = runner).test(listOf("logout"))
+
+        assertEquals(0, result.statusCode, result.stderr)
+        assertTrue(result.stdout.contains("Already logged out"), result.stdout)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/config/ConfigLoaderTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/config/ConfigLoaderTest.kt
@@ -1,0 +1,56 @@
+package org.octopusden.octopus.components.registry.cli.config
+
+import java.nio.file.Files
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class ConfigLoaderTest {
+
+    @Test
+    fun `missing config file is tolerated`() {
+        val absent = Files.createTempDirectory("crsctl-cfg").resolve("does-not-exist.json")
+        assertSame(CrsctlConfig.EMPTY, ConfigLoader.load(absent))
+    }
+
+    @Test
+    fun `blank config file yields empty`() {
+        val file = Files.createTempFile("crsctl-cfg", ".json")
+        file.writeText("   ")
+        assertSame(CrsctlConfig.EMPTY, ConfigLoader.load(file))
+    }
+
+    @Test
+    fun `valid config parses profiles and default`() {
+        val file = Files.createTempFile("crsctl-cfg", ".json")
+        file.writeText(
+            """
+            {
+              "defaultProfile": "qa",
+              "profiles": {
+                "qa": { "crsUrl": "https://qa.crs", "clientId": "crsctl" }
+              }
+            }
+            """.trimIndent(),
+        )
+        val config = ConfigLoader.load(file)
+        assertEquals("qa", config.defaultProfile)
+        assertEquals("https://qa.crs", config.profiles["qa"]?.crsUrl)
+        assertEquals("crsctl", config.profiles["qa"]?.clientId)
+    }
+
+    @Test
+    fun `malformed config file throws`() {
+        val file = Files.createTempFile("crsctl-cfg", ".json")
+        file.writeText("{ not json")
+        assertFailsWith<ConfigLoadException> { ConfigLoader.load(file) }
+    }
+
+    @Test
+    fun `config dir is non-empty and ends with crsctl`() {
+        assertTrue(ConfigLoader.configDir().endsWith("crsctl"))
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolverTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolverTest.kt
@@ -1,0 +1,79 @@
+package org.octopusden.octopus.components.registry.cli.config
+
+import org.octopusden.octopus.components.registry.cli.client.ConfigResolutionException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class TargetResolverTest {
+
+    private val config = CrsctlConfig(
+        defaultProfile = "qa",
+        profiles = mapOf(
+            "qa" to Profile(crsUrl = "https://qa.crs", clientId = "crsctl"),
+            "prod" to Profile(crsUrl = "https://prod.crs"),
+        ),
+    )
+
+    @Test
+    fun `flag beats env var beats profile`() {
+        val target = TargetResolver.resolve(
+            ResolverInputs(
+                crsUrlFlag = "https://flag.crs",
+                crsUrlEnv = "https://env.crs",
+                envFlag = "prod",
+            ),
+            config,
+        )
+        assertEquals("https://flag.crs", target.crsUrl)
+        assertNull(target.envName)
+    }
+
+    @Test
+    fun `env var beats profile`() {
+        val target = TargetResolver.resolve(
+            ResolverInputs(crsUrlEnv = "https://env.crs", envFlag = "prod"),
+            config,
+        )
+        assertEquals("https://env.crs", target.crsUrl)
+        assertNull(target.envName)
+    }
+
+    @Test
+    fun `named profile used when no flag or env`() {
+        val target = TargetResolver.resolve(ResolverInputs(envFlag = "prod"), config)
+        assertEquals("https://prod.crs", target.crsUrl)
+        assertEquals("prod", target.envName)
+    }
+
+    @Test
+    fun `default profile used when nothing else given`() {
+        val target = TargetResolver.resolve(ResolverInputs(), config)
+        assertEquals("https://qa.crs", target.crsUrl)
+        assertEquals("qa", target.envName)
+    }
+
+    @Test
+    fun `token precedence flag beats env`() {
+        val target = TargetResolver.resolve(
+            ResolverInputs(crsUrlFlag = "https://x", tokenFlag = "flagtok", tokenEnv = "envtok"),
+            config,
+        )
+        assertEquals("flagtok", target.token)
+    }
+
+    @Test
+    fun `unresolved target throws`() {
+        assertFailsWith<ConfigResolutionException> {
+            TargetResolver.resolve(ResolverInputs(), CrsctlConfig.EMPTY)
+        }
+    }
+
+    @Test
+    fun `unknown named profile throws`() {
+        assertFailsWith<ConfigResolutionException> {
+            TargetResolver.resolve(ResolverInputs(envFlag = "nope"), config)
+        }
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolverTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/config/TargetResolverTest.kt
@@ -76,4 +76,37 @@ class TargetResolverTest {
             TargetResolver.resolve(ResolverInputs(envFlag = "nope"), config)
         }
     }
+
+    @Test
+    fun `malformed url with a space throws`() {
+        assertFailsWith<ConfigResolutionException> {
+            TargetResolver.resolve(ResolverInputs(crsUrlFlag = "not a url"), config)
+        }
+    }
+
+    @Test
+    fun `non-http scheme throws`() {
+        assertFailsWith<ConfigResolutionException> {
+            TargetResolver.resolve(ResolverInputs(crsUrlFlag = "ftp://x"), config)
+        }
+    }
+
+    @Test
+    fun `url with empty host throws`() {
+        assertFailsWith<ConfigResolutionException> {
+            TargetResolver.resolve(ResolverInputs(crsUrlFlag = "http://"), config)
+        }
+    }
+
+    @Test
+    fun `valid https url passes`() {
+        val target = TargetResolver.resolve(ResolverInputs(crsUrlFlag = "https://crs.example"), config)
+        assertEquals("https://crs.example", target.crsUrl)
+    }
+
+    @Test
+    fun `trailing slash is normalized off the url`() {
+        val target = TargetResolver.resolve(ResolverInputs(crsUrlFlag = "https://crs.example/"), config)
+        assertEquals("https://crs.example", target.crsUrl)
+    }
 }

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/AuditLogResponseTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/AuditLogResponseTest.kt
@@ -1,0 +1,58 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class AuditLogResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decodesAuditPageWithFreeFormDiff() {
+        val literal = """
+            {
+              "content": [
+                {
+                  "id": 42,
+                  "action": "UPDATE",
+                  "entityType": "component",
+                  "entityId": "33333333-3333-3333-3333-333333333333",
+                  "changedAt": "2026-06-13T09:30:00Z",
+                  "changedBy": "user1",
+                  "source": "PORTAL",
+                  "correlationId": "corr-1",
+                  "changeDiff": { "displayName": "renamed" },
+                  "oldValue": { "displayName": "old" },
+                  "newValue": { "displayName": "new" }
+                }
+              ],
+              "number": 0,
+              "size": 50,
+              "totalElements": 1,
+              "totalPages": 1,
+              "last": true
+            }
+        """.trimIndent()
+
+        val page = json.decodeFromString<PageAuditLogResponse>(literal)
+
+        assertEquals(1, page.totalElements)
+        assertEquals(1, page.content?.size)
+
+        val row = page.content!!.first()
+        assertEquals(42L, row.id)
+        assertEquals("UPDATE", row.action)
+        assertEquals("component", row.entityType)
+        assertEquals("33333333-3333-3333-3333-333333333333", row.entityId)
+        assertEquals("user1", row.changedBy)
+        assertEquals("PORTAL", row.source)
+
+        val diff = row.changeDiff
+        assertNotNull(diff)
+        assertEquals("renamed", diff["displayName"]?.jsonPrimitive?.content)
+        assertEquals("new", row.newValue?.get("displayName")?.jsonPrimitive?.content)
+        assertEquals("old", row.oldValue?.get("displayName")?.jsonPrimitive?.content)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/ComponentDetailResponseTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/ComponentDetailResponseTest.kt
@@ -1,0 +1,88 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComponentDetailResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decodesDetailWithNestedConfiguration() {
+        val literal = """
+            {
+              "id": "22222222-2222-2222-2222-222222222222",
+              "name": "beta",
+              "displayName": "Beta",
+              "archived": false,
+              "canBeParent": false,
+              "version": 7,
+              "canEdit": true,
+              "componentOwner": "owner1",
+              "labels": ["lib"],
+              "artifactIds": [
+                { "id": "a1", "artifactPattern": "art-*", "groupPattern": "grp" }
+              ],
+              "configurations": [
+                {
+                  "id": "c1",
+                  "isSyntheticBase": true,
+                  "rowType": "BASE",
+                  "versionRange": "[1.0,)",
+                  "requiredTools": ["jdk"],
+                  "buildToolBeans": [],
+                  "dockerImages": [],
+                  "fileUrlArtifacts": [],
+                  "mavenArtifacts": [
+                    { "id": "m1", "artifactPattern": "p", "groupPattern": "g", "sortOrder": 0 }
+                  ],
+                  "packages": [],
+                  "vcsEntries": [
+                    { "id": "v1", "sortOrder": 0, "vcsPath": "ssh://repo", "branch": "main" }
+                  ],
+                  "build": { "buildSystem": "GRADLE", "javaVersion": "21" },
+                  "jira": { "projectKey": "BETA", "technical": false }
+                }
+              ],
+              "docs": [],
+              "releaseManager": ["rm1"],
+              "securityChampion": [],
+              "securityGroups": [
+                { "id": "s1", "groupName": "g", "groupType": "read" }
+              ],
+              "teamcityProjects": [
+                { "id": "t1", "projectId": "Tc_Beta", "sortOrder": 0 }
+              ],
+              "group": { "groupKey": "GK", "isFake": false, "role": "MEMBER" },
+              "createdAt": "2026-06-13T10:00:00Z",
+              "updatedAt": "2026-06-13T11:00:00Z"
+            }
+        """.trimIndent()
+
+        val detail = json.decodeFromString<ComponentDetailResponse>(literal)
+
+        assertEquals("22222222-2222-2222-2222-222222222222", detail.id)
+        assertEquals("beta", detail.name)
+        assertEquals(7L, detail.version)
+        assertEquals(true, detail.canEdit)
+        assertEquals("owner1", detail.componentOwner)
+        assertEquals(listOf("lib"), detail.labels)
+        assertEquals(1, detail.artifactIds.size)
+        assertEquals("art-*", detail.artifactIds.first().artifactPattern)
+        assertEquals(1, detail.configurations.size)
+
+        val cfg = detail.configurations.first()
+        assertEquals("BASE", cfg.rowType)
+        assertEquals("[1.0,)", cfg.versionRange)
+        assertEquals(true, cfg.isSyntheticBase)
+        assertEquals(listOf("jdk"), cfg.requiredTools)
+        assertEquals(1, cfg.mavenArtifacts.size)
+        assertEquals("GRADLE", cfg.build?.buildSystem)
+        assertEquals("21", cfg.build?.javaVersion)
+        assertEquals("BETA", cfg.jira?.projectKey)
+        assertEquals("main", cfg.vcsEntries.first().branch)
+
+        assertEquals("MEMBER", detail.group?.role)
+        assertEquals("Tc_Beta", detail.teamcityProjects.first().projectId)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/ComponentSummaryResponseTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/ComponentSummaryResponseTest.kt
@@ -1,0 +1,60 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ComponentSummaryResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decodesPageWithSummaryRows() {
+        val literal = """
+            {
+              "content": [
+                {
+                  "id": "11111111-1111-1111-1111-111111111111",
+                  "name": "alpha",
+                  "displayName": "Alpha",
+                  "archived": false,
+                  "canBeParent": true,
+                  "labels": ["core", "public"],
+                  "system": "SYS",
+                  "buildSystem": "GRADLE",
+                  "futureUnknownKey": "ignored"
+                }
+              ],
+              "empty": false,
+              "first": true,
+              "last": true,
+              "number": 0,
+              "numberOfElements": 1,
+              "size": 20,
+              "totalElements": 1,
+              "totalPages": 1,
+              "pageable": { "pageNumber": 0, "pageSize": 20, "paged": true },
+              "sort": { "empty": true, "sorted": false, "unsorted": true }
+            }
+        """.trimIndent()
+
+        val page = json.decodeFromString<PageComponentSummaryResponse>(literal)
+
+        assertEquals(1, page.totalElements)
+        assertEquals(1, page.totalPages)
+        assertEquals(0, page.number)
+        assertEquals(20, page.size)
+        assertEquals(true, page.last)
+        assertEquals(1, page.content?.size)
+
+        val row = page.content!!.first()
+        assertEquals("11111111-1111-1111-1111-111111111111", row.id)
+        assertEquals("alpha", row.name)
+        assertEquals("Alpha", row.displayName)
+        assertEquals(false, row.archived)
+        assertEquals(true, row.canBeParent)
+        assertEquals(listOf("core", "public"), row.labels)
+        assertEquals("GRADLE", row.buildSystem)
+        assertTrue(page.pageable?.paged == true)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/ErrorResponseTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/ErrorResponseTest.kt
@@ -1,0 +1,32 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ErrorResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decodesErrorWithCodeAndMessage() {
+        val literal = """
+            { "errorCode": "COMPONENT_NOT_FOUND", "errorMessage": "No component with id x" }
+        """.trimIndent()
+
+        val error = json.decodeFromString<ErrorResponse>(literal)
+
+        assertEquals("COMPONENT_NOT_FOUND", error.errorCode)
+        assertEquals("No component with id x", error.errorMessage)
+    }
+
+    @Test
+    fun decodesErrorWithoutOptionalCode() {
+        val literal = """{ "errorMessage": "boom" }"""
+
+        val error = json.decodeFromString<ErrorResponse>(literal)
+
+        assertNull(error.errorCode)
+        assertEquals("boom", error.errorMessage)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/FieldOverrideResponseTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/FieldOverrideResponseTest.kt
@@ -1,0 +1,58 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class FieldOverrideResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decodesFieldOverrideArray() {
+        val literal = """
+            [
+              {
+                "id": "44444444-4444-4444-4444-444444444444",
+                "overriddenAttribute": "build.javaVersion",
+                "rowType": "SCALAR_OVERRIDE",
+                "versionRange": "[2.0,3.0)",
+                "value": { "javaVersion": "17" },
+                "createdAt": "2026-06-13T08:00:00Z",
+                "updatedAt": "2026-06-13T08:05:00Z"
+              },
+              {
+                "id": "55555555-5555-5555-5555-555555555555",
+                "overriddenAttribute": "marker",
+                "rowType": "MARKER",
+                "versionRange": "[3.0,)",
+                "markerChildren": {
+                  "requiredTools": ["jdk", "maven"],
+                  "mavenArtifacts": [
+                    { "artifactPattern": "a", "groupPattern": "g" }
+                  ]
+                }
+              }
+            ]
+        """.trimIndent()
+
+        val overrides = json.decodeFromString<List<FieldOverrideResponse>>(literal)
+
+        assertEquals(2, overrides.size)
+
+        val scalar = overrides[0]
+        assertEquals("build.javaVersion", scalar.overriddenAttribute)
+        assertEquals("SCALAR_OVERRIDE", scalar.rowType)
+        assertEquals("[2.0,3.0)", scalar.versionRange)
+        assertEquals("17", scalar.value?.jsonObject?.get("javaVersion")?.jsonPrimitive?.content)
+
+        val marker = overrides[1]
+        assertEquals("MARKER", marker.rowType)
+        val children = marker.markerChildren
+        assertNotNull(children)
+        assertEquals(listOf("jdk", "maven"), children.requiredTools)
+        assertEquals("a", children.mavenArtifacts?.first()?.artifactPattern)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/MetaResponseTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/MetaResponseTest.kt
@@ -1,0 +1,52 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MetaResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decodesEmployeeMatchArray() {
+        val literal = """
+            [
+              { "username": "alice", "active": true },
+              { "username": "bob", "active": false }
+            ]
+        """.trimIndent()
+
+        val matches = json.decodeFromString<List<EmployeeMatchResponse>>(literal)
+
+        assertEquals(2, matches.size)
+        assertEquals("alice", matches[0].username)
+        assertEquals(true, matches[0].active)
+        assertEquals(false, matches[1].active)
+    }
+
+    @Test
+    fun decodesEditorsResponse() {
+        val literal = """
+            {
+              "componentOwner": "owner1",
+              "releaseManagers": ["rm1", "rm2"],
+              "securityChampions": ["sc1"]
+            }
+        """.trimIndent()
+
+        val editors = json.decodeFromString<ComponentEditorsResponse>(literal)
+
+        assertEquals("owner1", editors.componentOwner)
+        assertEquals(listOf("rm1", "rm2"), editors.releaseManagers)
+        assertEquals(listOf("sc1"), editors.securityChampions)
+    }
+
+    @Test
+    fun decodesEmployeeHealth() {
+        val literal = """{ "status": "UP" }"""
+
+        val health = json.decodeFromString<EmployeeIntegrationHealthResponse>(literal)
+
+        assertEquals("UP", health.status)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/UserTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/model/UserTest.kt
@@ -1,0 +1,32 @@
+package org.octopusden.octopus.components.registry.cli.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decodesAuthMe() {
+        val literal = """
+            {
+              "username": "jdoe",
+              "groups": ["dev", "release"],
+              "roles": [
+                { "name": "EDITOR", "permissions": ["EDIT_METADATA", "EDIT_ANY_COMPONENT"] },
+                { "name": "VIEWER", "permissions": ["READ"] }
+              ],
+              "extraServerField": true
+            }
+        """.trimIndent()
+
+        val user = json.decodeFromString<User>(literal)
+
+        assertEquals("jdoe", user.username)
+        assertEquals(listOf("dev", "release"), user.groups)
+        assertEquals(2, user.roles.size)
+        assertEquals("EDITOR", user.roles.first().name)
+        assertEquals(listOf("EDIT_METADATA", "EDIT_ANY_COMPONENT"), user.roles.first().permissions)
+    }
+}

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/output/RendererTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/output/RendererTest.kt
@@ -1,0 +1,60 @@
+package org.octopusden.octopus.components.registry.cli.output
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.octopusden.octopus.components.registry.cli.client.CrsApiException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RendererTest {
+
+    private val parser = Json
+
+    @Test
+    fun `renderError from CrsApiException carries errorCode and message`() {
+        val out = Renderer.renderError(CrsApiException(404, "NOT_FOUND", "missing component"))
+        val obj = parser.parseToJsonElement(out) as JsonObject
+        assertEquals("NOT_FOUND", obj["errorCode"]!!.jsonPrimitive.content)
+        assertEquals("missing component", obj["message"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `renderError null errorCode serializes as JSON null`() {
+        val out = Renderer.renderError(RuntimeException("boom"))
+        val obj = parser.parseToJsonElement(out) as JsonObject
+        assertTrue(obj.containsKey("errorCode"))
+        assertEquals(JsonNull, obj["errorCode"])
+        assertEquals("boom", obj["message"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `renderError falls back to class name when message is null`() {
+        val out = Renderer.renderError(NullPointerException())
+        val obj = parser.parseToJsonElement(out) as JsonObject
+        assertEquals("NullPointerException", obj["message"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `renderTable aligns columns and handles null cells`() {
+        val table = Renderer.renderTable(
+            headers = listOf("ID", "NAME"),
+            rows = listOf(
+                listOf("a", "Alpha"),
+                listOf("bbbb", null),
+            ),
+        )
+        val lines = table.lines()
+        assertEquals("ID    NAME", lines[0])
+        assertEquals("a     Alpha", lines[1])
+        assertEquals("bbbb", lines[2])
+    }
+
+    @Test
+    fun `renderTable with no rows emits only header`() {
+        val table = Renderer.renderTable(listOf("ID", "NAME"), emptyList())
+        assertEquals("ID  NAME", table)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,6 +53,10 @@ ktlint-gradle.version=14.0.1
 
 apache-commons-lang3.version=3.20.0
 
+# crsctl
+clikt.version=4.4.0
+kotlinx-serialization.version=1.6.3
+
 okd.active-deadline-seconds=1800
 okd.project=
 okd.cluster-domain=

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,7 @@ include ':components-registry-service-client'
 include ':components-registry-service-server'
 include ':components-registry-compat-test'
 include ':test-common'
+include ':components-registry-cli'
 def defaultVersion = {
     def crc = new CRC32()
     crc.update(InetAddress.localHost.hostName.bytes)


### PR DESCRIPTION
## What

Adds a new Gradle module **`:components-registry-cli`** — a Kotlin CLI (`crsctl`) that lets terminal AI agents (Claude Code / Codex) and developers read from CRS via the **v4 REST API** directly, without the Portal's browser/OAuth2 session.

This is the **first pass** of the planned work: the full **anonymous read surface** plus **auth + audit scaffolding**. It is intended to land as a **draft** because the auth/audit paths are **gated on a Keycloak spike** (see below).

## Scope of this PR

**Working today (anonymous, no login):**
- `components list` — all 18 v4 filters (mapped to the spec's param names incl. `labels`, `parentComponentName`) + pageable + `--all` auto-pagination (with a `totalPages` stop and a 10k-page safety cap).
- `component get <idOrName>` / `as-code <idOrName>` (direct `idOrName`, `as-code` is `text/plain`) / `overrides <uuid|name>` (UUID direct; name→UUID via `get`).
- `meta <owners|systems|labels|build-systems|…>` lookups (+ dictionary).
- `whoami` — static anonymous line, no server call.
- `help` / `help <command>` (git/kubectl-style; reuses Clikt's renderer at any depth; `help <unknown>` → exit 2). Per-command `--help`/`-h` everywhere.
- Global options: `--env` profiles, `--crs-url`/`CRS_URL`, `--token`/`CRS_TOKEN`, `-o json|table`, `--insecure-token-store`. **Global options precede the subcommand.**
- Agent contract: stable JSON on **stdout**, structured `{"errorCode","message"}` errors on **stderr**, pinned **exit codes** (0/2/3/4/5).
- `shadowJar` fat jar (runnable artifact: `components-registry-cli-<version>-all.jar`); smoke-tested against a live CRS (list/get/as-code/meta/whoami).

**Scaffolded but GATED on the Keycloak spike (not e2e-verified):**
- `login` (OIDC Device Authorization Grant, RFC 8628; `--offline` opt-in), `logout` (revoke-then-clear, RFC 7009, always clears the local token even if revoke/OIDC-config fails), `whoami` with a token (`/auth/me`).
- macOS **Keychain** `CredentialStore` via the `security` CLI: the refresh token is written with `add-generic-password -U -w <value>` (the only reliable non-interactive form — a bare `-w` prompts on the tty). Hard-fail on error, **no silent file fallback**; `--insecure-token-store` opts into a 0600 plaintext file. Known trade-off: `-w <value>` is briefly visible in `ps`; `// TODO(spike)` to move to a native Keychain API.
- `audit recent` / `audit history <type> <id>` — require login + `ACCESS_AUDIT`; fail fast with a clear exit-4 message before any HTTP when no credential.
- Endpoint paths / client-id carry `// TODO(spike)` markers; a real-Keycloak integration test exists but is `@Disabled` pending the spike.

**Explicitly out of scope (separate follow-ups):**
- The **Keycloak spike** itself (registering the public device-flow client + proving authority-resolution incl. `ACCESS_AUDIT`) — needs Keycloak owner approval.
- **Release track**: Homebrew tap, macOS codesign/notarization, CLI versioning, GraalVM native-image.
- Windows/Linux (paths and `CredentialStore` are kept portable, but only macOS is implemented/tested).

## Build / quality / CI notes
- Module reuses the root `configure(subprojects)` block (kotlin.jvm/java-library/publish/signing); only adds `shadow` + the serialization plugin + Clikt 4.4.0 / kotlinx-serialization-json 1.6.3. Keeps the thin `jar` (TeamCity `extractModuleInfo` needs it) and ships the fat jar under the `all` classifier — mirrors `:components-registry-automation`.
- Added to `octopusQuality.excludeProjects(...)` **and** the root coverage-aggregate exclusion list (it's a CLI tool, like `-automation`) to avoid blocking this first PR on detekt/ktlint baselines and the 70% jacoco gate; enabling those is a noted follow-up.
- DTOs are hand-mirrored from `…/openapi/v4.json` with round-trip tests; HTTP is JDK `java.net.http` (no Feign), with 10s connect / 30s request timeouts.

## Testing
- `./gradlew :components-registry-cli:build` green (compile + unit tests + shadowJar); GitHub Merge Gate green.
- Unit tests use injected fakes (`HttpExchange`, `CommandRunner`, `Sleeper`) — no network, no Keychain, no real sleeping.
- Live smoke against a real CRS confirmed: `components list` (table + `-o json`), `component get`/`as-code`, `meta`, `whoami`, and `audit` correctly gated (exit 4). Parse/usage errors return structured stderr + exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
