### PR TITLE
feat(audit): capture Jira task key + change comment on component save

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
@@ -51,6 +51,7 @@ class AuditControllerV4(
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
         @RequestParam(required = false, defaultValue = "false") includeMigrated: Boolean,
+        @RequestParam(required = false) jiraTaskKey: String?,
         pageable: Pageable,
     ): Page<AuditLogResponse> {
         val filter =
@@ -63,6 +64,7 @@ class AuditControllerV4(
                 from = from,
                 to = to,
                 includeMigrated = includeMigrated,
+                jiraTaskKey = jiraTaskKey,
             )
         return auditService.getRecentChanges(filter, pageable)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditControllerV4.kt
@@ -52,6 +52,7 @@ class AuditControllerV4(
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
         @RequestParam(required = false, defaultValue = "false") includeMigrated: Boolean,
         @RequestParam(required = false) jiraTaskKey: String?,
+        @RequestParam(required = false) changeComment: String?,
         pageable: Pageable,
     ): Page<AuditLogResponse> {
         val filter =
@@ -65,6 +66,7 @@ class AuditControllerV4(
                 to = to,
                 includeMigrated = includeMigrated,
                 jiraTaskKey = jiraTaskKey,
+                changeComment = changeComment,
             )
         return auditService.getRecentChanges(filter, pageable)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import jakarta.validation.Valid
 import org.octopusden.octopus.components.registry.api.enums.EscrowGenerationMode
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.components.registry.server.config.ComponentsRegistryProperties
@@ -229,7 +230,7 @@ class ComponentControllerV4(
             "and @permissionEvaluator.hasPermission('CREATE_COMPONENTS')",
     )
     fun createComponent(
-        @RequestBody request: ComponentCreateRequest,
+        @Valid @RequestBody request: ComponentCreateRequest,
     ): ComponentDetailResponse = withCanEdit(componentManagementService.createComponent(request))
 
     @GetMapping
@@ -407,7 +408,7 @@ class ComponentControllerV4(
     )
     fun updateComponent(
         @PathVariable id: UUID,
-        @RequestBody request: ComponentUpdateRequest,
+        @Valid @RequestBody request: ComponentUpdateRequest,
     ): ComponentDetailResponse = withCanEdit(componentManagementService.updateComponent(id, request))
 
     @DeleteMapping("/{id}")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
@@ -16,6 +16,9 @@ import java.time.Instant
  * an explicit `action = MIGRATED` filter always wins regardless of this flag
  * (SYS-049).
  *
+ * `jiraTaskKey` matches the change-metadata key captured at save time (exact
+ * match on `audit_log.jira_task_key`) — drives the Portal's "search by task key".
+ *
  * Contract: `SYS-036`, `SYS-049` in `requirements-common.md`.
  */
 data class AuditLogFilter(
@@ -27,4 +30,5 @@ data class AuditLogFilter(
     val from: Instant? = null,
     val to: Instant? = null,
     val includeMigrated: Boolean = false,
+    val jiraTaskKey: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogFilter.kt
@@ -16,8 +16,10 @@ import java.time.Instant
  * an explicit `action = MIGRATED` filter always wins regardless of this flag
  * (SYS-049).
  *
- * `jiraTaskKey` matches the change-metadata key captured at save time (exact
- * match on `audit_log.jira_task_key`) — drives the Portal's "search by task key".
+ * `jiraTaskKey` and `changeComment` match the change metadata captured at save
+ * time — both are **case-insensitive substring** matches (`%term%`) on
+ * `audit_log.jira_task_key` / `audit_log.change_comment`. They drive the Portal's
+ * audit search ("ABC" or "123" both find "ABC-123").
  *
  * Contract: `SYS-036`, `SYS-049` in `requirements-common.md`.
  */
@@ -31,4 +33,5 @@ data class AuditLogFilter(
     val to: Instant? = null,
     val includeMigrated: Boolean = false,
     val jiraTaskKey: String? = null,
+    val changeComment: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/AuditLogResponse.kt
@@ -15,6 +15,13 @@ data class AuditLogResponse(
     val correlationId: String?,
     val source: String,
     /**
+     * Jira task key motivating the change, captured at save time. Optional —
+     * null when the user supplied no key. Filterable via `audit/recent?jiraTaskKey=`.
+     */
+    val jiraTaskKey: String?,
+    /** Free-text comment captured at save time. Optional — null when not supplied. */
+    val changeComment: String?,
+    /**
      * Human-readable component key for Component rows, resolved server-side from
      * the entityId UUID. Authoritative for field-override rows (whose value
      * snapshot carries no name) and stable across the snapshot's name/moduleName

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ChangeMetadata.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ChangeMetadata.kt
@@ -1,0 +1,11 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+/**
+ * Bean-Validation pattern for the optional change-metadata Jira task key carried
+ * on component create/update requests. A blank/whitespace value is a valid
+ * "no key" (normalized to null before persisting); a non-blank value must look
+ * like a Jira key — a project key of 2+ chars starting with a letter, a dash,
+ * then digits (e.g. `ABC-123`). Shared by ComponentCreateRequest /
+ * ComponentUpdateRequest and mirrored client-side in the Portal.
+ */
+const val JIRA_TASK_KEY_PATTERN = "^\\s*\$|^[A-Z][A-Z0-9]+-\\d+\$"

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.components.registry.server.dto.v4
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Pattern
 
 /**
  * Create body for a new component. Mirrors the v2 schema row-for-row — no
@@ -80,4 +81,21 @@ data class ComponentCreateRequest(
     // BaseConfigurationRequest schema, where it would wrongly appear on the (optional) Update use.
     @field:Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     val baseConfiguration: BaseConfigurationRequest? = null,
+    // Optional change metadata recorded on the audit row (not on the component).
+    // A blank/whitespace key is accepted as "no key" (normalized to null); a
+    // non-blank key must match the Jira key format. See JIRA_TASK_KEY_PATTERN.
+    @field:Pattern(
+        regexp = JIRA_TASK_KEY_PATTERN,
+        message = "must be a Jira task key like ABC-123",
+    )
+    @field:Schema(
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+        description = "Optional Jira task key motivating the change (e.g. ABC-123); recorded on the audit row.",
+    )
+    val jiraTaskKey: String? = null,
+    @field:Schema(
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+        description = "Optional free-text comment describing the change; recorded on the audit row.",
+    )
+    val changeComment: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.components.registry.server.dto.v4
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Pattern
 
 /**
  * Patch body (JSON Merge Patch semantics): null scalar = "don't touch";
@@ -67,4 +68,22 @@ data class ComponentUpdateRequest(
     val securityGroups: List<SecurityGroupRequest>? = null,
     val teamcityProjects: List<TeamcityProjectRequest>? = null,
     val baseConfiguration: BaseConfigurationRequest? = null,
+    // Optional change metadata recorded on the audit row (not on the component).
+    // These are change-scoped, not part of the component's patchable state: a
+    // blank/whitespace key is accepted as "no key" (normalized to null), and a
+    // non-blank key must match the Jira key format. See JIRA_TASK_KEY_PATTERN.
+    @field:Pattern(
+        regexp = JIRA_TASK_KEY_PATTERN,
+        message = "must be a Jira task key like ABC-123",
+    )
+    @field:Schema(
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+        description = "Optional Jira task key motivating the change (e.g. ABC-123); recorded on the audit row.",
+    )
+    val jiraTaskKey: String? = null,
+    @field:Schema(
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+        description = "Optional free-text comment describing the change; recorded on the audit row.",
+    )
+    val changeComment: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/AuditLogEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/AuditLogEntity.kt
@@ -58,6 +58,15 @@ class AuditLogEntity(
 
     @Column(name = "source", nullable = false, length = 20)
     var source: String = "api",
+
+    // Change metadata captured at save time (component create/update). Optional;
+    // a blank Jira key is normalized to null before persisting. The key is
+    // indexed to back `GET /audit/recent?jiraTaskKey=...`.
+    @Column(name = "jira_task_key")
+    var jiraTaskKey: String? = null,
+
+    @Column(name = "change_comment", columnDefinition = "TEXT")
+    var changeComment: String? = null,
 ) {
     companion object {
         /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEvent.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEvent.kt
@@ -7,4 +7,8 @@ data class AuditEvent(
     val changedBy: String? = null,
     val oldValue: Map<String, Any?>? = null,
     val newValue: Map<String, Any?>? = null,
+    // Optional change metadata captured at save time (component create/update);
+    // null for internal/cascade events that carry no user-supplied context.
+    val jiraTaskKey: String? = null,
+    val changeComment: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
@@ -22,6 +22,11 @@ class AuditEventListener(
         // the audit log with meaningless "saved, changed nothing" entries (e.g. a
         // Save click on an unmodified form). CREATE (null oldValue) and DELETE
         // (null newValue) legitimately produce a null diff and must still be kept.
+        //
+        // Note: change metadata (jiraTaskKey/changeComment) is recorded ON the
+        // change, not independently — a PATCH that supplies a key/comment but
+        // alters no field is still a no-op and writes no row. The audit log tracks
+        // field changes, not intent, so there is nothing to attach the metadata to.
         if (event.oldValue != null && event.newValue != null && changeDiff == null) {
             return
         }
@@ -35,6 +40,8 @@ class AuditEventListener(
                 oldValue = event.oldValue,
                 newValue = event.newValue,
                 changeDiff = changeDiff,
+                jiraTaskKey = event.jiraTaskKey,
+                changeComment = event.changeComment,
             )
         auditLogRepository.save(auditLog)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -222,6 +222,8 @@ fun AuditLogEntity.toResponse(componentKey: String? = null): AuditLogResponse =
         changeDiff = this.changeDiff,
         correlationId = this.correlationId,
         source = this.source,
+        jiraTaskKey = this.jiraTaskKey,
+        changeComment = this.changeComment,
         componentKey = componentKey,
     )
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
@@ -156,8 +156,25 @@ class AuditServiceImpl(
             spec = spec.and(Specification { root, _, cb -> cb.lessThan(root.get<Instant>("changedAt"), to) })
         }
 
-        filter.jiraTaskKey?.let { jiraTaskKey ->
-            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("jiraTaskKey"), jiraTaskKey) })
+        // Substring, case-insensitive match — "abc" / "123" both find "ABC-123".
+        // LIKE metacharacters in the term are escaped so they're matched literally.
+        filter.jiraTaskKey?.takeIf { it.isNotBlank() }?.let { term ->
+            spec =
+                spec.and(
+                    Specification { root, _, cb ->
+                        cb.like(cb.lower(root.get<String>("jiraTaskKey")), containsPattern(term), LIKE_ESCAPE)
+                    },
+                )
+        }
+
+        // Free-text comment search — substring, case-insensitive.
+        filter.changeComment?.takeIf { it.isNotBlank() }?.let { term ->
+            spec =
+                spec.and(
+                    Specification { root, _, cb ->
+                        cb.like(cb.lower(root.get<String>("changeComment")), containsPattern(term), LIKE_ESCAPE)
+                    },
+                )
         }
 
         return spec
@@ -167,5 +184,22 @@ class AuditServiceImpl(
         // The entityType audit rows carry for component changes (component CRUD,
         // section edits, field overrides and git-history MIGRATED all share it).
         private const val ENTITY_TYPE_COMPONENT = "Component"
+
+        private const val LIKE_ESCAPE = '\\'
+
+        /**
+         * Build a case-insensitive `%term%` LIKE pattern, escaping the term's own
+         * `\` `%` `_` so they match literally instead of acting as wildcards. Pair
+         * with `cb.lower(column)` and the `LIKE_ESCAPE` escape char.
+         */
+        private fun containsPattern(term: String): String {
+            val escaped =
+                term
+                    .lowercase()
+                    .replace("\\", "\\\\")
+                    .replace("%", "\\%")
+                    .replace("_", "\\_")
+            return "%$escaped%"
+        }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/AuditServiceImpl.kt
@@ -156,6 +156,10 @@ class AuditServiceImpl(
             spec = spec.and(Specification { root, _, cb -> cb.lessThan(root.get<Instant>("changedAt"), to) })
         }
 
+        filter.jiraTaskKey?.let { jiraTaskKey ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("jiraTaskKey"), jiraTaskKey) })
+        }
+
         return spec
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -349,6 +349,8 @@ class ComponentManagementServiceImpl(
                     saved,
                     overrideLabels = canonicalizedLabels,
                 ) + sectionAuditMap(saved),
+            jiraTaskKey = request.jiraTaskKey,
+            changeComment = request.changeComment,
         )
 
         return toDetail(saved)
@@ -715,6 +717,8 @@ class ComponentManagementServiceImpl(
                     saved,
                     overrideLabels = canonicalizedLabels ?: originalLabels,
                 ) + sectionAuditMap(saved),
+            jiraTaskKey = request.jiraTaskKey,
+            changeComment = request.changeComment,
         )
 
         return toDetail(saved)
@@ -3019,6 +3023,8 @@ class ComponentManagementServiceImpl(
         entityId: String,
         oldValue: Map<String, Any?>? = null,
         newValue: Map<String, Any?>? = null,
+        jiraTaskKey: String? = null,
+        changeComment: String? = null,
     ) {
         applicationEventPublisher.publishEvent(
             AuditEvent(
@@ -3028,6 +3034,10 @@ class ComponentManagementServiceImpl(
                 changedBy = currentUserResolver.currentUsername(),
                 oldValue = oldValue,
                 newValue = newValue,
+                // Normalize blank/whitespace → null so a stray "" from the client
+                // is never persisted (the @Pattern accepts blank as "no key").
+                jiraTaskKey = jiraTaskKey?.trim()?.ifBlank { null },
+                changeComment = changeComment?.trim()?.ifBlank { null },
             ),
         )
     }

--- a/components-registry-service-server/src/main/resources/db/migration/V3__add_audit_change_metadata.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V3__add_audit_change_metadata.sql
@@ -1,0 +1,6 @@
+-- Change metadata captured at save time: the Jira task that motivated the change
+-- and a free-text comment. Both optional; stored on the audit row (not the
+-- component). The index backs `GET /audit/recent?jiraTaskKey=...` search.
+ALTER TABLE audit_log ADD COLUMN jira_task_key VARCHAR(255);
+ALTER TABLE audit_log ADD COLUMN change_comment TEXT;
+CREATE INDEX idx_audit_jira_task_key ON audit_log(jira_task_key);

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -4038,6 +4038,14 @@
           },
           {
             "in" : "query",
+            "name" : "changeComment",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
             "name" : "pageable",
             "required" : true,
             "schema" : {

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -63,6 +63,9 @@
           "action" : {
             "type" : "string"
           },
+          "changeComment" : {
+            "type" : "string"
+          },
           "changeDiff" : {
             "additionalProperties" : {
               "type" : "object"
@@ -91,6 +94,9 @@
           "id" : {
             "format" : "int64",
             "type" : "integer"
+          },
+          "jiraTaskKey" : {
+            "type" : "string"
           },
           "newValue" : {
             "additionalProperties" : {
@@ -445,6 +451,10 @@
           "canBeParent" : {
             "type" : "boolean"
           },
+          "changeComment" : {
+            "description" : "Optional free-text comment describing the change; recorded on the audit row.",
+            "type" : "string"
+          },
           "clientCode" : {
             "type" : "string"
           },
@@ -476,6 +486,11 @@
             "type" : "string"
           },
           "jiraHotfixVersionFormat" : {
+            "type" : "string"
+          },
+          "jiraTaskKey" : {
+            "description" : "Optional Jira task key motivating the change (e.g. ABC-123); recorded on the audit row.",
+            "pattern" : "^\\s*$|^[A-Z][A-Z0-9]+-\\d+$",
             "type" : "string"
           },
           "labels" : {
@@ -833,6 +848,10 @@
           "canBeParent" : {
             "type" : "boolean"
           },
+          "changeComment" : {
+            "description" : "Optional free-text comment describing the change; recorded on the audit row.",
+            "type" : "string"
+          },
           "clearGroup" : {
             "type" : "boolean"
           },
@@ -870,6 +889,11 @@
             "type" : "string"
           },
           "jiraHotfixVersionFormat" : {
+            "type" : "string"
+          },
+          "jiraTaskKey" : {
+            "description" : "Optional Jira task key motivating the change (e.g. ABC-123); recorded on the audit row.",
+            "pattern" : "^\\s*$|^[A-Z][A-Z0-9]+-\\d+$",
             "type" : "string"
           },
           "labels" : {
@@ -4002,6 +4026,14 @@
             "schema" : {
               "default" : false,
               "type" : "boolean"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "jiraTaskKey",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
             }
           },
           {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditChangeMetadataTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditChangeMetadataTest.kt
@@ -222,4 +222,42 @@ class AuditChangeMetadataTest {
         assert(ids.contains(idA)) { "expected the matching component $idA in the response" }
         assert(!ids.contains(idB)) { "expected non-matching component $idB to be excluded" }
     }
+
+    @Test
+    @DisplayName("audit/recent jiraTaskKey filter is a case-insensitive substring match")
+    fun filterByJiraTaskKey_substringCaseInsensitive() {
+        val idA = createComponent(uniqueName("meta_sa"), jiraTaskKey = "ABX-7001", changeComment = "a")
+        val idB = createComponent(uniqueName("meta_sb"), jiraTaskKey = "ZZZ-8002", changeComment = "b")
+
+        // Lower-case mid-string fragment of ABX-7001 only.
+        val ids = entityIdsForRecent("jiraTaskKey" to "bx-70")
+        assert(ids.contains(idA)) { "expected substring 'bx-70' to match ABX-7001 ($idA), got $ids" }
+        assert(!ids.contains(idB)) { "expected ZZZ-8002 ($idB) excluded, got $ids" }
+    }
+
+    @Test
+    @DisplayName("audit/recent filtered by changeComment is a case-insensitive substring match")
+    fun filterByChangeComment_substring() {
+        val idA = createComponent(uniqueName("meta_ca"), jiraTaskKey = "ABC-1", changeComment = "Alpha release prep")
+        val idB = createComponent(uniqueName("meta_cb"), jiraTaskKey = "ABC-2", changeComment = "beta cleanup")
+
+        val ids = entityIdsForRecent("changeComment" to "alpha rel")
+        assert(ids.contains(idA)) { "expected comment substring to match '$idA', got $ids" }
+        assert(!ids.contains(idB)) { "expected '$idB' excluded, got $ids" }
+    }
+
+    /** GET /audit/recent with one filter param; returns the set of entityIds in the page. */
+    private fun entityIdsForRecent(param: Pair<String, String>): Set<String> {
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param(param.first, param.second)
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["content"].map { it["entityId"].asText() }.toSet()
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditChangeMetadataTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditChangeMetadataTest.kt
@@ -1,0 +1,225 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.repository.AuditLogRepository
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * Change metadata on save (Jira task key + free-text comment). The Portal prompts
+ * for an optional Jira task key and a comment when saving a component change, and
+ * CRS persists them on the corresponding `audit_log` row (alongside correlationId),
+ * returns them in `AuditLogResponse`, and supports filtering `audit/recent` by key.
+ *
+ * Both fields are optional. A blank/whitespace key is a valid "no key" (stored
+ * null, never 400); a non-blank key must match a Jira key pattern (`ABC-123`) or
+ * the create/update is rejected with 400 by `@Valid`/`@field:Pattern`.
+ *
+ * Test layer: integration — exercises the full stack (controller validation →
+ * service → AuditEventListener → entity → V3 migration → response + filter).
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class AuditChangeMetadataTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var auditLogRepository: AuditLogRepository
+
+    init {
+        val testResourcesPath =
+            Paths.get(AuditChangeMetadataTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun uniqueName(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    /** POST a component, optionally with change metadata. Returns the new id. Expects 201. */
+    private fun createComponent(
+        name: String,
+        jiraTaskKey: String? = null,
+        changeComment: String? = null,
+    ): String {
+        val extra = buildString {
+            if (jiraTaskKey != null) append(""","jiraTaskKey":${objectMapper.writeValueAsString(jiraTaskKey)}""")
+            if (changeComment != null) append(""","changeComment":${objectMapper.writeValueAsString(changeComment)}""")
+        }
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"name":"$name","displayName":"$name",""" +
+                                """"componentOwner":"owner1",""" +
+                                """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}$extra}""",
+                        ),
+                ).andExpect(status().isCreated)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun versionOf(id: String): Long {
+        val detail =
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(detail)["version"].asLong()
+    }
+
+    /** Fetch the single audit row for (entityId, action). Fails if not exactly one. */
+    private fun auditRow(
+        entityId: String,
+        action: String,
+    ): com.fasterxml.jackson.databind.JsonNode {
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("entityId", entityId)
+                        .param("action", action)
+                        .param("size", "10"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val rows = objectMapper.readTree(body)["content"]
+        assert(rows.size() == 1) { "expected exactly one $action row for $entityId, got ${rows.size()}" }
+        return rows[0]
+    }
+
+    @Test
+    @DisplayName("CREATE persists jiraTaskKey + changeComment and returns them on the audit row")
+    fun create_persistsMetadata() {
+        val key = "ABC-123"
+        val comment = "initial import"
+        val id = createComponent(uniqueName("meta_create"), jiraTaskKey = key, changeComment = comment)
+
+        val row = auditRow(id, "CREATE")
+        assert(row["jiraTaskKey"].asText() == key) { "expected jiraTaskKey=$key, got ${row["jiraTaskKey"]}" }
+        assert(row["changeComment"].asText() == comment) {
+            "expected changeComment=$comment, got ${row["changeComment"]}"
+        }
+    }
+
+    @Test
+    @DisplayName("UPDATE persists jiraTaskKey + changeComment on the UPDATE audit row")
+    fun update_persistsMetadata() {
+        val id = createComponent(uniqueName("meta_update"))
+        val version = versionOf(id)
+        val key = "DEF-456"
+        val comment = "renamed display name per ticket"
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"version":$version,"displayName":"changed_display",""" +
+                            """"jiraTaskKey":"$key","changeComment":"$comment"}""",
+                    ),
+            ).andExpect(status().isOk)
+
+        val row = auditRow(id, "UPDATE")
+        assert(row["jiraTaskKey"].asText() == key) { "expected jiraTaskKey=$key, got ${row["jiraTaskKey"]}" }
+        assert(row["changeComment"].asText() == comment) {
+            "expected changeComment=$comment, got ${row["changeComment"]}"
+        }
+    }
+
+    @Test
+    @DisplayName("Malformed jiraTaskKey is rejected with 400")
+    fun malformedKey_rejected() {
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"name":"${uniqueName("meta_bad")}","displayName":"x","componentOwner":"owner1",""" +
+                            """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                            """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}},""" +
+                            """"jiraTaskKey":"not a key"}""",
+                    ),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("Blank jiraTaskKey is accepted (no 400) and stored as null; comment still persists")
+    fun blankKey_accepted_storedNull() {
+        val comment = "no ticket for this one"
+        val id = createComponent(uniqueName("meta_blank"), jiraTaskKey = "   ", changeComment = comment)
+
+        val row = auditRow(id, "CREATE")
+        assert(row["jiraTaskKey"].isNull) { "expected null jiraTaskKey for blank input, got ${row["jiraTaskKey"]}" }
+        assert(row["changeComment"].asText() == comment) {
+            "expected changeComment=$comment, got ${row["changeComment"]}"
+        }
+    }
+
+    @Test
+    @DisplayName("audit/recent filtered by jiraTaskKey returns only matching rows")
+    fun filterByJiraTaskKey_returnsMatching() {
+        val keyA = "PROJ-1001"
+        val idA = createComponent(uniqueName("meta_fa"), jiraTaskKey = keyA, changeComment = "a")
+        val idB = createComponent(uniqueName("meta_fb"), jiraTaskKey = "PROJ-2002", changeComment = "b")
+
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("jiraTaskKey", keyA)
+                        .param("size", "500"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        val json = objectMapper.readTree(body)
+
+        val keys = json["content"].map { it["jiraTaskKey"]?.asText() }.toSet()
+        assert(keys.all { it == keyA }) { "expected only $keyA, got $keys" }
+        val ids = json["content"].map { it["entityId"].asText() }.toSet()
+        assert(ids.contains(idA)) { "expected the matching component $idA in the response" }
+        assert(!ids.contains(idB)) { "expected non-matching component $idB to be excluded" }
+    }
+}


### PR DESCRIPTION
## What

Records optional **change metadata** — a Jira task key and a free-text comment — on the audit row when a component is created or updated, returns it in the audit API, and lets `audit/recent` be filtered by Jira task key.

## Changes
- **Flyway `V3`** adds `jira_task_key` + `change_comment` to `audit_log` (the key is indexed to back the search).
- Threaded through `AuditLogEntity` → `AuditEvent` → `AuditEventListener`, populated at the CREATE and top-level UPDATE `publishAuditEvent` callsites (cascade/field-override callsites stay null — follow-up if ever needed).
- `ComponentCreateRequest` / `ComponentUpdateRequest` accept both fields. The key is `@Valid`-validated against `^\s*$|^[A-Z][A-Z0-9]+-\d+$` (a blank/whitespace value is a valid "no key"); blank is normalized to `null` before persisting.
- `@Valid` added to the create/update `@RequestBody` params so the constraint actually fires (→ 400 via the existing `MethodArgumentNotValidException` handler).
- `AuditLogResponse` + `V4Mappers` expose both fields; `AuditLogFilter` / `AuditServiceImpl` / `AuditControllerV4` add the `jiraTaskKey` filter.
- OpenAPI v4 spec regenerated.

## Behavior
- Both fields optional. Blank/whitespace/null key → accepted, stored `null`, never 400. Malformed non-blank key → 400.
- Metadata rides on the existing audit-event flow, so a no-op PATCH (no field changed) still writes no row — the key/comment attach to a real change only.

## Tests
- New `AuditChangeMetadataTest` (5 integration tests, run under `dbTest`): CREATE/UPDATE persistence, malformed→400, blank→accepted+null, filter-by-key.
- Existing `AuditLogFilterTest` (9) green; `OpenApiV4SpecTest` drift gate green.

## Coordination
The portal vendors this spec — the portal-side PR depends on this landing on the released/pinned ref so it can re-vendor `v4.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)