### PR TITLE
chore: redact forbidden token from RangeOnlyParityGuardTest doc

### DIFF
--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeOnlyParityGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeOnlyParityGuardTest.kt
@@ -33,7 +33,7 @@ import org.octopusden.releng.versions.VersionNames
 import org.octopusden.releng.versions.VersionRangeFactory
 
 /**
- * Range-only parity guard (see plan: mcloud out-of-range resolution).
+ * Range-only parity guard (see #362 for the related migration-time validation).
  *
  * Pins V1 ↔ v3 behavioural parity for the "component-own default + a single
  * `[1.0.700,)` block" DSL shape, where the lowest declared range starts above


### PR DESCRIPTION
Content-validation on `v3` flagged a forbidden component-name literal in the `RangeOnlyParityGuardTest` KDoc (a "see plan: …" note left over from the investigation). This replaces it with a neutral pointer to #362. Comment-only, no behavior change; the merged squash commit message was already clean. Follow-up to #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)