### PR TITLE
fix(mapper): range-containment for override projection in range-view enumeration (TD-010)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -351,13 +351,21 @@ internal fun rangeApplies(
             return false
         }
 
-    val samples =
+    val bounds =
         try {
-            childRangeSamples(childRange, numericVersionFactory)
+            parseSingleInterval(childRange)
         } catch (_: Exception) {
-            // Unparseable / unbounded child: cannot enumerate samples, stay conservative.
+            // Unparseable / fully-unbounded child: cannot enumerate samples, stay conservative.
             return false
         }
+
+    // Structural guard: a child that runs to +inf (open upper) can only be contained in a parent that
+    // ALSO runs to +inf. A bounded parent never contains it, however high its finite upper bound is —
+    // so this must be decided structurally, not by probing a finite +inf sentinel against the parent
+    // (a finite sentinel below the parent's finite upper would otherwise yield a false positive).
+    if (bounds.upper == null && !isOpenUpper(parentRange)) return false
+
+    val samples = childRangeSamples(bounds, numericVersionFactory)
     if (samples.isEmpty()) return false
 
     return samples.all { sample ->
@@ -369,6 +377,20 @@ internal fun rangeApplies(
     }
 }
 
+/**
+ * True iff [range]'s trailing segment has an empty (open-ended) upper bound, i.e. the range runs to
+ * +inf — "[1.0,)", "(,0),[1.0,)". False for any finite or closed upper bound ("[1.0,2.0)",
+ * "[1.0,10000000.0)") and for a hard single version ("[1.0]"). Used by [rangeApplies] so an open-upper
+ * child is only ever matched against an open-upper parent.
+ */
+private fun isOpenUpper(range: String): Boolean {
+    val trimmed = range.trim()
+    if (trimmed.isEmpty() || trimmed.last() != ')') return false
+    val lastComma = trimmed.lastIndexOf(',')
+    return lastComma in 0 until trimmed.length - 1 &&
+        trimmed.substring(lastComma + 1, trimmed.length - 1).isBlank()
+}
+
 /** Number of interior probe points sampled strictly inside the child interval. */
 private const val INTERIOR_PROBE_COUNT = 8
 
@@ -376,28 +398,28 @@ private const val INTERIOR_PROBE_COUNT = 8
 private const val ZERO_VERSION = "0.0"
 
 /**
- * A version far above any real registry version, standing in for a child's unbounded UPPER side
- * ("[X,)"): a bounded parent cannot contain it (so the open-ended child is correctly rejected),
- * while an open-upper parent does (so it is accepted). Registry versions are small integer-component
- * numbers, so this is safely beyond every real upper bound.
+ * A high probe version standing in for a point well inside a child's open UPPER tail ("[X,)"). It is
+ * only ever evaluated against a parent that [rangeApplies] has ALREADY confirmed is itself open-upper
+ * (the bounded-parent case is rejected by the structural guard before sampling), so this value never
+ * has to out-rank a finite parent upper bound — it just confirms the open-upper parent's floor sits
+ * at or below the child's tail. It is not an encoding of +inf.
  */
 private const val HUGE_TAIL_VERSION = "9999999.0"
 
 /**
- * Build the set of probe versions for [childRange] used by the containment heuristic: the lower and
- * upper endpoints (closed bound inclusive; open finite bound shifted just inside) plus interior
- * probes across the interval. One-sided-unbounded children are supported by substituting a sentinel
- * for the open-ended side — [ZERO_VERSION] for an unbounded lower, [HUGE_TAIL_VERSION] for an
- * unbounded upper — so a child like "[2.0,)" probes its 2.0 floor AND the huge tail (rejected by a
- * bounded parent, accepted by an open-upper one). A fully-unbounded "(,)" child throws in
- * [parseSingleInterval] and the caller treats it conservatively.
+ * Build the set of probe versions for the already-parsed child [bounds] used by the containment
+ * heuristic: the lower and upper endpoints (closed bound inclusive; open finite bound shifted just
+ * inside) plus interior probes across the interval. One-sided-unbounded children are supported by
+ * substituting a sentinel for the open-ended side — [ZERO_VERSION] for an unbounded lower,
+ * [HUGE_TAIL_VERSION] for an unbounded upper — so a child like "[2.0,)" probes its 2.0 floor AND a
+ * point inside the tail. An open-upper child is only sampled at all once [rangeApplies] has confirmed
+ * the parent is open-upper (see the structural guard there); a bounded parent never reaches here with
+ * an open-upper child.
  */
 private fun childRangeSamples(
-    childRange: String,
+    bounds: IntervalBounds,
     numericVersionFactory: NumericVersionFactory,
 ): List<IVersionInfo> {
-    val bounds = parseSingleInterval(childRange)
-
     val samples = mutableListOf<IVersionInfo>()
 
     // Low edge for interior probing + the lower endpoint sample.
@@ -416,8 +438,10 @@ private fun childRangeSamples(
     // High edge for interior probing + (when in the interval) the upper endpoint sample.
     val upperEdge: IVersionInfo
     if (bounds.upper == null) {
-        // Unbounded above: a huge sentinel stands in for the tail and IS sampled directly — a bounded
-        // parent cannot contain it, an open-upper parent can.
+        // Unbounded above: a high probe stands in for a point inside the tail and IS sampled directly.
+        // We only reach here for an open-upper PARENT (the bounded-parent case is rejected by the
+        // structural guard in rangeApplies), so this probe just confirms the open-upper parent's floor
+        // is at/below the tail — it is not racing a finite parent upper bound.
         upperEdge = numericVersionFactory.create(HUGE_TAIL_VERSION)
         samples += upperEdge
     } else {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -33,7 +33,9 @@ import org.octopusden.octopus.escrow.model.VersionControlSystemRoot
 import org.octopusden.octopus.releng.dto.ComponentInfo
 import org.octopusden.octopus.releng.dto.JiraComponent
 import org.octopusden.releng.versions.ComponentVersionFormat
+import org.octopusden.releng.versions.IVersionInfo
 import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionRange
 import org.octopusden.releng.versions.VersionRangeFactory
 
 /** Must match EscrowConfigurationLoader.ALL_VERSIONS = "(,0),[0,)" */
@@ -94,7 +96,7 @@ internal object MarkerAttributes {
  */
 fun ComponentEntity.toEscrowModule(
     versionRangeFactory: VersionRangeFactory,
-    @Suppress("UNUSED_PARAMETER") numericVersionFactory: NumericVersionFactory,
+    numericVersionFactory: NumericVersionFactory,
 ): EscrowModule {
     val module = EscrowModule()
     module.moduleName = this.componentKey
@@ -156,6 +158,7 @@ fun ComponentEntity.toEscrowModule(
                 base = base,
                 overrides = overrides,
                 versionRangeFactory = versionRangeFactory,
+                numericVersionFactory = numericVersionFactory,
             )
         module.moduleConfigurations.add(resolved)
     }
@@ -269,21 +272,32 @@ private fun ComponentEntity.resolveForRange(
     base: ComponentConfigurationEntity,
     overrides: List<ComponentConfigurationEntity>,
     versionRangeFactory: VersionRangeFactory,
+    numericVersionFactory: NumericVersionFactory,
 ): EscrowModuleConfig {
     // For enumeration purposes, an override applies to `range` when its own
-    // range string equals `range` OR fully contains `range`. Equality is the
-    // common case (overrides are keyed by their own range); containment matters
-    // when the base's all-versions range is being enumerated and a narrower
-    // override exists.
+    // range CONTAINS `range` (child is a subset of parent). Equality is the
+    // common case (overrides are keyed by their own range); strict containment
+    // matters when a broader override range covers a narrower enumeration view
+    // (e.g. an override on [1.0,3.0) projected onto an enumerated [1.0,2.0)).
     val scalarOverrides =
         overrides.filter {
             it.rowType == "SCALAR_OVERRIDE" &&
-                rangeApplies(parentRange = it.versionRange, childRange = range, factory = versionRangeFactory)
+                rangeApplies(
+                    parentRange = it.versionRange,
+                    childRange = range,
+                    versionRangeFactory = versionRangeFactory,
+                    numericVersionFactory = numericVersionFactory,
+                )
         }
     val markerOverrides =
         overrides.filter {
             it.rowType == "MARKER" &&
-                rangeApplies(parentRange = it.versionRange, childRange = range, factory = versionRangeFactory)
+                rangeApplies(
+                    parentRange = it.versionRange,
+                    childRange = range,
+                    versionRangeFactory = versionRangeFactory,
+                    numericVersionFactory = numericVersionFactory,
+                )
         }
 
     return buildEscrowModuleConfig(
@@ -296,27 +310,218 @@ private fun ComponentEntity.resolveForRange(
 }
 
 /**
- * True when an override row with `parentRange` should apply to the enumeration
- * view `childRange`. Trivially true when equal; otherwise this should be
- * containment (`child ⊆ parent`), but the version-range library currently
- * exposes only `containsVersion` (point-in-range), not `containsRange`.
+ * True when an override row keyed by [parentRange] should apply to the enumeration view
+ * [childRange] — i.e. when child is a subset of parent (range containment).
  *
- * Current behaviour: returns true ONLY for the equal case. Strict-containment
- * overrides (e.g., override on `[1.0,3.0)` should apply when enumerating a
- * narrower `[1.0,2.0)` range) are NOT picked up. This is the conservative
- * choice — better to miss an override than to apply a non-matching one —
- * but it does mean a broader override on a real component is silently
- * dropped during enumeration.
+ * TD-010 (docs/registry/tech-debt/010-range-applies-containment.md). The version-range library
+ * exposes only point-in-range [VersionRange.containsVersion], not containsRange, so containment is
+ * approximated by a sample-points heuristic: sample the child's endpoints (closed bound inclusive;
+ * open bound epsilon-shifted just inside the interval) plus a fixed number of interior probes across
+ * the child interval, and return true iff EVERY sample lies in the parent. Equality short-circuits to
+ * true. A parent that fails to parse (e.g. the unbounded "(,)" — both-sides-open is rejected by the
+ * factory, deferred to TD-010-b) falls back to string equality, keeping the result conservative
+ * (a missed override, never a wrong one).
  *
- * See TD-010 (`docs/registry/tech-debt/010-range-applies-containment.md`)
- * for the matrix-tests acceptance + sample-points heuristic spec. Same
- * blocker as the partial-overlap write-side rejection item.
+ * The heuristic is exact for the bounded cases in the TD-010 matrix; the only theoretical false
+ * positive would be a child whose violating sub-interval is narrower than the probe spacing and sits
+ * between two samples, which cannot happen for the integer-component versions this registry uses.
  */
-private fun rangeApplies(
+internal fun rangeApplies(
     parentRange: String,
     childRange: String,
-    @Suppress("UNUSED_PARAMETER") factory: VersionRangeFactory,
-): Boolean = parentRange == childRange
+    versionRangeFactory: VersionRangeFactory,
+    numericVersionFactory: NumericVersionFactory,
+): Boolean {
+    if (parentRange == childRange) return true
+
+    val parent =
+        try {
+            versionRangeFactory.create(parentRange)
+        } catch (_: Exception) {
+            // Unparseable parent (e.g. unbounded "(,)", TD-010-b): fall back to the conservative
+            // equality test handled above — reaching here means it was not equal, so no match.
+            return false
+        }
+
+    val samples =
+        try {
+            childRangeSamples(childRange, numericVersionFactory)
+        } catch (_: Exception) {
+            // Unparseable / unbounded child: cannot enumerate samples, stay conservative.
+            return false
+        }
+    if (samples.isEmpty()) return false
+
+    return samples.all { sample ->
+        try {
+            parent.containsVersion(sample)
+        } catch (_: Exception) {
+            false
+        }
+    }
+}
+
+/** Number of interior probe points sampled strictly inside the child interval. */
+private const val INTERIOR_PROBE_COUNT = 8
+
+/**
+ * Build the set of probe versions for [childRange] used by the containment heuristic: the lower and
+ * upper endpoints (with open bounds shifted just inside the interval) plus [INTERIOR_PROBE_COUNT]
+ * interior probes spread across the interval. Only single-interval children are produced; a
+ * multi-segment or unbounded child throws and the caller treats it conservatively.
+ */
+private fun childRangeSamples(
+    childRange: String,
+    numericVersionFactory: NumericVersionFactory,
+): List<IVersionInfo> {
+    val bounds = parseSingleInterval(childRange)
+    val lower = numericVersionFactory.create(bounds.lower)
+    val upper = numericVersionFactory.create(bounds.upper)
+
+    val samples = mutableListOf<IVersionInfo>()
+    // Lower endpoint: closed bound is part of the interval; open bound is excluded, so probe just
+    // above it (epsilon-shift) to represent the smallest point that IS in the child.
+    samples += if (bounds.includeLower) lower else epsilonAbove(bounds.lower, numericVersionFactory)
+    // Upper endpoint: only the closed bound is part of the interval. For an open upper bound the
+    // supremum is not in the child; the interior probes below cover the approach to it.
+    if (bounds.includeUpper) {
+        samples += upper
+    }
+    // Interior probes: spread across [lower, upper] so that a child reaching past the parent (or
+    // sitting in a union-parent gap) is caught even when both endpoints individually land in parent.
+    samples += interiorProbes(lower, upper, numericVersionFactory)
+    return samples
+}
+
+/** A single closed/open version interval parsed from a range string such as "[1.0,2.0)". */
+private data class IntervalBounds(
+    val lower: String,
+    val includeLower: Boolean,
+    val upper: String,
+    val includeUpper: Boolean,
+)
+
+/**
+ * Parse a single-interval range string ("[1.0,2.0)", "(1.0,3.0)", "[1.0]") into its bounds. Throws
+ * for unbounded ("(,2.0)" / "[1.0,)"), multi-segment union, or otherwise malformed input so the
+ * caller can fall back to the conservative path.
+ */
+private fun parseSingleInterval(range: String): IntervalBounds {
+    val trimmed = range.trim()
+    require(trimmed.length >= 3) { "range too short: $range" }
+    val open = trimmed.first()
+    val close = trimmed.last()
+    require(open == '[' || open == '(') { "bad opening bracket: $range" }
+    require(close == ']' || close == ')') { "bad closing bracket: $range" }
+
+    val inner = trimmed.substring(1, trimmed.length - 1)
+    if (',' !in inner) {
+        // Hard single version "[1.0]" — degenerate closed interval [v, v]. Only the fully-closed
+        // bracket form is valid here (matches VersionRangeFactory, which rejects "(1.0)").
+        require(open == '[' && close == ']') { "hard version must be fully closed: $range" }
+        val v = inner.trim()
+        require(v.isNotEmpty()) { "empty hard version: $range" }
+        return IntervalBounds(v, true, v, true)
+    }
+    val parts = inner.split(',')
+    require(parts.size == 2) { "multi-segment or malformed range: $range" }
+    val lower = parts[0].trim()
+    val upper = parts[1].trim()
+    require(lower.isNotEmpty() && upper.isNotEmpty()) { "unbounded range not supported: $range" }
+    return IntervalBounds(lower, open == '[', upper, close == ']')
+}
+
+/**
+ * A version strictly greater than [version] by the smallest representable amount, used to represent
+ * the point just inside an open lower bound. Appends a low-order ".0.0.0.1" tail: trailing zero
+ * components compare equal under the factory's padding, so the final "1" makes the value sort
+ * immediately above the original.
+ */
+private fun epsilonAbove(
+    version: String,
+    numericVersionFactory: NumericVersionFactory,
+): IVersionInfo = numericVersionFactory.create("$version.0.0.0.1")
+
+/**
+ * A version strictly less than [upper] by the smallest representable amount, used as a near-upper
+ * interior probe for open upper bounds. Takes the upper's major and minor and, when minor > 0,
+ * drops one minor and appends a large low-order tail ("2.9" → "2.8.999999"); when minor == 0 but
+ * major > 0, probes just below the major ("3.0" → "2.999999"). Integer-component versions make this
+ * exact. When upper is "0.0" there is no representable version below it in this non-negative domain,
+ * so [upper] itself is returned — `offerIfInside`'s strict `< upper` check then drops it (rather than
+ * fabricating a "-1.999999" string, which the factory would misread via the `-` separator).
+ */
+private fun justBelow(
+    upper: IVersionInfo,
+    numericVersionFactory: NumericVersionFactory,
+): IVersionInfo {
+    val major = upper.getMajor()
+    val minor = upper.getMinor()
+    return when {
+        minor > 0 -> numericVersionFactory.create("$major.${minor - 1}.$NEAR_BOUNDARY_MINOR")
+        major > 0 -> numericVersionFactory.create("${major - 1}.$NEAR_BOUNDARY_MINOR")
+        else -> upper
+    }
+}
+
+/** Large minor index used to probe just below an integer-major boundary (e.g. 2.999999 < 3.0). */
+private const val NEAR_BOUNDARY_MINOR = 999_999
+
+/**
+ * Interior probe versions strictly between [lower] and [upper]. Combines three families so that any
+ * sub-interval where the child escapes the parent contains at least one sample:
+ *  - whole-version grid points (2.0, 3.0, …) lying strictly inside the interval;
+ *  - sub-major minor steps under each major in the span (covers narrow same-major intervals like
+ *    [1.0,2.0) that contain no whole-version grid point);
+ *  - a near-upper probe just below the upper bound's major (covers a child that overshoots an open
+ *    upper bound between the coarser samples, e.g. [1.5,2.9) escaping parent [1.0,2.5)).
+ * Versions in this registry are integer-component, so this set fully covers the interval; the
+ * INTERIOR_PROBE_COUNT cap bounds the TOTAL number of probes (across all three families, enforced by
+ * `offerIfInside` and every loop guard), not a per-family quota, keeping work bounded for very wide
+ * ranges without weakening the matrix cases.
+ */
+private fun interiorProbes(
+    lower: IVersionInfo,
+    upper: IVersionInfo,
+    numericVersionFactory: NumericVersionFactory,
+): List<IVersionInfo> {
+    val probes = mutableListOf<IVersionInfo>()
+    val lowMajor = lower.getMajor()
+    val highMajor = upper.getMajor()
+
+    fun offerIfInside(candidate: IVersionInfo) {
+        if (probes.size < INTERIOR_PROBE_COUNT &&
+            candidate.compareTo(lower) > 0 &&
+            candidate.compareTo(upper) < 0
+        ) {
+            probes += candidate
+        }
+    }
+
+    // Near-upper probe FIRST: a version just below the upper bound, catching an open-upper overshoot
+    // that sits above every whole-version grid point (e.g. the 2.5..2.9 tail of child [1.5,2.9)
+    // against a parent that stops at 2.5). It is the load-bearing sample for that family, so it is
+    // offered before the grid loop — otherwise a child spanning many majors could fill the probe cap
+    // with grid points and silently drop it, opening a false-positive for a wide overshooting child.
+    offerIfInside(justBelow(upper, numericVersionFactory))
+    // Whole-version grid points strictly inside the interval (e.g. 2.0 inside [1.5,2.5)).
+    var major = lowMajor + 1
+    while (major <= highMajor && probes.size < INTERIOR_PROBE_COUNT) {
+        offerIfInside(numericVersionFactory.create("$major.0"))
+        major++
+    }
+    // Sub-major minor steps across the span, covering narrow same-major intervals such as [1.0,2.0).
+    major = lowMajor
+    while (major <= highMajor && probes.size < INTERIOR_PROBE_COUNT) {
+        var minor = 1
+        while (minor <= INTERIOR_PROBE_COUNT && probes.size < INTERIOR_PROBE_COUNT) {
+            offerIfInside(numericVersionFactory.create("$major.$minor"))
+            minor++
+        }
+        major++
+    }
+    return probes
+}
 
 // ============================================================
 // Internal: build EscrowModuleConfig from base + overrides

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -316,15 +316,23 @@ private fun ComponentEntity.resolveForRange(
  * TD-010 (docs/registry/tech-debt/010-range-applies-containment.md). The version-range library
  * exposes only point-in-range [VersionRange.containsVersion], not containsRange, so containment is
  * approximated by a sample-points heuristic: sample the child's endpoints (closed bound inclusive;
- * open bound epsilon-shifted just inside the interval) plus a fixed number of interior probes across
- * the child interval, and return true iff EVERY sample lies in the parent. Equality short-circuits to
- * true. A parent that fails to parse (e.g. the unbounded "(,)" — both-sides-open is rejected by the
+ * open finite bound epsilon-shifted just inside the interval) plus a fixed number of interior probes
+ * across the child interval, and return true iff EVERY sample lies in the parent. Equality
+ * short-circuits to true.
+ *
+ * One-sided-unbounded children ("[2.0,)" open-upper, "(,5.0)" open-lower — the everyday
+ * "from this version onward" / "up to this version" shapes) ARE supported: the open-ended side is
+ * probed via a sentinel (a huge tail version for open-upper, the zero version for open-lower), so an
+ * open-upper child is contained iff its floor is in the parent AND the parent is itself open-upper.
+ * A parent that fails to parse (the fully-unbounded "(,)" — both-sides-open is rejected by the
  * factory, deferred to TD-010-b) falls back to string equality, keeping the result conservative
  * (a missed override, never a wrong one).
  *
- * The heuristic is exact for the bounded cases in the TD-010 matrix; the only theoretical false
- * positive would be a child whose violating sub-interval is narrower than the probe spacing and sits
- * between two samples, which cannot happen for the integer-component versions this registry uses.
+ * The heuristic is exact for the bounded and one-sided-unbounded cases in the TD-010 matrix against a
+ * single-interval or open-left-union parent. The only theoretical false positive is a parent gap
+ * narrower than the probe spacing sitting between two samples (e.g. a multi-segment override row with
+ * a far-out internal gap); this does not occur for the integer-component, single-range overrides this
+ * registry uses, and is noted as a deferred approximation in the TD-010 doc.
  */
 internal fun rangeApplies(
     parentRange: String,
@@ -364,47 +372,86 @@ internal fun rangeApplies(
 /** Number of interior probe points sampled strictly inside the child interval. */
 private const val INTERIOR_PROBE_COUNT = 8
 
+/** Smallest representable version, standing in for a child's unbounded LOWER side ("(,X)"). */
+private const val ZERO_VERSION = "0.0"
+
+/**
+ * A version far above any real registry version, standing in for a child's unbounded UPPER side
+ * ("[X,)"): a bounded parent cannot contain it (so the open-ended child is correctly rejected),
+ * while an open-upper parent does (so it is accepted). Registry versions are small integer-component
+ * numbers, so this is safely beyond every real upper bound.
+ */
+private const val HUGE_TAIL_VERSION = "9999999.0"
+
 /**
  * Build the set of probe versions for [childRange] used by the containment heuristic: the lower and
- * upper endpoints (with open bounds shifted just inside the interval) plus [INTERIOR_PROBE_COUNT]
- * interior probes spread across the interval. Only single-interval children are produced; a
- * multi-segment or unbounded child throws and the caller treats it conservatively.
+ * upper endpoints (closed bound inclusive; open finite bound shifted just inside) plus interior
+ * probes across the interval. One-sided-unbounded children are supported by substituting a sentinel
+ * for the open-ended side — [ZERO_VERSION] for an unbounded lower, [HUGE_TAIL_VERSION] for an
+ * unbounded upper — so a child like "[2.0,)" probes its 2.0 floor AND the huge tail (rejected by a
+ * bounded parent, accepted by an open-upper one). A fully-unbounded "(,)" child throws in
+ * [parseSingleInterval] and the caller treats it conservatively.
  */
 private fun childRangeSamples(
     childRange: String,
     numericVersionFactory: NumericVersionFactory,
 ): List<IVersionInfo> {
     val bounds = parseSingleInterval(childRange)
-    val lower = numericVersionFactory.create(bounds.lower)
-    val upper = numericVersionFactory.create(bounds.upper)
 
     val samples = mutableListOf<IVersionInfo>()
-    // Lower endpoint: closed bound is part of the interval; open bound is excluded, so probe just
-    // above it (epsilon-shift) to represent the smallest point that IS in the child.
-    samples += if (bounds.includeLower) lower else epsilonAbove(bounds.lower, numericVersionFactory)
-    // Upper endpoint: only the closed bound is part of the interval. For an open upper bound the
-    // supremum is not in the child; the interior probes below cover the approach to it.
-    if (bounds.includeUpper) {
-        samples += upper
+
+    // Low edge for interior probing + the lower endpoint sample.
+    val lowerEdge: IVersionInfo
+    if (bounds.lower == null) {
+        // Unbounded below: the child reaches down to the smallest representable version.
+        lowerEdge = numericVersionFactory.create(ZERO_VERSION)
+        samples += lowerEdge
+    } else {
+        lowerEdge = numericVersionFactory.create(bounds.lower)
+        // Closed bound is part of the interval; open bound is excluded, so probe just above it
+        // (epsilon-shift) to represent the smallest point that IS in the child.
+        samples += if (bounds.includeLower) lowerEdge else epsilonAbove(bounds.lower, numericVersionFactory)
     }
-    // Interior probes: spread across [lower, upper] so that a child reaching past the parent (or
-    // sitting in a union-parent gap) is caught even when both endpoints individually land in parent.
-    samples += interiorProbes(lower, upper, numericVersionFactory)
+
+    // High edge for interior probing + (when in the interval) the upper endpoint sample.
+    val upperEdge: IVersionInfo
+    if (bounds.upper == null) {
+        // Unbounded above: a huge sentinel stands in for the tail and IS sampled directly — a bounded
+        // parent cannot contain it, an open-upper parent can.
+        upperEdge = numericVersionFactory.create(HUGE_TAIL_VERSION)
+        samples += upperEdge
+    } else {
+        upperEdge = numericVersionFactory.create(bounds.upper)
+        // Only a closed finite upper bound is part of the interval; an open finite upper bound's
+        // supremum is excluded — the near-upper interior probe covers the approach to it.
+        if (bounds.includeUpper) {
+            samples += upperEdge
+        }
+    }
+
+    // Interior probes: spread across [lowerEdge, upperEdge] so that a child reaching past the parent
+    // (or sitting in a union-parent gap) is caught even when both endpoints individually land inside.
+    samples += interiorProbes(lowerEdge, upperEdge, numericVersionFactory)
     return samples
 }
 
-/** A single closed/open version interval parsed from a range string such as "[1.0,2.0)". */
+/**
+ * A single version interval parsed from a range string such as "[1.0,2.0)". A null [lower]/[upper]
+ * means that side is unbounded (open-ended), e.g. "[1.0,)" → upper == null. An unbounded side is by
+ * definition exclusive, so its include-flag is always false.
+ */
 private data class IntervalBounds(
-    val lower: String,
+    val lower: String?,
     val includeLower: Boolean,
-    val upper: String,
+    val upper: String?,
     val includeUpper: Boolean,
 )
 
 /**
- * Parse a single-interval range string ("[1.0,2.0)", "(1.0,3.0)", "[1.0]") into its bounds. Throws
- * for unbounded ("(,2.0)" / "[1.0,)"), multi-segment union, or otherwise malformed input so the
- * caller can fall back to the conservative path.
+ * Parse a single-interval range string into its bounds: "[1.0,2.0)", "(1.0,3.0)", "[1.0]", and the
+ * one-sided-unbounded forms "[1.0,)" / "(,2.0]". Throws for the fully-unbounded "(,)" (both sides
+ * empty — deferred to TD-010-b, cannot be sampled), a multi-segment union, or otherwise malformed
+ * input, so the caller can fall back to the conservative path.
  */
 private fun parseSingleInterval(range: String): IntervalBounds {
     val trimmed = range.trim()
@@ -425,10 +472,16 @@ private fun parseSingleInterval(range: String): IntervalBounds {
     }
     val parts = inner.split(',')
     require(parts.size == 2) { "multi-segment or malformed range: $range" }
-    val lower = parts[0].trim()
-    val upper = parts[1].trim()
-    require(lower.isNotEmpty() && upper.isNotEmpty()) { "unbounded range not supported: $range" }
-    return IntervalBounds(lower, open == '[', upper, close == ']')
+    val lower = parts[0].trim().ifEmpty { null }
+    val upper = parts[1].trim().ifEmpty { null }
+    // Fully-unbounded "(,)" cannot be sampled (no endpoint to anchor probes) — deferred to TD-010-b.
+    require(lower != null || upper != null) { "fully-unbounded range not supported: $range" }
+    return IntervalBounds(
+        lower = lower,
+        includeLower = open == '[' && lower != null,
+        upper = upper,
+        includeUpper = close == ']' && upper != null,
+    )
 }
 
 /**

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
@@ -1,0 +1,164 @@
+package org.octopusden.octopus.components.registry.server.mapper
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * TD-010 acceptance matrix for [rangeApplies] — range-VIEW enumeration override selection.
+ *
+ * The predicate decides whether an override row keyed by parentRange should be projected onto an
+ * enumeration view childRange. The contract is range containment (child is a subset of parent),
+ * approximated by the sample-points heuristic specified in
+ * docs/registry/tech-debt/010-range-applies-containment.md.
+ *
+ * Bounded cases 1-9 plus the parseable union cases 10-11 ship here. The unbounded case 12 (parent
+ * "(,)") is deferred to TD-010-b: the underlying VersionRangeFactory rejects a both-sides-open
+ * restriction at parse time ("Bad range: no minimum, maximum allowed versions are specified"), so a
+ * sample-points containment check cannot be evaluated against it. The predicate falls back to
+ * string equality when the parent fails to parse, which keeps "(,)" vs concrete child conservative
+ * (false) rather than wrong. See the deferral note appended to the doc.
+ */
+class RangeAppliesContainmentTest {
+
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+
+    @Nested
+    @DisplayName("bounded cases 1-9 (TD-010 acceptance bar)")
+    inner class Bounded {
+        @ParameterizedTest(name = "#{0}: rangeApplies(parent={1}, child={2}) == {3} — {4}")
+        @MethodSource("org.octopusden.octopus.components.registry.server.mapper.RangeAppliesContainmentTest#boundedCases")
+        fun matches(
+            case: Int,
+            parent: String,
+            child: String,
+            expected: Boolean,
+            rationale: String,
+        ) {
+            assertEquals(
+                expected,
+                rangeApplies(parent, child, versionRangeFactory, numericVersionFactory),
+                "case #$case: $rationale",
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("union cases 10-11 (parseable; case 12 deferred to TD-010-b)")
+    inner class Union {
+        @ParameterizedTest(name = "#{0}: rangeApplies(parent={1}, child={2}) == {3} — {4}")
+        @MethodSource("org.octopusden.octopus.components.registry.server.mapper.RangeAppliesContainmentTest#unionCases")
+        fun matches(
+            case: Int,
+            parent: String,
+            child: String,
+            expected: Boolean,
+            rationale: String,
+        ) {
+            assertEquals(
+                expected,
+                rangeApplies(parent, child, versionRangeFactory, numericVersionFactory),
+                "case #$case: $rationale",
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("robustness beyond the matrix — near-upper overshoot of an open bound")
+    inner class Robustness {
+        @org.junit.jupiter.api.Test
+        @DisplayName("child overshoots parent only in the tail above the coarse grid (not contained)")
+        fun openUpperOvershootBetweenGridPoints() {
+            // child [1.5,2.9) escapes parent [1.0,2.5) only in (2.5,2.9); both endpoints and the whole
+            // 2.0 grid point are inside the parent, so endpoint+grid sampling alone would wrongly pass.
+            // The near-upper probe makes this correctly false.
+            assertEquals(
+                false,
+                rangeApplies("[1.0,2.5)", "[1.5,2.9)", versionRangeFactory, numericVersionFactory),
+                "child's open-upper tail past the parent must be detected",
+            )
+        }
+
+        @org.junit.jupiter.api.Test
+        @DisplayName("genuinely contained narrow child stays true")
+        fun narrowContainedChildStaysTrue() {
+            assertEquals(
+                true,
+                rangeApplies("[1.0,3.0)", "[1.5,2.9)", versionRangeFactory, numericVersionFactory),
+                "a child fully inside a wider parent must remain a match",
+            )
+        }
+
+        @org.junit.jupiter.api.Test
+        @DisplayName("wide child (9+ major span) overshooting the parent is still detected (probe-cap guard)")
+        fun wideSpanOvershootStillDetected() {
+            // child [0.5,8.9) spans 9 majors, so the whole-version grid points (1.0..8.0) alone would
+            // fill the interior-probe cap; the near-upper probe just below 8.9 must still be sampled so
+            // the overshoot past the parent's 8.5 upper is caught. Guards the offer-near-upper-first
+            // ordering in interiorProbes.
+            assertEquals(
+                false,
+                rangeApplies("[0.5,8.5)", "[0.5,8.9)", versionRangeFactory, numericVersionFactory),
+                "a wide child overshooting the parent's open upper must not be a false match",
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("case 12 deferred — unbounded parent falls back to string equality (conservative)")
+    inner class UnboundedDeferred {
+        @org.junit.jupiter.api.Test
+        @DisplayName("#12: parent \"(,)\" vs concrete child is conservatively false (parse-fail fallback)")
+        fun unboundedParentFallsBackToEquality() {
+            // TD-010-b: "(,)" is unparseable by VersionRangeFactory, so the heuristic cannot run and
+            // we fall back to parent == child. Asserting the documented conservative behaviour here
+            // (false), NOT the eventual TD-010-b target (true), so the deferral is explicit in code.
+            assertEquals(
+                false,
+                rangeApplies("(,)", "[1.0,2.0)", versionRangeFactory, numericVersionFactory),
+                "case #12 deferred: unbounded parent cannot be parsed; conservative false until TD-010-b",
+            )
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun boundedCases(): List<Arguments> =
+            listOf(
+                Arguments.of(1, "[1.0,2.0)", "[1.0,2.0)", true, "exact equality (preserved)"),
+                Arguments.of(2, "[1.0,3.0)", "[1.0,2.0)", true, "strict left-aligned containment"),
+                Arguments.of(3, "[1.0,3.0)", "[2.0,3.0)", true, "strict right-aligned containment"),
+                Arguments.of(4, "[1.0,3.0)", "[1.5,2.5)", true, "strict interior containment"),
+                Arguments.of(5, "[1.0,2.0)", "[1.5,2.5)", false, "partial overlap, child extends past parent"),
+                Arguments.of(6, "[1.0,2.0]", "[2.0,3.0)", false, "single-point intersection at closed boundary, NOT containment"),
+                Arguments.of(7, "[1.0,2.0)", "[2.0,3.0)", false, "adjacent disjoint, no overlap"),
+                Arguments.of(8, "(1.0,3.0)", "[1.5,2.5]", true, "strict interior, mixed bound styles"),
+                Arguments.of(9, "[1.0,2.0)", "[1.0,2.0]", false, "child closed upper exceeds parent open upper by epsilon"),
+            )
+
+        @JvmStatic
+        fun unionCases(): List<Arguments> =
+            // NOTE on revert-guarding: case 10 expects `true`, which the old exact-match predicate
+            // ("(,0),[1.0,)" == "[2.0,3.0)" → false) could NOT produce — so case 10 actively guards the
+            // new containment behaviour. Case 11 expects `false`, which the old predicate ALSO returns
+            // (string inequality), so case 11 is a conservative documentation case, NOT a live revert
+            // guard. The behaviour-guarding load is carried by bounded cases 2/3/4/8 (true) + case 10.
+            listOf(
+                Arguments.of(10, "(,0),[1.0,)", "[2.0,3.0)", true, "union-parent contains right-segment-only child"),
+                // Doc case 11 prints the child as [-1.0,0.5); negative versions are unsupported by the
+                // factory (the '-' is a separator, so "-1.0" parses to "1.0" and "[1.0,0.5)" then fails
+                // the min<=max check). Substitute the semantically equivalent gap-straddling child
+                // [0.5,1.5): its lower endpoint 0.5 lies in the union-parent's gap [0,1.0), so it is not
+                // contained. Intent preserved; recorded in the doc.
+                Arguments.of(11, "(,0),[1.0,)", "[0.5,1.5)", false, "child straddles a gap in the union-parent"),
+            )
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
@@ -113,6 +113,26 @@ class RangeAppliesContainmentTest {
     }
 
     @Nested
+    @DisplayName("open-ended children — '[X,)' / '(,Y)' the everyday from-version-onward shapes")
+    inner class OpenEnded {
+        @ParameterizedTest(name = "{0}: rangeApplies(parent={1}, child={2}) == {3} — {4}")
+        @MethodSource("org.octopusden.octopus.components.registry.server.mapper.RangeAppliesContainmentTest#openEndedCases")
+        fun matches(
+            label: String,
+            parent: String,
+            child: String,
+            expected: Boolean,
+            rationale: String,
+        ) {
+            assertEquals(
+                expected,
+                rangeApplies(parent, child, versionRangeFactory, numericVersionFactory),
+                "$label: $rationale",
+            )
+        }
+    }
+
+    @Nested
     @DisplayName("case 12 deferred — unbounded parent falls back to string equality (conservative)")
     inner class UnboundedDeferred {
         @org.junit.jupiter.api.Test
@@ -159,6 +179,23 @@ class RangeAppliesContainmentTest {
                 // [0.5,1.5): its lower endpoint 0.5 lies in the union-parent's gap [0,1.0), so it is not
                 // contained. Intent preserved; recorded in the doc.
                 Arguments.of(11, "(,0),[1.0,)", "[0.5,1.5)", false, "child straddles a gap in the union-parent"),
+            )
+
+        @JvmStatic
+        fun openEndedCases(): List<Arguments> =
+            // Open-ended (one-sided-unbounded) children — the everyday "from version X onward" /
+            // "up to version Y" shapes. The three OE-1..OE-3 cases are the reviewer's acceptance bar
+            // for open-upper child support (incl. the open-left-union parent); the rest pin the
+            // boundaries (bounded parent cannot contain an open-upper tail; open-lower symmetry).
+            listOf(
+                Arguments.of("OE-1", "[1.0,)", "[2.0,)", true, "open-upper child inside a wider open-upper parent"),
+                Arguments.of("OE-2", "[2.0,)", "[1.0,)", false, "open-upper child's floor (1.0) is below the parent's floor (2.0)"),
+                Arguments.of("OE-3", "(,0),[1.0,)", "[2.0,)", true, "open-upper child inside an open-left-union parent's right segment"),
+                Arguments.of("OE-4", "[1.0,3.0)", "[2.0,)", false, "bounded parent cannot contain an open-upper child's tail"),
+                Arguments.of("OE-5", "[1.0,)", "(2.0,)", true, "open-lower-open-upper child still contained in a wider open-upper parent"),
+                Arguments.of("OE-6", "(,5.0)", "(,3.0)", true, "open-lower child up to 3.0 inside a wider open-lower parent up to 5.0"),
+                Arguments.of("OE-7", "(,3.0)", "(,5.0)", false, "open-lower child up to 5.0 reaches past the narrower parent's 3.0 upper"),
+                Arguments.of("OE-8", "[1.0,)", "[1.0,5.0)", true, "bounded child inside an open-upper parent"),
             )
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/RangeAppliesContainmentTest.kt
@@ -196,6 +196,13 @@ class RangeAppliesContainmentTest {
                 Arguments.of("OE-6", "(,5.0)", "(,3.0)", true, "open-lower child up to 3.0 inside a wider open-lower parent up to 5.0"),
                 Arguments.of("OE-7", "(,3.0)", "(,5.0)", false, "open-lower child up to 5.0 reaches past the narrower parent's 3.0 upper"),
                 Arguments.of("OE-8", "[1.0,)", "[1.0,5.0)", true, "bounded child inside an open-upper parent"),
+                // OE-9 is the reviewer's exact counterexample: a bounded parent whose finite upper
+                // exceeds the open-upper sentinel must STILL reject an open-upper child (the child runs
+                // to +inf past the parent's finite top). The structural guard (open-upper child requires
+                // an open-upper parent) makes this false regardless of how high the parent's finite
+                // upper is — encoding +inf as a finite number is the flaw being fixed.
+                Arguments.of("OE-9", "[1.0,10000000.0)", "[2.0,)", false, "bounded parent above the sentinel must NOT contain an open-upper child"),
+                Arguments.of("OE-10", "[5.0,)", "[2.0,)", false, "open-upper child's floor (2.0) is below the open-upper parent's floor (5.0)"),
             )
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeViewBroadOverrideContainmentIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeViewBroadOverrideContainmentIntegrationTest.kt
@@ -1,0 +1,146 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentRegistryResolver
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Paths
+
+/**
+ * TD-010 regression guard (DB-backed, schema-v2).
+ *
+ * Proves the range-VIEW enumeration applies a broad scalar override to a strictly contained narrow
+ * enumeration range. The component declares:
+ *   - BASE on ALL_VERSIONS with buildFilePath = "BasePath";
+ *   - a RANGE_PRESENCE row on the narrow [1.0,2.0) (so that range is enumerated as its own view);
+ *   - a broad SCALAR_OVERRIDE on [1.0,3.0) setting buildFilePath = "BroadOverridePath".
+ *
+ * The narrow [1.0,2.0) view is strictly contained in the broad [1.0,3.0) override, so the override
+ * must win on that view. Before the fix, rangeApplies used string equality ("[1.0,3.0)" !=
+ * "[1.0,2.0)"), so the broad override was silently dropped and the [1.0,2.0) view fell back to the
+ * base "BasePath" — the exact symptom TD-010 describes. The fix's containment heuristic projects the
+ * override onto the contained view.
+ *
+ * Scaffold mirrors TypeConfigurationArrayLeakReproTest: SpringBootTest + test-db profile + a
+ * Postgres testcontainer, seeding entities directly through the repository.
+ */
+@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
+@ActiveProfiles("common", "test-db")
+@Timeout(120)
+@Tag("integration")
+class RangeViewBroadOverrideContainmentIntegrationTest {
+
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    @Qualifier("databaseComponentRegistryResolver")
+    private lateinit var resolver: ComponentRegistryResolver
+
+    init {
+        // application-common.yml binds components-registry.work-dir from this env-backed property.
+        val testResourcesPath =
+            Paths.get(
+                RangeViewBroadOverrideContainmentIntegrationTest::class.java
+                    .getResource("/expected-data")!!.toURI(),
+            ).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @AfterEach
+    fun cleanDatabase() {
+        componentRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("TD-010: broad scalar override [1.0,3.0) is applied to the contained narrow view [1.0,2.0)")
+    fun broadOverrideAppliesToContainedNarrowEnumerationRange() {
+        val key = "td010-containment-comp"
+        val component = ComponentEntity(componentKey = key, archived = false)
+
+        val base = ComponentConfigurationEntity(
+            component = component,
+            versionRange = ALL_VERSIONS,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            buildSystem = "MAVEN",
+            buildFilePath = "BasePath",
+            deprecated = false,
+        )
+        // Narrow presence row: makes [1.0,2.0) a distinct enumerated view (carries no scalars itself).
+        val narrowPresence = ComponentConfigurationEntity(
+            component = component,
+            versionRange = "[1.0,2.0)",
+            overriddenAttribute = null,
+            rowType = "RANGE_PRESENCE",
+        )
+        // Broad scalar override strictly containing the narrow view.
+        val broadOverride = ComponentConfigurationEntity(
+            component = component,
+            versionRange = "[1.0,3.0)",
+            overriddenAttribute = "build.buildFilePath",
+            rowType = "SCALAR_OVERRIDE",
+            buildFilePath = "BroadOverridePath",
+        )
+        component.configurations.addAll(listOf(base, narrowPresence, broadOverride))
+        // An ownership mapping keeps the component well-formed for the full toEscrowModule walk.
+        component.addOwnershipMapping("com.example.td010", "widget-a")
+        componentRepository.save(component)
+
+        val module = resolver.getComponentById(key)
+        assertNotNull(module, "component must resolve to an EscrowModule")
+
+        val narrowView = module!!.moduleConfigurations.firstOrNull { it.versionRangeString == "[1.0,2.0)" }
+        assertNotNull(
+            narrowView,
+            "the narrow [1.0,2.0) range must be enumerated as its own view; " +
+                "got ranges=${module.moduleConfigurations.map { it.versionRangeString }}",
+        )
+        assertEquals(
+            "BroadOverridePath",
+            narrowView!!.buildFilePath,
+            "the broad [1.0,3.0) override must be applied to the contained narrow [1.0,2.0) view " +
+                "(TD-010 containment); base 'BasePath' here means the override was dropped",
+        )
+
+        // Sanity: the broad override's own [1.0,3.0) view also carries the override (equality path).
+        val broadView = module.moduleConfigurations.firstOrNull { it.versionRangeString == "[1.0,3.0)" }
+        assertNotNull(broadView, "the broad [1.0,3.0) override range must also be enumerated")
+        assertEquals("BroadOverridePath", broadView!!.buildFilePath)
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeViewBroadOverrideContainmentIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeViewBroadOverrideContainmentIntegrationTest.kt
@@ -131,6 +131,62 @@ class RangeViewBroadOverrideContainmentIntegrationTest {
         assertEquals("BroadOverridePath", broadView!!.buildFilePath)
     }
 
+    @Test
+    @DisplayName("TD-010 open-ended: broad open-upper override [1.0,) is applied to the contained open-upper view [2.0,)")
+    fun openUpperOverrideAppliesToContainedOpenUpperView() {
+        // The motivating "default from this version onward" case: a broad open-upper override must
+        // project onto a narrower open-upper enumeration view it contains. Before open-ended support,
+        // parseSingleInterval rejected "[2.0,)" so rangeApplies returned false and the [2.0,) view fell
+        // back to base "BasePath". With sentinel-tail sampling, [2.0,) ⊆ [1.0,) holds and the override
+        // wins on that view.
+        val key = "td010-openupper-comp"
+        val component = ComponentEntity(componentKey = key, archived = false)
+
+        val base = ComponentConfigurationEntity(
+            component = component,
+            versionRange = ALL_VERSIONS,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            buildSystem = "MAVEN",
+            buildFilePath = "BasePath",
+            deprecated = false,
+        )
+        // Open-upper presence row: makes [2.0,) a distinct enumerated view.
+        val openUpperPresence = ComponentConfigurationEntity(
+            component = component,
+            versionRange = "[2.0,)",
+            overriddenAttribute = null,
+            rowType = "RANGE_PRESENCE",
+        )
+        // Broad open-upper override strictly containing the [2.0,) view.
+        val broadOpenUpperOverride = ComponentConfigurationEntity(
+            component = component,
+            versionRange = "[1.0,)",
+            overriddenAttribute = "build.buildFilePath",
+            rowType = "SCALAR_OVERRIDE",
+            buildFilePath = "FuturePath",
+        )
+        component.configurations.addAll(listOf(base, openUpperPresence, broadOpenUpperOverride))
+        component.addOwnershipMapping("com.example.td010", "widget-a")
+        componentRepository.save(component)
+
+        val module = resolver.getComponentById(key)
+        assertNotNull(module, "component must resolve to an EscrowModule")
+
+        val openUpperView = module!!.moduleConfigurations.firstOrNull { it.versionRangeString == "[2.0,)" }
+        assertNotNull(
+            openUpperView,
+            "the open-upper [2.0,) range must be enumerated as its own view; " +
+                "got ranges=${module.moduleConfigurations.map { it.versionRangeString }}",
+        )
+        assertEquals(
+            "FuturePath",
+            openUpperView!!.buildFilePath,
+            "the broad open-upper [1.0,) override must be applied to the contained [2.0,) view " +
+                "(TD-010 open-ended containment); base 'BasePath' here means the override was dropped",
+        )
+    }
+
     companion object {
         @JvmStatic
         val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }

--- a/docs/registry/tech-debt/010-range-applies-containment.md
+++ b/docs/registry/tech-debt/010-range-applies-containment.md
@@ -12,7 +12,7 @@ containment contract. Scope is the **range-VIEW enumeration** path only; the sin
 `resolve` path (`toResolvedEscrowModuleConfig` / `ComponentCodeRenderer.renderResolved`) was already
 correct (point `containsVersion`) and is untouched.
 
-Bounded cases 1–9, union cases 10–11, and **open-ended cases OE-1..OE-8** (the everyday
+Bounded cases 1–9, union cases 10–11, and **open-ended cases OE-1..OE-10** (the everyday
 "from version X onward" `[X,)` / "up to version Y" `(,Y)` shapes) ship as a parameterized matrix in
 `RangeAppliesContainmentTest`; the DB-backed `@Tag("integration")`
 `RangeViewBroadOverrideContainmentIntegrationTest` proves a broad `[1.0,3.0)` scalar override is
@@ -68,18 +68,28 @@ For each case, the test asserts the expected `rangeApplies(parent, child)` outco
 
 **Acceptance bar:** all 9 **bounded** cases (1–9) must ship in the TD-010 PR. The 3 **union/unbounded** cases (10–12) may be deferred to a `TD-010-b` follow-up if the underlying `VersionRangeFactory` API doesn't yet support union/unbounded ranges — track explicitly. The "minimum 8" headline above is satisfied by the bounded subset alone.
 
-**As shipped:** cases 1–9, **10–11**, and the **open-ended OE-1..OE-8** cases are green in
+**As shipped:** cases 1–9, **10–11**, and the **open-ended OE-1..OE-10** cases are green in
 `RangeAppliesContainmentTest`. The `VersionRangeFactory` (releng-lib 2.0.8) *does* parse the
 open-left-unbounded union parent `(,0),[1.0,)`, so the heuristic evaluates 10/11 correctly.
 
 **Open-ended child support (review follow-up).** One-sided-unbounded children — the everyday
 `[X,)` "from version X onward" and `(,Y)` "up to version Y" shapes — are supported: `parseSingleInterval`
-accepts one empty bound, and `childRangeSamples` substitutes a sentinel for the open side (`ZERO_VERSION`
-for an unbounded lower, `HUGE_TAIL_VERSION` for an unbounded upper). So `[2.0,)` probes its `2.0` floor
-AND the huge tail — a bounded parent cannot contain the tail (correctly rejected), an open-upper parent
-can (accepted). Acceptance cases: `rangeApplies("[1.0,)","[2.0,)")==true` (OE-1),
+accepts one empty bound. The **open-upper** case is decided **structurally**, not by probing: a child
+that runs to +inf can only be contained in a parent that ALSO runs to +inf, so `rangeApplies` first
+checks `isOpenUpper(parentRange)` and returns `false` for an open-upper child against any
+non-open-upper (i.e. bounded, including closed-or-finite-upper) parent — *regardless* of how high the
+parent's finite upper bound is. Only once the parent is confirmed open-upper does sampling proceed,
+where `childRangeSamples` probes the child's floor plus a high in-tail probe (`HUGE_TAIL_VERSION`)
+against that confirmed-open-upper parent. The high probe is therefore a sample *within a confirmed
+unbounded tail*, **not** a finite stand-in for +inf that a bounded parent could exceed — encoding
+infinity as a finite number was the original flaw (a parent like `[1.0,10000000.0)` would have
+"contained" `[2.0,)`, a false positive). The open-lower side uses `ZERO_VERSION` symmetrically.
+Acceptance cases: `rangeApplies("[1.0,)","[2.0,)")==true` (OE-1),
 `rangeApplies("[2.0,)","[1.0,)")==false` (OE-2), `rangeApplies("(,0),[1.0,)","[2.0,)")==true` (OE-3,
-open-left-union parent). Only the fully-unbounded `(,)` (both sides empty) remains unparseable/deferred.
+open-left-union parent), and the structural-guard guards
+`rangeApplies("[1.0,10000000.0)","[2.0,)")==false` (OE-9, bounded parent above the sentinel) and
+`rangeApplies("[5.0,)","[2.0,)")==false` (OE-10, open-upper parent, child floor below). Only the
+fully-unbounded `(,)` (both sides empty) remains unparseable/deferred.
 
 Two adjustments are recorded:
 

--- a/docs/registry/tech-debt/010-range-applies-containment.md
+++ b/docs/registry/tech-debt/010-range-applies-containment.md
@@ -2,7 +2,21 @@
 
 ## Status
 
-Open · P2 · correctness gap, not contract drift · sister to MIG-049-bis follow-ups · referenced from `EntityMappers.kt:243`.
+**Resolved** · P2 · correctness gap, not contract drift · sister to MIG-049-bis follow-ups.
+
+Fixed in branch `fix/td-010-range-containment`: `EntityMappers.rangeApplies` now implements range
+containment (child is a subset of parent) via the sample-points heuristic below, threading
+`numericVersionFactory: NumericVersionFactory` through `toEscrowModule` → `resolveForRange` →
+`rangeApplies`. The conservative `// see TD-010` KDoc at the callsite is replaced with the
+containment contract. Scope is the **range-VIEW enumeration** path only; the single-version
+`resolve` path (`toResolvedEscrowModuleConfig` / `ComponentCodeRenderer.renderResolved`) was already
+correct (point `containsVersion`) and is untouched.
+
+Bounded cases 1–9 and union cases 10–11 ship as a parameterized matrix in
+`RangeAppliesContainmentTest`; the DB-backed `@Tag("integration")`
+`RangeViewBroadOverrideContainmentIntegrationTest` proves a broad `[1.0,3.0)` scalar override is
+projected onto a contained narrow `[1.0,2.0)` enumeration view (RED-verified against the old
+equality predicate). Two carve-outs are deferred to **TD-010-b** (see Deferred below).
 
 ## Problem
 
@@ -52,16 +66,46 @@ For each case, the test asserts the expected `rangeApplies(parent, child)` outco
 
 **Acceptance bar:** all 9 **bounded** cases (1–9) must ship in the TD-010 PR. The 3 **union/unbounded** cases (10–12) may be deferred to a `TD-010-b` follow-up if the underlying `VersionRangeFactory` API doesn't yet support union/unbounded ranges — track explicitly. The "minimum 8" headline above is satisfied by the bounded subset alone.
 
+**As shipped:** cases 1–9 plus **10–11** are green in `RangeAppliesContainmentTest`. The
+`VersionRangeFactory` (releng-lib 2.0.8) *does* parse the open-left-unbounded union parent
+`(,0),[1.0,)`, so the heuristic evaluates 10/11 correctly. Two adjustments are recorded:
+
+- **Case 11 child** is shipped as `[0.5,1.5)` rather than the literal `[-1.0,0.5)`. The factory treats
+  `-` as a version separator (so `-1.0` parses to `1.0`), which makes `[-1.0,0.5)` fail the
+  `min ≤ max` check at parse time — negative versions are unsupported. `[0.5,1.5)` preserves the
+  case's intent: its lower endpoint `0.5` lies in the union-parent's gap `[0,1.0)`, so it is not
+  contained → `false`.
+- **Case 12** (`(,)`, both-sides-open unbounded parent) is **deferred to TD-010-b**: the factory
+  rejects a restriction with neither bound at parse time ("Bad range: no minimum, maximum allowed
+  versions are specified"), so the heuristic cannot probe against it. `rangeApplies` falls back to
+  string equality when the parent fails to parse, which keeps `(,)` vs a concrete child conservatively
+  `false` (a missed override, never a wrong one). The deferral is pinned by an explicit test asserting
+  the current conservative `false`, so TD-010-b will flip a known assertion rather than discover the
+  gap.
+
 ### 2. Implementation approach
 
 Sample-points heuristic over `NumericVersionFactory.parse(...)`:
 
-1. Parse `parent` and `child` ranges via `VersionRangeFactory`.
-2. Sample the child endpoints (closed-bound: inclusive; open-bound: ε-shifted via `NumericVersion.bump()`).
-3. Sample at least N interior probes between child endpoints.
+1. Parse `parent` via `VersionRangeFactory`; parse the `child` bound string into its endpoints.
+2. Sample the child endpoints (closed-bound: inclusive; open-bound: ε-shifted just inside the interval).
+3. Sample N interior probes between child endpoints.
 4. Return `true` iff EVERY sample satisfies `parent.containsVersion(sample)`.
 
-Thread `numericVersionFactory: NumericVersionFactory` through `resolveForRange` → `toEscrowModule` → `rangeApplies` (currently `factory: VersionRangeFactory` is unused; rename or replace).
+Thread `numericVersionFactory: NumericVersionFactory` through `toEscrowModule` → `resolveForRange` → `rangeApplies` (the old `factory: VersionRangeFactory` param was unused).
+
+**As implemented (API note).** releng-lib 2.0.8 exposes `NumericVersion`/`IVersionInfo` with **no
+`bump()`** method, so the ε-shift is done by constructing a successor/predecessor version from the
+endpoint string rather than calling `bump()`:
+
+- ε-above (open lower bound): append a low-order `.0.0.0.1` tail — trailing zeros compare equal under
+  the factory's padding, so the value sorts immediately above the endpoint.
+- near-upper probe (open upper bound): a value just below `upper` (drop one minor and append a large
+  low-order tail), covering an overshoot above the coarse whole-version grid.
+- interior probes: whole-version grid points plus sub-major minor steps across the span; versions in
+  this registry are integer-component, so the grid + endpoints + near-upper probe fully cover any
+  sub-interval that could escape the parent. A parent that fails to parse falls back to string
+  equality (conservative).
 
 ### 3. Regression-guard tests
 
@@ -70,6 +114,18 @@ In addition to the matrix above, add at least one **integration-level** test usi
 ### 4. Migration sanity
 
 Per `project_crs_schema_v2_migration_policy`: schema-v2 is not in prod yet. The QA stand pererecreates from `V1__schema.sql` and re-imports from Groovy DSL. The fix changes only **read-side** semantics — no backfill / migration script needed.
+
+## Deferred — TD-010-b
+
+- **Unbounded parent `(,)` (matrix case 12).** `VersionRangeFactory` rejects a both-sides-open
+  restriction at parse time, so the sample-points heuristic cannot run against it. `rangeApplies`
+  falls back to string equality (conservative `false`). A pinned test asserts the current `false` so
+  TD-010-b is a known flip rather than a discovery. Options for TD-010-b: special-case `(,)` (and any
+  `ALL_VERSIONS`-equivalent) as "contains everything" before the parse, or add a `containsRange` to
+  the version-range library.
+- **Negative version bounds.** The factory parses `-` as a separator, so negative endpoints (e.g.
+  `[-1.0,…)`) are unrepresentable; not a real registry case, noted only because the original matrix
+  case 11 used one.
 
 ## Out of scope
 
@@ -83,4 +139,9 @@ Trace-replay against the candidate stand surfaces this if it bites; if no diff a
 
 ## Related
 
-- `EntityMappers.kt:243` — the FIXME callsite, now replaced with `// see TD-010` in PR fix/pr-192-docs-test-strengthening.
+- `EntityMappers.kt` — `rangeApplies` (the former FIXME callsite); the `// see TD-010` KDoc is now the
+  containment contract. The predicate is `internal` so `RangeAppliesContainmentTest` calls it directly.
+- `RangeAppliesContainmentTest` — the cases 1–11 matrix + the case-12 deferral pin + near-upper
+  robustness cases.
+- `RangeViewBroadOverrideContainmentIntegrationTest` — DB-backed (`@Tag("integration")`,
+  `:components-registry-service-server:dbTest`) end-to-end guard.

--- a/docs/registry/tech-debt/010-range-applies-containment.md
+++ b/docs/registry/tech-debt/010-range-applies-containment.md
@@ -12,11 +12,13 @@ containment contract. Scope is the **range-VIEW enumeration** path only; the sin
 `resolve` path (`toResolvedEscrowModuleConfig` / `ComponentCodeRenderer.renderResolved`) was already
 correct (point `containsVersion`) and is untouched.
 
-Bounded cases 1–9 and union cases 10–11 ship as a parameterized matrix in
+Bounded cases 1–9, union cases 10–11, and **open-ended cases OE-1..OE-8** (the everyday
+"from version X onward" `[X,)` / "up to version Y" `(,Y)` shapes) ship as a parameterized matrix in
 `RangeAppliesContainmentTest`; the DB-backed `@Tag("integration")`
 `RangeViewBroadOverrideContainmentIntegrationTest` proves a broad `[1.0,3.0)` scalar override is
 projected onto a contained narrow `[1.0,2.0)` enumeration view (RED-verified against the old
-equality predicate). Two carve-outs are deferred to **TD-010-b** (see Deferred below).
+equality predicate). Only the fully-unbounded `(,)` parent/child and negative bounds are deferred to
+**TD-010-b** (see Deferred below).
 
 ## Problem
 
@@ -66,9 +68,20 @@ For each case, the test asserts the expected `rangeApplies(parent, child)` outco
 
 **Acceptance bar:** all 9 **bounded** cases (1–9) must ship in the TD-010 PR. The 3 **union/unbounded** cases (10–12) may be deferred to a `TD-010-b` follow-up if the underlying `VersionRangeFactory` API doesn't yet support union/unbounded ranges — track explicitly. The "minimum 8" headline above is satisfied by the bounded subset alone.
 
-**As shipped:** cases 1–9 plus **10–11** are green in `RangeAppliesContainmentTest`. The
-`VersionRangeFactory` (releng-lib 2.0.8) *does* parse the open-left-unbounded union parent
-`(,0),[1.0,)`, so the heuristic evaluates 10/11 correctly. Two adjustments are recorded:
+**As shipped:** cases 1–9, **10–11**, and the **open-ended OE-1..OE-8** cases are green in
+`RangeAppliesContainmentTest`. The `VersionRangeFactory` (releng-lib 2.0.8) *does* parse the
+open-left-unbounded union parent `(,0),[1.0,)`, so the heuristic evaluates 10/11 correctly.
+
+**Open-ended child support (review follow-up).** One-sided-unbounded children — the everyday
+`[X,)` "from version X onward" and `(,Y)` "up to version Y" shapes — are supported: `parseSingleInterval`
+accepts one empty bound, and `childRangeSamples` substitutes a sentinel for the open side (`ZERO_VERSION`
+for an unbounded lower, `HUGE_TAIL_VERSION` for an unbounded upper). So `[2.0,)` probes its `2.0` floor
+AND the huge tail — a bounded parent cannot contain the tail (correctly rejected), an open-upper parent
+can (accepted). Acceptance cases: `rangeApplies("[1.0,)","[2.0,)")==true` (OE-1),
+`rangeApplies("[2.0,)","[1.0,)")==false` (OE-2), `rangeApplies("(,0),[1.0,)","[2.0,)")==true` (OE-3,
+open-left-union parent). Only the fully-unbounded `(,)` (both sides empty) remains unparseable/deferred.
+
+Two adjustments are recorded:
 
 - **Case 11 child** is shipped as `[0.5,1.5)` rather than the literal `[-1.0,0.5)`. The factory treats
   `-` as a version separator (so `-1.0` parses to `1.0`), which makes `[-1.0,0.5)` fail the
@@ -126,6 +139,11 @@ Per `project_crs_schema_v2_migration_policy`: schema-v2 is not in prod yet. The 
 - **Negative version bounds.** The factory parses `-` as a separator, so negative endpoints (e.g.
   `[-1.0,…)`) are unrepresentable; not a real registry case, noted only because the original matrix
   case 11 used one.
+- **Multi-segment parent with a far-out internal gap.** The sample-points heuristic can theoretically
+  false-positive if a parent (an override row) has an internal gap narrower than the probe spacing and
+  located beyond the sampled grid (e.g. a union override missing `[500,600)` while an open-ended child
+  spans it). Override rows in this registry are single ranges of small integer-component versions, so
+  this does not occur in practice; a real `containsRange` API would remove the approximation entirely.
 
 ## Out of scope
 


### PR DESCRIPTION
## What

Resolves **TD-010** (`docs/registry/tech-debt/010-range-applies-containment.md`).

`EntityMappers.rangeApplies` was a string-equality predicate, so in the **range-VIEW enumeration** path a broad scalar/marker override (e.g. `[1.0,3.0)`) was silently dropped when enumerating a strictly contained child range (e.g. `[1.0,2.0)`) — consumers (`getAllJiraComponentVersionRanges`, `getMavenArtifactParameters`) saw the unmodified base value where the DSL intended an override.

This replaces equality with **range containment** (child is a subset of parent) via the sample-points heuristic the doc specifies:

1. Parse the parent via `VersionRangeFactory`; parse the child bound string into endpoints.
2. Sample the child endpoints — closed bound inclusive, open lower bound ε-shifted just inside, plus a near-upper probe just below an open upper bound — and interior probes across the interval.
3. Return `true` iff **every** sample satisfies `parent.containsVersion(sample)`.

`numericVersionFactory: NumericVersionFactory` is threaded through `toEscrowModule → resolveForRange → rangeApplies` (the old unused `factory: VersionRangeFactory` param is gone).

**API note:** releng-lib 2.0.8's `NumericVersion` has no `bump()`, so the ε-shift is done by constructing a successor/predecessor from the endpoint string (append a low-order `.0.0.0.1` for ε-above; drop one minor + large tail for the near-upper probe). Integer-component versions make this exact.

## Scope guard

Only the range-view enumeration path changes. The single-version resolve path (`toResolvedEscrowModuleConfig` / `ComponentCodeRenderer.renderResolved`) already used point `containsVersion` and is untouched. **Read-side only — no migration / backfill.**

## Tests

- **`RangeAppliesContainmentTest`** — bounded matrix **cases 1–9** (the acceptance bar) + union **cases 10–11**, plus near-upper-overshoot and wide-span (9+ major) robustness cases.
  - Case 11's child is shipped as `[0.5,1.5)` instead of the doc's literal `[-1.0,0.5)`: the factory treats `-` as a separator so negative versions are unrepresentable; `[0.5,1.5)` preserves the gap-straddling intent. Recorded in the doc.
  - **Case 12** (unbounded `(,)`) is **deferred to TD-010-b** — the factory rejects a both-sides-open restriction at parse time, so the heuristic can't probe it; `rangeApplies` falls back to string equality (conservative `false`). Pinned by an explicit test asserting the current `false`.
- **`RangeViewBroadOverrideContainmentIntegrationTest`** — DB-backed `@Tag("integration")` (run via `:components-registry-service-server:dbTest`, Postgres testcontainer). Seeds a component with a BASE, a narrow `RANGE_PRESENCE` view on `[1.0,2.0)`, and a broad `SCALAR_OVERRIDE` on `[1.0,3.0)`; asserts the broad override is projected onto the contained narrow view. **RED-verified** against the old equality predicate (fails on the old code, passes on the fix).

## Verification

- `:components-registry-service-server:test` — green
- `:components-registry-service-server:check` — green
- `:components-registry-service-server:dbTest` (integration test) — green; RED-confirmed against the pre-fix code

## Deferred (TD-010-b)

- Unbounded `(,)` parent (matrix case 12) and negative version bounds — tracked in the doc's Deferred section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)