### PR TITLE
feat(registry): supported-versions edit API + faithful as-code coverage (ADR-018) — PR-3b

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -15,6 +15,8 @@ import org.octopusden.octopus.components.registry.server.dto.v4.EmployeeIntegrat
 import org.octopusden.octopus.components.registry.server.dto.v4.EmployeeMatchResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideResponse
+import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpdateRequest
 import org.octopusden.octopus.components.registry.server.repository.ComponentGroupRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
@@ -40,6 +42,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -467,6 +470,24 @@ class ComponentControllerV4(
     fun listFieldOverrides(
         @PathVariable id: UUID,
     ): List<FieldOverrideResponse> = componentManagementService.listFieldOverrides(id)
+
+    @GetMapping("/{id}/supported-versions")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getSupportedVersions(
+        @PathVariable id: UUID,
+    ): SupportedVersionsResponse = componentManagementService.getSupportedVersions(id)
+
+    // Supported-versions (coverage) editing is a per-component edit, gated by the same
+    // component-level ownership check as the scalar PATCH / field overrides.
+    @PutMapping("/{id}/supported-versions")
+    @PreAuthorize(
+        "@permissionEvaluator.hasPermission('ACCESS_COMPONENTS') " +
+            "and @permissionEvaluator.canEditComponent(#id.toString())",
+    )
+    fun setSupportedVersions(
+        @PathVariable id: UUID,
+        @RequestBody request: SupportedVersionsRequest,
+    ): SupportedVersionsResponse = componentManagementService.setSupportedVersions(id, request)
 
     companion object {
         // Numeric-aware version order: compare dot-separated segments as integers so

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/SupportedVersionsDto.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/SupportedVersionsDto.kt
@@ -1,0 +1,32 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+/**
+ * The component's **supported versions** (coverage) — the first layer of the decoupled version
+ * model (ADR-018), independent of per-attribute overrides. `resolve(v)` returns 404 outside it.
+ *
+ * - `all = true` ⇔ the component is defined for **all** versions (no bounded `RANGE_PRESENCE` rows);
+ *   `ranges` is then empty.
+ * - `all = false` ⇒ `supported = ∪ ranges`, the verbatim declared coverage ranges (a composite
+ *   range stays a single string).
+ *
+ * `warnings` carries non-blocking advisories from a write (e.g. an override left outside supported).
+ */
+data class SupportedVersionsResponse(
+    val all: Boolean,
+    val ranges: List<String>,
+    val warnings: List<String> = emptyList(),
+)
+
+/**
+ * Declarative replacement of a component's supported versions. The portal computes the desired set
+ * (extend / limit / split) client-side and PUTs the result; the server replaces the `RANGE_PRESENCE`
+ * coverage rows to match and re-aligns existing per-attribute overrides to the new breakpoints
+ * (write-time auto-split, ADR-018 (b)).
+ *
+ * - `all = true` (or both fields omitted / `ranges` empty) → supported = ALL (clears bounded coverage).
+ * - otherwise → supported = `∪ ranges`. Each range must parse; composite ranges are accepted verbatim.
+ */
+data class SupportedVersionsRequest(
+    val all: Boolean? = null,
+    val ranges: List<String>? = null,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentManagementService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentManagementService.kt
@@ -9,6 +9,8 @@ import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateR
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpdateRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsResponse
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import java.util.UUID
@@ -50,6 +52,19 @@ interface ComponentManagementService {
     )
 
     fun listFieldOverrides(componentId: UUID): List<FieldOverrideResponse>
+
+    /** Read the component's supported versions (coverage layer — ADR-018). */
+    fun getSupportedVersions(componentId: UUID): SupportedVersionsResponse
+
+    /**
+     * Declaratively replace the component's supported versions (coverage), re-aligning existing
+     * per-attribute overrides to the new breakpoints. Returns the resulting coverage plus any
+     * non-blocking warnings (e.g. an override left outside supported).
+     */
+    fun setSupportedVersions(
+        componentId: UUID,
+        request: SupportedVersionsRequest,
+    ): SupportedVersionsResponse
 
     /**
      * Render the component (resolved by UUID or name) as a Groovy-style "as-code"

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -18,6 +18,8 @@ import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateR
 import org.octopusden.octopus.components.registry.server.dto.v4.DockerImageRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideResponse
+import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpdateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FileUrlArtifactRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.MarkerChildrenPayload
@@ -976,15 +978,6 @@ class ComponentManagementServiceImpl(
     }
 
     /**
-     * MIG-047: refuse V4 write paths for MARKER rows whose `overriddenAttribute`
-     * is NOT in [MarkerAttributes.ALL] — those are import-internal markers
-     * (currently only [MarkerAttributes.GROUP_ARTIFACT_PATTERN]) created by
-     * `ImportServiceImpl` and recovered on re-import. The V4 admin API surfaces
-     * them read-only via `listFieldOverrides` so users can see the configuration;
-     * editing or deleting them would diverge the DB from the DSL source of
-     * truth until the next import overwrote the change.
-     */
-    /**
      * Write-time auto-split of supported coverage (ADR-018 refinement (b)). After a field-override
      * write whose range introduces a boundary INSIDE a covering `RANGE_PRESENCE` row, split that
      * presence row at the override's interior edges so each enumerated range keeps constant resolved
@@ -1052,6 +1045,15 @@ class ComponentManagementServiceImpl(
         }
     }
 
+    /**
+     * MIG-047: refuse V4 write paths for MARKER rows whose `overriddenAttribute`
+     * is NOT in [MarkerAttributes.ALL] — those are import-internal markers
+     * (currently only [MarkerAttributes.GROUP_ARTIFACT_PATTERN]) created by
+     * `ImportServiceImpl` and recovered on re-import. The V4 admin API surfaces
+     * them read-only via `listFieldOverrides` so users can see the configuration;
+     * editing or deleting them would diverge the DB from the DSL source of
+     * truth until the next import overwrote the change.
+     */
     private fun requireNotImportManagedMarker(
         row: ComponentConfigurationEntity,
         operation: String,
@@ -1074,6 +1076,101 @@ class ComponentManagementServiceImpl(
             .findByComponentId(componentId)
             .filter { it.rowType == "SCALAR_OVERRIDE" || it.rowType == "MARKER" }
             .map { it.toFieldOverrideResponse() }
+    }
+
+    @Transactional(readOnly = true)
+    override fun getSupportedVersions(componentId: UUID): SupportedVersionsResponse {
+        if (!componentRepository.existsById(componentId)) {
+            throw NotFoundException("Component with id '$componentId' not found")
+        }
+        val ranges =
+            configurationRepository
+                .findByComponentId(componentId)
+                .filter { it.rowType == "RANGE_PRESENCE" }
+                .map { it.versionRange }
+                .sortedWith(SUPPORTED_RANGE_ORDER)
+        // No bounded RANGE_PRESENCE rows ⇒ the ALL_VERSIONS base covers everything (ADR-018).
+        return SupportedVersionsResponse(all = ranges.isEmpty(), ranges = ranges)
+    }
+
+    @Transactional
+    override fun setSupportedVersions(
+        componentId: UUID,
+        request: SupportedVersionsRequest,
+    ): SupportedVersionsResponse {
+        val component = findComponentOr404(componentId)
+        // supported = ALL when explicitly requested, or when no ranges are supplied.
+        val all = request.all == true || request.ranges.isNullOrEmpty()
+        val requested =
+            if (all) {
+                emptyList()
+            } else {
+                request.ranges!!.map { normalizeRange(it) }.also { it.forEach(::validateRangeSyntax) }.distinct()
+            }
+
+        // Declarative replace: drop the existing coverage rows, add the requested set. orphanRemoval +
+        // cascade persist the change. (RANGE_PRESENCE rows carry no scalar/marker payload, so there is
+        // nothing else to migrate off them.)
+        val existingPresence = component.configurations.filter { it.rowType == "RANGE_PRESENCE" }
+        component.configurations.removeAll(existingPresence)
+        for (range in requested) {
+            component.configurations.add(
+                ComponentConfigurationEntity(
+                    component = component,
+                    versionRange = range,
+                    overriddenAttribute = null,
+                    rowType = "RANGE_PRESENCE",
+                ),
+            )
+        }
+
+        // Re-align the new coverage to existing per-attribute override edges so each enumerated range
+        // keeps constant resolved values (ADR-018 (b)). Skipped for supported = ALL (no presence rows).
+        if (!all) {
+            component.configurations
+                .filter { it.rowType in FIELD_OVERRIDE_ROW_TYPES }
+                .map { it.versionRange }
+                .distinct()
+                .forEach { autoSplitCoverage(component, it) }
+        }
+
+        // V1/V5 (warn-and-allow): surface overrides left entirely outside the new supported set — they
+        // never resolve (the coverage gate 404s first). Non-blocking; the write still succeeds.
+        val warnings = supportedCoverageWarnings(component, requested, all)
+
+        bumpParentVersion(component)
+        publishAuditEvent(
+            action = "UPDATE",
+            entityId = component.id.toString(),
+            oldValue = mapOf("supportedVersions" to existingPresence.map { it.versionRange }.sortedWith(SUPPORTED_RANGE_ORDER)),
+            newValue = mapOf("supportedVersions" to if (all) listOf("ALL") else requested),
+        )
+        val resulting =
+            component.configurations
+                .filter { it.rowType == "RANGE_PRESENCE" }
+                .map { it.versionRange }
+                .sortedWith(SUPPORTED_RANGE_ORDER)
+        return SupportedVersionsResponse(all = resulting.isEmpty(), ranges = resulting, warnings = warnings)
+    }
+
+    /** V1/V5 advisories: an override whose range no longer intersects supported is unreachable. */
+    private fun supportedCoverageWarnings(
+        component: ComponentEntity,
+        supported: List<String>,
+        all: Boolean,
+    ): List<String> {
+        if (all) return emptyList()
+        val supportedObjs = supported.mapNotNull { runCatching { versionRangeFactory.create(it) }.getOrNull() }
+        return component.configurations
+            .filter { it.rowType in FIELD_OVERRIDE_ROW_TYPES }
+            .filter { ov ->
+                val ovObj = runCatching { versionRangeFactory.create(ov.versionRange) }.getOrNull() ?: return@filter false
+                supportedObjs.none { it.isIntersect(ovObj) }
+            }
+            .map { ov ->
+                "Override '${ov.overriddenAttribute}' on range '${ov.versionRange}' is outside the supported " +
+                    "versions and will never resolve (V1/V5) — remove it or extend supported to cover it."
+            }
     }
 
     // ============================================================
@@ -1893,6 +1990,16 @@ class ComponentManagementServiceImpl(
 
     private fun compareMavenVersions(a: String, b: String): Int =
         DefaultArtifactVersion(a).compareTo(DefaultArtifactVersion(b))
+
+    /**
+     * Stable display ordering for supported-coverage ranges: by lower bound (open-lower / composite
+     * ranges, whose simple floor is null, sort first via the "0" fallback), then by raw string.
+     */
+    private val SUPPORTED_RANGE_ORDER: Comparator<String> =
+        compareBy<String>(
+            { parseSimpleSegment(it)?.lo?.let(::DefaultArtifactVersion) ?: DefaultArtifactVersion("0") },
+            { it },
+        )
 
     private fun simpleContains(outer: ParsedSimpleRange, inner: ParsedSimpleRange): Boolean {
         val leftOK = when {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1105,24 +1105,32 @@ class ComponentManagementServiceImpl(
             if (all) {
                 emptyList()
             } else {
-                request.ranges!!.map { normalizeRange(it) }.also { it.forEach(::validateRangeSyntax) }.distinct()
+                request.ranges!!.map { normalizeRange(it) }.distinct().also { validateSupportedRanges(it) }
             }
 
-        // Declarative replace: drop the existing coverage rows, add the requested set. orphanRemoval +
-        // cascade persist the change. (RANGE_PRESENCE rows carry no scalar/marker payload, so there is
-        // nothing else to migrate off them.)
+        // Declarative replace, applied as a DELTA so an idempotent (same-range) re-PUT is a no-op
+        // rather than a unique-index violation: Hibernate would otherwise flush the INSERT of a
+        // re-added range before the orphan-removal DELETE of the identical old row, tripping
+        // uq_component_configurations_one_range_presence (component_id, version_range). orphanRemoval +
+        // cascade persist the delta. (RANGE_PRESENCE rows carry no payload, so nothing else migrates.)
         val existingPresence = component.configurations.filter { it.rowType == "RANGE_PRESENCE" }
-        component.configurations.removeAll(existingPresence)
-        for (range in requested) {
-            component.configurations.add(
-                ComponentConfigurationEntity(
-                    component = component,
-                    versionRange = range,
-                    overriddenAttribute = null,
-                    rowType = "RANGE_PRESENCE",
-                ),
-            )
-        }
+        val existingRanges = existingPresence.map { it.versionRange }.toSet()
+        val requestedSet = requested.toSet()
+        existingPresence
+            .filter { it.versionRange !in requestedSet }
+            .forEach { component.configurations.remove(it) }
+        requested
+            .filter { it !in existingRanges }
+            .forEach {
+                component.configurations.add(
+                    ComponentConfigurationEntity(
+                        component = component,
+                        versionRange = it,
+                        overriddenAttribute = null,
+                        rowType = "RANGE_PRESENCE",
+                    ),
+                )
+            }
 
         // Re-align the new coverage to existing per-attribute override edges so each enumerated range
         // keeps constant resolved values (ADR-018 (b)). Skipped for supported = ALL (no presence rows).
@@ -1139,18 +1147,52 @@ class ComponentManagementServiceImpl(
         val warnings = supportedCoverageWarnings(component, requested, all)
 
         bumpParentVersion(component)
-        publishAuditEvent(
-            action = "UPDATE",
-            entityId = component.id.toString(),
-            oldValue = mapOf("supportedVersions" to existingPresence.map { it.versionRange }.sortedWith(SUPPORTED_RANGE_ORDER)),
-            newValue = mapOf("supportedVersions" to if (all) listOf("ALL") else requested),
-        )
+        // `resulting` reflects the actual persisted rows after auto-split re-alignment (the audit log
+        // must reconstruct real DB state, not the pre-split request).
         val resulting =
             component.configurations
                 .filter { it.rowType == "RANGE_PRESENCE" }
                 .map { it.versionRange }
                 .sortedWith(SUPPORTED_RANGE_ORDER)
+        publishAuditEvent(
+            action = "UPDATE",
+            entityId = component.id.toString(),
+            oldValue = mapOf("supportedVersions" to existingPresence.map { it.versionRange }.sortedWith(SUPPORTED_RANGE_ORDER)),
+            newValue = mapOf("supportedVersions" to resulting.ifEmpty { listOf("ALL") }),
+        )
         return SupportedVersionsResponse(all = resulting.isEmpty(), ranges = resulting, warnings = warnings)
+    }
+
+    /**
+     * Validate a requested supported-versions set (PUT): each range must parse, must NOT be an
+     * all-versions sentinel (use `all:true` instead of a bounded-looking RANGE_PRESENCE row that
+     * would report `all=false` yet match every override), and the ranges must be pairwise DISJOINT
+     * (ADR-018 stores canonical, non-overlapping coverage segments; overlap would expose multiple
+     * enumerated views for the same versions). Composite (multi-segment) coverage ranges are allowed
+     * verbatim — they just must not overlap each other.
+     */
+    private fun validateSupportedRanges(ranges: List<String>) {
+        ranges.forEach { r ->
+            validateRangeSyntax(r)
+            require(!isAllVersionsCoverage(r)) {
+                "Range '$r' denotes all versions — request supported = ALL via {\"all\": true} " +
+                    "instead of an all-versions coverage row."
+            }
+        }
+        for (i in ranges.indices) {
+            for (j in i + 1 until ranges.size) {
+                require(!rangesIntersect(ranges[i], ranges[j])) {
+                    "Supported ranges must be disjoint, but '${ranges[i]}' and '${ranges[j]}' overlap. " +
+                        "Supply a non-overlapping coverage partition."
+                }
+            }
+        }
+    }
+
+    /** True iff [range] denotes all versions (the ALL_VERSIONS sentinel or the unbounded `(,)`). */
+    private fun isAllVersionsCoverage(range: String): Boolean {
+        val n = normalizeRange(range)
+        return n == ALL_VERSIONS || n == "(,)"
     }
 
     /** V1/V5 advisories: an override whose range no longer intersects supported is unreachable. */
@@ -1164,7 +1206,9 @@ class ComponentManagementServiceImpl(
         return component.configurations
             .filter { it.rowType in FIELD_OVERRIDE_ROW_TYPES }
             .filter { ov ->
-                val ovObj = runCatching { versionRangeFactory.create(ov.versionRange) }.getOrNull() ?: return@filter false
+                // An unparseable override range is itself unreachable — surface it (warn), do NOT
+                // silently treat it as covered (that would suppress the very advisory it should raise).
+                val ovObj = runCatching { versionRangeFactory.create(ov.versionRange) }.getOrNull() ?: return@filter true
                 supportedObjs.none { it.isIntersect(ovObj) }
             }
             .map { ov ->

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
@@ -586,10 +586,19 @@ class ComponentCodeRenderer(
         // (e.g. MarkerAttributes.GROUP_ARTIFACT_PATTERN, deliberately not in `ALL`)
         // carry no renderable block — including them would emit an empty range block.
         val markers = rows.filter { it.rowType == ROW_MARKER && it.overriddenAttribute in MarkerAttributes.ALL }
-        // RANGE_PRESENCE-only (or import-marker-only) ranges with no ownership override contribute
-        // nothing → skip (no empty block). A range whose ONLY override is artifact ownership still
-        // renders (ownership left the GROUP_ARTIFACT_PATTERN marker for component_artifact_mappings).
-        if (scalarOverrides.isEmpty() && markers.isEmpty() && ownershipMappings.isEmpty()) return
+        if (scalarOverrides.isEmpty() && markers.isEmpty() && ownershipMappings.isEmpty()) {
+            // No editable override content for this range. Under the decoupled model (ADR-018) the
+            // base is always ALL_VERSIONS and supported coverage lives in RANGE_PRESENCE rows, so a
+            // RANGE_PRESENCE-only range still declares that the component is SUPPORTED there — render
+            // it as an explicit empty block (`"[1.0,)" {}`) so full as-code stays faithful (otherwise
+            // a bounded-coverage component would render as all-versions). Import-internal-marker-only
+            // ranges (e.g. GROUP_ARTIFACT_PATTERN, no presence row) still contribute nothing → skip.
+            if (rows.any { it.rowType == ROW_RANGE_PRESENCE }) {
+                cb.open(doubleQuoted(range))
+                cb.close()
+            }
+            return
+        }
 
         cb.open(doubleQuoted(range))
         writeAspectOverrides(cb, "build", scalarOverrides, markers)

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -2001,6 +2001,45 @@
         },
         "type" : "object"
       },
+      "SupportedVersionsRequest" : {
+        "properties" : {
+          "all" : {
+            "type" : "boolean"
+          },
+          "ranges" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "type" : "object"
+      },
+      "SupportedVersionsResponse" : {
+        "properties" : {
+          "all" : {
+            "type" : "boolean"
+          },
+          "ranges" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "warnings" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [
+          "all",
+          "ranges",
+          "warnings"
+        ],
+        "type" : "object"
+      },
       "TeamcityProjectRequest" : {
         "properties" : {
           "projectId" : {
@@ -7116,6 +7155,216 @@
               "*/*" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/FieldOverrideResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/{id}/supported-versions" : {
+      "get" : {
+        "operationId" : "getSupportedVersions",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SupportedVersionsResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      },
+      "put" : {
+        "operationId" : "setSupportedVersions",
+        "parameters" : [
+          {
+            "in" : "path",
+            "name" : "id",
+            "required" : true,
+            "schema" : {
+              "format" : "uuid",
+              "type" : "string"
+            }
+          }
+        ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SupportedVersionsRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SupportedVersionsResponse"
                 }
               }
             },

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
@@ -1,0 +1,174 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Paths
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * PR-3b — supported-versions (coverage) edit API (ADR-018). Drives the real `GET` / `PUT
+ * /rest/api/4/components/{id}/supported-versions` end-to-end (ft-db = H2 + auto-migrate) and asserts
+ * the declarative replace, the auto-split re-alignment with an existing override, the ALL reset, and
+ * the V1/V5 warn-and-allow advisory.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class SupportedVersionsApiTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(SupportedVersionsApiTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("a freshly-created component reports supported = ALL (no bounded coverage)")
+    fun `fresh component is all-versions`() {
+        val id = createComponent("sv_all_${UUID.randomUUID().toString().take(8)}")
+        val resp = getSupported(id)
+        assertEquals(true, resp.path("all").asBoolean())
+        assertEquals(0, resp.path("ranges").size())
+    }
+
+    @Test
+    @DisplayName("PUT replaces coverage; GET reflects it; PUT {all:true} clears back to ALL")
+    fun `put replaces and clears coverage`() {
+        val id = createComponent("sv_put_${UUID.randomUUID().toString().take(8)}")
+
+        putSupported(id, """{"ranges":["[1.0,2.0)","[2.0,)"]}""")
+        val after = getSupported(id)
+        assertEquals(false, after.path("all").asBoolean())
+        assertEquals(listOf("[1.0,2.0)", "[2.0,)"), after.path("ranges").map { it.asText() })
+
+        putSupported(id, """{"all":true}""")
+        val cleared = getSupported(id)
+        assertEquals(true, cleared.path("all").asBoolean())
+        assertEquals(0, cleared.path("ranges").size())
+    }
+
+    @Test
+    @DisplayName("setting supported re-aligns an existing override via auto-split")
+    fun `put re-aligns existing override`() {
+        val id = createComponent("sv_align_${UUID.randomUUID().toString().take(8)}")
+        // Override first (component is all-versions, so this is a free-standing override view).
+        createFieldOverride(id, """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"11"}""")
+
+        // Now declare supported = [1.0,10.0): the override edge 2.0/3.0 falls inside → auto-split.
+        putSupported(id, """{"ranges":["[1.0,10.0)"]}""")
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,10.0)"),
+            getSupported(id).path("ranges").map { it.asText() },
+            "PUT supported must re-align coverage to the existing override's edges",
+        )
+    }
+
+    @Test
+    @DisplayName("V1/V5: an override left outside the new supported set produces a non-blocking warning")
+    fun `override outside supported warns`() {
+        val id = createComponent("sv_warn_${UUID.randomUUID().toString().take(8)}")
+        createFieldOverride(id, """{"overriddenAttribute":"build.javaVersion","versionRange":"[5.0,6.0)","value":"11"}""")
+
+        val resp = putSupported(id, """{"ranges":["[1.0,2.0)"]}""")
+        val warnings = resp.path("warnings").map { it.asText() }
+        assertTrue(
+            warnings.any { it.contains("[5.0,6.0)") },
+            "expected a V1/V5 warning that the [5.0,6.0) override is outside supported; got: $warnings",
+        )
+        // Still applied (warn-and-allow): supported is the requested set.
+        assertEquals(listOf("[1.0,2.0)"), resp.path("ranges").map { it.asText() })
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun createComponent(name: String): String {
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"name":"$name",""" +
+                                """"componentOwner":"owner1",""" +
+                                """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+                        ),
+                ).andExpect(status().is2xxSuccessful)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun createFieldOverride(
+        componentId: String,
+        payload: String,
+    ) {
+        mvc
+            .perform(
+                post("/rest/api/4/components/$componentId/field-overrides")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(status().is2xxSuccessful)
+    }
+
+    private fun getSupported(componentId: String) =
+        objectMapper.readTree(
+            mvc
+                .perform(get("/rest/api/4/components/$componentId/supported-versions").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString,
+        )
+
+    private fun putSupported(
+        componentId: String,
+        payload: String,
+    ) = objectMapper.readTree(
+        mvc
+            .perform(
+                put("/rest/api/4/components/$componentId/supported-versions")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(status().isOk)
+            .andReturn()
+            .response.contentAsString,
+    )
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
@@ -114,7 +114,47 @@ class SupportedVersionsApiTest {
         assertEquals(listOf("[1.0,2.0)"), resp.path("ranges").map { it.asText() })
     }
 
+    @Test
+    @DisplayName("idempotent re-PUT of the same coverage set is a no-op (no unique-index 500)")
+    fun `idempotent re-put is safe`() {
+        val id = createComponent("sv_idem_${UUID.randomUUID().toString().take(8)}")
+        putSupported(id, """{"ranges":["[1.0,2.0)","[2.0,)"]}""")
+        // Re-PUT the identical set — the delta replace must add/delete nothing, not violate the
+        // partial unique index by re-inserting a row whose range already exists.
+        val second = putSupported(id, """{"ranges":["[1.0,2.0)","[2.0,)"]}""")
+        assertEquals(listOf("[1.0,2.0)", "[2.0,)"), second.path("ranges").map { it.asText() })
+    }
+
+    @Test
+    @DisplayName("PUT rejects overlapping supported ranges (must be a disjoint partition)")
+    fun `overlapping ranges rejected`() {
+        val id = createComponent("sv_ovl_${UUID.randomUUID().toString().take(8)}")
+        putSupportedExpectingStatus(id, """{"ranges":["[1.0,3.0)","[2.0,4.0)"]}""", status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("PUT rejects an all-versions sentinel as a coverage range (use all:true instead)")
+    fun `all versions sentinel rejected`() {
+        val id = createComponent("sv_sent_${UUID.randomUUID().toString().take(8)}")
+        putSupportedExpectingStatus(id, """{"ranges":["(,0),[0,)"]}""", status().isBadRequest)
+        putSupportedExpectingStatus(id, """{"ranges":["(,)"]}""", status().isBadRequest)
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun putSupportedExpectingStatus(
+        componentId: String,
+        payload: String,
+        matcher: org.springframework.test.web.servlet.ResultMatcher,
+    ) {
+        mvc
+            .perform(
+                put("/rest/api/4/components/$componentId/supported-versions")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(matcher)
+    }
 
     private fun createComponent(name: String): String {
         val body =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
@@ -272,8 +272,8 @@ class ComponentCodeRendererTest {
     }
 
     @Test
-    @DisplayName("FULL: RANGE_PRESENCE-only range does not emit an empty block")
-    fun fullRangePresenceSkipped() {
+    @DisplayName("FULL: RANGE_PRESENCE-only range renders as an explicit empty block (coverage is faithful — ADR-018)")
+    fun fullRangePresenceRendersEmptyBlock() {
         val c = component()
         base(c) { buildSystem = "MAVEN" }
         c.configurations.add(
@@ -286,7 +286,33 @@ class ComponentCodeRendererTest {
             ),
         )
         val out = renderer.renderFull(c)
-        assertFalse(out.contains("\"[9,10)\""), out)
+        // Decoupled model: the ALL_VERSIONS base carries the values; the RANGE_PRESENCE row is the
+        // SOLE record that the component is supported on [9,10). It must surface so as-code does not
+        // misrepresent a bounded-coverage component as all-versions.
+        assertTrue(out.contains("\"[9,10)\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: a declared empty coverage block on a defaulted component is faithful (M2 shape)")
+    fun fullEmptyCoverageBlockIsFaithful() {
+        // build{jV=17} top-level (→ ALL_VERSIONS base) + supported only from [1.0,) (empty block,
+        // a RANGE_PRESENCE row). as-code must show the [1.0,) coverage block, not look all-versions.
+        val c = component()
+        base(c) {
+            buildSystem = "MAVEN"
+            javaVersion = "17"
+        }
+        c.configurations.add(
+            ComponentConfigurationEntity(
+                id = UUID.randomUUID(),
+                component = c,
+                versionRange = "[1.0,)",
+                overriddenAttribute = null,
+                rowType = "RANGE_PRESENCE",
+            ),
+        )
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("\"[1.0,)\""), "as-code must surface the [1.0,) supported-coverage block: $out")
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR-3b of the version-model plan (ADR-018). Adds the **supported-versions (coverage) edit API** deferred from PR-3, and fixes an **as-code fidelity regression** introduced by PR-2 — together making "supported versions" a first-class, *visible & editable* concern. Unblocks PR-4 (portal coverage editor).

## Supported-versions edit API (ADR-018 layer 1)
- `GET /rest/api/4/components/{id}/supported-versions` → `{ all, ranges, warnings }` (`all=true` ⇔ no bounded `RANGE_PRESENCE` rows).
- `PUT` — **declarative replace**: `all:true` (or empty `ranges`) clears bounded coverage → supported = ALL; otherwise `supported = ∪ ranges`. The portal computes extend/limit/split client-side and PUTs the desired set. Existing per-attribute overrides are **re-aligned to the new breakpoints** via the PR-3 write-time auto-split.
- **V1/V5 warn-and-allow**: an override left entirely outside the new supported set is reported in `warnings` (non-blocking) — it never resolves (coverage gate 404s first).
- New DTOs, service methods, stable `SUPPORTED_RANGE_ORDER`; `v4.json` regenerated via `generateOpenApiDocs` (OpenApiV4SpecTest drift gate green).

## As-code fidelity fix (PR-2 P2 regression)
`ComponentCodeRenderer.writeRangeBlock` now renders a `RANGE_PRESENCE`-only range as an explicit empty block (`"[1.0,)" {}`). After PR-2 the base is always `ALL_VERSIONS` and declared coverage lives only in `RANGE_PRESENCE` rows, so dropping presence-only ranges made a bounded-coverage component (e.g. `build{jV=17}` + `"[1.0,)" {}`) render as **all-versions** in `GET /{id}/as-code` — unfaithful. Import-internal-marker-only ranges (no presence row) still render nothing. Also restored a KDoc detached during PR-3.

## Design note (for review)
The PUT contract is **declarative** (replace the set) rather than imperative (extend/limit/split verbs) — simplest, idempotent backend; the portal owns the set-algebra. Additive, non-breaking. Easy to evolve before PR-4 consumes it.

## Testing
- `SupportedVersionsApiTest` (dbTest): fresh=ALL, PUT replace + GET, `all:true` reset, override re-align via auto-split, V1/V5 warning.
- `ComponentCodeRendererTest`: presence-only range + M2 empty-coverage-block now render.
- Full unit + `:dbTest` (incl OpenApiV4SpecTest) + static `check` green; no banned tokens.

## Deferred
Composite-coverage editing (PR-3 rejects an override intersecting a composite presence row); supported-coverage compaction on repeated edits (P3). Portal PR-4 consumes this API (needs `vendor-spec` + `generate-types` + a CRS redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)