### PR TITLE
fix(migration): compute migration-status 'git' as a set difference

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1313,10 +1313,12 @@ object id30DeployToOkdQaDevAuto : BuildType({
 // Post-deploy: trigger Git→DB component migration on the freshly-deployed
 // QA pod. Idempotent and tolerant — exits 0 (skip, don't fail) if the
 // /admin/migration-status endpoint is missing (pre-v3 build) or returns
-// git==0 (nothing left to migrate). Fails the build only when migration
-// was attempted and ended in a FAILED state, so the QA-deploy chain
-// surfaces real migration breakage but does not break on routine
-// redeploys of an already-migrated stand.
+// git==0 with total>0 (nothing left to migrate). Fails the build when
+// migration was attempted and ended in a FAILED state, OR when the status is
+// indeterminate (git==0 with total==0 — a Git-resolver load failure), so the
+// QA-deploy chain surfaces real migration breakage and never silently skips on
+// an indeterminate status, while not breaking on routine redeploys of an
+// already-migrated stand.
 //
 // Pure shell-script build (no Gradle template) — VCS root is attached
 // explicitly, same pattern as id17 / id20. Script source lives at

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceController.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceController.kt
@@ -76,7 +76,7 @@ class ComponentsRegistryServiceController(
                 .body<Any>(ErrorResponse("A cache refresh is already in progress; retry updateCache after it completes"))
         }
         try {
-            // DB-mode only: getMigrationStatus() reads countBySource("db"). In no-db
+            // DB-mode only: getMigrationStatus() reads findComponentKeysBySource("db"). In no-db
             // mode ImportService is absent (importService == null) — there is no
             // migration that can be "fully done", so always fall through to the Git
             // re-read and return HTTP 200, exactly like the pre-v3 endpoint.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceController.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceController.kt
@@ -43,14 +43,18 @@ class ComponentsRegistryServiceController(
      *
      * The endpoint is retired with **410 Gone** ONLY when we can positively
      * confirm full migration: the Git resolver parsed components (`total > 0`)
-     * AND none are still git-served (`git == 0`, i.e. `gitResolver.size ==
-     * countBySource("db")`). Two cases deliberately do NOT retire and instead
-     * attempt the refresh (the recovery action):
+     * AND none are still git-only (`git == 0`, where `git` is the set of DSL
+     * component keys NOT present as `source='db'` rows). One case deliberately
+     * does NOT retire and instead attempts the refresh (the recovery action):
      *  - `total == 0` — Git status is indeterminate (the resolver returned empty
      *    or failed to load); falsely returning 410 here would block the very
      *    re-read an operator needs to recover the cache.
-     *  - `git < 0` — stale/extra `source='db'` rows skew the count below zero
-     *    while git-served components may still exist.
+     *
+     * `git` is now a set difference and so is always `>= 0`; extra db-only rows
+     * (e.g. components created via the v4 write API after migration) no longer
+     * push it negative the way the old `gitResolver.size - countBySource("db")`
+     * subtraction did. The controller still treats a (now-unreachable) negative
+     * defensively — `git == 0` is the only retire trigger.
      *
      * Refused with **409** when (a) a COMPONENTS migration is running (it reads
      * from the Git resolver to validate each component, so swapping the in-memory
@@ -78,8 +82,8 @@ class ComponentsRegistryServiceController(
             // re-read and return HTTP 200, exactly like the pre-v3 endpoint.
             val status = importService?.getMigrationStatus()
             // status.total = git-resolver component count (0 if it errored/empty);
-            // status.git = total - countBySource("db"). Retire only on a confirmed
-            // fully-migrated state; otherwise attempt the refresh.
+            // status.git = DSL component keys not yet in the DB (set difference, always >= 0).
+            // Retire only on a confirmed fully-migrated state; otherwise attempt the refresh.
             val fullyMigrated = status != null && status.total > 0 && status.git == 0L
             if (!fullyMigrated) {
                 return ResponseEntity.ok<Any>(componentsRegistryService.updateConfigCache())

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -591,17 +591,26 @@ class ImportServiceImpl(
     }
 
     override fun getMigrationStatus(): MigrationStatus {
-        val dbCount = componentSourceRepository.countBySource("db")
-        val totalInGit =
+        // `git` is "how many DSL (git-sourced) components are NOT yet in the DB".
+        // It MUST be a set difference (git keys minus db-sourced keys), not
+        // `gitResolver.size - countBySource("db")`: the subtraction goes negative the
+        // moment the DB holds a component the DSL does not (e.g. one created via the
+        // v4 write API after migration), which showed `Git -1` in the admin panel and
+        // broke every `git == 0` "fully migrated" check (updateCache 410-retirement,
+        // the Portal Run gate). The set difference is >= 0 by construction and still
+        // counts a genuinely-unmigrated git component even when an unrelated db-only
+        // row keeps the totals equal.
+        val dbKeys = componentSourceRepository.findComponentKeysBySource("db").toSet()
+        val gitKeys =
             try {
-                gitResolver.getComponents().size.toLong()
+                gitResolver.getComponents().mapTo(mutableSetOf()) { it.moduleName }
             } catch (_: Exception) {
-                0L
+                emptySet()
             }
         return MigrationStatus(
-            git = totalInGit - dbCount,
-            db = dbCount,
-            total = totalInGit,
+            git = gitKeys.count { it !in dbKeys }.toLong(),
+            db = dbKeys.size.toLong(),
+            total = gitKeys.size.toLong(),
         )
     }
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceControllerUpdateCacheTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceControllerUpdateCacheTest.kt
@@ -19,8 +19,9 @@ import org.springframework.http.HttpStatus
  * Retirement (410) is gated on `status.total > 0 && status.git == 0L`:
  * - `git > 0` (total > 0)  → 200 + the refresh duration; re-reads the Git config (matches 2.0.87).
  * - `git == 0` (total > 0) → 410 Gone (fully migrated — cutover to DB complete).
- * - `git < 0`  → 200 (not 410): `git = gitResolver.size - countBySource("db")`, so stale/extra
- *   `source='db'` rows can push it negative while git-served components may still exist.
+ * - `git < 0`  → 200 (not 410): defensive only. `git` is now a set difference (DSL component keys
+ *   not present as `source='db'` rows) and is always >= 0, so getMigrationStatus no longer emits a
+ *   negative; this case just pins that the controller never mis-retires on an unexpected negative.
  * - `total == 0` → 200 (not 410): the Git resolver returned empty or errored — indeterminate;
  *   attempt the re-read (the recovery action), not a false retirement.
  * - COMPONENTS migration active → 409, without re-reading or even querying status.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceControllerUpdateCacheTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentsRegistryServiceControllerUpdateCacheTest.kt
@@ -58,10 +58,11 @@ class ComponentsRegistryServiceControllerUpdateCacheTest {
     }
 
     @Test
-    fun `negative git from stale db rows attempts refresh, not 410`() {
-        // total > 0 (the Git resolver parsed components) but git < 0 from stale/extra
-        // source='db' rows: git-served components may still exist, so re-read rather
-        // than falsely retire.
+    fun `negative git attempts refresh, not 410 (defensive)`() {
+        // Defensive only: `git` is now a set difference (DSL keys not in the DB) and is
+        // always >= 0, so getMigrationStatus no longer emits a negative. This pins that
+        // the controller never falsely retires (410) on an unexpected negative — it
+        // re-reads instead.
         doReturn(MigrationStatus(git = -2, db = 7, total = 5)).`when`(importService).getMigrationStatus()
         doReturn(7L).`when`(componentsRegistryService).updateConfigCache()
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImplMigrationStatusTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImplMigrationStatusTest.kt
@@ -1,0 +1,136 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.octopusden.octopus.components.registry.server.repository.ComponentArtifactMappingRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSourceRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionDockerImageRepository
+import org.octopusden.octopus.components.registry.server.repository.DistributionMavenArtifactRepository
+import org.octopusden.octopus.components.registry.server.repository.LabelRepository
+import org.octopusden.octopus.components.registry.server.repository.SystemRepository
+import org.octopusden.octopus.components.registry.server.repository.ToolRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.EscrowModule
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * Unit tests for `ImportServiceImpl.getMigrationStatus`.
+ *
+ * The migration-status `git` counter is "how many DSL (git-sourced) components are
+ * still NOT in the DB". It must be a set difference (git component keys minus
+ * db-sourced keys), NOT `gitResolver.size - countBySource("db")`: the subtraction
+ * goes negative the moment the DB holds a component the DSL does not (e.g. one
+ * created via the v4 write API after migration), which made the panel show `Git -1`
+ * and broke every `git == 0` "fully migrated" check (updateCache 410-retirement,
+ * the Portal Run gate).
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class ImportServiceImplMigrationStatusTest {
+
+    private lateinit var service: ImportServiceImpl
+    private lateinit var gitResolver: ComponentRegistryResolverImpl
+    private lateinit var componentSourceRepository: ComponentSourceRepository
+
+    @BeforeEach
+    fun setUp() {
+        gitResolver = mock(ComponentRegistryResolverImpl::class.java)
+        componentSourceRepository = mock(ComponentSourceRepository::class.java)
+        service = ImportServiceImpl(
+            gitResolver = gitResolver,
+            dbResolver = mock(DatabaseComponentRegistryResolver::class.java),
+            componentSourceRepository = componentSourceRepository,
+            sourceRegistry = mock(ComponentSourceRegistry::class.java),
+            configurationLoader = mock(EscrowConfigurationLoader::class.java),
+            configSyncService = mock(ConfigSyncService::class.java),
+            componentRepository = mock(ComponentRepository::class.java),
+            configurationRepository = mock(ComponentConfigurationRepository::class.java),
+            componentGroupRepository = mock(ComponentGroupRepository::class.java),
+            systemRepository = mock(SystemRepository::class.java),
+            toolRepository = mock(ToolRepository::class.java),
+            labelRepository = mock(LabelRepository::class.java),
+            componentLabelRepository = mock(ComponentLabelRepository::class.java),
+            componentRequiredToolRepository = mock(ComponentRequiredToolRepository::class.java),
+            componentBuildToolBeanRepository = mock(ComponentBuildToolBeanRepository::class.java),
+            mavenArtifactRepository = mock(DistributionMavenArtifactRepository::class.java),
+            componentArtifactMappingRepository = mock(ComponentArtifactMappingRepository::class.java),
+            dockerImageRepository = mock(DistributionDockerImageRepository::class.java),
+            versionRangeFactory = VersionRangeFactory(VersionNames("serviceCBranch", "serviceC", "minorC")),
+        )
+    }
+
+    // getComponents() is a Java-defined Collection (platform type MutableCollection<EscrowModule!>!),
+    // so the stub return value must be a MutableCollection, not a read-only List.
+    private fun gitModules(vararg names: String): MutableList<EscrowModule> =
+        names.mapTo(mutableListOf()) { name ->
+            mock(EscrowModule::class.java).also { Mockito.`when`(it.moduleName).thenReturn(name) }
+        }
+
+    private fun stubGit(vararg names: String) {
+        // Build (and stub moduleName on) the module mocks BEFORE opening the outer
+        // `when(getComponents())` stubbing — nesting Mockito.`when` calls trips
+        // UnfinishedStubbingException.
+        val modules = gitModules(*names)
+        Mockito.`when`(gitResolver.getComponents()).thenReturn(modules)
+    }
+
+    private fun stubDb(vararg keys: String) {
+        Mockito.`when`(componentSourceRepository.findComponentKeysBySource("db")).thenReturn(keys.toList())
+    }
+
+    @Test
+    fun `remaining is zero (never negative) when an extra db-only row exceeds the git count`() {
+        // Reproduces the reported `Git -1`: every DSL component is migrated AND a
+        // later v4-API-created component adds a db-only row, so db (3) > git (2).
+        stubGit("a", "b")
+        stubDb("a", "b", "x")
+        val status = service.getMigrationStatus()
+        assertEquals(0L, status.git, "remaining must never go negative when the DB has extra (api-created) rows")
+        assertEquals(3L, status.db)
+        assertEquals(2L, status.total)
+    }
+
+    @Test
+    fun `remaining counts git components missing from db even when a db-only row keeps the totals close`() {
+        // git: a, b, c ; db: a (migrated) + x (api-created). b, c are still outstanding.
+        // The old subtraction would report 3 - 2 = 1; the set difference reports 2.
+        stubGit("a", "b", "c")
+        stubDb("a", "x")
+        val status = service.getMigrationStatus()
+        assertEquals(2L, status.git)
+        assertEquals(2L, status.db, "db must count all db-sourced rows, including the api-created extra")
+        assertEquals(3L, status.total)
+    }
+
+    @Test
+    fun `remaining is zero and counts match when every git component is migrated`() {
+        stubGit("a", "b")
+        stubDb("a", "b")
+        val status = service.getMigrationStatus()
+        assertEquals(0L, status.git)
+        assertEquals(2L, status.db)
+        assertEquals(2L, status.total)
+    }
+
+    @Test
+    fun `git resolver failure yields zero git and total (defensive)`() {
+        Mockito.`when`(gitResolver.getComponents()).thenThrow(RuntimeException("git unavailable"))
+        stubDb("a")
+        val status = service.getMigrationStatus()
+        assertEquals(0L, status.git)
+        assertEquals(1L, status.db)
+        assertEquals(0L, status.total)
+    }
+}

--- a/scripts/teamcity/qa-post-deploy-migrate.sh
+++ b/scripts/teamcity/qa-post-deploy-migrate.sh
@@ -6,9 +6,12 @@
 #   - git == 0 AND total > 0          → nothing left to migrate, exit 0 (skip)
 #     (git == 0 with total == 0 is indeterminate — the Git resolver returned no
 #      components, usually a load failure — and fails loudly, never skips)
-# It exits non-zero only when migration was *attempted* and ended in FAILED
-# state (or pod never became ready). That matches the user contract: "if there
-# is no new code, just skip — don't fail".
+# It exits non-zero when migration was *attempted* and ended in FAILED state
+# (or the pod never became ready), AND on an indeterminate migration-status
+# (git == 0 with total == 0, or a non-numeric git/total — a contract break or
+# Git-resolver load failure). It exits 0 (skip) on the "nothing to do" cases
+# above. That matches the user contract: "if there is no new code, just skip —
+# don't fail" — while never silently skipping on an indeterminate status.
 #
 # Required env:
 #   CRS_BASE_URL          e.g. https://components-registry.qa.example/

--- a/scripts/teamcity/qa-post-deploy-migrate.sh
+++ b/scripts/teamcity/qa-post-deploy-migrate.sh
@@ -3,7 +3,9 @@
 #
 # Designed to be tolerant of "this build does not need / cannot run migration":
 #   - 404 on /admin/migration-status  → pre-v3 build deployed, exit 0 (skip)
-#   - git == 0                        → nothing left to migrate, exit 0 (skip)
+#   - git == 0 AND total > 0          → nothing left to migrate, exit 0 (skip)
+#     (git == 0 with total == 0 is indeterminate — the Git resolver returned no
+#      components, usually a load failure — and fails loudly, never skips)
 # It exits non-zero only when migration was *attempted* and ended in FAILED
 # state (or pod never became ready). That matches the user contract: "if there
 # is no new code, just skip — don't fail".
@@ -174,7 +176,24 @@ case "$status_code" in
         exit 1
         ;;
     esac
+    case "$total" in
+      ''|*[!0-9]*)
+        log "ERROR: /admin/migration-status returned a non-numeric 'total' field: '$total'"
+        log "Response body suppressed (may contain unexpected payload). Investigate the API contract."
+        exit 1
+        ;;
+    esac
     if [ "$git_count" = "0" ]; then
+      # git is now a set difference (DSL keys not yet in the DB), so it is >= 0.
+      # git == 0 with total == 0 is NOT "fully migrated" — it means the Git resolver
+      # enumerated zero components (an empty/failed DSL load), which is indeterminate.
+      # Fail loudly rather than silently skipping the migration on a resolver outage.
+      if [ "$total" = "0" ]; then
+        log "ERROR: git=0 but total=0 — migration status is indeterminate (the Git resolver"
+        log "returned no components, usually a DSL load failure). Refusing to treat this as"
+        log "'fully migrated'. Investigate the CRS Git resolver / DSL load before retrying."
+        exit 1
+      fi
       log "Nothing left to migrate — skip"
       exit 0
     fi


### PR DESCRIPTION
## Problem
`GET /rest/api/4/admin/migration-status` reported **Git = -1** on stands where the DB held more components than the DSL. Root cause in `ImportServiceImpl.getMigrationStatus`:

```kotlin
git = gitResolver.getComponents().size - countBySource("db")
```

The subtraction goes negative the moment the DB holds a component the DSL does not — e.g. one created via the **v4 write API** after migration. Two consequences:
1. Admin panel shows a nonsensical `Git -1`.
2. Worse: every `git == 0` "fully migrated" check silently stops firing (the legacy `updateCache` 410-retirement; the Portal migration Run gate), because `-1 != 0`. It also **under-counts** genuinely-unmigrated components when an unrelated db-only row keeps the totals close.

## Fix
Compute `git` as a **set difference**: DSL (git-sourced) component keys not present as `source='db'` rows.

```kotlin
val dbKeys  = componentSourceRepository.findComponentKeysBySource("db").toSet()
val gitKeys = gitResolver.getComponents().mapTo(mutableSetOf()) { it.moduleName }   // DSL key == component_source key
git = gitKeys.count { it !in dbKeys }   // >= 0 by construction
```

`db` and `total` keep their meaning (db-sourced count; git-resolver count), so the **`MigrationStatus` wire contract is unchanged** — no Portal type / OpenAPI churn. Also re-fires the `updateCache` 410-retirement correctly and refreshes the now-stale comments describing the old subtraction.

## Scope note
Git-resolver removal is ADR-013 Phase 5 (post-cutover, out of scope), so gitResolver stays available through cutover + bake-in. A persistent completion latch (for when git is decommissioned) is a deferred Phase-5 follow-up, **not** part of this fix.

## Tests (TDD)
New `ImportServiceImplMigrationStatusTest`: extra-db-row → `git=0` not negative; unmigrated-git still counted despite a db-only extra; all-migrated → 0; git-resolver failure → 0/0.

Independent code review (second model): APPROVE — verified DSL key == `EscrowModule.moduleName` == `component_source.component_key` through the loader; no other consumer relies on the old semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)