### PR TITLE
feat(migration): SYS-054 anonymous migration-status probe for tokenless callers

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiV4Config.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiV4Config.kt
@@ -35,6 +35,8 @@ class OpenApiV4Config {
                 "/rest/api/4/config/**",
                 // InfoControllerV4 (not DB-gated).
                 "/rest/api/4/info",
+                // MigrationStatusControllerV4 — anonymous migration-activity probe (SYS-055).
+                "/rest/api/4/migration-status",
                 // AuthController at /auth/me — outside /rest/api/4.
                 "/auth/**",
             )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
@@ -93,6 +93,16 @@ class WebSecurityConfig(
                     // gateway does not have to special-case auth for /info.
                     .requestMatchers(HttpMethod.GET, "/rest/api/4/info")
                     .permitAll()
+                    // TRANSITIONAL (DSL→DB migration era): anonymous migration-activity
+                    // probe. The portal's tokenless validation sweep reads this to skip
+                    // while a migration/resync is RUNNING and the legacy v2/v3 resolver
+                    // may serve inconsistent (not-yet-migrated) `archived` flags. The
+                    // authoritative state is admin-gated under /rest/api/4/admin/** and
+                    // unreachable without a JWT, hence this non-sensitive permitAll
+                    // sibling. Remove together with MigrationStatusControllerV4 once the
+                    // migration era is over (no body detail, just a running flag — no leak).
+                    .requestMatchers(HttpMethod.GET, "/rest/api/4/migration-status")
+                    .permitAll()
                     // v4 writes + admin + audit — authenticated + method-level @PreAuthorize.
                     .requestMatchers("/rest/api/4/**")
                     .authenticated()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/MigrationStatusControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/MigrationStatusControllerV4.kt
@@ -1,0 +1,54 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * ANONYMOUS (permitAll) probe of whether a migration / resync job is currently
+ * RUNNING in this pod.
+ *
+ * WHY PUBLIC: the portal's background validation sweep calls CRS WITHOUT a JWT
+ * (no user token on a scheduled sweep) and must skip while a migration is in
+ * flight — during a Git→DB migration the legacy v2/v3 resolver can serve
+ * components with not-yet-migrated archived flags, which the sweep would
+ * otherwise validate and report as spurious problems. The authoritative job
+ * state lives behind the admin-gated /rest/api/4/admin API which the
+ * tokenless sweep cannot read, hence this minimal, non-sensitive sibling on a
+ * permitAll path. Only the boolean is load-bearing; kind is for logs/ops.
+ *
+ * TRANSITIONAL: this endpoint only matters during the DSL→DB migration era.
+ * Once all components are DB-native and the legacy migration/resync jobs are
+ * retired, this controller AND its permitAll rule in
+ * [org.octopusden.octopus.components.registry.server.config.WebSecurityConfig]
+ * can be deleted.
+ *
+ * Single-pod scope: backed by [MigrationLifecycleGate]'s in-memory
+ * AtomicReference (same caveat as the admin job endpoints) — if CRS runs with
+ * replicas > 1 during a migration, a probe may hit a non-migrating pod. Making
+ * the gate DB-backed is the documented followup (MigrationLifecycleGate KDoc).
+ */
+@RestController
+@RequestMapping("rest/api/4/migration-status")
+class MigrationStatusControllerV4(
+    private val migrationLifecycleGate: MigrationLifecycleGate,
+) {
+    @GetMapping
+    fun migrationStatus(): MigrationStatusResponse {
+        val active = migrationLifecycleGate.current()
+        return MigrationStatusResponse(running = active != null, kind = active?.kind?.name)
+    }
+}
+
+/**
+ * Minimal, non-sensitive migration-activity signal.
+ *
+ * - [running] — true iff a migration / resync job holds the lifecycle gate.
+ * - [kind] — which job kind holds it (COMPONENTS / HISTORY / TC_RESYNC), or null
+ *   when nothing is running. Informational only.
+ */
+data class MigrationStatusResponse(
+    val running: Boolean,
+    val kind: String?,
+)

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -1639,6 +1639,20 @@
         ],
         "type" : "object"
       },
+      "MigrationStatusResponse" : {
+        "properties" : {
+          "kind" : {
+            "type" : "string"
+          },
+          "running" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [
+          "running"
+        ],
+        "type" : "object"
+      },
       "PackageRequest" : {
         "properties" : {
           "packageName" : {
@@ -7317,6 +7331,96 @@
         },
         "tags" : [
           "info-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/migration-status" : {
+      "get" : {
+        "operationId" : "migrationStatus",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MigrationStatusResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "migration-status-controller-v-4"
         ]
       }
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MigrationStatusControllerV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MigrationStatusControllerV4Test.kt
@@ -1,0 +1,86 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Path
+import java.nio.file.Paths
+
+// Pins the transitional, ANONYMOUS migration-status probe (GET /rest/api/4/migration-status):
+//   - permitAll URL rule in WebSecurityConfig → 200 (not 401) for a tokenless caller.
+//     This is the whole point — the portal's validation sweep calls CRS without a JWT
+//     and must be able to read this signal (the admin /migrate/job endpoint cannot).
+//   - body maps MigrationLifecycleGate.current() → { running, kind }.
+// Exercised through the full security stack (a slice @WebMvcTest wouldn't load the real
+// WebSecurityConfig), mirroring AdminControllerV4SecurityTest.
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "test")
+@Tag("integration")
+class MigrationStatusControllerV4Test {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @MockBean
+    private lateinit var migrationLifecycleGate: MigrationLifecycleGate
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Test
+    @DisplayName("SYS-055: anonymous GET /migration-status returns 200 with running=false when no job is active")
+    fun `SYS-055 anonymous probe returns running false when gate is free`() {
+        `when`(migrationLifecycleGate.current()).thenReturn(null)
+
+        mvc
+            .perform(get("/rest/api/4/migration-status"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.running").value(false))
+            .andExpect(jsonPath("$.kind").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("SYS-055: anonymous GET /migration-status returns 200 with running=true + kind while a job is active")
+    fun `SYS-055 anonymous probe returns running true with kind while a migration runs`() {
+        `when`(migrationLifecycleGate.current()).thenReturn(
+            MigrationLifecycleGate.ActiveJob(
+                kind = MigrationLifecycleGate.JobKind.COMPONENTS,
+                jobId = "00000000-0000-0000-0000-000000000000",
+            ),
+        )
+
+        mvc
+            .perform(get("/rest/api/4/migration-status"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.running").value(true))
+            .andExpect(jsonPath("$.kind").value("COMPONENTS"))
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun configureTestDataDir() {
+            val resourcesPath: Path =
+                Paths.get(MigrationStatusControllerV4Test::class.java.getResource("/expected-data")!!.toURI()).parent
+            System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", resourcesPath.toString())
+        }
+    }
+}

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -63,6 +63,7 @@
 | SYS-052 | An `employee-service.url` whose placeholder does not resolve in the current environment is treated as "not configured": the client bean is not registered and context refresh succeeds (fail-open), instead of failing application boot | High | unit-test | ✅ Tested |
 | SYS-053 | Component audit snapshots include section fields (BASE-configuration build/escrow/jira scalars, versionRange, section + per-component child collections), so a section-only PATCH writes an UPDATE audit row with a field-level diff instead of being dropped by the SYS-048 no-op guard; collection snapshots are content-only (no row ids) so an identical re-save stays a no-op | High | integration-test | ✅ Tested |
 | SYS-054 | Audit read endpoints expose a server-resolved `componentKey` on each Component row: resolved from the `entityId` UUID to the component's current key, batched per page; falls back to the snapshot `name` (CRUD) / `moduleName` (MIGRATED) for components that no longer exist; `null` for non-Component rows or when unresolvable. Covers field-override rows whose value snapshot carries no name | High | integration-test | ✅ Tested |
+| SYS-055 | Anonymous `GET /rest/api/4/migration-status` reports whether a migration/resync job is RUNNING ({running, kind}) so a tokenless caller (the portal validation sweep) can skip while the legacy resolver may serve not-yet-migrated data | Medium | integration-test | ✅ Tested |
 
 ---
 
@@ -1850,3 +1851,46 @@ rows resolve to `null`. On `RENAME` rows the live key is the current
 `SYS-054 blank snapshot name resolves to null` (criterion 3),
 `SYS-054 non-component rows resolve to null` (criterion 4).
 Criterion 5 is covered by `OpenApiV4SpecTest` (componentKey present in `v4.json`, absent from `required`).
+
+### SYS-055: Anonymous migration-status probe for tokenless callers
+
+**Priority:** Medium
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+The portal runs a background validation sweep that calls CRS WITHOUT a JWT (no
+user token on a scheduled sweep) and must skip while a migration is in flight:
+mid Git→DB migration the legacy v2/v3 resolver can serve components with
+not-yet-migrated `archived` flags, which the sweep would otherwise validate and
+cache as spurious problems on already-archived components. The authoritative job
+state is exposed only under the admin-gated `/rest/api/4/admin/**` API, which the
+tokenless sweep cannot read — so there was no signal an unauthenticated caller
+could use to detect an in-flight migration.
+
+**Description:**
+`GET /rest/api/4/migration-status` is an anonymous (permitAll) endpoint returning
+`{ "running": Boolean, "kind": String? }`, derived from
+`MigrationLifecycleGate.current()` — `running` is true iff a COMPONENTS, HISTORY,
+or TC_RESYNC job currently holds the gate; `kind` is that job kind (informational,
+null when idle). The body carries no component data or internal topology. It sits
+on a permitAll path next to `GET /rest/api/4/info`, ordered before the
+`/rest/api/4/**` authenticated catch-all so it does not widen any other route.
+
+This endpoint is **transitional**: it only matters during the DSL→DB migration
+era. Once all components are DB-native and the legacy migration/resync jobs are
+retired, `MigrationStatusControllerV4` and its permitAll rule can be deleted.
+
+Single-pod scope: `MigrationLifecycleGate` is an in-memory AtomicReference (same
+caveat as the admin job endpoints) — with CRS replicas > 1 a probe may hit a
+non-migrating pod. Making the gate DB-backed is the documented follow-up (MIG-028).
+
+**Acceptance criteria:**
+1. An unauthenticated (no JWT) `GET /rest/api/4/migration-status` returns `200 OK` (NOT 401) — the route is permitAll.
+2. When no migration/resync job holds the lifecycle gate, the body is `{ "running": false }` (the `kind` key is omitted/null).
+3. While a job holds the gate, the body is `{ "running": true, "kind": "<COMPONENTS|HISTORY|TC_RESYNC>" }`.
+4. The body never carries component data, credentials, or internal topology.
+
+**Test method:** `MigrationStatusControllerV4Test` —
+`SYS-055 anonymous probe returns running false when gate is free`,
+`SYS-055 anonymous probe returns running true with kind while a migration runs`.


### PR DESCRIPTION
## What

Adds an **anonymous** `GET /rest/api/4/migration-status` endpoint returning `{ "running": Boolean, "kind": String? }`, derived from `MigrationLifecycleGate.current()` (`running` = a COMPONENTS/HISTORY/TC_RESYNC job holds the gate; `kind` = which one, informational).

## Why

The portal runs a background **validation sweep** that calls CRS **without a JWT**. During a Git→DB migration the legacy v2/v3 resolver can serve components with not-yet-migrated `archived` flags, so the sweep validates already-archived components and caches spurious "problems". The authoritative job state is admin-gated under `/rest/api/4/admin/**`, unreachable by the tokenless sweep — hence this minimal, non-sensitive `permitAll` sibling so the sweep can detect an in-flight migration and skip.

Consumed by the portal change in octopusden/octopus-components-management-portal (`feat/validation-skip-during-migration`) — **merge this first**; that side is inert until this endpoint ships.

## Security

`permitAll`, GET-only, exact path, ordered before the `/rest/api/4/**` authenticated catch-all (next to `GET /rest/api/4/info`). Body carries only `{running, kind}` — no component data, credentials, or topology.

## Transitional

Only relevant during the DSL→DB migration era — remove `MigrationStatusControllerV4` and its `permitAll` rule once components are DB-native and the legacy migration/resync jobs are retired.

**Caveat:** `MigrationLifecycleGate` is in-memory per-pod; with CRS replicas > 1 a probe may hit a non-migrating pod. DB-backed gate is the documented follow-up (MIG-028).

## Traceability

SYS-054 in `docs/registry/requirements-common.md` (acceptance criteria); `MigrationStatusControllerV4Test` carries the ID in method name + `@DisplayName`. Verified via `dbTest`; module `check` (ktlint/detekt + unit) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)