### PR TITLE
feat(registry): write-time coverage auto-split + per-attribute open-upper rule (ADR-018) — PR-3

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -865,6 +865,8 @@ class ComponentManagementServiceImpl(
             syncRequiredTools(saved.id!!, pendingTools)
             refreshConfigRequiredToolsInMemory(saved, pendingTools)
         }
+        // ADR-018 (b): align supported-coverage breakpoints to this override's interior edges.
+        autoSplitCoverage(component, canonicalRange)
         bumpParentVersion(component)
         // Review #2: an override row can carry mavenArtifacts/dockerImages/jira
         // coordinates that collide with another component — re-run the same 409 /
@@ -930,6 +932,8 @@ class ComponentManagementServiceImpl(
             syncRequiredTools(saved.id!!, pendingTools)
             refreshConfigRequiredToolsInMemory(saved, pendingTools)
         }
+        // ADR-018 (b): a range change can introduce new interior breakpoints — realign coverage.
+        autoSplitCoverage(row.component, saved.versionRange)
         bumpParentVersion(row.component)
         // Review #2: re-run the cross-component composite checks — an UPDATE to a
         // marker override can introduce a colliding GAV / docker image / jira
@@ -980,6 +984,47 @@ class ComponentManagementServiceImpl(
      * editing or deleting them would diverge the DB from the DSL source of
      * truth until the next import overwrote the change.
      */
+    /**
+     * Write-time auto-split of supported coverage (ADR-018 refinement (b)). After a field-override
+     * write whose range introduces a boundary INSIDE a covering `RANGE_PRESENCE` row, split that
+     * presence row at the override's interior edges so each enumerated range keeps constant resolved
+     * values (range-view enumeration is anchored to `RANGE_PRESENCE`, one config per row). Without
+     * this, the covering range's enumerated view would span versions whose resolved values differ.
+     *
+     * No-op for components with no `RANGE_PRESENCE` rows (supported = ALL, or API-created components
+     * whose override range is enumerated as its own view) and for overrides that introduce no interior
+     * edge (equal to / wider than / disjoint from the presence range). Idempotent: re-running on an
+     * already-aligned set adds nothing. Coverage (the union of ranges) is unchanged — only the
+     * breakpoints move. Uses collection mutation so JPA orphanRemoval/cascade persist the change.
+     */
+    private fun autoSplitCoverage(
+        component: ComponentEntity,
+        overrideRange: String,
+    ) {
+        val presenceRows = component.configurations.filter { it.rowType == "RANGE_PRESENCE" }
+        for (presence in presenceRows) {
+            val parts = VersionCoverageSplit.split(presence.versionRange, overrideRange) ?: continue
+            if (parts.size <= 1) continue
+            component.configurations.remove(presence) // orphanRemoval deletes it on flush
+            val existingRanges =
+                component.configurations
+                    .filter { it.rowType == "RANGE_PRESENCE" }
+                    .mapTo(mutableSetOf()) { it.versionRange }
+            for (sub in parts) {
+                if (sub in existingRanges) continue // partial unique index: one presence per (component, range)
+                component.configurations.add(
+                    ComponentConfigurationEntity(
+                        component = component,
+                        versionRange = sub,
+                        overriddenAttribute = null,
+                        rowType = "RANGE_PRESENCE",
+                    ),
+                )
+                existingRanges += sub
+            }
+        }
+    }
+
     private fun requireNotImportManagedMarker(
         row: ComponentConfigurationEntity,
         operation: String,
@@ -1911,6 +1956,17 @@ class ComponentManagementServiceImpl(
                         "override range '${row.versionRange}' on attribute " +
                         "'$attribute'. Each version range can only have one " +
                         "override per attribute (schema-spec §3.5 / UNIQUE).",
+                )
+            }
+            // V2 (ADR-018 §6): at most one open-upper override per attribute. Two open-upper
+            // ranges (`[X,)`) always overlap (both run to +∞), so this is a special case of the
+            // disjointness rule below — surfaced with a clearer, actionable message.
+            if (parsedExisting != null && parsedNew.hi == null && parsedExisting.hi == null) {
+                throw IllegalArgumentException(
+                    "Range '$range' and existing override range '${row.versionRange}' on attribute " +
+                        "'$attribute' are both open-upper (run to +∞) and therefore always overlap. " +
+                        "At most one open-upper override is allowed per attribute (V2) — bound one of " +
+                        "them (e.g. close the earlier range at the later range's floor).",
                 )
             }
             // Reached for partial overlap, strict containment, and (composite

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -996,14 +996,41 @@ class ComponentManagementServiceImpl(
      * edge (equal to / wider than / disjoint from the presence range). Idempotent: re-running on an
      * already-aligned set adds nothing. Coverage (the union of ranges) is unchanged — only the
      * breakpoints move. Uses collection mutation so JPA orphanRemoval/cascade persist the change.
+     *
+     * A composite override range (only possible on a value-only update of an import-created composite
+     * override row) introduces no single new edge — coverage was aligned at import — so it is a no-op.
+     * A composite COVERING presence row cannot be split by this simple-segment helper; if a simple
+     * override intersects one, we reject the write (clear 400) rather than silently leave a range
+     * whose enumerated view would no longer have constant resolved values — composite-coverage editing
+     * is a follow-up.
+     *
+     * Known limitation (P3): a range CHANGE on an override adds new breakpoints but does not merge the
+     * old ones back, so repeated range edits fragment `RANGE_PRESENCE` over time. Correctness holds
+     * (union + per-row constant values); a compaction pass is a follow-up.
      */
     private fun autoSplitCoverage(
         component: ComponentEntity,
         overrideRange: String,
     ) {
+        // Only a single-segment override can introduce one new interior edge to align to. A composite
+        // override range (import-created, value-only updated) was already aligned at import → no-op.
+        VersionCoverageSplit.parseSegment(overrideRange) ?: return
         val presenceRows = component.configurations.filter { it.rowType == "RANGE_PRESENCE" }
         for (presence in presenceRows) {
-            val parts = VersionCoverageSplit.split(presence.versionRange, overrideRange) ?: continue
+            val parts = VersionCoverageSplit.split(presence.versionRange, overrideRange)
+            if (parts == null) {
+                // Composite / unparseable covering range: cannot split simply. If the simple override
+                // intersects it, an interior edge would misalign enumeration — fail loudly.
+                if (rangesIntersect(presence.versionRange, overrideRange)) {
+                    throw IllegalArgumentException(
+                        "Field-override range '$overrideRange' intersects composite supported-coverage " +
+                            "range '${presence.versionRange}'. Splitting composite coverage at an override " +
+                            "edge is not yet supported — edit coverage via DSL re-import, or split the " +
+                            "composite coverage first.",
+                    )
+                }
+                continue
+            }
             if (parts.size <= 1) continue
             component.configurations.remove(presence) // orphanRemoval deletes it on flush
             val existingRanges =
@@ -1806,6 +1833,21 @@ class ComponentManagementServiceImpl(
             throw IllegalArgumentException("Invalid version range: '$range'", e)
         }
     }
+
+    /**
+     * True iff [a] and [b] share any version. Used by auto-split to decide whether a simple override
+     * collides with a composite covering range it cannot split. Conservative: an unparseable range
+     * yields `false` (never a false reject).
+     */
+    private fun rangesIntersect(
+        a: String,
+        b: String,
+    ): Boolean =
+        try {
+            versionRangeFactory.create(a).isIntersect(versionRangeFactory.create(b))
+        } catch (_: Exception) {
+            false
+        }
 
     // ─── Field-override range validation (disjoint-only, matches Portal) ─────────
     //

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplit.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplit.kt
@@ -74,9 +74,14 @@ internal object VersionCoverageSplit {
      * is not a single parseable segment — composite / malformed presence rows are left untouched
      * (the caller skips them).
      *
-     * The split is half-open at the introduced edges: splitting `[1,10)` at `2` and `3` (override
-     * `[2,3)`) yields `[1,2)`, `[2,3)`, `[3,10)`; the outer endpoints keep the original range's
-     * inclusivity. Idempotent: re-splitting an already-aligned set of ranges is a no-op.
+     * The breakpoint inclusivity mirrors the override endpoint that produced it, so the resulting
+     * middle sub-range is EXACTLY the override's range (it then resolves with the override by
+     * containment, neighbours without it):
+     *  - override `[2,3)` in `[1,10)` → `[1,2)`, `[2,3)`, `[3,10)`;
+     *  - override `(2,3)` in `[1,10)` → `[1,2]`, `(2,3)`, `[3,10)` (open lower → `2` joins the left piece);
+     *  - override `[2,3]` in `[1,10)` → `[1,2)`, `[2,3]`, `(3,10)` (closed upper → `3` joins the left piece).
+     * The outer endpoints keep the original range's inclusivity. Idempotent: re-splitting an
+     * already-aligned set of ranges is a no-op.
      */
     internal fun split(
         presenceRange: String,
@@ -85,22 +90,27 @@ internal object VersionCoverageSplit {
         val presence = parseSegment(presenceRange) ?: return null
         val override = parseSegment(overrideRange) ?: return null
 
-        // The override's finite endpoints are the candidate internal breakpoints.
-        val edges = listOfNotNull(override.lo, override.hi)
-            .filter { strictlyInside(presence, it) }
-            .distinct()
-            .sortedWith { a, b -> cmp(a, b) }
+        // The override's finite endpoints are the candidate internal breakpoints. For each, record
+        // whether the breakpoint value belongs to the LEFT (lower) piece — i.e. is NOT in the
+        // override on that side: an OPEN lower bound excludes its value (joins the left piece); a
+        // CLOSED upper bound includes its value (the override owns it, so it joins the left/override
+        // piece). The segment ending at the edge takes hiIncl = inLeft; the next segment takes
+        // loIncl = !inLeft.
+        val edges =
+            buildList {
+                override.lo?.let { if (strictlyInside(presence, it)) add(it to !override.loIncl) }
+                override.hi?.let { if (strictlyInside(presence, it)) add(it to override.hiIncl) }
+            }.sortedWith { a, b -> cmp(a.first, b.first) }
 
         if (edges.isEmpty()) return listOf(render(presence))
 
         val result = mutableListOf<Segment>()
         var curLo = presence.lo
         var curLoIncl = presence.loIncl
-        for (edge in edges) {
-            // [curLo, edge) — upper-exclusive at the introduced breakpoint.
-            result += Segment(lo = curLo, loIncl = curLoIncl, hi = edge, hiIncl = false)
+        for ((edge, inLeft) in edges) {
+            result += Segment(lo = curLo, loIncl = curLoIncl, hi = edge, hiIncl = inLeft)
             curLo = edge
-            curLoIncl = true // the breakpoint belongs to the upper piece
+            curLoIncl = !inLeft
         }
         // Final piece runs to the presence range's original upper bound / inclusivity.
         result += Segment(lo = curLo, loIncl = curLoIncl, hi = presence.hi, hiIncl = presence.hiIncl)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplit.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplit.kt
@@ -1,0 +1,109 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+
+/**
+ * Write-time auto-split of supported-coverage ranges (ADR-018 refinement (b)).
+ *
+ * Migrated declared ranges are breakpoint-aligned: every attribute is constant across each
+ * `RANGE_PRESENCE` range, so range-view enumeration emits one config per presence row. A v4 write
+ * that adds a per-attribute override whose range introduces a boundary **inside** a covering
+ * presence range would break that invariant — the enumerated view of the covering range would no
+ * longer have constant resolved values. To keep reads trivial we **auto-split** the covering
+ * `RANGE_PRESENCE` at the override's internal edges on write, so each enumerated range again has
+ * constant values. (The rejected alternative — partition by override edges at enumerate time —
+ * pushes complexity onto the hot read path.)
+ *
+ * These helpers are pure (string-in / string-out, Maven version comparison only) so they are unit
+ * testable without a Spring/DB context; [ComponentManagementServiceImpl] wires them into the
+ * field-override write path.
+ */
+internal object VersionCoverageSplit {
+
+    /** A single half-open/closed Maven version interval, e.g. `[1.0,2.0)`, `[2.0,)`, `(,3.0]`. */
+    internal data class Segment(
+        val lo: String?,
+        val loIncl: Boolean,
+        val hi: String?,
+        val hiIncl: Boolean,
+    )
+
+    private val SIMPLE_SEGMENT_PATTERN = Regex("^([\\[(])([^,]*),([^,]*)([\\])])$")
+
+    internal fun normalize(range: String): String = range.trim().replace(Regex("\\s+"), "")
+
+    /**
+     * Parse a single-segment range string into a [Segment], or `null` for a composite / malformed
+     * range (e.g. `(,1.0),[2.0,)` or `[1.0]`). A null bound denotes an open (unbounded) side.
+     */
+    internal fun parseSegment(range: String): Segment? {
+        val m = SIMPLE_SEGMENT_PATTERN.matchEntire(normalize(range)) ?: return null
+        val (open, loStr, hiStr, close) = m.destructured
+        if (loStr.any { it in "()[]" } || hiStr.any { it in "()[]" }) return null
+        return Segment(
+            lo = loStr.trim().takeIf { it.isNotEmpty() },
+            loIncl = open == "[",
+            hi = hiStr.trim().takeIf { it.isNotEmpty() },
+            hiIncl = close == "]",
+        )
+    }
+
+    /** Render a [Segment] back to canonical Maven-range text (`[1.0,2.0)`). */
+    internal fun render(seg: Segment): String =
+        buildString {
+            append(if (seg.loIncl) '[' else '(')
+            append(seg.lo ?: "")
+            append(',')
+            append(seg.hi ?: "")
+            append(if (seg.hiIncl) ']' else ')')
+        }
+
+    private fun cmp(a: String, b: String): Int = DefaultArtifactVersion(a).compareTo(DefaultArtifactVersion(b))
+
+    /** True iff finite [point] lies STRICTLY inside [seg] (excluding both endpoints). */
+    private fun strictlyInside(seg: Segment, point: String): Boolean {
+        val aboveLo = seg.lo == null || cmp(point, seg.lo) > 0
+        val belowHi = seg.hi == null || cmp(point, seg.hi) < 0
+        return aboveLo && belowHi
+    }
+
+    /**
+     * Split [presenceRange] at every finite endpoint of [overrideRange] that falls strictly inside
+     * it, returning the ordered list of resulting sub-range strings. Returns a single-element list
+     * (the normalized original) when no override edge is interior. Returns `null` when either range
+     * is not a single parseable segment — composite / malformed presence rows are left untouched
+     * (the caller skips them).
+     *
+     * The split is half-open at the introduced edges: splitting `[1,10)` at `2` and `3` (override
+     * `[2,3)`) yields `[1,2)`, `[2,3)`, `[3,10)`; the outer endpoints keep the original range's
+     * inclusivity. Idempotent: re-splitting an already-aligned set of ranges is a no-op.
+     */
+    internal fun split(
+        presenceRange: String,
+        overrideRange: String,
+    ): List<String>? {
+        val presence = parseSegment(presenceRange) ?: return null
+        val override = parseSegment(overrideRange) ?: return null
+
+        // The override's finite endpoints are the candidate internal breakpoints.
+        val edges = listOfNotNull(override.lo, override.hi)
+            .filter { strictlyInside(presence, it) }
+            .distinct()
+            .sortedWith { a, b -> cmp(a, b) }
+
+        if (edges.isEmpty()) return listOf(render(presence))
+
+        val result = mutableListOf<Segment>()
+        var curLo = presence.lo
+        var curLoIncl = presence.loIncl
+        for (edge in edges) {
+            // [curLo, edge) — upper-exclusive at the introduced breakpoint.
+            result += Segment(lo = curLo, loIncl = curLoIncl, hi = edge, hiIncl = false)
+            curLo = edge
+            curLoIncl = true // the breakpoint belongs to the upper piece
+        }
+        // Final piece runs to the presence range's original upper bound / inclusivity.
+        result += Segment(lo = curLo, loIncl = curLoIncl, hi = presence.hi, hiIncl = presence.hiIncl)
+        return result.map { render(it) }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAutoSplitTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAutoSplitTest.kt
@@ -1,0 +1,230 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Paths
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * ADR-018 refinement (b): write-time auto-split. When a per-attribute field override introduces a
+ * boundary INSIDE a covering `RANGE_PRESENCE` range, the covering presence row must be split at the
+ * override's interior edges so range-view enumeration (one config per presence row) keeps constant
+ * resolved values within each range. Coverage (the union) is unchanged — only the breakpoints move.
+ *
+ * Integration test (ft-db = H2 + auto-migrate): an API-created component gets a RANGE_PRESENCE row
+ * injected to mimic a migrated (bounded-coverage) component, then a real field-override POST drives
+ * the auto-split, asserted on the persisted presence rows.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class FieldOverrideAutoSplitTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+
+    init {
+        val testResourcesPath =
+            Paths.get(FieldOverrideAutoSplitTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("ADR-018(b): override [2.0,3.0) inside presence [1.0,10.0) splits coverage into three rows")
+    fun `interior override auto-splits the covering presence row`() {
+        val id = createComponent("autosplit_${UUID.randomUUID().toString().take(8)}")
+        seedRangePresence(id, "[1.0,10.0)")
+
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"11"}""",
+        )
+
+        val presenceRanges = rangePresenceRanges(id)
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,10.0)"),
+            presenceRanges,
+            "the covering [1.0,10.0) presence row must split at the override's interior edges 2.0 and 3.0",
+        )
+    }
+
+    @Test
+    @DisplayName("ADR-018(b): open-upper override [2.0,) inside presence [1.0,) splits into [1.0,2.0),[2.0,)")
+    fun `open upper override auto-splits at its floor`() {
+        val id = createComponent("autosplitopen_${UUID.randomUUID().toString().take(8)}")
+        seedRangePresence(id, "[1.0,)")
+
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,)","value":"21"}""",
+        )
+
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,)"),
+            rangePresenceRanges(id),
+            "open-upper override floor 2.0 must split the open-upper presence row",
+        )
+    }
+
+    @Test
+    @DisplayName("ADR-018(b): override equal to the covering presence range leaves coverage unchanged")
+    fun `override equal to presence is a no-op for coverage`() {
+        val id = createComponent("autosplitnoop_${UUID.randomUUID().toString().take(8)}")
+        seedRangePresence(id, "[1.0,2.0)")
+
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0,2.0)","value":"11"}""",
+        )
+
+        assertEquals(
+            listOf("[1.0,2.0)"),
+            rangePresenceRanges(id),
+            "an override equal to the presence range introduces no interior edge → no split",
+        )
+    }
+
+    @Test
+    @DisplayName("V2 (ADR-018 §6): a second open-upper override on the same attribute is rejected (400)")
+    fun `two open upper overrides on same attribute are rejected`() {
+        val id = createComponent("v2_${UUID.randomUUID().toString().take(8)}")
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0,)","value":"11"}""",
+        )
+        // Second open-upper on the SAME attribute → always overlaps → 400 with the V2 message.
+        val response =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,)","value":"17"}"""),
+                ).andExpect(status().isBadRequest)
+                .andReturn()
+                .response.contentAsString
+        assertEquals(true, response.contains("open-upper"), "rejection message should explain the open-upper conflict; got: $response")
+    }
+
+    @Test
+    @DisplayName("V4 (ADR-018 §6): open-upper overrides on DIFFERENT attributes are both allowed")
+    fun `open upper overrides on different attributes are allowed`() {
+        val id = createComponent("v4_${UUID.randomUUID().toString().take(8)}")
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0,)","value":"11"}""",
+        )
+        // Different attribute → independent → allowed (no V2/V3 conflict across attributes).
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.mavenVersion","versionRange":"[1.0,)","value":"3.9.0"}""",
+        )
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun createComponent(name: String): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"name":"$name",""" +
+                                """"componentOwner":"owner1",""" +
+                                """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+                        ),
+                ).andExpect(status().is2xxSuccessful)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    /** Insert a RANGE_PRESENCE coverage row directly, mimicking a migrated bounded-coverage component. */
+    private fun seedRangePresence(
+        componentId: String,
+        range: String,
+    ) {
+        val component = componentRepository.findById(UUID.fromString(componentId)).orElseThrow()
+        configurationRepository.save(
+            ComponentConfigurationEntity(
+                component = component,
+                versionRange = range,
+                overriddenAttribute = null,
+                rowType = "RANGE_PRESENCE",
+            ),
+        )
+    }
+
+    private fun createFieldOverride(
+        componentId: String,
+        payload: String,
+    ) {
+        mvc
+            .perform(
+                post("/rest/api/4/components/$componentId/field-overrides")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(status().is2xxSuccessful)
+    }
+
+    private fun rangePresenceRanges(componentId: String): List<String> =
+        configurationRepository
+            .findByComponentId(UUID.fromString(componentId))
+            .filter { it.rowType == "RANGE_PRESENCE" }
+            .map { it.versionRange }
+            .sortedWith { a, b -> compareRangeFloors(a, b) }
+
+    /** Order presence ranges by their lower bound so the assertion is deterministic. */
+    private fun compareRangeFloors(
+        a: String,
+        b: String,
+    ): Int {
+        fun floor(r: String): org.apache.maven.artifact.versioning.DefaultArtifactVersion {
+            val lo = r.trim().removePrefix("[").removePrefix("(").substringBefore(",").trim()
+            return org.apache.maven.artifact.versioning.DefaultArtifactVersion(lo.ifEmpty { "0" })
+        }
+        return floor(a).compareTo(floor(b))
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAutoSplitTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/FieldOverrideAutoSplitTest.kt
@@ -123,6 +123,81 @@ class FieldOverrideAutoSplitTest {
     }
 
     @Test
+    @DisplayName("ADR-018(b): a range CHANGE on update also auto-splits the covering presence row")
+    fun `update path range change auto-splits`() {
+        val id = createComponent("autosplitupd_${UUID.randomUUID().toString().take(8)}")
+        seedRangePresence(id, "[1.0,10.0)")
+        val overrideId =
+            createFieldOverride(
+                id,
+                """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"11"}""",
+            )
+        // create already split into [1.0,2.0),[2.0,3.0),[3.0,10.0)
+        assertEquals(listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,10.0)"), rangePresenceRanges(id))
+
+        // PATCH the override's range → must re-split the now-covering [3.0,10.0) at 5.0 and 7.0.
+        patchFieldOverride(id, overrideId, """{"versionRange":"[5.0,7.0)"}""")
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,5.0)", "[5.0,7.0)", "[7.0,10.0)"),
+            rangePresenceRanges(id),
+            "update-path range change must auto-split (old breakpoints are retained — P3 fragmentation)",
+        )
+    }
+
+    @Test
+    @DisplayName("ADR-018(b): a value-only update introduces no new edge → coverage unchanged")
+    fun `value only update does not re-split`() {
+        val id = createComponent("autosplitval_${UUID.randomUUID().toString().take(8)}")
+        seedRangePresence(id, "[1.0,10.0)")
+        val overrideId =
+            createFieldOverride(
+                id,
+                """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"11"}""",
+            )
+        patchFieldOverride(id, overrideId, """{"value":"17"}""")
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,10.0)"),
+            rangePresenceRanges(id),
+            "a value-only update must not change coverage",
+        )
+    }
+
+    @Test
+    @DisplayName("ADR-018(b): one override spanning two presence rows splits each at its interior edge")
+    fun `override spanning two presence rows splits both`() {
+        val id = createComponent("autosplitspan_${UUID.randomUUID().toString().take(8)}")
+        seedRangePresence(id, "[1.0,3.0)")
+        seedRangePresence(id, "[3.0,5.0)")
+        createFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,4.0)","value":"11"}""",
+        )
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,4.0)", "[4.0,5.0)"),
+            rangePresenceRanges(id),
+            "edge 2.0 splits [1.0,3.0); edge 4.0 splits [3.0,5.0)",
+        )
+    }
+
+    @Test
+    @DisplayName("ADR-018(b): an override intersecting a composite coverage row is rejected (400, not silent)")
+    fun `override intersecting composite coverage is rejected`() {
+        val id = createComponent("autosplitcomp_${UUID.randomUUID().toString().take(8)}")
+        seedRangePresence(id, "[1.0,2.0),[5.0,)")
+        val response =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"overriddenAttribute":"build.javaVersion","versionRange":"[5.5,6.0)","value":"11"}"""),
+                ).andExpect(status().isBadRequest)
+                .andReturn()
+                .response.contentAsString
+        assertEquals(true, response.contains("composite"), "rejection must explain the composite-coverage limitation; got: $response")
+    }
+
+    @Test
     @DisplayName("V2 (ADR-018 §6): a second open-upper override on the same attribute is rejected (400)")
     fun `two open upper overrides on same attribute are rejected`() {
         val id = createComponent("v2_${UUID.randomUUID().toString().take(8)}")
@@ -199,14 +274,33 @@ class FieldOverrideAutoSplitTest {
     private fun createFieldOverride(
         componentId: String,
         payload: String,
+    ): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$componentId/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload),
+                ).andExpect(status().is2xxSuccessful)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun patchFieldOverride(
+        componentId: String,
+        overrideId: String,
+        payload: String,
     ) {
         mvc
             .perform(
-                post("/rest/api/4/components/$componentId/field-overrides")
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                    .patch("/rest/api/4/components/$componentId/field-overrides/$overrideId")
                     .with(adminJwt())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(payload),
-            ).andExpect(status().is2xxSuccessful)
+            ).andExpect(status().isOk)
     }
 
     private fun rangePresenceRanges(componentId: String): List<String> =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplitTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplitTest.kt
@@ -74,6 +74,43 @@ class VersionCoverageSplitTest {
     }
 
     @Test
+    @DisplayName("override with inclusive upper [5,8] → 8 joins the override/left piece: [1,5),[5,8],(8,10)")
+    fun `inclusive upper override keeps its endpoint`() {
+        assertEquals(
+            listOf("[1,5)", "[5,8]", "(8,10)"),
+            VersionCoverageSplit.split("[1,10)", "[5,8]"),
+        )
+    }
+
+    @Test
+    @DisplayName("override with open lower (2,3) → 2 joins the left piece: [1,2],(2,3),[3,10)")
+    fun `open lower override keeps endpoint on left`() {
+        assertEquals(
+            listOf("[1,2]", "(2,3)", "[3,10)"),
+            VersionCoverageSplit.split("[1,10)", "(2,3)"),
+        )
+    }
+
+    @Test
+    @DisplayName("override (2,3] → both endpoints handled: [1,2],(2,3],(3,10)")
+    fun `open lower inclusive upper override`() {
+        assertEquals(
+            listOf("[1,2]", "(2,3]", "(3,10)"),
+            VersionCoverageSplit.split("[1,10)", "(2,3]"),
+        )
+    }
+
+    @Test
+    @DisplayName("the middle sub-range is exactly the override range for every endpoint shape")
+    fun `middle sub-range equals override`() {
+        // For each shape the override range must appear verbatim among the split parts.
+        for (ov in listOf("[2,3)", "(2,3)", "[2,3]", "(2,3]")) {
+            val parts = VersionCoverageSplit.split("[1,10)", ov)!!
+            assertEquals(true, ov in parts, "override $ov must be one of the split sub-ranges: $parts")
+        }
+    }
+
+    @Test
     @DisplayName("composite or malformed presence range → null (left untouched)")
     fun `composite presence returns null`() {
         assertNull(VersionCoverageSplit.split("(,1.0),[2.0,)", "[3.0,4.0)"))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplitTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionCoverageSplitTest.kt
@@ -1,0 +1,82 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [VersionCoverageSplit] — the write-time auto-split helper (ADR-018 refinement b).
+ * Pure string-in / string-out, no Spring/DB.
+ */
+class VersionCoverageSplitTest {
+
+    @Test
+    @DisplayName("canonical: override [2,3) inside presence [1,10) → [1,2),[2,3),[3,10)")
+    fun `internal override splits into three`() {
+        assertEquals(
+            listOf("[1,2)", "[2,3)", "[3,10)"),
+            VersionCoverageSplit.split("[1,10)", "[2,3)"),
+        )
+    }
+
+    @Test
+    @DisplayName("open-upper override [2,) inside presence [1,) → [1,2),[2,)")
+    fun `open upper override splits at its floor`() {
+        assertEquals(
+            listOf("[1,2)", "[2,)"),
+            VersionCoverageSplit.split("[1,)", "[2,)"),
+        )
+    }
+
+    @Test
+    @DisplayName("override sharing the presence lower bound only splits at the interior edge")
+    fun `override at lower bound splits once`() {
+        // [1,5)'s lower edge 1 is NOT strictly inside [1,10); only 5 is interior.
+        assertEquals(
+            listOf("[1,5)", "[5,10)"),
+            VersionCoverageSplit.split("[1,10)", "[1,5)"),
+        )
+    }
+
+    @Test
+    @DisplayName("override equal to the presence range introduces no interior edge → unchanged")
+    fun `override equal to presence is no-op`() {
+        assertEquals(listOf("[1,10)"), VersionCoverageSplit.split("[1,10)", "[1,10)"))
+    }
+
+    @Test
+    @DisplayName("override disjoint from presence → unchanged")
+    fun `disjoint override is no-op`() {
+        assertEquals(listOf("[1,2)"), VersionCoverageSplit.split("[1,2)", "[5,6)"))
+    }
+
+    @Test
+    @DisplayName("override wider than presence (edges outside) → unchanged")
+    fun `wider override is no-op`() {
+        assertEquals(listOf("[2,3)"), VersionCoverageSplit.split("[2,3)", "[1,10)"))
+    }
+
+    @Test
+    @DisplayName("idempotent: re-splitting an already-aligned sub-range is a no-op")
+    fun `idempotent on aligned ranges`() {
+        // After the first split [1,10)→[1,2),[2,3),[3,10), applying the same override again
+        // to each sub-range introduces no new interior edge.
+        assertEquals(listOf("[1,2)"), VersionCoverageSplit.split("[1,2)", "[2,3)"))
+        assertEquals(listOf("[2,3)"), VersionCoverageSplit.split("[2,3)", "[2,3)"))
+        assertEquals(listOf("[3,10)"), VersionCoverageSplit.split("[3,10)", "[2,3)"))
+    }
+
+    @Test
+    @DisplayName("inclusive upper bound preserved on the final piece")
+    fun `preserves outer inclusivity`() {
+        assertEquals(listOf("[1,5)", "[5,10]"), VersionCoverageSplit.split("[1,10]", "[5,)"))
+    }
+
+    @Test
+    @DisplayName("composite or malformed presence range → null (left untouched)")
+    fun `composite presence returns null`() {
+        assertNull(VersionCoverageSplit.split("(,1.0),[2.0,)", "[3.0,4.0)"))
+        assertNull(VersionCoverageSplit.split("[1,10)", "(,1.0),[2.0,)"))
+    }
+}

--- a/docs/registry/requirements-resolver.md
+++ b/docs/registry/requirements-resolver.md
@@ -51,7 +51,30 @@ All RES-NNN contracts below resolve against the **decoupled version model** (`ad
 
 **`enumerate()`** (range-list endpoints — RES-001, RES-018): iterate the declared ranges (`RANGE_PRESENCE` + override rows), resolving each by **containment**. The `ALL_VERSIONS` base is enumerated as its own view **only** when there are no `RANGE_PRESENCE` rows (so a version-range-only component enumerates exactly its declared ranges — no spurious `(,0),[0,)` entry).
 
-Real-version resolve/enumerate output is **byte-identical** to the previous v4 model (audit A1: no overlapping legacy blocks; the ~130k compat baseline is the merge gate). Write-side invariants (V1–V6, write-time auto-split) are **planned for PR-3**, not yet enforced.
+Real-version resolve/enumerate output is **byte-identical** to the previous v4 model (audit A1: no overlapping legacy blocks; the ~130k compat baseline is the merge gate).
+
+### Write-side invariants (PR-3)
+
+- **Write-time auto-split (ADR-018 (b)).** When a field-override write (`createFieldOverride` /
+  `updateFieldOverride`) adds a range whose finite endpoint falls **strictly inside** a covering
+  `RANGE_PRESENCE` row, that row is split at the interior edge(s) so each enumerated range keeps
+  constant resolved values (`ComponentManagementServiceImpl.autoSplitCoverage`,
+  `VersionCoverageSplit`). Coverage (the union) is unchanged — only the breakpoints move. No-op for
+  components with no `RANGE_PRESENCE` rows (the override range is enumerated as its own view) and for
+  overrides equal to / wider than / disjoint from the covering range. Idempotent.
+- **V2 / V3 / V4 — per-attribute override ranges.** `validateFieldOverrideRange` rejects any two
+  overrides on the **same** attribute whose ranges intersect (V3 disjointness); two **open-upper**
+  ranges on one attribute always intersect, so they are rejected with a V2-specific message (≤1
+  open-upper per attribute). Open-upper overrides on **different** attributes are allowed (V4) — each
+  attribute resolves independently. Open-upper overrides are accepted server-side (the portal's
+  former D5 closed-only restriction is not mirrored on the server).
+- **V6 — required-field write coverage:** not applicable. Audit A2 kept the BASE `build_system NOT
+  NULL` DB CHECK (the base is always the `ALL_VERSIONS` effective default, non-null via `Defaults`),
+  so no covered version can resolve a required field to null; the guard the V6 write-check would
+  provide is already supplied by the retained CHECK.
+- **V1 (override outside supported) / V5 (shrink supported under an override):** warn-and-allow;
+  meaningful once the supported-versions edit API lands (a follow-up), since today coverage is fixed
+  at migration. An override outside supported never resolves (the coverage gate 404s first).
 
 ---
 


### PR DESCRIPTION
## Summary

PR-3 of the version-model plan (ADR-018) — write-side invariants for the decoupled model. Builds on PR-2 (merged).

### Write-time auto-split (ADR-018 refinement b)
When a field-override write adds a range whose finite endpoint falls **strictly inside** a covering `RANGE_PRESENCE` row, that row is split at the interior edge(s) so range-view **enumeration keeps constant resolved values** within each range (enumeration is anchored to `RANGE_PRESENCE`, one config per row). Coverage — the union — is unchanged; only the breakpoints move.

- New pure helper `VersionCoverageSplit` (string-in/out, Maven comparison): handles open-upper, preserves outer inclusivity, idempotent, leaves composites untouched.
- `ComponentManagementServiceImpl.autoSplitCoverage` wires it into `createFieldOverride` + `updateFieldOverride`. No-op when the component has no `RANGE_PRESENCE` rows (the override range enumerates as its own view) or the override adds no interior edge. Collection mutation → JPA orphanRemoval/cascade persist it.

### Per-attribute override rules (V2 / V3 / V4)
- **V2** (≤1 open-upper per attribute): two open-upper ranges always overlap, so they were already rejected by V3 — now surfaced with a clear, actionable V2-specific message.
- **V3** (disjointness) and **V4** (open-upper on *different* attributes allowed) already held; open-upper accepted server-side (former portal-only D5 not mirrored).

### Not applicable / deferred
- **V6** — N/A: audit A2 kept the BASE `build_system NOT NULL` CHECK (base is always the `ALL_VERSIONS` effective default, non-null via `Defaults`), so no covered version resolves a required field to null.
- **V1 / V5 warnings** + the **supported-versions edit API** (extend/limit/split coverage) — follow-up; coverage is fixed at migration until that API lands. An override outside supported never resolves (the coverage gate 404s first).

## Testing
- `VersionCoverageSplitTest` — 9 helper cases (canonical `[1,10)`+`[2,3)`→3, open-upper, lower-bound-shared, equal/disjoint/wider no-ops, idempotency, inclusive-upper, composite→null).
- `FieldOverrideAutoSplitTest` (dbTest) — 3 end-to-end auto-split cases + V2 reject (400) + V4 allow.
- Full unit + `:dbTest` + `:integrationTest` + static `check` green locally; no banned tokens; no new endpoints/DTOs (no OpenAPI change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Field overrides now automatically split matching coverage ranges when a version boundary falls inside them.
  * Open-ended override conflicts are now detected with a clearer validation message.
* **Bug Fixes**
  * Preserves existing coverage when an override exactly matches, is wider than, or does not intersect a range.
  * Prevents duplicate coverage ranges and rejects unsupported composite coverage cases.
* **Tests**
  * Added integration and unit tests covering splitting behavior, edge cases, and validation rules.
* **Documentation**
  * Updated requirements notes to reflect the new write-time behavior and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->