### PR TITLE
feat(audit): resolve componentKey on AuditLogResponse

### DIFF
--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/AuditCommand.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/commands/AuditCommand.kt
@@ -133,9 +133,9 @@ private fun CliktCommand.renderAuditPage(ctx: CliContext, response: PageAuditLog
         json = { Renderer.renderJson(rows, ListSerializer(AuditLogResponse.serializer())) },
         table = {
             Renderer.renderTable(
-                headers = listOf("CHANGED_AT", "ACTION", "ENTITY_TYPE", "ENTITY_ID", "CHANGED_BY"),
+                headers = listOf("CHANGED_AT", "ACTION", "ENTITY_TYPE", "COMPONENT_KEY", "ENTITY_ID", "CHANGED_BY"),
                 rows = rows.map {
-                    listOf(it.changedAt, it.action, it.entityType, it.entityId, it.changedBy)
+                    listOf(it.changedAt, it.action, it.entityType, it.componentKey, it.entityId, it.changedBy)
                 },
             )
         },

--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Audit.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Audit.kt
@@ -12,6 +12,9 @@ import kotlinx.serialization.json.JsonElement
  * String to avoid pulling a date dependency into the DTO layer).
  *
  * Required per spec: action, changedAt, entityId, entityType, id, source.
+ *
+ * `componentKey` is the server-resolved human-readable key for Component rows
+ * (SYS-054); null for non-Component rows or when unresolvable.
  */
 @Serializable
 data class AuditLogResponse(
@@ -21,6 +24,7 @@ data class AuditLogResponse(
     val entityId: String,
     val changedAt: String,
     val source: String,
+    val componentKey: String? = null,
     val changedBy: String? = null,
     val correlationId: String? = null,
     val changeDiff: Map<String, JsonElement>? = null,

--- a/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
+++ b/components-registry-cli/src/test/kotlin/org/octopusden/octopus/components/registry/cli/commands/CommandsTest.kt
@@ -351,20 +351,25 @@ class CommandsTest {
     @Test
     fun `audit recent renders table by default and json on -o json`() {
         val page = """{"content":[{"id":1,"action":"UPDATE","entityType":"COMPONENT",""" +
-            """"entityId":"abc","changedAt":"2026-06-14T00:00:00Z","source":"PORTAL","changedBy":"alice"}],""" +
+            """"entityId":"abc","componentKey":"my-component","changedAt":"2026-06-14T00:00:00Z",""" +
+            """"source":"PORTAL","changedBy":"alice"}],""" +
             """"last":true}"""
         val tableEx = QueueExchange(listOf(200 to page))
         val table = cli(tableEx).test(listOf(URL, "--token=tok", "audit", "recent"))
         assertEquals(0, table.statusCode, table.stderr)
         assertTrue(table.stdout.contains("CHANGED_AT"), "table header expected: ${table.stdout}")
+        assertTrue(table.stdout.contains("COMPONENT_KEY"), "componentKey column expected: ${table.stdout}")
         assertTrue(table.stdout.contains("UPDATE"))
         assertTrue(table.stdout.contains("alice"))
+        // SYS-054: the resolved key must survive decode->render, not be dropped.
+        assertTrue(table.stdout.contains("my-component"), "componentKey value expected in table: ${table.stdout}")
 
         val jsonEx = QueueExchange(listOf(200 to page))
         val json = cli(jsonEx).test(listOf(URL, "--token=tok", "-o", "json", "audit", "recent"))
         assertEquals(0, json.statusCode, json.stderr)
         assertTrue(json.stdout.trimStart().startsWith("["), "json array expected: ${json.stdout}")
         assertTrue(json.stdout.contains("\"action\""))
+        assertTrue(json.stdout.contains("my-component"), "componentKey must survive into json output: ${json.stdout}")
     }
 
     @Test

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogResponse.kt
@@ -14,4 +14,12 @@ data class AuditLogResponse(
     val changeDiff: Map<String, Any?>?,
     val correlationId: String?,
     val source: String,
+    /**
+     * Human-readable component key for Component rows, resolved server-side from
+     * the entityId UUID. Authoritative for field-override rows (whose value
+     * snapshot carries no name) and stable across the snapshot's name/moduleName
+     * divergence. Null for non-Component entity types or when the component can
+     * no longer be resolved and the snapshot has no usable name.
+     */
+    val componentKey: String?,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -202,7 +202,11 @@ fun ComponentConfigurationEntity.toFieldOverrideResponse(): FieldOverrideRespons
     )
 }
 
-fun AuditLogEntity.toResponse(): AuditLogResponse =
+// `componentKey` is resolved by the service layer (which owns the component
+// repository) and threaded in here; the mapper itself stays a pure projection
+// with no DB access. Defaults to null so the few non-audit callers / tests that
+// don't resolve a key still compile.
+fun AuditLogEntity.toResponse(componentKey: String? = null): AuditLogResponse =
     AuditLogResponse(
         id = this.id!!,
         entityType = this.entityType,
@@ -215,6 +219,7 @@ fun AuditLogEntity.toResponse(): AuditLogResponse =
         changeDiff = this.changeDiff,
         correlationId = this.correlationId,
         source = this.source,
+        componentKey = componentKey,
     )
 
 // ============================================================

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
@@ -6,6 +6,7 @@ import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogResponse
 import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
 import org.octopusden.octopus.components.registry.server.mapper.toResponse
 import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.service.AuditService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -15,12 +16,14 @@ import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.util.UUID
 
 @ConditionalOnDatabaseEnabled
 @Service
 @Transactional(readOnly = true)
 class AuditServiceImpl(
     private val auditLogRepository: AuditLogRepository,
+    private val componentRepository: ComponentRepository,
 ) : AuditService {
     override fun getEntityHistory(
         entityType: String,
@@ -41,7 +44,7 @@ class AuditServiceImpl(
                 AuditLogEntity.ACTION_MIGRATED,
                 sorted,
             )
-        }.map { it.toResponse() }
+        }.toResponsePage()
     }
 
     override fun getRecentChanges(
@@ -50,7 +53,49 @@ class AuditServiceImpl(
     ): Page<AuditLogResponse> =
         auditLogRepository
             .findAll(buildSpecification(filter), withDefaultSort(pageable))
-            .map { it.toResponse() }
+            .toResponsePage()
+
+    /**
+     * Map a page of audit rows to responses, resolving each Component row's
+     * human-readable componentKey. Resolution is batched: one findAllById over
+     * the page's distinct component UUIDs, not a query per row.
+     */
+    private fun Page<AuditLogEntity>.toResponsePage(): Page<AuditLogResponse> {
+        val liveKeys = resolveLiveComponentKeys(content)
+        return map { it.toResponse(it.resolveComponentKey(liveKeys)) }
+    }
+
+    /** entityId UUID -> current componentKey, for the Component rows on a page. */
+    private fun resolveLiveComponentKeys(entities: List<AuditLogEntity>): Map<UUID, String> {
+        val ids =
+            entities
+                .filter { it.entityType == ENTITY_TYPE_COMPONENT }
+                .mapNotNull { it.entityId.toUuidOrNull() }
+                .distinct()
+        if (ids.isEmpty()) return emptyMap()
+        return componentRepository.findAllById(ids).associate { it.id!! to it.componentKey }
+    }
+
+    private fun AuditLogEntity.resolveComponentKey(liveKeys: Map<UUID, String>): String? {
+        if (entityType != ENTITY_TYPE_COMPONENT) return null
+        // Live key = the component's CURRENT key. On RENAME rows this is the new
+        // (post-rename) key by design: the log shows each row under the
+        // component's present identity, and the old key stays visible in oldValue.
+        entityId.toUuidOrNull()?.let { liveKeys[it] }?.let { return it }
+        // Component no longer exists (DELETE / MIGRATED / hard-deleted): fall
+        // back to the human-readable name captured in the snapshot. Component
+        // CRUD snapshots use `name`; git-history (MIGRATED) snapshots `moduleName`.
+        // takeIf{isNotBlank} keeps the null contract honest if a snapshot ever
+        // carried a blank name (the response advertises null for "unresolvable").
+        return (
+            newValue?.get("name")
+                ?: oldValue?.get("name")
+                ?: newValue?.get("moduleName")
+                ?: oldValue?.get("moduleName")
+        ).let { it as? String }?.takeIf { it.isNotBlank() }
+    }
+
+    private fun String.toUuidOrNull(): UUID? = runCatching { UUID.fromString(this) }.getOrNull()
 
     /**
      * `audit_log` rows are most useful "newest first" by `changed_at`. The legacy
@@ -112,5 +157,11 @@ class AuditServiceImpl(
         }
 
         return spec
+    }
+
+    companion object {
+        // The entityType audit rows carry for component changes (component CRUD,
+        // section edits, field overrides and git-history MIGRATED all share it).
+        private const val ENTITY_TYPE_COMPONENT = "Component"
     }
 }

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -54,6 +54,9 @@
           "changedBy" : {
             "type" : "string"
           },
+          "componentKey" : {
+            "type" : "string"
+          },
           "correlationId" : {
             "type" : "string"
           },

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditComponentKeyResolutionTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditComponentKeyResolutionTest.kt
@@ -1,0 +1,129 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.dto.v4.AuditLogFilter
+import org.octopusden.octopus.components.registry.server.entity.AuditLogEntity
+import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+import org.octopusden.octopus.components.registry.server.service.AuditService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * SYS-054 — `AuditLogResponse.componentKey` resolution branches that the live
+ * field-override lookup (covered in `FieldOverrideAuditTest`) does not exercise:
+ * the snapshot `name` / `moduleName` fallback for components that no longer
+ * exist, blank-name normalization to null, and null for non-Component rows.
+ *
+ * Drives `AuditService.getRecentChanges` directly against synthetic audit rows
+ * (random UUIDs absent from the components table, so the live lookup misses and
+ * the fallback path runs deterministically).
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class AuditComponentKeyResolutionTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var auditService: AuditService
+
+    @Autowired
+    private lateinit var auditLogRepository: AuditLogRepository
+
+    init {
+        // Same bootstrap as the other ft-db integration tests: the context binds
+        // components-registry.groovy-path from this env placeholder.
+        val testResourcesPath =
+            Paths.get(AuditComponentKeyResolutionTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("SYS-054: a deleted component (absent from the repo) falls back to the snapshot name")
+    fun `SYS-054 deleted component falls back to snapshot name`() {
+        val entityId = UUID.randomUUID().toString()
+        saveRow("Component", entityId, "DELETE", oldValue = mapOf("name" to "ghost-comp", "archived" to true))
+
+        assertEquals("ghost-comp", resolvedKey(entityId))
+    }
+
+    @Test
+    @DisplayName("SYS-054: a MIGRATED row with no name falls back to the snapshot moduleName")
+    fun `SYS-054 migrated row falls back to snapshot moduleName`() {
+        val entityId = UUID.randomUUID().toString()
+        saveRow(
+            "Component",
+            entityId,
+            AuditLogEntity.ACTION_MIGRATED,
+            newValue = mapOf("moduleName" to "legacy-module", "moduleConfigurations" to emptyList<Any>()),
+        )
+
+        assertEquals("legacy-module", resolvedKey(entityId))
+    }
+
+    @Test
+    @DisplayName("SYS-054: a blank snapshot name resolves to null, not an empty key")
+    fun `SYS-054 blank snapshot name resolves to null`() {
+        val entityId = UUID.randomUUID().toString()
+        saveRow("Component", entityId, "UPDATE", newValue = mapOf("name" to "   "))
+
+        assertNull(resolvedKey(entityId))
+    }
+
+    @Test
+    @DisplayName("SYS-054: non-Component rows resolve componentKey to null")
+    fun `SYS-054 non-component rows resolve to null`() {
+        val entityId = "non-component-entity-id"
+        saveRow("FieldDefinition", entityId, "UPDATE", newValue = mapOf("token" to "x"))
+
+        assertNull(resolvedKey(entityId))
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun saveRow(
+        entityType: String,
+        entityId: String,
+        action: String,
+        oldValue: Map<String, Any?>? = null,
+        newValue: Map<String, Any?>? = null,
+    ) {
+        auditLogRepository.save(
+            AuditLogEntity(
+                entityType = entityType,
+                entityId = entityId,
+                action = action,
+                oldValue = oldValue,
+                newValue = newValue,
+            ),
+        )
+    }
+
+    /** componentKey of the single audit row carrying [entityId] (includeMigrated so MIGRATED is visible). */
+    private fun resolvedKey(entityId: String): String? =
+        auditService
+            .getRecentChanges(AuditLogFilter(entityId = entityId, includeMigrated = true), PageRequest.of(0, 10))
+            .content
+            .single()
+            .componentKey
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
@@ -114,8 +114,8 @@ class FieldOverrideAuditTest {
     }
 
     @Test
-    @DisplayName("field-override audit rows expose the resolved componentKey, not just the UUID entityId")
-    fun `field-override audit rows expose componentKey`() {
+    @DisplayName("SYS-054: field-override audit rows expose the resolved componentKey, not just the UUID entityId")
+    fun `SYS-054 field-override audit rows expose the resolved componentKey, not just the UUID entityId`() {
         val name = "sys050key_${UUID.randomUUID().toString().take(8)}"
         val id = createComponent(name)
         createFieldOverride(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAuditTest.kt
@@ -113,6 +113,31 @@ class FieldOverrideAuditTest {
         )
     }
 
+    @Test
+    @DisplayName("field-override audit rows expose the resolved componentKey, not just the UUID entityId")
+    fun `field-override audit rows expose componentKey`() {
+        val name = "sys050key_${UUID.randomUUID().toString().take(8)}"
+        val id = createComponent(name)
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"FileA"}""",
+        )
+
+        // Field-override snapshots carry only the override payload (no "name"),
+        // so a populated componentKey proves it is resolved from the live
+        // component by entityId UUID — the part the value snapshot can't supply.
+        val updateRows = history(id).filter { it["action"].asText() == "UPDATE" }
+        assertTrue(updateRows.isNotEmpty(), "expected at least one override UPDATE row, got ${historyActions(id)}")
+        updateRows.forEach { row ->
+            assertTrue(row.has("componentKey"), "override UPDATE row must carry a componentKey field")
+            assertEquals(
+                name,
+                row["componentKey"].asText(),
+                "override UPDATE row must resolve componentKey to the component key, not the UUID",
+            )
+        }
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private fun createComponent(name: String): String {

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -1842,5 +1842,11 @@ rows resolve to `null`. On `RENAME` rows the live key is the current
 4. Rows whose `entityType` is not `Component` expose `componentKey = null`.
 5. The field is `null`-not-`required` in the generated OpenAPI `v4.json`.
 
-**Test method:** `FieldOverrideAuditTest` —
-`SYS-054 field-override audit rows expose the resolved componentKey, not just the UUID entityId`.
+**Test method:**
+`FieldOverrideAuditTest` — `SYS-054 field-override audit rows expose the resolved componentKey, not just the UUID entityId`: the override UPDATE rows belong to a live component, so this exercises the live-lookup path (criteria 1 and 2);
+`AuditComponentKeyResolutionTest` —
+`SYS-054 deleted component falls back to snapshot name` (criterion 3),
+`SYS-054 migrated row falls back to snapshot moduleName` (criterion 3),
+`SYS-054 blank snapshot name resolves to null` (criterion 3),
+`SYS-054 non-component rows resolve to null` (criterion 4).
+Criterion 5 is covered by `OpenApiV4SpecTest` (componentKey present in `v4.json`, absent from `required`).

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -62,6 +62,7 @@
 | SYS-051 | TeamCity sync (automated `changedBy=system` reconciliation) does NOT write an audit row — the re-link is traced via an INFO log instead | Medium | unit-test | ✅ Tested |
 | SYS-052 | An `employee-service.url` whose placeholder does not resolve in the current environment is treated as "not configured": the client bean is not registered and context refresh succeeds (fail-open), instead of failing application boot | High | unit-test | ✅ Tested |
 | SYS-053 | Component audit snapshots include section fields (BASE-configuration build/escrow/jira scalars, versionRange, section + per-component child collections), so a section-only PATCH writes an UPDATE audit row with a field-level diff instead of being dropped by the SYS-048 no-op guard; collection snapshots are content-only (no row ids) so an identical re-save stays a no-op | High | integration-test | ✅ Tested |
+| SYS-054 | Audit read endpoints expose a server-resolved `componentKey` on each Component row: resolved from the `entityId` UUID to the component's current key, batched per page; falls back to the snapshot `name` (CRUD) / `moduleName` (MIGRATED) for components that no longer exist; `null` for non-Component rows or when unresolvable. Covers field-override rows whose value snapshot carries no name | High | integration-test | ✅ Tested |
 
 ---
 
@@ -1807,3 +1808,39 @@ snapshot — their writes publish their own attribute-keyed events (SYS-050).
 `SYS-053 requiredTools PATCH writes an UPDATE audit row and identical re-send does not`,
 `SYS-053 securityGroups PATCH writes an UPDATE audit row and identical re-send does not`,
 `SYS-053 no-op section PATCH writes no audit row`.
+
+### SYS-054: Audit rows expose a resolved componentKey
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+Audit rows store `entityId` as the component UUID, so the audit read API
+exposed no human-readable key. Consumers (the Portal history table) had to dig
+the key out of the value snapshot, which fails for two row shapes: git-history
+`MIGRATED` snapshots key the component under `moduleName` (not `name`), and
+field-override (SYS-050) snapshots carry only the override payload — no name at
+all — leaving only the UUID. Those rows rendered an opaque UUID instead of a
+component key.
+
+**Description:**
+`AuditLogResponse` gains a nullable `componentKey`. For Component rows the
+service resolves it from the `entityId` UUID to the component's **current**
+`componentKey`, batched once per page (a single `findAllById` over the page's
+distinct UUIDs — no per-row query). When the component no longer exists
+(`DELETE` / `MIGRATED` / hard-deleted) it falls back to the name captured in
+the snapshot — `newValue.name` → `oldValue.name` → `newValue.moduleName` →
+`oldValue.moduleName` — and a blank name normalizes to `null`. Non-Component
+rows resolve to `null`. On `RENAME` rows the live key is the current
+(post-rename) key by design; the prior key remains in `oldValue`.
+
+**Acceptance criteria:**
+1. A Component CREATE/UPDATE row exposes `componentKey` equal to the component's current key.
+2. A field-override `UPDATE` row (snapshot has no `name`) exposes `componentKey` resolved from the live component — i.e. not the UUID.
+3. A row for a deleted/migrated component (absent from the repository) falls back to the snapshot `name` / `moduleName`; a blank name yields `null`.
+4. Rows whose `entityType` is not `Component` expose `componentKey = null`.
+5. The field is `null`-not-`required` in the generated OpenAPI `v4.json`.
+
+**Test method:** `FieldOverrideAuditTest` —
+`SYS-054 field-override audit rows expose the resolved componentKey, not just the UUID entityId`.


### PR DESCRIPTION
## What & why

Audit rows store `entityId` as the component **UUID**, so the audit REST contract exposed no human-readable component key. The portal audit table had to fall back to the value snapshot, which breaks for two row shapes:

- **field-override** rows — snapshot carries only the override payload, **no name at all** → only the UUID was available;
- **git-history MIGRATED** rows — key lives under `moduleName`, not `name`.

This adds a server-resolved `componentKey` to `AuditLogResponse` so consumers get an authoritative key for every Component row.

## How

- `dto/v4/AuditLogResponse.kt` — new nullable `componentKey` field.
- `service/impl/AuditServiceImpl.kt` — injects `ComponentRepository`; resolves the key **batched per page** (one `findAllById` over the page's distinct component UUIDs — no N+1) to the component's *current* key. Falls back to snapshot `name` (CRUD) → `moduleName` (MIGRATED) for components that no longer exist; `null` for non-Component rows or when unresolvable (blank names normalized to null).
- `mapper/V4Mappers.kt` — `toResponse()` takes the resolved key (mapper stays a pure projection, no DB access).
- `openapi/v4.json` — regenerated; `componentKey` added to `AuditLogResponse` (optional, not in `required`).

On RENAME rows the live key is the current (post-rename) key by design — each row shows the component's present identity; the old key stays in `oldValue`.

## Tests
- New case in `FieldOverrideAuditTest` asserts field-override audit rows expose `componentKey == <component key>` — since their snapshot has no `name`, a populated value proves the live UUID lookup (the exact gap this PR closes).
- `dbTest`: `FieldOverrideAuditTest`, `AuditLogFilterTest`, `AuditMigratedVisibilityTest`, `ComponentSectionAuditTest`, `AuditEventListenerTest` green.
- OpenAPI drift gate (`OpenApiV4SpecTest`) green against the regenerated spec.

## Follow-up (portal)
Once this merges and a CRS image is built, the portal side is already wired: `AuditLogEntry.componentKey` is consumed in `AuditLogTable` (PR #122). I'll vendor the updated spec + bump `crs.version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Traceability:** SYS-054 (requirements-common.md) — covered by `FieldOverrideAuditTest."SYS-054 …"`.
