### PR TITLE
chore(meta): drop Maven 3.8 from the offered build-tool versions

### DIFF
--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -20,7 +20,6 @@ components-registry:
       - "3.3.9"
       - "3.6"
       - "3.6.3"
-      - "3.8"
       - "3.9"
 
   # Admin config-as-code BASELINE (product defaults). service-config overrides

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentDisplayNameEditorsV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentDisplayNameEditorsV4Test.kt
@@ -197,7 +197,7 @@ class ComponentDisplayNameEditorsV4Test {
                 .andExpect(jsonPath("$").isArray)
                 .andReturn().response.contentAsString
         val versions = objectMapper.readTree(result).map { it.asText() }
-        assert(versions == listOf("2.2.1", "3", "3.3.9", "3.6", "3.6.3", "3.8", "3.9")) {
+        assert(versions == listOf("2.2.1", "3", "3.3.9", "3.6", "3.6.3", "3.9")) {
             "expected configured Maven versions numeric-sorted; got $versions"
         }
     }


### PR DESCRIPTION
## What

Remove `"3.8"` from `components-registry.build-tool-versions.maven` in `application.yml`. This list is the baseline served by `GET /components/meta/maven-versions`, which populates the Portal's **Maven Version** dropdown. Maven 3.8 is no longer a supported build-tool version, so it should not be offered.

## Effect

The Portal's Maven Version dropdown (editor Build tab) no longer offers 3.8. Installations that override the whole list in service-config are unaffected (Spring relaxed binding replaces the list); no such override exists for the current stand, so the baseline is the effective source.

`mavenVersion` is **free-form** on the write side — create/PATCH and the field-override path store the string directly and never validate it against this list (confirmed in review). So existing components with `mavenVersion = "3.8"` continue to round-trip and PATCH cleanly; only the offered options change.

## Tests

- Updated the `GET /meta/maven-versions` assertion in `ComponentDisplayNameEditorsV4Test` to the trimmed list. Ran the class via `dbTest` (Testcontainers): **7 tests, 0 failures**.
- `VersionComparatorTest` and `ComponentSectionAuditTest` keep `"3.8"` as arbitrary sample data (sort input / audit-diff value) — they don't exercise the offered vocabulary, so they're intentionally untouched.

Reviewed by Codex — no P1/P2; verdict SAFE TO MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)