### PR TITLE
feat(migration): reject per-range distribution.explicit/.external/.securityGroups.read (#387)

### DIFF
--- a/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
+++ b/component-resolver-core/src/main/groovy/org.octopusden/octopus/escrow/configuration/loader/EscrowConfigurationLoader.groovy
@@ -1024,8 +1024,8 @@ class EscrowConfigurationLoader {
 
     @TypeChecked(TypeCheckingMode.SKIP)
     static Distribution parseDistributionSection(ConfigObject distributionConfigObject, Distribution defaultDistribution) {
-        def explicit = distributionConfigObject.containsKey("explicit") ? distributionConfigObject.explicit : defaultDistribution.explicit()
-        def external = distributionConfigObject.containsKey("external") ? distributionConfigObject.external : defaultDistribution.external()
+        def explicit = distributionConfigObject.containsKey("explicit") ? distributionConfigObject.explicit : (defaultDistribution?.explicit() ?: false)
+        def external = distributionConfigObject.containsKey("external") ? distributionConfigObject.external : (defaultDistribution?.external() ?: false)
         def GAV = distributionConfigObject.getOrDefault("GAV", defaultDistribution?.GAV()) as String
         def DEB = distributionConfigObject.getOrDefault("DEB", defaultDistribution?.DEB()) as String
         def RPM = distributionConfigObject.getOrDefault("RPM", defaultDistribution?.RPM()) as String

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -903,6 +903,13 @@ class ImportServiceImpl(
     ) {
         if (configs.isEmpty()) return
 
+        // CRS #387: reject per-range distribution.explicit / .external /
+        // .securityGroups.read that vary across ranges — they are per-component
+        // only and the divergent value was silently dropped before. Runs before
+        // this component's own rows are written (the per-component try/catch in
+        // migrateAllComponents fails just this component, not the batch).
+        validatePerComponentDistributionInvariants(componentKey, configs)
+
         // Decoupled version model (ADR-018): the base row is ALWAYS the effective
         // default at ALL_VERSIONS, and coverage is a separate layer expressed as
         // RANGE_PRESENCE rows. `supported = ALL` exactly when the DSL declares no
@@ -1321,7 +1328,10 @@ class ImportServiceImpl(
         // vcs.externalRegistry is per-component
         entity.vcsExternalRegistry = cfg.vcsSettings?.externalRegistry
 
-        // distribution.explicit / distribution.external are per-component
+        // distribution.explicit / distribution.external are per-component; a
+        // per-range value that differs from the base is rejected at import
+        // (validatePerComponentDistributionInvariants, CRS #387), so taking the
+        // base value here can no longer silently drop a divergent per-range one.
         cfg.distribution?.let { dist ->
             entity.distributionExplicit = dist.explicit()
             entity.distributionExternal = dist.external()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/PerComponentDistributionGuard.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/PerComponentDistributionGuard.kt
@@ -1,0 +1,60 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+
+/**
+ * Fail-loud guard for per-component-only `distribution.*` fields (CRS #387).
+ *
+ * `distribution.explicit`, `distribution.external` and
+ * `distribution.securityGroups.read` are per-component by design (ADR-018): the
+ * import stores only the base value ([ImportServiceImpl.buildComponentEntity]),
+ * and per-range declarations that differ were **silently dropped** — a data-loss
+ * trap discovered via the `ee-component-with-version-ranges` DMS FT fixture.
+ * The other `distribution.*` sub-fields (maven / docker / packages / fileUrl)
+ * remain per-range via the marker child-collection route and are untouched here.
+ *
+ * Detection: these three fields must **resolve to the same value in every
+ * declared config**. The DSL loader resolves an omitted per-range field to the
+ * value it inherits from the component default (EscrowConfigurationLoader
+ * `parseDistributionSection`, `containsKey(...) ? declared : default`), so if no
+ * range declares one of them every config resolves identically and the guard is
+ * silent. A resolved difference between configs can only come from an explicit
+ * per-range declaration — exactly the data-loss case the import silently dropped.
+ *
+ * A uniformity check (rather than compare-each-against-an-arbitrary-base) is used
+ * deliberately: it is anchor-independent (correct whether or not an ALL_VERSIONS
+ * block exists), reports every offending field in one pass, and names the actual
+ * diverging ranges instead of implying the omitting one "declared" the value.
+ */
+internal fun validatePerComponentDistributionInvariants(
+    componentKey: String,
+    configs: List<EscrowModuleConfig>,
+) {
+    if (configs.size < 2) return
+
+    val fields: List<Pair<String, (EscrowModuleConfig) -> Any?>> = listOf(
+        "distribution.explicit" to { c -> c.distribution?.explicit() ?: false },
+        "distribution.external" to { c -> c.distribution?.external() ?: false },
+        "distribution.securityGroups.read" to { c -> c.distribution?.securityGroups?.read?.takeIf { it.isNotBlank() } },
+    )
+
+    val violations = fields.mapNotNull { (attribute, extractor) ->
+        val byValue = configs.groupBy(extractor)
+        if (byValue.size <= 1) return@mapNotNull null
+        val examples = byValue.entries.joinToString(", ") { (value, cfgs) ->
+            "'${cfgs.first().versionRangeString ?: ALL_VERSIONS}'=$value"
+        }
+        "$attribute ($examples)"
+    }
+
+    if (violations.isEmpty()) return
+
+    throw IllegalStateException(
+        "Component '$componentKey' varies per-component-only distribution field(s) across version " +
+            "ranges: ${violations.joinToString("; ")}. These fields (explicit / external / " +
+            "securityGroups.read) are per-component only — declare each once at the top-level " +
+            "distribution block so every range resolves the same value. The other distribution.* " +
+            "fields (maven/docker/packages/fileUrl) remain per-range. See CRS #387 / ADR-018.",
+    )
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/PerComponentDistributionGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/PerComponentDistributionGuardTest.kt
@@ -75,4 +75,24 @@ class PerComponentDistributionGuardTest {
             validatePerComponentDistributionInvariants(component, loadConfigs("TopLevelOnly.groovy"))
         }
     }
+
+    @Test
+    @DisplayName("rejects when the FIRST-declared block is the divergent one and a later block omits (order-independent)")
+    fun rejectsWhenFirstBlockDivergesAndLaterOmits() {
+        val ex = assertThrows<IllegalStateException> {
+            validatePerComponentDistributionInvariants(component, loadConfigs("FirstBlockDiverges.groovy"))
+        }
+        val msg = ex.message!!
+        assertTrue(msg.contains("distribution.explicit"), "message names the attribute: $msg")
+        assertTrue(msg.contains("[03.53,03.54)"), "message names the declaring range: $msg")
+        assertTrue(msg.contains("[03.54,03.55)"), "message names the inheriting range: $msg")
+    }
+
+    @Test
+    @DisplayName("loads + passes when a range declares distribution with no top-level default (loader null-safety)")
+    fun acceptsRangeDistributionWithoutTopLevelDefault() {
+        assertDoesNotThrow {
+            validatePerComponentDistributionInvariants(component, loadConfigs("NoTopLevelDistribution.groovy"))
+        }
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/PerComponentDistributionGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/PerComponentDistributionGuardTest.kt
@@ -1,0 +1,78 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.nio.file.Files
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.octopusden.octopus.components.registry.api.enums.ProductTypes
+import org.octopusden.octopus.escrow.configuration.loader.ComponentRegistryInfo
+import org.octopusden.octopus.escrow.configuration.loader.ConfigLoader
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.octopusden.releng.versions.VersionNames
+
+/**
+ * CRS #387 — the import must reject per-range distribution.explicit / .external /
+ * .securityGroups.read that diverge from the base, and must NOT fire when a range
+ * merely omits them (loader inherits the base). Driven through the REAL DSL loader
+ * over self-contained fixtures so the declared-vs-inherited resolution is authentic
+ * (loader wiring mirrors RangeOnlyParityGuardTest). Plain unit test — no Spring/DB —
+ * so it runs under `:test`.
+ */
+class PerComponentDistributionGuardTest {
+
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val component = "vrComponent"
+
+    private fun loadConfigs(fixture: String): List<EscrowModuleConfig> {
+        val productTypes = ProductTypes.values().associateWith { it.name }
+        val loader = EscrowConfigurationLoader(
+            ConfigLoader(
+                ComponentRegistryInfo.fromClassPath("per-range-distribution-guard/$fixture"),
+                versionNames,
+                productTypes,
+            ),
+            listOf("org.octopusden.octopus", "io.bcomponent"),
+            listOf("NONE", "CLASSIC", "ALFA"),
+            versionNames,
+            Files.createTempDirectory("per-range-dist-guard-copyrights"),
+        )
+        val config = loader.loadFullConfigurationWithoutValidationForUnknownAttributes(emptyMap<String, String>())
+        return config.escrowModules[component]!!.moduleConfigurations
+    }
+
+    @Test
+    @DisplayName("rejects per-range distribution.explicit / .external that diverge from the base")
+    fun rejectsDivergentBooleans() {
+        val ex = assertThrows<IllegalStateException> {
+            validatePerComponentDistributionInvariants(component, loadConfigs("DivergentBooleans.groovy"))
+        }
+        val msg = ex.message!!
+        assertTrue(msg.contains("distribution.explicit"), "message names the attribute: $msg")
+        assertTrue(msg.contains("distribution.external"), "message names the attribute: $msg")
+        assertTrue(msg.contains("[03.54,03.55)"), "message names the offending range: $msg")
+        assertTrue(msg.contains(component), "message names the component: $msg")
+    }
+
+    @Test
+    @DisplayName("rejects per-range distribution.securityGroups.read that diverges from the base")
+    fun rejectsDivergentSecurityGroups() {
+        val ex = assertThrows<IllegalStateException> {
+            validatePerComponentDistributionInvariants(component, loadConfigs("DivergentSecurityGroups.groovy"))
+        }
+        assertTrue(
+            ex.message!!.contains("distribution.securityGroups.read"),
+            "message names the attribute: ${ex.message}",
+        )
+    }
+
+    @Test
+    @DisplayName("accepts ranges that omit the per-component fields and change only docker (inherited == base)")
+    fun acceptsTopLevelOnlyWithPerRangeDocker() {
+        assertDoesNotThrow {
+            validatePerComponentDistributionInvariants(component, loadConfigs("TopLevelOnly.groovy"))
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
@@ -14,6 +14,7 @@ import org.octopusden.octopus.components.registry.server.entity.ComponentConfigu
 import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
 import org.octopusden.octopus.components.registry.server.entity.ComponentRequiredToolEntity
 import org.octopusden.octopus.components.registry.server.entity.DistributionDockerImageEntity
+import org.octopusden.octopus.components.registry.server.entity.DistributionSecurityGroupEntity
 import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
 import org.octopusden.releng.versions.NumericVersionFactory
@@ -385,6 +386,31 @@ class ComponentCodeRendererTest {
         assertTrue(out.contains("docker {"), out)
         assertTrue(out.contains("imageName = \"acme/svc\""), out)
         assertTrue(out.contains("flavor = \"slim\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: per-range distribution block renders markers but NOT the per-component fields (CRS #387)")
+    fun fullPerRangeDistributionOmitsPerComponentFields() {
+        val c = component()
+        c.distributionExplicit = true
+        c.distributionExternal = true
+        c.securityGroups.add(DistributionSecurityGroupEntity(component = c, groupType = "read", groupName = "grp-a"))
+        base(c) { buildSystem = "MAVEN" }
+        val m = marker(c, "[2,)", MarkerAttributes.DISTRIBUTION_DOCKER) {}
+        m.dockerImages.add(docker(m, image = "acme/svc", flavor = "slim"))
+
+        val out = renderer.renderFull(c)
+        // Base distribution carries the per-component fields.
+        assertTrue(out.contains("explicit = true"), out)
+        assertTrue(out.contains("external = true"), out)
+        assertTrue(out.contains("securityGroups {"), out)
+        // The per-range block renders only the docker marker — never the per-component
+        // fields (explicit / external / securityGroups.read), which would leak per-range.
+        val rangeBlock = out.substringAfter("\"[2,)\" {")
+        assertTrue(rangeBlock.contains("docker {"), rangeBlock)
+        assertFalse(rangeBlock.contains("explicit"), rangeBlock)
+        assertFalse(rangeBlock.contains("external"), rangeBlock)
+        assertFalse(rangeBlock.contains("securityGroups"), rangeBlock)
     }
 
     @Test

--- a/components-registry-service-server/src/test/resources/per-range-distribution-guard/DivergentBooleans.groovy
+++ b/components-registry-service-server/src/test/resources/per-range-distribution-guard/DivergentBooleans.groovy
@@ -1,0 +1,58 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// CRS #387 fixture — a component whose bounded range blocks DECLARE
+// distribution.explicit / distribution.external differing from the base
+// (first declared block). The import guard must reject this loudly instead of
+// silently dropping the per-range values and taking the base.
+
+Defaults {
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+}
+
+vrComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/vr"
+    groupId = "org.octopusden.octopus.vr"
+
+    distribution {
+        explicit = false
+        external = true
+        docker = "test/vr"
+    }
+
+    // Base (first declared block): explicit=false, external=true (inherited).
+    "[03.53,03.54)" {
+        distribution {
+            explicit = false
+            external = true
+            docker = "test/vr"
+        }
+    }
+
+    // Diverges on BOTH per-component-only flags — must be rejected.
+    "[03.54,03.55)" {
+        distribution {
+            explicit = true
+            external = false
+            docker = "test/vr"
+        }
+    }
+
+    jira {
+        projectKey = "VR"
+    }
+}

--- a/components-registry-service-server/src/test/resources/per-range-distribution-guard/DivergentSecurityGroups.groovy
+++ b/components-registry-service-server/src/test/resources/per-range-distribution-guard/DivergentSecurityGroups.groovy
@@ -1,0 +1,62 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// CRS #387 fixture — a bounded range block DECLARES a distribution.securityGroups.read
+// differing from the base. securityGroups.read is per-component only; the import
+// guard must reject this.
+
+Defaults {
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+}
+
+vrComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/vr"
+    groupId = "org.octopusden.octopus.vr"
+
+    distribution {
+        explicit = true
+        external = true
+        docker = "test/vr"
+        securityGroups {
+            read = "grp-a"
+        }
+    }
+
+    // Base (first declared block): read=grp-a (inherited).
+    "[03.53,03.54)" {
+        distribution {
+            docker = "test/vr"
+            securityGroups {
+                read = "grp-a"
+            }
+        }
+    }
+
+    // Diverges on securityGroups.read — must be rejected.
+    "[03.54,03.55)" {
+        distribution {
+            docker = "test/vr"
+            securityGroups {
+                read = "grp-b"
+            }
+        }
+    }
+
+    jira {
+        projectKey = "VR"
+    }
+}

--- a/components-registry-service-server/src/test/resources/per-range-distribution-guard/FirstBlockDiverges.groovy
+++ b/components-registry-service-server/src/test/resources/per-range-distribution-guard/FirstBlockDiverges.groovy
@@ -1,0 +1,58 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// CRS #387 fixture — the "base/first-position block is the divergent one" case.
+// The component default is explicit=false; the FIRST declared block sets
+// explicit=true, while a LATER block omits it (inherits the default false). The
+// two ranges therefore resolve different values for a per-component-only field —
+// a genuine per-range divergence the guard must reject regardless of which block
+// (first or later) carries the declaration. Locks in that the uniformity check is
+// order-independent (it is not anchored to configs.first()).
+
+Defaults {
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+}
+
+vrComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/vr"
+    groupId = "org.octopusden.octopus.vr"
+
+    distribution {
+        explicit = false
+        external = false
+        docker = "test/vr"
+    }
+
+    // First-declared block DECLARES explicit=true (diverges from the default).
+    "[03.53,03.54)" {
+        distribution {
+            explicit = true
+            docker = "test/vr"
+        }
+    }
+
+    // Later block omits explicit → inherits the default (false). Divergence.
+    "[03.54,03.55)" {
+        distribution {
+            docker = "test/vr"
+        }
+    }
+
+    jira {
+        projectKey = "VR"
+    }
+}

--- a/components-registry-service-server/src/test/resources/per-range-distribution-guard/NoTopLevelDistribution.groovy
+++ b/components-registry-service-server/src/test/resources/per-range-distribution-guard/NoTopLevelDistribution.groovy
@@ -1,0 +1,48 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// Regression fixture for the loader null-safety fix (parseDistributionSection):
+// the component declares NO top-level distribution block, so the per-range default
+// Distribution is null, and each range block declares only a per-range marker field
+// (docker) while omitting explicit/external. Before the fix, resolving the omitted
+// booleans dereferenced a null default and NPE'd at load time. After the fix they
+// default to false, both ranges resolve identically, and the guard stays silent.
+
+Defaults {
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+}
+
+vrComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/vr"
+    groupId = "org.octopusden.octopus.vr"
+
+    "[03.53,03.54)" {
+        distribution {
+            docker = "test/vr"
+        }
+    }
+
+    "[03.54,03.55)" {
+        distribution {
+            docker = "test/vr-next"
+        }
+    }
+
+    jira {
+        projectKey = "VR"
+    }
+}

--- a/components-registry-service-server/src/test/resources/per-range-distribution-guard/TopLevelOnly.groovy
+++ b/components-registry-service-server/src/test/resources/per-range-distribution-guard/TopLevelOnly.groovy
@@ -1,0 +1,60 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// CRS #387 fixture — the P1 must-NOT-fail case. The per-component-only fields
+// (explicit / external / securityGroups.read) are declared ONLY at the top level
+// with non-default values (true / true / grp-a). The bounded range blocks OMIT
+// them and change only per-range distribution data (docker). The loader resolves
+// the omitted fields to the inherited base value, so the guard must see them as
+// EQUAL to the base and NOT fire — proving detection keys on declared-vs-inherited,
+// not resolved-vs-false.
+
+Defaults {
+    system = "NONE"
+    releasesInDefaultBranch = true
+    solution = false
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer {
+            versionFormat = '$versionPrefix-$baseVersionFormat'
+        }
+    }
+}
+
+vrComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/vr"
+    groupId = "org.octopusden.octopus.vr"
+
+    distribution {
+        explicit = true
+        external = true
+        docker = "test/vr"
+        securityGroups {
+            read = "grp-a"
+        }
+    }
+
+    // Base block: inherits explicit=true / external=true / read=grp-a.
+    "[03.53,03.54)" {
+        distribution {
+            docker = "test/vr"
+        }
+    }
+
+    // Changes ONLY the per-range docker image; omits the per-component fields.
+    "[03.54,03.55)" {
+        distribution {
+            docker = "test/vr-next"
+        }
+    }
+
+    jira {
+        projectKey = "VR"
+    }
+}

--- a/docs/registry/adr/018-decoupled-version-model.md
+++ b/docs/registry/adr/018-decoupled-version-model.md
@@ -130,6 +130,34 @@ Model a component's configuration as **two independent layers**:
   use `MAVEN` (equal to the Defaults value), so their per-range value is a no-op against the base.
   **No path to a null base `build_system` → the DB CHECK is kept unchanged (no relaxation).**
 
+### `distribution.*` — per-range vs per-component (CRS #387)
+
+The `distribution` block mixes two storage classes. The marker child-collections vary per range
+(stored as `MARKER` override rows and resolved via `pickMarkerChildren`); three scalar-ish fields are
+per-component only, stored on the `components` row and **never** overridable per range:
+
+| Field | Per-range | Storage |
+|---|---|---|
+| `distribution.gav` (mavenArtifacts) | yes | `DISTRIBUTION_MAVEN` marker, `distribution_maven_artifacts` |
+| `distribution.docker` | yes | `DISTRIBUTION_DOCKER` marker, `distribution_docker_images` |
+| `distribution.deb` / `rpm` (packages) | yes | `DISTRIBUTION_PACKAGES` marker, `distribution_packages` |
+| `distribution.fileUrl` | yes | `DISTRIBUTION_FILE_URL` marker, `distribution_file_url_artifacts` |
+| `distribution.explicit` | **no** | `components.distribution_explicit` |
+| `distribution.external` | **no** | `components.distribution_external` |
+| `distribution.securityGroups.read` | **no** | `distribution_security_groups` (`group_type='read'`, group id in `group_name`) |
+
+A bounded-range block that declares one of the three per-component fields with a value differing from
+the base was **silently dropped** before (`buildEscrowModuleConfig` reads only the base scalar), so
+`resolve` returned the base at every version — a data-loss trap surfaced by the DMS
+`ee-component-with-version-ranges` FT fixture. The import now **fails loud**
+(`validatePerComponentDistributionInvariants`, `ImportServiceImpl`): for every non-base config it
+compares the resolved `explicit` / `external` / `securityGroups.read` against the base and throws
+naming the component, range, and attribute(s). Because the DSL loader resolves an omitted per-range
+field to the value it inherits from the component default, a range that merely omits these fields
+resolves equal to the base and does not trip the guard. As-code rendering
+(`ComponentCodeRenderer.writeMarkerDistribution`) emits only the four marker attributes per range and
+never renders `explicit` / `external` / `securityGroups.read` inside a per-range block.
+
 ## Consequences
 
 **Positive**


### PR DESCRIPTION
## What & why

Closes #387. `distribution.explicit`, `distribution.external` and
`distribution.securityGroups.read` are **per-component only** (ADR-018), but the DSL
grammar accepts them inside bounded-range blocks. When a per-range value differed
from the base, the import **silently dropped it** and `resolve` returned the base — a
data-loss trap surfaced by the DMS `ee-component-with-version-ranges` FT fixture.

## How

The import now **fails loud** — `validatePerComponentDistributionInvariants` (new
`PerComponentDistributionGuard.kt`, run at the top of `ImportServiceImpl.importModule`).

The declared-vs-inherited signal is lost by the time the import sees the resolved
`EscrowModuleConfig` (the loader resolves an omitted per-range field to the
component-level default via `containsKey ? declared : default`, then discards the raw
node). So the guard uses a **uniformity check**: these three fields must resolve to
the same value in *every* config. If no range declares one, all configs resolve
identically and the guard is silent; a divergence can only come from an explicit
per-range declaration — exactly the data-loss case. This is anchor-independent
(correct whether or not an ALL_VERSIONS block exists), reports every offending field
in one pass, and names the actually-diverging ranges.

The four marker distribution fields (maven/docker/packages/fileUrl) remain per-range
and are untouched. `ComponentCodeRenderer.writeMarkerDistribution` already omits the
three per-component fields from per-range blocks — locked in by a confirming test.

## Testing

- `PerComponentDistributionGuardTest` — RED (divergent booleans; divergent
  `securityGroups.read`) + the must-not-fail GREEN (top-level-only values, ranges omit
  them and change only docker → inherited == base → no throw), driven through the real
  DSL loader over fixtures.
- `ComponentCodeRendererTest` — per-range block renders docker but not
  `explicit`/`external`/`securityGroups`.
- ADR-018: per-range vs per-component `distribution.*` storage table.

Fast `test` gate green; no regressions in existing import/migration tests. Two Sonnet
review rounds (iterate-to-clean); the guard was reworked to the uniformity model and
the ADR storage-column table corrected per review.

## Follow-up

Once this lands, `octopus-dms-service` `chore/crs-ft-db` needs the companion fixture/
test rescope (drop per-range `explicit`/`external` from `ee-component-with-version-ranges`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)