### PR TITLE
fix: preserve range-only parity in as-code rendering

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
@@ -8,6 +8,7 @@ import org.octopusden.octopus.components.registry.server.entity.DistributionFile
 import org.octopusden.octopus.components.registry.server.entity.DistributionMavenArtifactEntity
 import org.octopusden.octopus.components.registry.server.entity.DistributionPackageEntity
 import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
 import org.octopusden.octopus.components.registry.server.mapper.ComponentConfigurationView
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.octopus.components.registry.server.mapper.extractScalarValue
@@ -113,11 +114,21 @@ class ComponentCodeRenderer(
             buildToolBeans = base.buildToolBeans.toList(),
         )
 
+        val overrideRanges = overrides.map { it.versionRange }.distinct()
+
+        // If the BASE row itself is scoped to a bounded range (not ALL_VERSIONS), surface that
+        // range as an explicit — possibly empty — block so the view makes clear the component is
+        // supported ONLY within it (versions outside resolve to 404; see renderResolved's gate).
+        // The base body above is the component-level default that this range inherits, so the
+        // block carries no fields of its own. Skipped when an override row already declares the
+        // same range (writeRangeBlock renders it with content below).
+        if (base.versionRange != ALL_VERSIONS && base.versionRange !in overrideRanges) {
+            cb.open(doubleQuoted(base.versionRange))
+            cb.close()
+        }
+
         // Distinct override ranges in deterministic (DSL declaration) order.
-        overrides
-            .map { it.versionRange }
-            .distinct()
-            .forEach { range -> writeRangeBlock(cb, range, overrides.filter { it.versionRange == range }) }
+        overrideRanges.forEach { range -> writeRangeBlock(cb, range, overrides.filter { it.versionRange == range }) }
 
         cb.close()
         return cb.toString()
@@ -141,6 +152,28 @@ class ComponentCodeRenderer(
             } catch (_: Exception) {
                 return null
             }
+
+        // Mirror EntityMappers.toResolvedEscrowModuleConfig's version-range gate (MIG-042): a
+        // version outside the component's effective range union resolves to NO config (404).
+        // Without this the as-code resolved view was more lenient than the real resolver and
+        // would render a component for a version the v2 endpoints return 404 for. Canonical
+        // logic lives in EntityMappers.kt; kept in sync by tests on both sides.
+        if (base.versionRange != ALL_VERSIONS) {
+            val containsVersion = { range: String? ->
+                range.isNullOrBlank() ||
+                    range == ALL_VERSIONS ||
+                    try {
+                        versionRangeFactory.create(range).containsVersion(numericVersion)
+                    } catch (_: Exception) {
+                        true
+                    }
+            }
+            val inEffectiveRange =
+                containsVersion(base.versionRange) ||
+                    configs.any { it.rowType != ROW_BASE && containsVersion(it.versionRange) }
+            if (!inEffectiveRange) return null
+        }
+
         val matching =
             configs.filter { it.rowType == ROW_SCALAR_OVERRIDE || it.rowType == ROW_MARKER }
                 .filter { override ->

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeOnlyParityGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeOnlyParityGuardTest.kt
@@ -1,0 +1,231 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.api.enums.ProductTypes
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentRequiredToolEntity
+import org.octopusden.octopus.components.registry.server.entity.ToolEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.octopus.escrow.configuration.loader.ComponentRegistryInfo
+import org.octopusden.octopus.escrow.configuration.loader.ConfigLoader
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.EscrowConfiguration
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.octopusden.octopus.releng.dto.ComponentVersion
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * Range-only parity guard (see plan: mcloud out-of-range resolution).
+ *
+ * Pins V1 ↔ v3 behavioural parity for the "component-own default + a single
+ * `[1.0.700,)` block" DSL shape, where the lowest declared range starts above
+ * the component's earliest released versions. The V1 loader builds
+ * `moduleConfigurations` ONLY from the range block, so a version below 1.0.700
+ * (here `1.0.1`) matches no module and resolves to `null` (HTTP 404) — the
+ * component-own default `javaVersion = "17"` is never applied to any version.
+ * The v3 import mirrors this as a single **non-synthetic** BASE row with
+ * `versionRange = [1.0.700,)` (`isSyntheticBase = false`), so the DB-mode
+ * resolver's range gate must produce the same not-found across every read API.
+ *
+ * This is NOT a regression — both stacks agree. The guard exists so a future
+ * change to either the V1 loader's range expansion or the v3 range gate cannot
+ * silently diverge for this shape.
+ *
+ * V1 side: the real `EscrowConfigurationLoader` over the self-contained fixture
+ * `range-only-guard/GuardComponent.groovy` (loader wiring replicated from
+ * `component-resolver-core`'s `TestConfigUtils`, which is test-only and not
+ * visible cross-module). v3 side: a hand-built entity graph driven through
+ * `DatabaseComponentRegistryResolver` with a mocked repository (the established
+ * `DatabaseComponentRegistryResolverTest` pattern). Plain mocked-repo unit test
+ * — no Spring/DB context — so it runs under `:test` / `:build`, not `:dbTest`.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class RangeOnlyParityGuardTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    // ====================================================================
+    // V1 side — real loader over the fixture
+    // ====================================================================
+
+    private fun loadV1Configuration(): EscrowConfiguration {
+        val productTypes = ProductTypes.values().associateWith { it.name }
+        val loader = EscrowConfigurationLoader(
+            ConfigLoader(
+                ComponentRegistryInfo.fromClassPath("range-only-guard/GuardComponent.groovy"),
+                versionNames,
+                productTypes,
+            ),
+            listOf("org.octopusden.octopus", "io.bcomponent"),
+            listOf("NONE", "CLASSIC", "ALFA"),
+            versionNames,
+            // The loader validates that the copyright path is an existing directory, but only
+            // reads it when a component declares `copyright`. The fixture declares none, so an
+            // empty temp dir satisfies the check without shipping a repo artifact.
+            java.nio.file.Files.createTempDirectory("range-only-guard-copyrights"),
+        )
+        return loader.loadFullConfigurationWithoutValidationForUnknownAttributes(emptyMap<String, String>())
+    }
+
+    private fun resolveV1(config: EscrowConfiguration, version: String): EscrowModuleConfig? =
+        EscrowConfigurationLoader.resolveComponentConfiguration(
+            config,
+            ComponentVersion.create(COMPONENT, version),
+        )
+
+    // ====================================================================
+    // v3 side — entity graph mirroring the imported shape
+    // ====================================================================
+
+    /**
+     * Single non-synthetic BASE row at `[1.0.700,)` carrying `javaVersion = 21`
+     * (the range override) and the inherited `GuardTool` required-tool junction
+     * (the range block overrode only `javaVersion`, not tools). This is exactly
+     * what `ImportServiceImpl` produces for the fixture: `firstOrNull { ALL_VERSIONS }
+     * ?: configs.first()` selects the sole `[1.0.700,)` config as the base.
+     */
+    private fun buildV3Component(): ComponentEntity {
+        val comp = ComponentEntity(id = UUID.randomUUID(), componentKey = COMPONENT)
+        val base = ComponentConfigurationEntity(
+            component = comp,
+            versionRange = IN_RANGE_LOWER_BOUND,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            isSyntheticBase = false,
+            buildSystem = "MAVEN",
+            javaVersion = "21",
+            jiraProjectKey = "GUARD",
+            deprecated = false,
+        )
+        base.jiraMajorVersionFormat = "\$major"
+        base.jiraReleaseVersionFormat = "\$major.\$minor.\$service"
+        base.vcsEntries.add(
+            VcsSettingsEntryEntity(
+                componentConfiguration = base,
+                vcsPath = "ssh://git@example/guard",
+                name = "main",
+                branch = "master",
+                sortOrder = 0,
+            ),
+        )
+        base.requiredToolJunctions.add(
+            ComponentRequiredToolEntity(toolName = "GuardTool", tool = ToolEntity(name = "GuardTool")),
+        )
+        comp.configurations.add(base)
+        return comp
+    }
+
+    private fun stubComponent(component: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(component.componentKey)).thenReturn(component)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(component))
+    }
+
+    // ====================================================================
+    // Tests
+    // ====================================================================
+
+    @Test
+    @DisplayName("out-of-range 1.0.1 is not-found in BOTH V1 and v3 (component-own default never applies)")
+    fun `out of range version is not-found in V1 and v3 alike`() {
+        // --- V1 ---
+        val v1Config = loadV1Configuration()
+        val v1Resolved = resolveV1(v1Config, OUT_OF_RANGE)
+        assertNull(v1Resolved, "V1 must return null for $OUT_OF_RANGE (no module covers it)")
+
+        // sanity: V1 does resolve a version that IS in range, so the null above is the
+        // range gate, not a broken fixture.
+        assertNotNull(resolveV1(v1Config, IN_RANGE), "V1 must resolve in-range $IN_RANGE")
+
+        // --- v3 ---
+        val comp = buildV3Component()
+        stubComponent(comp)
+
+        // component detail (GET /v2/components/{c}?version=) → toResolvedEscrowModuleConfig
+        assertNull(
+            resolver.getResolvedComponentDefinition(COMPONENT, OUT_OF_RANGE),
+            "v3 getResolvedComponentDefinition must be null for $OUT_OF_RANGE (range gate)",
+        )
+        // detailed-version / jira-component → getJiraComponentVersion
+        assertThrows<NotFoundException> {
+            resolver.getJiraComponentVersion(COMPONENT, OUT_OF_RANGE)
+        }
+        // vcs-settings → getVCSSettings
+        assertThrows<NotFoundException> {
+            resolver.getVCSSettings(COMPONENT, OUT_OF_RANGE)
+        }
+        // batch detailed-versions → getJiraComponentVersions silently drops the unresolvable version
+        val batch = resolver.getJiraComponentVersions(COMPONENT, listOf(OUT_OF_RANGE, IN_RANGE))
+        assertEquals(setOf(IN_RANGE), batch.keys, "Only the in-range version may appear in the batch map")
+    }
+
+    @Test
+    @DisplayName("in-range 1.0.700 resolves identically in V1 and v3 (java 21 + inherited GuardTool)")
+    fun `in range version resolves with same javaVersion and tool in V1 and v3`() {
+        // --- V1 ---
+        val v1Config = loadV1Configuration()
+        val v1Resolved = resolveV1(v1Config, IN_RANGE)
+        assertNotNull(v1Resolved, "V1 must resolve in-range $IN_RANGE")
+        assertEquals("21", v1Resolved!!.buildConfiguration?.javaVersion, "V1 in-range javaVersion is the override 21")
+        assertTrue(
+            v1Resolved.buildConfiguration?.tools?.any { it.name == "GuardTool" } == true,
+            "V1 in-range config inherits the component-own default required tool GuardTool",
+        )
+
+        // --- v3 ---
+        val comp = buildV3Component()
+        stubComponent(comp)
+        val v3Resolved = resolver.getResolvedComponentDefinition(COMPONENT, IN_RANGE)
+        assertNotNull(v3Resolved, "v3 must resolve in-range $IN_RANGE")
+        assertEquals("21", v3Resolved!!.buildConfiguration?.javaVersion, "v3 in-range javaVersion is the override 21")
+        assertTrue(
+            v3Resolved.buildConfiguration?.tools?.any { it.name == "GuardTool" } == true,
+            "v3 in-range config carries the inherited GuardTool required tool",
+        )
+
+        // the jira/vcs read paths resolve in-range on the v3 side
+        assertNotNull(resolver.getJiraComponentVersion(COMPONENT, IN_RANGE))
+        assertNotNull(resolver.getVCSSettings(COMPONENT, IN_RANGE))
+    }
+
+    companion object {
+        private const val COMPONENT = "guardComponent"
+        private const val IN_RANGE_LOWER_BOUND = "[1.0.700,)"
+        private const val IN_RANGE = "1.0.700"
+        private const val OUT_OF_RANGE = "1.0.1"
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
@@ -461,4 +461,61 @@ class ComponentCodeRendererTest {
         assertTrue(out.contains("buildSystem = MAVEN"), out)
         assertFalse(out.contains("javaVersion = \"11\""), out)
     }
+
+    // ----------------------------------------------------------------------
+    // Bounded base row (versionRange != ALL_VERSIONS)
+    // ----------------------------------------------------------------------
+
+    /** A BASE row scoped to a bounded range instead of the default ALL_VERSIONS. */
+    private fun boundedBase(
+        c: ComponentEntity,
+        range: String,
+        block: ComponentConfigurationEntity.() -> Unit = {},
+    ): ComponentConfigurationEntity {
+        val row =
+            ComponentConfigurationEntity(
+                id = UUID.randomUUID(),
+                component = c,
+                versionRange = range,
+                overriddenAttribute = null,
+                rowType = "BASE",
+                isSyntheticBase = false,
+            ).apply(block)
+        c.configurations.add(row)
+        return row
+    }
+
+    @Test
+    @DisplayName("FULL: bounded base range is surfaced as an explicit (empty) block")
+    fun fullEmitsBoundedBaseRangeBlock() {
+        val c = component()
+        boundedBase(c, "[1.0.700,)") {
+            buildSystem = "MAVEN"
+            javaVersion = "21"
+            jiraProjectKey = "X"
+        }
+        val out = renderer.renderFull(c)
+        // The component-level defaults still render in the top-level body...
+        assertTrue(out.contains("javaVersion = \"21\""), out)
+        // ...and the bounded base range is shown as its own block so it's clear the component
+        // is supported ONLY within it. It is empty (all fields inherited from the body above).
+        assertTrue(out.contains("\"[1.0.700,)\" {"), out)
+    }
+
+    @Test
+    @DisplayName("RESOLVED: version below the bounded base range returns null (range gate, mirrors v2 404)")
+    fun resolvedNullWhenBelowBoundedBaseRange() {
+        val c = component()
+        boundedBase(c, "[1.0.700,)") {
+            buildSystem = "MAVEN"
+            javaVersion = "21"
+            jiraProjectKey = "X"
+        }
+        // 1.0.1 is below the only declared range → no config resolves → null (404), matching
+        // EntityMappers.toResolvedEscrowModuleConfig and the real v2 resolver.
+        assertNull(renderer.renderResolved(c, "1.0.1"))
+        // In-range still resolves.
+        val inRange = renderer.renderResolved(c, "1.0.700")
+        assertTrue(inRange != null && inRange.contains("javaVersion = \"21\""), "$inRange")
+    }
 }

--- a/components-registry-service-server/src/test/resources/range-only-guard/GuardComponent.groovy
+++ b/components-registry-service-server/src/test/resources/range-only-guard/GuardComponent.groovy
@@ -1,0 +1,65 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// Self-contained V1 DSL fixture for RangeOnlyParityGuardTest.
+//
+// Shape under test: a component whose top-level `build { javaVersion = "17" }` is the
+// component-own DEFAULT, plus a SINGLE version-range block "[1.0.700,)" that overrides
+// only `javaVersion` to "21". The V1 loader builds moduleConfigurations ONLY from the
+// range block, so versions below 1.0.700 (e.g. 1.0.1) match no module and resolve to
+// null — there is no all-versions coverage. The component-own default javaVersion "17"
+// is therefore never applied to any version. This guard pins that V1 behaviour so the
+// v3 DB-mode resolver (separate fixture in the same test) stays in parity.
+
+final DEFAULT_TAG = '$module-$version'
+final ANY_ARTIFACT = /[\w-]+/
+
+Defaults {
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = ANY_ARTIFACT
+    tag = DEFAULT_TAG
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+}
+
+Tools {
+    GuardTool {
+        escrowEnvironmentVariable = "GUARD_TOOL"
+        targetLocation = "tools/GUARD_TOOL"
+        sourceLocation = "env.GUARD_TOOL"
+        installScript = "script"
+    }
+}
+
+guardComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/guard"
+    groupId = "org.octopusden.octopus.guard"
+
+    // Component-own default: applies to all versions in principle, but see below.
+    build {
+        javaVersion = "17"
+        requiredTools = "GuardTool"
+    }
+
+    // The ONLY declared version-range block. Overrides javaVersion to 21 and inherits
+    // requiredTools = GuardTool from the component-own default.
+    "[1.0.700,)" {
+        build {
+            javaVersion = "21"
+        }
+    }
+
+    jira {
+        projectKey = "GUARD"
+    }
+}


### PR DESCRIPTION
## What & why

The "View component as code" renderer diverged from the real version resolver for components whose
single `BASE` configuration row is scoped to a **bounded** version range (`versionRange != ALL_VERSIONS`,
e.g. `[1.0.700,)`) rather than the default `ALL_VERSIONS`:

- `renderResolved` resolved **any** parseable version off the base row, so the as-code view rendered a
  component for versions the real v2 endpoints return `404` for.
- `renderFull` hid the base row's own range, making a range-only component look like an all-versions one.

This is the as-code side of the range-only investigation: for a `default + single "[N,)"` DSL shape, the
V1 loader produces no all-versions coverage, so versions below `N` are not-found in **both** V1 and v3
(not a regression) — but the as-code view was masking that.

## Changes (`ComponentCodeRenderer.kt`)

1. **`renderFull`** — when `base.versionRange != ALL_VERSIONS`, surface that range as an explicit
   (possibly empty) `"[N,)" { }` block, so it is clear the component is supported only within it.
   Skipped when an override row already declares the same range (that block renders it instead).
2. **`renderResolved`** — apply the same version-range gate as
   `EntityMappers.toResolvedEscrowModuleConfig` (base range ∪ every non-BASE row incl. `RANGE_PRESENCE`,
   with the conservative unparseable-range = "contains" fallback): return `null` → `404` for
   out-of-range instead of resolving off the base unconditionally.

## Tests

- `ComponentCodeRendererTest` (+2): bounded base range emits its block; out-of-range → `null`.
- `RangeOnlyParityGuardTest` (new) + synthetic fixture `range-only-guard/GuardComponent.groovy`
  (no real component names): pins V1↔v3 parity for the `default + single "[1.0.700,)"` shape —
  `1.0.1` → not-found on both (across `getResolvedComponentDefinition` / `getJiraComponentVersion` /
  batch `getJiraComponentVersions` / `getVCSSettings`); `1.0.700` → resolves on both (java 21 +
  inherited `GuardTool` via `buildConfiguration.tools`).

## Verification

`./gradlew :components-registry-service-server:test --tests '*ComponentCodeRendererTest' --tests '*RangeOnlyParityGuardTest'` → green (also full server `:test` lane green). Independent Sonnet review: no P1; gate is a faithful copy of the resolver's union, `ALL_VERSIONS` is the shared constant.

## Notes

- Scope is intentionally only the as-code renderer + tests; the **migration-time** detection of the
  underlying dead-default config is tracked separately in #362.
- Known narrow edge (documented, importer-unreachable, non-blocking): if a `RANGE_PRESENCE` row shared
  the bounded base's exact range, the explicit base-range block would be suppressed (the same range
  already counts as an override range, and an empty presence block doesn't render). The importer does
  not produce that shape for a non-synthetic bounded base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
