### PR TITLE
feat(health): surface the real downstream cause in employeeService health reason

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicator.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicator.kt
@@ -7,8 +7,9 @@ import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.stereotype.Component
 
 /**
- * Actuator surface of [EmployeeDirectoryService.probe]: component
- * `employeeService` under `/actuator/health`.
+ * Actuator surface of [EmployeeDirectoryService.probeHealth]: component
+ * `employeeService` under `/actuator/health`, surfacing the probe's failure
+ * detail (the real downstream cause) in the `reason`.
  *
  * Deployment safety: the OKD probes hit `/actuator/health/liveness` (the
  * liveness GROUP), and Spring only places livenessState/readinessState in the
@@ -30,16 +31,26 @@ import org.springframework.stereotype.Component
 class EmployeeServiceHealthIndicator(
     private val employeeDirectory: EmployeeDirectoryService,
 ) : HealthIndicator {
-    override fun health(): Health =
-        when (employeeDirectory.probe()) {
+    override fun health(): Health {
+        val result = employeeDirectory.probeHealth()
+        return when (result.health) {
             IntegrationHealth.UP -> Health.up().build()
             IntegrationHealth.DOWN ->
                 Health.down()
                     .withDetail(
                         "reason",
-                        "employee-service lookup failed (credentials / gateway route / directory backend — see logs)",
+                        // Carry the real downstream cause (e.g. "...403 Forbidden") so the
+                        // aggregate /actuator/health and the Portal banner name access-denied
+                        // vs unreachable; fall back to the generic hint when none was captured.
+                        result.detail?.let { "employee-service lookup failed — $it" } ?: GENERIC_REASON,
                     )
                     .build()
             IntegrationHealth.DISABLED -> Health.unknown().withDetail("enabled", false).build()
         }
+    }
+
+    private companion object {
+        private const val GENERIC_REASON =
+            "employee-service lookup failed (credentials / gateway route / directory backend — see logs)"
+    }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryService.kt
@@ -113,25 +113,40 @@ class EmployeeDirectoryService(
 
     /**
      * Transport-chain health probe for monitoring surfaces (actuator indicator
-     * and the Portal admin banner). Reuses [isActive] on a synthetic username
-     * that must not exist in the directory: a NOT-FOUND answer proves the whole
-     * CRS → api-gateway → employee-service → directory chain end-to-end, while
-     * [ActiveStatus.UNAVAILABLE] (missing/bad credentials, unreachable service)
-     * is the only state reported as [IntegrationHealth.DOWN].
+     * and the Portal admin banner), with the failure detail. Looks up a synthetic
+     * username that must not exist in the directory: a NOT-FOUND answer proves the
+     * whole CRS → api-gateway → employee-service → directory chain end-to-end.
+     *
+     * On failure it captures the real downstream cause — the exception class and
+     * message, which carries the HTTP status (e.g. "403 Forbidden") — so the
+     * actuator reason can distinguish access-denied (401/403, e.g. a token missing
+     * the `openid` scope) from unreachable, instead of a generic "see logs".
      *
      * Unlike the lookup paths this is NOT fail-open — its whole purpose is to
-     * surface the failure — but it still never throws.
-     *
-     * Calls [isActive] directly (same instance, not through the Spring proxy):
-     * if [isActive] ever grows proxy-bound behavior (caching, retry), probe()
-     * will bypass it — route through a self-injection then.
+     * surface the failure — but it still never throws. Calls the client directly
+     * (not via [isActive]) so the exception is observable rather than collapsed
+     * into [ActiveStatus.UNAVAILABLE].
      */
-    fun probe(): IntegrationHealth =
-        when (isActive(PROBE_USERNAME)) {
-            ActiveStatus.ACTIVE, ActiveStatus.INACTIVE, ActiveStatus.UNKNOWN -> IntegrationHealth.UP
-            ActiveStatus.UNAVAILABLE -> IntegrationHealth.DOWN
-            ActiveStatus.DISABLED -> IntegrationHealth.DISABLED
+    @Suppress("TooGenericExceptionCaught")
+    fun probeHealth(): ProbeResult {
+        val client = clientProvider.getIfAvailable()
+            ?: return ProbeResult(IntegrationHealth.DISABLED, null)
+        return try {
+            // Any answer (even INACTIVE) proves the chain end-to-end.
+            client.getEmployee(PROBE_USERNAME)
+            ProbeResult(IntegrationHealth.UP, null)
+        } catch (e: NotFoundException) {
+            // The expected answer for the synthetic probe user: chain is alive.
+            ProbeResult(IntegrationHealth.UP, null)
+        } catch (e: Exception) {
+            val detail = "${e.javaClass.simpleName}: ${e.message ?: "no message"}"
+            log.warn("employee-service health probe failed — {}", detail, e)
+            ProbeResult(IntegrationHealth.DOWN, detail)
         }
+    }
+
+    /** Coarse health enum for callers that don't need the failure detail. */
+    fun probe(): IntegrationHealth = probeHealth().health
 
     companion object {
         /**
@@ -167,3 +182,14 @@ enum class IntegrationHealth {
     DOWN,
     DISABLED,
 }
+
+/**
+ * Probe outcome for monitoring: the coarse [IntegrationHealth] plus, on
+ * [IntegrationHealth.DOWN], a short detail naming the real downstream cause
+ * (exception class + message, which carries the HTTP status). `null` detail on
+ * UP/DISABLED.
+ */
+data class ProbeResult(
+    val health: IntegrationHealth,
+    val detail: String?,
+)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicatorTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/health/EmployeeServiceHealthIndicatorTest.kt
@@ -1,12 +1,14 @@
 package org.octopusden.octopus.components.registry.server.health
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.octopusden.octopus.components.registry.server.service.impl.EmployeeDirectoryService
 import org.octopusden.octopus.components.registry.server.service.impl.IntegrationHealth
+import org.octopusden.octopus.components.registry.server.service.impl.ProbeResult
 import org.springframework.boot.actuate.health.Status
 
 /**
@@ -17,22 +19,32 @@ import org.springframework.boot.actuate.health.Status
  * only flips the aggregate `/actuator/health` and its own component path.
  */
 class EmployeeServiceHealthIndicatorTest {
-    private fun indicatorWith(health: IntegrationHealth): EmployeeServiceHealthIndicator {
+    private fun indicatorWith(result: ProbeResult): EmployeeServiceHealthIndicator {
         val directory = mock(EmployeeDirectoryService::class.java)
-        `when`(directory.probe()).thenReturn(health)
+        `when`(directory.probeHealth()).thenReturn(result)
         return EmployeeServiceHealthIndicator(directory)
     }
 
     @Test
     @DisplayName("probe UP → actuator UP")
     fun `up maps to UP`() {
-        assertEquals(Status.UP, indicatorWith(IntegrationHealth.UP).health().status)
+        assertEquals(Status.UP, indicatorWith(ProbeResult(IntegrationHealth.UP, null)).health().status)
     }
 
     @Test
-    @DisplayName("probe DOWN → actuator DOWN with a reason detail")
-    fun `down maps to DOWN`() {
-        val health = indicatorWith(IntegrationHealth.DOWN).health()
+    @DisplayName("probe DOWN with a detail → actuator DOWN surfacing the real cause")
+    fun `down surfaces the probe detail`() {
+        val health = indicatorWith(ProbeResult(IntegrationHealth.DOWN, "Forbidden: 403 Forbidden")).health()
+        assertEquals(Status.DOWN, health.status)
+        val reason = health.details["reason"] as String
+        assertTrue(reason.contains("403")) { "reason should carry the downstream status: $reason" }
+        assertTrue(reason.contains("employee-service lookup failed")) { reason }
+    }
+
+    @Test
+    @DisplayName("probe DOWN without a detail → actuator DOWN with the generic hint")
+    fun `down falls back to the generic reason`() {
+        val health = indicatorWith(ProbeResult(IntegrationHealth.DOWN, null)).health()
         assertEquals(Status.DOWN, health.status)
         assertEquals(
             "employee-service lookup failed (credentials / gateway route / directory backend — see logs)",
@@ -43,7 +55,7 @@ class EmployeeServiceHealthIndicatorTest {
     @Test
     @DisplayName("probe DISABLED → actuator UNKNOWN with enabled=false detail")
     fun `disabled maps to UNKNOWN`() {
-        val health = indicatorWith(IntegrationHealth.DISABLED).health()
+        val health = indicatorWith(ProbeResult(IntegrationHealth.DISABLED, null)).health()
         assertEquals(Status.UNKNOWN, health.status)
         assertEquals(false, health.details["enabled"])
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/EmployeeDirectoryServiceTest.kt
@@ -1,6 +1,8 @@
 package org.octopusden.octopus.components.registry.server.service.impl
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -127,5 +129,47 @@ class EmployeeDirectoryServiceTest {
     @DisplayName("probe(): no client bean → DISABLED")
     fun `probe disabled`() {
         assertEquals(IntegrationHealth.DISABLED, disabledDirectory().probe())
+    }
+
+    @Test
+    @DisplayName("probeHealth(): downstream error → DOWN carrying the real cause in the detail")
+    fun `probeHealth surfaces the failure detail`() {
+        val client = mock(EmployeeServiceClient::class.java)
+        `when`(client.getEmployee(EmployeeDirectoryService.PROBE_USERNAME))
+            .thenThrow(RuntimeException("403 Forbidden: [no body]"))
+        val result = directoryWith(client).probeHealth()
+        assertEquals(IntegrationHealth.DOWN, result.health)
+        assertTrue(result.detail!!.contains("403")) { "detail should carry the downstream status: ${result.detail}" }
+        assertTrue(result.detail!!.contains("RuntimeException")) { result.detail!! }
+    }
+
+    @Test
+    @DisplayName("probeHealth(): a real answer (active or not) → UP with no detail")
+    fun `probeHealth real answer is UP`() {
+        val client = mock(EmployeeServiceClient::class.java)
+        `when`(client.getEmployee(EmployeeDirectoryService.PROBE_USERNAME))
+            .thenReturn(Employee(EmployeeDirectoryService.PROBE_USERNAME, false))
+        val result = directoryWith(client).probeHealth()
+        assertEquals(IntegrationHealth.UP, result.health)
+        assertNull(result.detail)
+    }
+
+    @Test
+    @DisplayName("probeHealth(): NotFound → UP with no detail")
+    fun `probeHealth notfound is UP`() {
+        val client = mock(EmployeeServiceClient::class.java)
+        `when`(client.getEmployee(EmployeeDirectoryService.PROBE_USERNAME))
+            .thenThrow(NotFoundException("no such employee"))
+        val result = directoryWith(client).probeHealth()
+        assertEquals(IntegrationHealth.UP, result.health)
+        assertNull(result.detail)
+    }
+
+    @Test
+    @DisplayName("probeHealth(): no client bean → DISABLED with no detail")
+    fun `probeHealth disabled`() {
+        val result = disabledDirectory().probeHealth()
+        assertEquals(IntegrationHealth.DISABLED, result.health)
+        assertNull(result.detail)
     }
 }


### PR DESCRIPTION
## Why
The `employeeService` actuator component (and the Portal admin banner that mirrors it via `/actuator/health`) reported a **generic** reason for every DOWN:

> employee-service lookup failed (credentials / gateway route / directory backend — see logs)

So an **access** failure (e.g. a token missing the `openid` scope → 403 at the gateway/userinfo) was indistinguishable from **unreachable** without digging through employee-service logs. `probe()` collapsed the cause into `ActiveStatus.UNAVAILABLE` and threw it away.

## What
- Add `EmployeeDirectoryService.probeHealth(): ProbeResult(health, detail)`. It calls the employee client directly and, on failure, captures the exception class + message — which carries the HTTP status (e.g. `403 Forbidden`) — into `detail`. Classification parity with the old probe: client answer (active or not) → UP; `NotFoundException` (synthetic probe user) → UP; any other exception → DOWN (+detail); no client bean → DISABLED. Still never throws (health probe).
- `probe(): IntegrationHealth` now delegates to `probeHealth().health`, so the v4 `/meta/employees/health` endpoint (`ComponentControllerV4`) is unchanged.
- `EmployeeServiceHealthIndicator` surfaces the detail in the `reason` (`employee-service lookup failed — <cause>`), falling back to the original generic hint when no detail was captured.

## Effect
`/actuator/health/employeeService` (and the Portal banner) now show e.g. `…403 Forbidden…` instead of "see logs" — immediately distinguishing access/scope problems from unreachable.

## Tests
- `EmployeeDirectoryServiceTest`: `probeHealth()` — downstream error → DOWN carrying the cause; real answer → UP no detail; NotFound → UP no detail; no bean → DISABLED. Existing `probe()` tests unchanged (delegation).
- `EmployeeServiceHealthIndicatorTest`: DOWN surfaces the detail; DOWN without detail falls back to the generic hint; UP/DISABLED unchanged.

## Note
`detail` is only exposed where `management.endpoint.health.show-details` is on (dev); prod leaves it `never`. The detail is the downstream exception message (status + the call signature) — no credentials (tokens live in headers, not the message). Reviewer flagged that in dev (show-details=always + permitAll) this is anonymously visible; kept as-is since the operator value outweighs it and prod does not expose details. Easy to trim to class+status if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)