### PR TITLE
ci(compat): surface trace-replay request volume on the build status

### DIFF
--- a/scripts/local-stands/teamcity-run.sh
+++ b/scripts/local-stands/teamcity-run.sh
@@ -429,4 +429,25 @@ fi
 # shellcheck disable=SC2086  # GRADLE_*_ARG(S) are space-separated -P tokens or empty
 "$SCRIPT_DIR/compat.sh" $GRADLE_PARALLELISM_ARG $GRADLE_MODE_ARGS "$@"
 COMPAT_EXIT=$?
+
+# Surface the production-trace replay VOLUME on the build status + statistics.
+# TeamCity's "Tests passed: N" counts the (~130k-tuple) trace replay as a SINGLE
+# @Test method, so the real number of replayed requests is otherwise invisible on
+# the build tile. Read the machine-readable summary the replay test already writes
+# (TraceReplayCompatTest.writeSummary -> build/reports/compat/trace-replay-summary.json)
+# and publish TOTALS ONLY — never endpoint paths, which may carry component IDs.
+# Fully guarded (`[ -f ]`, `|| true`, `:-`) so a missing/renamed summary or a
+# no-match grep can never disturb the compat result/exit code.
+TRACE_SUMMARY="$CANDIDATE_WORKTREE/components-registry-compat-test/build/reports/compat/trace-replay-summary.json"
+if [ -f "$TRACE_SUMMARY" ]; then
+  TUPLES=$(grep -oE '"tuplesReplayed"[^0-9-]*[0-9]+' "$TRACE_SUMMARY" | grep -oE '[0-9]+$' | head -1 || true)
+  DIFFS=$(grep -oE '"tuplesWithDiffs"[^0-9-]*[0-9]+' "$TRACE_SUMMARY" | grep -oE '[0-9]+$' | head -1 || true)
+  if [ -n "${TUPLES:-}" ]; then
+    REQS=$(( TUPLES * 2 ))   # each tuple is replayed against BOTH stands (baseline + candidate)
+    echo "##teamcity[buildStatisticValue key='compatTraceTuples' value='$TUPLES']"
+    echo "##teamcity[buildStatisticValue key='compatTraceRequests' value='$REQS']"
+    echo "##teamcity[buildStatus text='{build.status.text}; trace-replay: $TUPLES tuples / $REQS reqs (${DIFFS:-?} diffs)']"
+  fi
+fi
+
 exit $COMPAT_EXIT


### PR DESCRIPTION
## Why
The id17/id18 compat builds replay the full deduplicated production trace (currently **130,700** `(method,path)` tuples after PR #5's enrichment) — but TeamCity's status line only shows **JUnit test count** (`Tests passed: N`). The trace replay is a *single* `@Test` method, so it contributes **1** to that count and the real request volume is invisible on the build tile. (This is exactly what made it look like the new requests "weren't there".)

## What
After `compat.sh`, `teamcity-run.sh` reads the summary the replay test **already** writes (`build/reports/compat/trace-replay-summary.json`, via `TraceReplayCompatTest.writeSummary`) and publishes **totals only**:
- `##teamcity[buildStatisticValue key='compatTraceTuples' value='130700']`
- `##teamcity[buildStatisticValue key='compatTraceRequests' value='261400']` (tuples × 2 stands: baseline + candidate)
- appends `trace-replay: 130700 tuples / 261400 reqs (0 diffs)` to the build status text.

So the tile shows e.g. `Tests passed: 21811 … ; compat: 0 active diff(s); trace-replay: 130700 tuples / 261400 reqs (0 diffs)`.

## Safety / scope
- **Totals only — no endpoint paths** emitted (they may carry component IDs; see `writeSummary` kdoc).
- Fully guarded (`[ -f ]`, `|| true`, `${:-}`) → a missing/renamed summary or a no-match grep can never change the compat exit code. `bash -n` clean.
- One file; runs for both **[1.7]** db-mode and **[1.8]** git-mode (shared `teamcity-run.sh`).
- Verified the JSON parse against a real `2.0.88-3994` build artifact: `tuplesReplayed=130700` → `261400` requests, `0` diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)