### PR TITLE
feat(registry): accept field overrides on the component PATCH (desired-full-set)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -9,8 +9,10 @@ import jakarta.validation.constraints.Pattern
  * the client; mismatch → 409.
  *
  * `baseConfiguration` (when present) is also patched in-place with the same
- * rules — null aspect fields preserve, present child lists replace. Override
- * rows are managed via the field-override API, not from here.
+ * rules — null aspect fields preserve, present child lists replace. Field
+ * overrides may also ride this PATCH via `fieldOverrides` (item D) as a
+ * desired-FULL-SET; null there = don't touch (see that field's doc). They
+ * remain editable one-at-a-time through the field-override sub-resource API too.
  *
  * **`group` is migration-owned and is NEVER modified via PATCH** (R1
  * aggregator/parentComponent decouple): a ComponentGroup is DSL aggregator
@@ -68,6 +70,16 @@ data class ComponentUpdateRequest(
     val securityGroups: List<SecurityGroupRequest>? = null,
     val teamcityProjects: List<TeamcityProjectRequest>? = null,
     val baseConfiguration: BaseConfigurationRequest? = null,
+    /**
+     * Field overrides as a desired-FULL-SET (item D): when present, this is the
+     * complete set of V4-editable overrides for the component — entries with an
+     * id upsert that row, entries without an id create one, and any existing
+     * editable override absent from the list is deleted, all in this PATCH's
+     * transaction. null = don't touch overrides (so a component-only PATCH never
+     * wipes them). Import-managed markers (group-artifact-pattern) are out of
+     * scope and preserved.
+     */
+    val fieldOverrides: List<FieldOverrideUpsertRequest>? = null,
     // Optional change metadata recorded on the audit row (not on the component).
     // These are change-scoped, not part of the component's patchable state: a
     // blank/whitespace key is accepted as "no key" (normalized to null), and a

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/FieldOverrideRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/FieldOverrideRequest.kt
@@ -28,6 +28,28 @@ data class FieldOverrideCreateRequest(
     val markerChildren: MarkerChildrenPayload? = null,
 )
 
+/**
+ * One entry of the desired-FULL-SET sent in ComponentUpdateRequest.fieldOverrides
+ * (item D — folding field overrides into the component PATCH). Same tagged-union
+ * shape as [FieldOverrideCreateRequest], plus an optional [id]:
+ *
+ *  - id == null  → CREATE this override.
+ *  - id != null  → UPDATE the existing override with that id. value/range are set
+ *                  to exactly what is sent here (DESIRED state, not the PATCH
+ *                  null-is-no-op semantic of [FieldOverrideUpdateRequest]).
+ *
+ * Any existing V4-editable override NOT present in the list is DELETED. Import-
+ * managed markers (group-artifact-pattern) are out of scope: never created,
+ * updated or deleted via this path, and a client echo of one (by id) is a no-op.
+ */
+data class FieldOverrideUpsertRequest(
+    val id: UUID? = null,
+    val overriddenAttribute: String,
+    val versionRange: String,
+    val value: Any? = null,
+    val markerChildren: MarkerChildrenPayload? = null,
+)
+
 data class FieldOverrideUpdateRequest(
     val versionRange: String? = null,
     /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -21,6 +21,7 @@ import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideRes
 import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.SupportedVersionsResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpdateRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpsertRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FileUrlArtifactRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.MarkerChildrenPayload
 import org.octopusden.octopus.components.registry.server.dto.v4.MavenArtifactRequest
@@ -656,6 +657,13 @@ class ComponentManagementServiceImpl(
                 base.takeIf { patch.requiredTools != null }
             }
 
+        // Field overrides (item D): desired-FULL-SET applied in-place on the
+        // configuration collection — cascade (orphanRemoval) persists the
+        // inserts/deletes on the saveAndFlush below, bumping the aggregate
+        // @Version once. null = don't touch. The returned plan carries the
+        // post-flush required-tool syncs + per-override audit rows.
+        val fieldOverridePlan = request.fieldOverrides?.let { applyFieldOverrideDesiredSet(entity, it) }
+
         // Cross-component / malformed-input checks are GRANDFATHERED on update:
         // they re-run only when the PATCH actually touches a field they govern
         // (distribution coordinates / jira / docs / the explicit-external-archived
@@ -673,7 +681,8 @@ class ComponentManagementServiceImpl(
                 request.docs != null ||
                 request.distributionExplicit != null ||
                 request.distributionExternal != null ||
-                request.archived != null
+                request.archived != null ||
+                request.fieldOverrides != null // marker overrides can carry colliding maven GAV / docker / jira coordinates
 
         // Malformed-input single-field checks (400) against the PATCHed final
         // entity state (so a caller need not resend unchanged fields).
@@ -710,6 +719,41 @@ class ComponentManagementServiceImpl(
         canonicalizedLabels?.let { refreshComponentLabelsInMemory(saved, it) }
         if (baseConfigForToolsSync != null && patchedRequiredTools != null) {
             refreshConfigRequiredToolsInMemory(baseConfigForToolsSync, patchedRequiredTools)
+        }
+
+        // Item D: field-override post-flush work — sync the (non-cascaded)
+        // required-tool junctions now that newly-inserted rows have ids, then
+        // publish one audit row per override change (same granularity as the
+        // standalone field-override CRUD).
+        fieldOverridePlan?.let { plan ->
+            plan.pendingTools.forEach { (row, tools) ->
+                syncRequiredTools(row.id!!, tools)
+                refreshConfigRequiredToolsInMemory(row, tools)
+            }
+            plan.deletedSnapshots.forEach { snapshot ->
+                publishAuditEvent(
+                    action = "UPDATE",
+                    entityId = saved.id.toString(),
+                    oldValue = snapshot,
+                    newValue = emptyMap(),
+                )
+            }
+            plan.updated.forEach { (row, before) ->
+                publishAuditEvent(
+                    action = "UPDATE",
+                    entityId = saved.id.toString(),
+                    oldValue = before,
+                    newValue = fieldOverrideAuditSnapshot(row),
+                )
+            }
+            plan.created.forEach { row ->
+                publishAuditEvent(
+                    action = "UPDATE",
+                    entityId = saved.id.toString(),
+                    oldValue = emptyMap(),
+                    newValue = fieldOverrideAuditSnapshot(row),
+                )
+            }
         }
 
         if (isRename) sourceRegistry.renameComponent(oldKey, saved.componentKey)
@@ -1011,6 +1055,149 @@ class ComponentManagementServiceImpl(
             .findByComponentId(componentId)
             .filter { it.rowType == "SCALAR_OVERRIDE" || it.rowType == "MARKER" }
             .map { it.toFieldOverrideResponse() }
+    }
+
+    /**
+     * What [applyFieldOverrideDesiredSet] changed, so [updateComponent] can do the
+     * post-flush work that needs assigned ids: sync the non-cascaded required-tool
+     * junctions and publish one audit row per override change.
+     */
+    private data class FieldOverrideApplyPlan(
+        val created: List<ComponentConfigurationEntity>,
+        val updated: List<Pair<ComponentConfigurationEntity, Map<String, Any?>>>,
+        val deletedSnapshots: List<Map<String, Any?>>,
+        val pendingTools: Map<ComponentConfigurationEntity, List<String>>,
+    )
+
+    /**
+     * Item D — apply [desired] as the desired-FULL-SET of V4-editable field
+     * overrides for [component], mutating the in-memory configuration collection
+     * so the caller's single saveAndFlush cascades inserts + orphan-deletes and
+     * bumps the aggregate @Version once. Reuses the same validators/appliers as
+     * the standalone CRUD (disjoint-range rule, scalar typing, marker children).
+     *
+     * Order is DELETE -> UPDATE -> CREATE so the in-memory disjoint-range check
+     * (which walks the live collection) never trips on a row that is itself being
+     * removed in the same request. Import-managed markers (group-artifact-pattern)
+     * are out of scope: never updated or deleted, and a client echo of one (by id)
+     * is preserved as a no-op.
+     *
+     * Known limitation (shared with sequential standalone updates): a single
+     * request that SWAPS two existing rows' ranges on the same attribute is
+     * rejected, because each update validates against the other row still at its
+     * old range. Such a swap must be done in two saves (or delete + create).
+     */
+    private fun applyFieldOverrideDesiredSet(
+        component: ComponentEntity,
+        desired: List<FieldOverrideUpsertRequest>,
+    ): FieldOverrideApplyPlan {
+        fun isImportManaged(row: ComponentConfigurationEntity) =
+            row.rowType == "MARKER" && row.overriddenAttribute !in MarkerAttributes.ALL
+
+        val existing = component.configurations.filter { it.rowType in FIELD_OVERRIDE_ROW_TYPES }
+        val byId = existing.mapNotNull { row -> row.id?.let { it to row } }.toMap()
+
+        // Referenced ids must exist on this component (clear 400, not a silent create).
+        desired.forEach { d ->
+            if (d.id != null && d.id !in byId) {
+                throw IllegalArgumentException(
+                    "fieldOverrides: override id '${d.id}' not found on component '${component.id}'",
+                )
+            }
+        }
+        val keepIds = desired.mapNotNull { it.id }.toSet()
+        val pendingTools = LinkedHashMap<ComponentConfigurationEntity, List<String>>()
+
+        // 1) DELETE editable rows omitted from the desired set (orphanRemoval on flush).
+        val deletedSnapshots = mutableListOf<Map<String, Any?>>()
+        existing.filter { !isImportManaged(it) && it.id !in keepIds }.forEach { row ->
+            deletedSnapshots += fieldOverrideAuditSnapshot(row)
+            component.configurations.remove(row)
+        }
+
+        // 2) UPDATE existing editable rows referenced by id.
+        val updated = mutableListOf<Pair<ComponentConfigurationEntity, Map<String, Any?>>>()
+        desired.filter { it.id != null }.forEach { d ->
+            val row = byId.getValue(d.id!!)
+            if (isImportManaged(row)) return@forEach // preserve; ignore client echo
+            require(d.overriddenAttribute == row.overriddenAttribute) {
+                "fieldOverrides: cannot change overriddenAttribute of override '${d.id}' " +
+                    "(${row.overriddenAttribute} -> ${d.overriddenAttribute})"
+            }
+            val before = fieldOverrideAuditSnapshot(row)
+            applyOverrideUpsertPayload(component, row, d, excludeOverrideId = row.id)?.let { pendingTools[row] = it }
+            updated += row to before
+        }
+
+        // 3) CREATE rows without an id.
+        val created = mutableListOf<ComponentConfigurationEntity>()
+        desired.filter { it.id == null }.forEach { d ->
+            val row =
+                ComponentConfigurationEntity(
+                    component = component,
+                    versionRange = "",
+                    overriddenAttribute = d.overriddenAttribute,
+                    rowType = "",
+                )
+            applyOverrideUpsertPayload(component, row, d, excludeOverrideId = null)?.let { pendingTools[row] = it }
+            component.configurations.add(row)
+            // Explicit save (like the single-row create path) so the generated id
+            // is assigned to this instance now — the parent saveAndFlush's cascade
+            // does not back-populate it onto our reference, which the post-flush
+            // required-tool sync + audit snapshot need.
+            configurationRepository.save(row)
+            created += row
+        }
+        return FieldOverrideApplyPlan(created, updated, deletedSnapshots, pendingTools)
+    }
+
+    /**
+     * Set [row]'s range/value/markerChildren to the desired state in [d]
+     * (validating the range against siblings, excluding self), classify its
+     * rowType, and return the pending required-tool list for build.requiredTools
+     * markers (synced post-flush), or null. Shared by the upsert create + update
+     * paths; mirrors the single-row create/update validation exactly.
+     */
+    private fun applyOverrideUpsertPayload(
+        component: ComponentEntity,
+        row: ComponentConfigurationEntity,
+        d: FieldOverrideUpsertRequest,
+        excludeOverrideId: UUID?,
+    ): List<String>? {
+        val canonicalRange = normalizeRange(d.versionRange)
+        validateFieldOverrideRange(
+            range = canonicalRange,
+            component = component,
+            attribute = d.overriddenAttribute,
+            excludeOverrideId = excludeOverrideId,
+        )
+        row.versionRange = canonicalRange
+        return when {
+            d.overriddenAttribute in MarkerAttributes.ALL -> {
+                row.rowType = "MARKER"
+                require(d.value == null) {
+                    "Marker override '${d.overriddenAttribute}' must not carry a scalar value"
+                }
+                requireNotNull(d.markerChildren) {
+                    "Marker override '${d.overriddenAttribute}' requires markerChildren payload"
+                }
+                applyMarkerChildren(row, d.overriddenAttribute, d.markerChildren)
+            }
+
+            d.overriddenAttribute in SCALAR_ATTRIBUTE_PATHS -> {
+                row.rowType = "SCALAR_OVERRIDE"
+                require(d.markerChildren == null) {
+                    "Scalar override '${d.overriddenAttribute}' must not carry markerChildren"
+                }
+                row.applyScalarValue(d.overriddenAttribute, d.value)
+                null
+            }
+
+            else -> throw IllegalArgumentException(
+                "Unknown overriddenAttribute: '${d.overriddenAttribute}'. " +
+                    "Must be a scalar aspect.field path or one of ${MarkerAttributes.ALL}",
+            )
+        }
     }
 
     @Transactional(readOnly = true)

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -882,6 +882,12 @@
             },
             "type" : "array"
           },
+          "fieldOverrides" : {
+            "items" : {
+              "$ref" : "#/components/schemas/FieldOverrideUpsertRequest"
+            },
+            "type" : "array"
+          },
           "group" : {
             "$ref" : "#/components/schemas/ComponentGroupRequest"
           },
@@ -1220,6 +1226,31 @@
             "type" : "string"
           }
         },
+        "type" : "object"
+      },
+      "FieldOverrideUpsertRequest" : {
+        "properties" : {
+          "id" : {
+            "format" : "uuid",
+            "type" : "string"
+          },
+          "markerChildren" : {
+            "$ref" : "#/components/schemas/MarkerChildrenPayload"
+          },
+          "overriddenAttribute" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "object"
+          },
+          "versionRange" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "overriddenAttribute",
+          "versionRange"
+        ],
         "type" : "object"
       },
       "FileUrlArtifactRequest" : {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentFieldOverridesPatchTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentFieldOverridesPatchTest.kt
@@ -1,0 +1,178 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Paths
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * Item D — field overrides can ride the component PATCH as a desired-FULL-SET in
+ * `fieldOverrides`, so the portal's one combined Save persists overrides + the
+ * rest of the component atomically. Semantics:
+ *   - absent/null      → overrides untouched
+ *   - present array    → upsert by id, CREATE entries without id, DELETE any
+ *                        existing (V4-editable) override not in the list
+ * Applied in the same transaction as the component update; import-managed
+ * markers (group-artifact-pattern) are out of scope and preserved.
+ *
+ * Integration test (ft-db = H2 + auto-migrate): drives the real V4 PATCH and
+ * reads overrides back through the field-override list API.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class ComponentFieldOverridesPatchTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(ComponentFieldOverridesPatchTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("PATCH fieldOverrides=[create] adds a new override in the same request")
+    fun `patch fieldOverrides creates`() {
+        val id = newComponent()
+        patchComponent(
+            id,
+            """"fieldOverrides":[{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"FileA"}]""",
+        )
+        val overrides = listFieldOverrides(id)
+        assertEquals(1, overrides.size, "PATCH fieldOverrides must create the override")
+        assertEquals("build.buildFilePath", overrides[0]["overriddenAttribute"].asText())
+        assertEquals("FileA", overrides[0]["value"].asText())
+    }
+
+    @Test
+    @DisplayName("PATCH fieldOverrides absent leaves existing overrides untouched")
+    fun `patch without fieldOverrides is a no-op for overrides`() {
+        val id = newComponent()
+        seedOverride(id, "build.buildFilePath", "[1.0,2.0)", "FileA")
+        // A component-only PATCH (no fieldOverrides key) must not wipe overrides.
+        patchComponent(id, """"displayName":"Renamed"""")
+        assertEquals(1, listFieldOverrides(id).size, "overrides must survive a fieldOverrides-absent PATCH")
+    }
+
+    @Test
+    @DisplayName("PATCH fieldOverrides=[] (empty desired set) deletes all editable overrides")
+    fun `patch empty fieldOverrides clears`() {
+        val id = newComponent()
+        seedOverride(id, "build.buildFilePath", "[1.0,2.0)", "FileA")
+        patchComponent(id, """"fieldOverrides":[]""")
+        assertEquals(0, listFieldOverrides(id).size, "empty desired set must delete all editable overrides")
+    }
+
+    @Test
+    @DisplayName("PATCH fieldOverrides upserts by id (value change) and deletes the omitted one")
+    fun `patch upsert and delete-omitted`() {
+        val id = newComponent()
+        val keepId = seedOverride(id, "build.buildFilePath", "[1.0,2.0)", "FileA")
+        seedOverride(id, "build.javaVersion", "[1.0,2.0)", "17") // omitted below → must be deleted
+
+        patchComponent(
+            id,
+            """"fieldOverrides":[{"id":"$keepId","overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"FileB"}]""",
+        )
+
+        val overrides = listFieldOverrides(id)
+        assertEquals(1, overrides.size, "only the kept override should remain")
+        assertEquals(keepId, overrides[0]["id"].asText())
+        assertEquals("FileB", overrides[0]["value"].asText(), "the kept override must reflect the new value")
+    }
+
+    @Test
+    @DisplayName("PATCH applies a component field AND fieldOverrides in one request, bumping version once")
+    fun `patch component field and overrides together`() {
+        val id = newComponent()
+        val before = currentVersion(id)
+        patchComponent(
+            id,
+            """"displayName":"Combined","fieldOverrides":[{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"FileA"}]""",
+        )
+        val detail = getComponent(id)
+        assertEquals("Combined", detail["displayName"].asText())
+        assertEquals(1, listFieldOverrides(id).size)
+        assertEquals(before + 1, detail["version"].asLong(), "one combined PATCH must bump the version exactly once")
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private fun newComponent(): String {
+        val name = "fo-patch-${UUID.randomUUID().toString().take(8)}"
+        val body = mvc.perform(
+            post("/rest/api/4/components").with(adminJwt()).contentType(MediaType.APPLICATION_JSON).content(
+                """{"name":"$name","componentOwner":"owner1",""" +
+                    """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+            ),
+        ).andExpect(status().is2xxSuccessful).andReturn().response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun seedOverride(componentId: String, attribute: String, range: String, value: String): String {
+        val body = mvc.perform(
+            post("/rest/api/4/components/$componentId/field-overrides").with(adminJwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"overriddenAttribute":"$attribute","versionRange":"$range","value":"$value"}"""),
+        ).andExpect(status().is2xxSuccessful).andReturn().response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun currentVersion(componentId: String): Long = getComponent(componentId)["version"].asLong()
+
+    private fun getComponent(componentId: String): JsonNode {
+        val body = mvc.perform(get("/rest/api/4/components/$componentId").with(adminJwt()))
+            .andExpect(status().isOk).andReturn().response.contentAsString
+        return objectMapper.readTree(body)
+    }
+
+    private fun patchComponent(componentId: String, fieldsWithoutVersion: String) {
+        val payload = """{"version":${currentVersion(componentId)},$fieldsWithoutVersion}"""
+        mvc.perform(
+            patch("/rest/api/4/components/$componentId").with(adminJwt())
+                .contentType(MediaType.APPLICATION_JSON).content(payload),
+        ).andExpect(status().isOk)
+    }
+
+    private fun listFieldOverrides(componentId: String): List<JsonNode> {
+        val body = mvc.perform(get("/rest/api/4/components/$componentId/field-overrides").with(adminJwt()))
+            .andExpect(status().isOk).andReturn().response.contentAsString
+        return objectMapper.readTree(body).toList().also { assertTrue(it.isEmpty() || it[0].has("id")) }
+    }
+}


### PR DESCRIPTION
## What & why

Lets a single component PATCH carry the component's field overrides **atomically** — the prerequisite for Portal item D (folding per-version field overrides into the editor's one combined Save). Today overrides are a separate REST sub-resource that writes immediately; this adds them to `ComponentUpdateRequest` so the portal's combined Save persists overrides + the rest of the component in one transaction.

## Contract

`ComponentUpdateRequest.fieldOverrides: List<FieldOverrideUpsertRequest>?` (new DTO: `id?`, `overriddenAttribute`, `versionRange`, `value?`, `markerChildren?`):
- **absent / null** → overrides untouched (a component-only PATCH never wipes them)
- **present** → desired **FULL SET**: upsert by `id`, create entries without an `id`, and **delete any existing V4-editable override not in the list**

The PATCH response already echoes the persisted overrides via `configurations`.

## How

Applied in-place on the configuration collection inside `updateComponent`'s existing transaction (`applyFieldOverrideDesiredSet` / `applyOverrideUpsertPayload`):
- Order **delete → update → create** so the in-memory disjoint-range validator never trips on a row being removed in the same request.
- Cascade + `orphanRemoval` persist inserts/deletes on the single `saveAndFlush` → the aggregate `@Version` bumps **exactly once** (no client-version lag → no false 409).
- Reuses the standalone CRUD's validators/appliers verbatim (`validateFieldOverrideRange`, `applyScalarValue`, `applyMarkerChildren`, `syncRequiredTools`); runs the cross-component composite checks (maven GAV / docker / jira) when overrides change; publishes one audit row per override change (same granularity as the single-row endpoints).
- **Import-managed markers** (`group-artifact-pattern`, MIG-047) are out of scope: never created/updated/deleted, and a client echo of one (by id) is preserved as a no-op.
- Created rows are saved explicitly so the generated id is assigned for the post-flush required-tool sync + audit snapshot.

Known limitation (shared with sequential standalone updates): a single request that *swaps* two existing rows' ranges on the same attribute is rejected — do it in two saves.

## Testing

TDD. New integration test `ComponentFieldOverridesPatchTest` (H2 / `ft-db`, `@Tag("integration")` → `dbTest`) covers create / delete-omitted / upsert+delete-omitted / absent-is-no-op / combined-component-field-and-overrides-one-version-bump — **5/5 green**. Fast `test` gate (incl. `OpenApiV4SpecTest` drift) green. OpenAPI v4 spec regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)