### PR TITLE
fix(as-code): text/plain 404 instead of 500 for unresolvable version

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -365,10 +365,24 @@ class ComponentControllerV4(
         @RequestParam(required = false) version: String?,
     ): ResponseEntity<String> {
         val rendered =
-            if (version.isNullOrBlank()) {
-                componentManagementService.renderComponentAsCode(idOrName)
-            } else {
-                componentManagementService.renderResolvedComponentAsCode(idOrName, version)
+            try {
+                if (version.isNullOrBlank()) {
+                    componentManagementService.renderComponentAsCode(idOrName)
+                } else {
+                    componentManagementService.renderResolvedComponentAsCode(idOrName, version)
+                }
+            } catch (e: NotFoundException) {
+                // This endpoint is produces=text/plain. The global @ExceptionHandler for
+                // NotFoundException returns a JSON ErrorResponse, which has no acceptable
+                // representation for a text/plain request → HttpMediaTypeNotAcceptableException
+                // → the 404 surfaces as a misleading 500. Handle it locally and return a clean
+                // text/plain 404 instead: an unknown component, or (resolved mode) a version
+                // that falls outside every configured range. The Portal's resolved view treats
+                // this 404 as "no configuration resolves for this version" and shows a hint.
+                return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .contentType(MediaType.parseMediaType(TEXT_PLAIN_UTF8))
+                    .body(e.message ?: "No configuration resolves for the requested version.")
             }
         val disposition =
             ContentDisposition

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerAsCodeV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerAsCodeV4Test.kt
@@ -128,4 +128,41 @@ class ComponentControllerAsCodeV4Test {
             .perform(get("/rest/api/4/components/bcomponent/as-code?version=99.0").with(editorJwt()))
             .andExpect(status().isNotFound)
     }
+
+    @Test
+    @DisplayName("Unresolvable version with Accept: text/plain → text/plain 404 (not 500)")
+    fun versionNotResolvableTextPlain404() {
+        // Regression: the endpoint is produces=text/plain and the Portal sends Accept: text/plain.
+        // The global JSON NotFound handler then has no acceptable representation
+        // (HttpMediaTypeNotAcceptableException) and the 404 used to surface as a 500. The endpoint
+        // now handles NotFoundException locally and returns a clean text/plain 404.
+        `when`(componentManagementService.renderResolvedComponentAsCode("bcomponent", "2.1"))
+            .thenThrow(NotFoundException("No configuration resolves for component 'bcomponent' at version '2.1'"))
+
+        mvc
+            .perform(
+                get("/rest/api/4/components/bcomponent/as-code?version=2.1")
+                    .accept(MediaType.TEXT_PLAIN)
+                    .with(editorJwt()),
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+            .andExpect(content().string(containsString("No configuration resolves")))
+    }
+
+    @Test
+    @DisplayName("Unknown component with Accept: text/plain → text/plain 404 (not 500)")
+    fun unknownComponentTextPlain404() {
+        `when`(componentManagementService.renderComponentAsCode("ghost"))
+            .thenThrow(NotFoundException("Component 'ghost' not found"))
+
+        mvc
+            .perform(
+                get("/rest/api/4/components/ghost/as-code")
+                    .accept(MediaType.TEXT_PLAIN)
+                    .with(editorJwt()),
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerAsCodeV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerAsCodeV4Test.kt
@@ -164,5 +164,6 @@ class ComponentControllerAsCodeV4Test {
             )
             .andExpect(status().isNotFound)
             .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+            .andExpect(content().string(containsString("not found")))
     }
 }


### PR DESCRIPTION
## Problem
`GET /rest/api/4/components/{id}/as-code?version=X` returns **500 Internal Server Error** when the version resolves to no configuration (e.g. a version above all override ranges), instead of a 404.

Root cause (from the QA stack trace): the endpoint is `produces=text/plain`. The resolved render throws `NotFoundException` ("No configuration resolves…") — the correct 404 — but the global `@ExceptionHandler(NotFoundException)` returns a **JSON** `ErrorResponse`. For a `text/plain` request (the Portal's `api.getText` sends `Accept: text/plain`) there's no acceptable representation → `HttpMediaTypeNotAcceptableException` → the 404 surfaces as a **500**.

```
NotFoundException: No configuration resolves for component '…' at version '2.1'
  at ComponentManagementServiceImpl.renderResolvedComponentAsCode(...:393)
→ ExceptionHandlerExceptionResolver: Failure in @ExceptionHandler …notFoundExceptionHandler
  org.springframework.web.HttpMediaTypeNotAcceptableException: No acceptable representation → 500
```

## Fix
Handle `NotFoundException` locally in `getComponentAsCode` and return a clean **text/plain 404** (unknown component, or resolved-mode version outside every configured range). The Portal's resolved view already treats 404 as "no configuration resolves for this version" and shows a friendly hint instead of "Internal Server Error".

## Tests
Added `Accept: text/plain` cases (unresolvable version + unknown component) to `ComponentControllerAsCodeV4Test`, asserting **404 + text/plain body**. The existing 404 tests used the default `Accept: */*`, so they never exercised this content-negotiation path.

Verified: `:components-registry-service-server:dbTest --tests "*ComponentControllerAsCodeV4Test"` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)