### PR TITLE
Fix handle multiple Docker image tags in component lookup

### DIFF
--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -16,6 +16,7 @@ import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsR
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentArtifactConfigurationDTO
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.ComponentV1
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersions
@@ -114,6 +115,9 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     override fun getComponentArtifactsParameters(component: String): Map<String, ComponentArtifactConfigurationDTO> =
         componentsRegistryClient.getComponentArtifactsParameters(component)
+
+    override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> =
+        componentsRegistryClient.findComponentsByDockerImages(images)
 
     override fun getSupportedGroupIds(): Set<String> = componentsRegistryClient.getSupportedGroupIds()
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -219,10 +219,11 @@ class ComponentRegistryResolverImpl(
     }
 
     override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> {
-        val imageNames = images.map { it.name }.toSet()
-        return buildImageToComponentMap().filterKeys(imageNames::contains).mapNotNull { (imgName, component) ->
-            images.find { it.name == imgName }?.let { requiredImage ->
-                findConfigurationByImage(imgName, requiredImage.tag, component)
+        val imageToComponentMap = buildImageToComponentMap()
+        return images.mapNotNull { image ->
+            val component = imageToComponentMap[image.name]
+            component?.let {
+                findConfigurationByImage(image.name, image.tag, it)
             }
         }.toSet()
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -12,12 +12,14 @@ import org.octopusden.octopus.components.registry.core.dto.ArtifactComponentsDTO
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentArtifactConfigurationDTO
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.ComponentV1
 import org.octopusden.octopus.components.registry.core.dto.ComponentV2
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponent
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersions
 import org.octopusden.octopus.components.registry.core.dto.DistributionDTO
+import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.DocDTO
 import org.octopusden.octopus.components.registry.core.dto.EscrowDTO
 import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
@@ -303,6 +305,18 @@ class ComponentsRegistryServiceControllerTest : BaseComponentsRegistryServiceTes
             .andReturn()
             .response
             .toObject(object : TypeReference<Map<String, ComponentArtifactConfigurationDTO>>() {})
+
+    override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> =
+        mvc.perform(
+            MockMvcRequestBuilders.post("/rest/api/3/components/find-by-docker-images")
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(images))
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .toObject(object : TypeReference<Set<ComponentImage>>() {})
 
     @Test
     fun testPing() {

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -23,6 +23,7 @@ import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildParametersDTO
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentArtifactConfigurationDTO
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.ComponentInfoDTO
 import org.octopusden.octopus.components.registry.core.dto.ComponentRegistryVersion
 import org.octopusden.octopus.components.registry.core.dto.ComponentV1
@@ -34,6 +35,7 @@ import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVers
 import org.octopusden.octopus.components.registry.core.dto.DistributionDTO
 import org.octopusden.octopus.components.registry.core.dto.EscrowDTO
 import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
+import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentDTO
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionDTO
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionRangeDTO
@@ -131,6 +133,7 @@ abstract class BaseComponentsRegistryServiceTest {
     //    protected abstract fun findByArtifactsV2(artifacts: Set<ArtifactDependency>): Map<ArtifactDependency, VersionedComponent?>
     protected abstract fun findByArtifactsV3(artifacts: Set<ArtifactDependency>): ArtifactComponentsDTO
     protected abstract fun getComponentArtifactsParameters(component: String): Map<String, ComponentArtifactConfigurationDTO>
+    protected abstract fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage>
 
     @Test
     fun testGetAllJiraComponentVersionRanges() {
@@ -475,6 +478,33 @@ abstract class BaseComponentsRegistryServiceTest {
         val expectedComponent = testDataDir.resolve("expected-data/sub-component2-versioned-component.json")
             .toObject(VersionedComponent::class.java)
         Assertions.assertEquals(expectedComponent, actualComponent)
+    }
+
+    @Test
+    fun testFindComponentsByDockerImagesMultipleComponents() {
+        val images = setOf(
+            Image("test/versions-api", "1.0"),
+            Image("test-docker-1", "1.0.0"),
+            Image("test-docker-1_1", "1.0.0"),
+            Image("test-docker-1_1", "1.1.0")
+        )
+        val result = findComponentsByDockerImages(images).map {
+            it.component to it.version
+        }.toSet()
+        val expected = setOf(
+            "TESTONE" to "1.0",
+            "TEST_COMPONENT_WITH_DOCKER_1" to "1.0.0",
+            "TEST_COMPONENT_WITH_DOCKER_1_1" to "1.0.0",
+            "TEST_COMPONENT_WITH_DOCKER_1_1" to "1.1.0"
+        )
+        Assertions.assertEquals(expected, result)
+    }
+
+    @Test
+    fun testFindComponentsByDockerImagesNotFound() {
+        val images = setOf(Image("non-existent-image", "latest"))
+        val result = findComponentsByDockerImages(images)
+        Assertions.assertTrue(result.isEmpty())
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for finding components by Docker images through the API.
  * Component lookup now considers both image name and tag, improving matches when multiple tags share the same name.

* **Bug Fixes**
  * Fixed component resolution so results are selected per provided image, rather than collapsing matches by name alone.
  * Empty or non-matching Docker image queries now return no results as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->