### PR TITLE
fix(registry): single-delta supported-versions PUT — no flush violation on coarse re-PUT (ADR-018) — PR-3c

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1001,6 +1001,40 @@ class ComponentManagementServiceImpl(
      * old ones back, so repeated range edits fragment `RANGE_PRESENCE` over time. Correctness holds
      * (union + per-row constant values); a compaction pass is a follow-up.
      */
+    /**
+     * Pure auto-split (ADR-018 (b)) of a requested supported set: split each requested range at every
+     * single-segment override edge that falls inside it, so the result is breakpoint-aligned. A
+     * composite override range is import-aligned and introduces no single edge (skipped). A composite
+     * COVERING range that a simple override intersects cannot be split here → reject (same as the
+     * field-override write path). String-only so `setSupportedVersions` can delta against the final
+     * rows in ONE pass — avoiding the remove-then-re-add of identical rows that a post-hoc
+     * [autoSplitCoverage] would cause (and the resulting partial-unique-index flush violation).
+     */
+    private fun coverageAfterOverrideSplit(
+        requested: List<String>,
+        overrideRanges: List<String>,
+    ): List<String> {
+        var acc = requested
+        for (ovr in overrideRanges) {
+            if (VersionCoverageSplit.parseSegment(ovr) == null) continue // composite override: no single edge
+            acc =
+                acc.flatMap { pres ->
+                    val parts = VersionCoverageSplit.split(pres, ovr)
+                    when {
+                        parts != null -> parts
+                        rangesIntersect(pres, ovr) ->
+                            throw IllegalArgumentException(
+                                "Supported range '$pres' is composite and intersects override '$ovr'; " +
+                                    "splitting composite coverage at an override edge is not yet supported — " +
+                                    "edit coverage via DSL re-import, or split the composite first.",
+                            )
+                        else -> listOf(pres)
+                    }
+                }
+        }
+        return acc.distinct()
+    }
+
     private fun autoSplitCoverage(
         component: ComponentEntity,
         overrideRange: String,
@@ -1108,18 +1142,28 @@ class ComponentManagementServiceImpl(
                 request.ranges!!.map { normalizeRange(it) }.distinct().also { validateSupportedRanges(it) }
             }
 
-        // Declarative replace, applied as a DELTA so an idempotent (same-range) re-PUT is a no-op
-        // rather than a unique-index violation: Hibernate would otherwise flush the INSERT of a
-        // re-added range before the orphan-removal DELETE of the identical old row, tripping
-        // uq_component_configurations_one_range_presence (component_id, version_range). orphanRemoval +
-        // cascade persist the delta. (RANGE_PRESENCE rows carry no payload, so nothing else migrates.)
+        // Compute the FINAL coverage rows up front: the requested ranges, pre-split at every existing
+        // per-attribute override edge (ADR-018 (b) — each enumerated range keeps constant values).
+        // Computing the post-split set first lets us apply ONE delta against the current rows, so a
+        // range that is unchanged is KEPT (not removed-then-re-added). Removing then re-adding the
+        // identical (component, range) — which a separate auto-split step would do for a coarse PUT of
+        // [1,10) over already-split [1,2),[2,3),[3,10) — trips the partial unique index
+        // uq_component_configurations_one_range_presence on flush (Hibernate orders INSERTs before the
+        // orphan-removal DELETEs). The single-delta approach makes such a re-PUT a true no-op.
+        val overrideRanges =
+            component.configurations
+                .filter { it.rowType in FIELD_OVERRIDE_ROW_TYPES }
+                .map { it.versionRange }
+                .distinct()
+        val finalRanges = if (all) emptyList() else coverageAfterOverrideSplit(requested, overrideRanges)
+        val finalSet = finalRanges.toSet()
+
         val existingPresence = component.configurations.filter { it.rowType == "RANGE_PRESENCE" }
         val existingRanges = existingPresence.map { it.versionRange }.toSet()
-        val requestedSet = requested.toSet()
         existingPresence
-            .filter { it.versionRange !in requestedSet }
+            .filter { it.versionRange !in finalSet }
             .forEach { component.configurations.remove(it) }
-        requested
+        finalRanges
             .filter { it !in existingRanges }
             .forEach {
                 component.configurations.add(
@@ -1131,16 +1175,6 @@ class ComponentManagementServiceImpl(
                     ),
                 )
             }
-
-        // Re-align the new coverage to existing per-attribute override edges so each enumerated range
-        // keeps constant resolved values (ADR-018 (b)). Skipped for supported = ALL (no presence rows).
-        if (!all) {
-            component.configurations
-                .filter { it.rowType in FIELD_OVERRIDE_ROW_TYPES }
-                .map { it.versionRange }
-                .distinct()
-                .forEach { autoSplitCoverage(component, it) }
-        }
 
         // V1/V5 (warn-and-allow): surface overrides left entirely outside the new supported set — they
         // never resolve (the coverage gate 404s first). Non-blocking; the write still succeeds.

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -978,30 +978,6 @@ class ComponentManagementServiceImpl(
     }
 
     /**
-     * Write-time auto-split of supported coverage (ADR-018 refinement (b)). After a field-override
-     * write whose range introduces a boundary INSIDE a covering `RANGE_PRESENCE` row, split that
-     * presence row at the override's interior edges so each enumerated range keeps constant resolved
-     * values (range-view enumeration is anchored to `RANGE_PRESENCE`, one config per row). Without
-     * this, the covering range's enumerated view would span versions whose resolved values differ.
-     *
-     * No-op for components with no `RANGE_PRESENCE` rows (supported = ALL, or API-created components
-     * whose override range is enumerated as its own view) and for overrides that introduce no interior
-     * edge (equal to / wider than / disjoint from the presence range). Idempotent: re-running on an
-     * already-aligned set adds nothing. Coverage (the union of ranges) is unchanged — only the
-     * breakpoints move. Uses collection mutation so JPA orphanRemoval/cascade persist the change.
-     *
-     * A composite override range (only possible on a value-only update of an import-created composite
-     * override row) introduces no single new edge — coverage was aligned at import — so it is a no-op.
-     * A composite COVERING presence row cannot be split by this simple-segment helper; if a simple
-     * override intersects one, we reject the write (clear 400) rather than silently leave a range
-     * whose enumerated view would no longer have constant resolved values — composite-coverage editing
-     * is a follow-up.
-     *
-     * Known limitation (P3): a range CHANGE on an override adds new breakpoints but does not merge the
-     * old ones back, so repeated range edits fragment `RANGE_PRESENCE` over time. Correctness holds
-     * (union + per-row constant values); a compaction pass is a follow-up.
-     */
-    /**
      * Pure auto-split (ADR-018 (b)) of a requested supported set: split each requested range at every
      * single-segment override edge that falls inside it, so the result is breakpoint-aligned. A
      * composite override range is import-aligned and introduces no single edge (skipped). A composite
@@ -1035,6 +1011,29 @@ class ComponentManagementServiceImpl(
         return acc.distinct()
     }
 
+    /**
+     * Write-time auto-split of supported coverage (ADR-018 refinement (b)), used by the FIELD-OVERRIDE
+     * write paths (create/update). After a field-override write whose range introduces a boundary
+     * INSIDE a covering `RANGE_PRESENCE` row, split that presence row at the override's interior edges
+     * so each enumerated range keeps constant resolved values (range-view enumeration is anchored to
+     * `RANGE_PRESENCE`, one config per row). Without this, the covering range's enumerated view would
+     * span versions whose resolved values differ.
+     *
+     * No-op for components with no `RANGE_PRESENCE` rows (supported = ALL, or API-created components
+     * whose override range is enumerated as its own view) and for overrides that introduce no interior
+     * edge (equal to / wider than / disjoint from the presence range). Idempotent. Coverage (the union
+     * of ranges) is unchanged — only the breakpoints move. Uses collection mutation so JPA
+     * orphanRemoval/cascade persist the change.
+     *
+     * A composite override range introduces no single new edge — no-op. A composite COVERING presence
+     * row cannot be split by this simple-segment helper; if a simple override intersects one, reject
+     * the write (clear 400) — composite-coverage editing is a follow-up.
+     *
+     * NOTE: `setSupportedVersions` does NOT call this — it computes the post-split set up front via
+     * [coverageAfterOverrideSplit] and applies a single delta (avoids the remove-then-re-add flush
+     * violation). Known limitation (P3): a range CHANGE on an override fragments `RANGE_PRESENCE` over
+     * time (no compaction); correctness holds.
+     */
     private fun autoSplitCoverage(
         component: ComponentEntity,
         overrideRange: String,
@@ -1181,7 +1180,8 @@ class ComponentManagementServiceImpl(
         val warnings = supportedCoverageWarnings(component, requested, all)
 
         bumpParentVersion(component)
-        // `resulting` reflects the actual persisted rows after auto-split re-alignment (the audit log
+        // `resulting` reflects the actual persisted rows (the requested set after the upfront
+        // override-edge split applied as a single delta) so the audit log
         // must reconstruct real DB state, not the pre-split request).
         val resulting =
             component.configurations

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
@@ -99,6 +99,25 @@ class SupportedVersionsApiTest {
     }
 
     @Test
+    @DisplayName("coarse re-PUT over already-split coverage is a no-op (no unique-index 500)")
+    fun `coarse re-put over split coverage is safe`() {
+        val id = createComponent("sv_coarse_${UUID.randomUUID().toString().take(8)}")
+        putSupported(id, """{"ranges":["[1.0,10.0)"]}""")
+        // An override inside [1.0,10.0) auto-splits coverage into three rows.
+        createFieldOverride(id, """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"11"}""")
+        assertEquals(listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,10.0)"), getSupported(id).path("ranges").map { it.asText() })
+
+        // Re-PUT the COARSE range over the split rows. The server must re-split to the same three rows
+        // without removing-then-re-adding identical (component, range) rows in one flush — i.e. no 500.
+        val resp = putSupported(id, """{"ranges":["[1.0,10.0)"]}""")
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,10.0)"),
+            resp.path("ranges").map { it.asText() },
+            "coarse re-PUT must re-split to the aligned rows (computed as a single delta, no flush violation)",
+        )
+    }
+
+    @Test
     @DisplayName("V1/V5: an override left outside the new supported set produces a non-blocking warning")
     fun `override outside supported warns`() {
         val id = createComponent("sv_warn_${UUID.randomUUID().toString().take(8)}")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SupportedVersionsApiTest.kt
@@ -118,6 +118,26 @@ class SupportedVersionsApiTest {
     }
 
     @Test
+    @DisplayName("coverage splits at TWO non-adjacent override edges (sequential-split composition)")
+    fun `coarse coverage splits at multiple override edges`() {
+        val id = createComponent("sv_multi_${UUID.randomUUID().toString().take(8)}")
+        putSupported(id, """{"ranges":["[1.0,10.0)"]}""")
+        createFieldOverride(id, """{"overriddenAttribute":"build.javaVersion","versionRange":"[2.0,3.0)","value":"11"}""")
+        createFieldOverride(id, """{"overriddenAttribute":"build.mavenVersion","versionRange":"[5.0,7.0)","value":"3.9.0"}""")
+        // Both override edges (2.0/3.0 and 5.0/7.0) partition [1.0,10.0).
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,5.0)", "[5.0,7.0)", "[7.0,10.0)"),
+            getSupported(id).path("ranges").map { it.asText() },
+        )
+        // A coarse re-PUT must re-split to the same five rows in one delta (no-op, no 500).
+        val resp = putSupported(id, """{"ranges":["[1.0,10.0)"]}""")
+        assertEquals(
+            listOf("[1.0,2.0)", "[2.0,3.0)", "[3.0,5.0)", "[5.0,7.0)", "[7.0,10.0)"),
+            resp.path("ranges").map { it.asText() },
+        )
+    }
+
+    @Test
     @DisplayName("V1/V5: an override left outside the new supported set produces a non-blocking warning")
     fun `override outside supported warns`() {
         val id = createComponent("sv_warn_${UUID.randomUUID().toString().take(8)}")


### PR DESCRIPTION
## Summary

Follow-up to PR-3b (#381). A re-review found a remaining **unique-index risk** the first delta fix missed: a **coarse PUT over already-split coverage** could trip `uq_component_configurations_one_range_presence` (500).

### The bug
Component has override `[2,3)` and supported rows `[1,2)`, `[2,3)`, `[3,10)` (from a prior auto-split). `PUT {ranges:["[1,10)"]}`: the delta step removed the three split rows and added `[1,10)`, then the **separate** `autoSplitCoverage` removed `[1,10)` and re-added `[1,2)`, `[2,3)`, `[3,10)` — re-adding the **identical** `(component, range)` rows that were just orphan-removed, in the same flush. Hibernate orders INSERTs before the orphan-removal DELETEs → duplicate-key violation.

### The fix
Compute the **final post-split coverage up front** (new pure `coverageAfterOverrideSplit`: split the requested ranges at every single-segment override edge; reject a composite covering range intersected by a simple override), then apply **one delta** against the current rows — identical rows are **kept**, never removed-then-re-added. A coarse re-PUT is now a true no-op. `setSupportedVersions` no longer calls `autoSplitCoverage` (the field-override write paths still do).

## Testing
- `SupportedVersionsApiTest`: new coarse-re-PUT-over-split regression (200, re-aligned rows, no 500) + existing idempotent/overlap/sentinel/re-align cases.
- Full unit + `:dbTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)