### PR TITLE
feat(migration): merge adjacent same-value scalar overrides (MIG-048)

### DIFF
--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -159,8 +159,9 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
     fun testGetAllComponents() {
         // 56 pre-MIG-041 + 2 aggregator-handling fixtures (TEST_AGGREGATOR_FAKE +
         // TEST_AGGREGATOR_MEMBER) + 1 task-#16 fixture (TEST_PER_RANGE_HOTFIX_FORMAT)
+        // + 1 MIG-048 fixture (TEST_MERGED_SCALAR_OVERRIDES),
         // which all inherit the Defaults `system = "NONE"`.
-        assertEquals(59, componentsRegistryClient.getAllComponents().components.size)
+        assertEquals(60, componentsRegistryClient.getAllComponents().components.size)
         assertEquals(
             3,
             componentsRegistryClient.getAllComponents("ssh://hg@mercurial/technical", null).components.size,
@@ -176,11 +177,11 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
         )
         assertEquals(2, componentsRegistryClient.getAllComponents(systems = listOf("ALFA")).components.size)
         assertEquals(6, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC")).components.size)
-        assertEquals(53, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
+        assertEquals(54, componentsRegistryClient.getAllComponents(systems = listOf("NONE")).components.size)
         assertEquals(6, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC")).components.size)
-        assertEquals(55, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "NONE")).components.size)
-        assertEquals(59, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
-        assertEquals(59, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC", "NONE", "TEST")).components.size)
+        assertEquals(56, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "NONE")).components.size)
+        assertEquals(60, componentsRegistryClient.getAllComponents(systems = listOf("CLASSIC", "NONE")).components.size)
+        assertEquals(60, componentsRegistryClient.getAllComponents(systems = listOf("ALFA", "CLASSIC", "NONE", "TEST")).components.size)
     }
 
     @Test

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1002,10 +1002,16 @@ class ImportServiceImpl(
         // of its own — it equals the base by construction; the OLDER blocks become the overrides. No
         // RES-001 fallback presence row: coverage is the merged union above, and an empty block (no
         // value change vs base) simply contributes no edge.
+        //
+        // Scalar overrides are emitted MERGED per attribute (MIG-048): with base = the newest block,
+        // an attribute set only there makes EVERY older block diff identically (they all inherit the
+        // same top-level/Defaults value), which would emit one identical row per block. Adjacent
+        // same-value ranges collapse into their union (spec: "adjacent same-value MAY be merged").
+        // Markers stay per declared block — their per-block boundaries also anchor enumeration edges.
         val tOverridesStart = System.nanoTime()
         val nonBaseConfigs = configs.filter { it !== baseConfig }
+        emitMergedScalarOverrides(saved, baseConfig, nonBaseConfigs)
         for (override in nonBaseConfigs) {
-            emitScalarOverrides(saved, baseConfig, override)
             emitMarkerOverrides(saved, savedBase, baseConfig, override)
         }
         val tOverridesMs = (System.nanoTime() - tOverridesStart) / 1_000_000
@@ -1547,7 +1553,7 @@ class ImportServiceImpl(
 
     /**
      * Emit a RANGE_PRESENCE row for a DSL-declared version range whose
-     * scalars/markers all match base (so neither `emitScalarOverrides` nor
+     * scalars/markers all match base (so neither `emitMergedScalarOverrides` nor
      * `emitMarkerOverrides` produced any row). Without this, the range is
      * invisible to the resolver and disappears from
      * `/jira-component-version-ranges` and `/{component}/maven-artifacts`
@@ -1660,14 +1666,32 @@ class ImportServiceImpl(
     // =========================================================================
 
     /**
-     * Emit scalar override rows for each scalar attribute that differs
-     * between [base] config and [override] config.
+     * Emit SCALAR_OVERRIDE rows for every attribute where a non-base config differs from the base,
+     * MERGING adjacent/overlapping ranges that carry the same value into one row (MIG-048).
+     *
+     * With the base = the OPEN-UPPER (newest) block (ADR-018 amendment), an attribute declared only
+     * there makes every OLDER block diff identically against it — they all resolve the same inherited
+     * top-level/Defaults value — which would emit one identical row per declared block (e.g. two
+     * adjacent `javaVersion=1.8` rows). The spec allows merging ("adjacent same-value MAY be merged"),
+     * so ranges are grouped per (attribute, value) and collapsed via [VersionRangePartition.mergeUnion]
+     * with the component's scheme-aware ordering. Non-adjacent same-value ranges stay separate rows.
+     *
+     * Defensive guard: if a merged union collapses to the all-versions shape, the group's VERBATIM
+     * per-block ranges are emitted instead — a SCALAR_OVERRIDE at ALL_VERSIONS would shadow the base
+     * row for the whole version space. The shape is unreachable today ONLY because of a loader
+     * invariant, not structure: the Groovy loader merges top-level defaults INTO each range config
+     * rather than emitting a separate all-versions config (see [isAllVersionsRange] KDoc), so
+     * `selectBaseConfig` branch 1 (explicit all-versions base) never coexists with bounded siblings
+     * whose union tiles everything. If it ever fires, the fallback deliberately reintroduces the
+     * duplicated-adjacent-rows shape this merge removes (fail-safe over fail-wrong), and the verbatim
+     * strings are unnormalized DSL text — the idempotency lookup below then depends on DSL string
+     * stability.
      */
     @Suppress("CyclomaticComplexMethod")
-    private fun emitScalarOverrides(
+    private fun emitMergedScalarOverrides(
         component: ComponentEntity,
         base: EscrowModuleConfig,
-        override: EscrowModuleConfig,
+        nonBaseConfigs: List<EscrowModuleConfig>,
     ): List<ComponentConfigurationEntity> {
         // Transient throwaway entities used only as carriers for the diff
         // computation; never persisted. They still need a `rowType` because
@@ -1681,42 +1705,69 @@ class ImportServiceImpl(
             )
         populateScalarsFromConfig(baseRow, base)
 
-        val overRow =
-            ComponentConfigurationEntity(
-                component = component,
-                versionRange = "",
-                rowType = "BASE",
-            )
-        populateScalarsFromConfig(overRow, override)
-
-        val versionRange = override.versionRangeString ?: return emptyList()
-
-        val saved = mutableListOf<ComponentConfigurationEntity>()
-        // Collect changed scalar attribute → value pairs
-        val changed = collectScalarDiffs(baseRow, overRow)
-        for ((attrPath, newValue) in changed) {
-            // Avoid duplicate rows for same (component, range, attribute)
-            val existing =
-                configurationRepository.findByComponentIdAndVersionRangeAndOverriddenAttribute(
-                    component.id!!,
-                    versionRange,
-                    attrPath,
-                )
-            if (existing != null) {
-                saved += existing
-                continue // idempotent
-            }
-
-            val scalarRow =
+        // (attribute, value) -> the declared ranges carrying that diff. The value is part of the
+        // grouping key (nullable — an explicit null-clear groups like any other value), so only
+        // SAME-value ranges ever merge; a range with a different value keeps its own group.
+        val rangesByAttrValue = LinkedHashMap<Pair<String, Any?>, MutableList<String>>()
+        for (override in nonBaseConfigs) {
+            val versionRange = override.versionRangeString ?: continue
+            val overRow =
                 ComponentConfigurationEntity(
                     component = component,
-                    versionRange = versionRange,
-                    overriddenAttribute = attrPath,
-                    rowType = "SCALAR_OVERRIDE",
-                    isSyntheticBase = false,
+                    versionRange = "",
+                    rowType = "BASE",
                 )
-            applyScalarValueToRow(scalarRow, attrPath, newValue)
-            saved += configurationRepository.save(scalarRow)
+            populateScalarsFromConfig(overRow, override)
+            for ((attrPath, newValue) in collectScalarDiffs(baseRow, overRow)) {
+                rangesByAttrValue.getOrPut(attrPath to newValue) { mutableListOf() }.add(versionRange)
+            }
+        }
+
+        val saved = mutableListOf<ComponentConfigurationEntity>()
+        val compare = numericVersionComparator(numericVersionFactory)
+        for ((attrValue, ranges) in rangesByAttrValue) {
+            val (attrPath, newValue) = attrValue
+            // The jira uniqueness pair `(projectKey, versionPrefix)` is reconstructed from PERSISTED
+            // rows by grouping on the EXACT versionRange (computeEffectiveJiraPairs: pkRow+prefixRow
+            // must sit in the SAME range group; mirrored by the API-side validator). Merging one of
+            // the two attributes independently of the other would tear companion rows apart —
+            // e.g. a widened projectKey row paired with the BASE prefix instead of its range's
+            // prefix — corrupting collision detection. Keep these two attributes on their VERBATIM
+            // per-block ranges; every other scalar merges.
+            val merged =
+                if (attrPath in JIRA_UNIQUENESS_PAIR_ATTRS) ranges
+                else VersionRangePartition.mergeUnion(ranges, compare)
+            val effectiveRanges = if (merged.any { isAllVersionsRange(it) }) ranges else merged
+            for (versionRange in effectiveRanges) {
+                // Avoid duplicate rows for same (component, range, attribute). NOTE: this exact-range
+                // lookup assumes import never re-runs over a component that already has override rows
+                // (both importModule call sites hard-skip components present in the DB). If a
+                // re-migration/refresh path is ever added, rows persisted by an OLDER import at
+                // unmerged per-block ranges would NOT be found under the merged range and the same
+                // attribute would end up with overlapping rows — there is no import-side disjointness
+                // validator (validateFieldOverrideRange guards only the v4 API write path).
+                val existing =
+                    configurationRepository.findByComponentIdAndVersionRangeAndOverriddenAttribute(
+                        component.id!!,
+                        versionRange,
+                        attrPath,
+                    )
+                if (existing != null) {
+                    saved += existing
+                    continue // idempotent
+                }
+
+                val scalarRow =
+                    ComponentConfigurationEntity(
+                        component = component,
+                        versionRange = versionRange,
+                        overriddenAttribute = attrPath,
+                        rowType = "SCALAR_OVERRIDE",
+                        isSyntheticBase = false,
+                    )
+                applyScalarValueToRow(scalarRow, attrPath, newValue)
+                saved += configurationRepository.save(scalarRow)
+            }
         }
         return saved
     }
@@ -2525,6 +2576,14 @@ class ImportServiceImpl(
 
     companion object {
         private val LOG = LoggerFactory.getLogger(ImportServiceImpl::class.java)
+
+        /**
+         * Attributes EXCLUDED from adjacent same-value override merging (MIG-048): the jira
+         * uniqueness pair is reconstructed from persisted rows by exact-range grouping
+         * (`computeEffectiveJiraPairs`), so `jira.projectKey` / `jira.versionPrefix` rows must keep
+         * their verbatim per-block ranges — see [emitMergedScalarOverrides].
+         */
+        private val JIRA_UNIQUENESS_PAIR_ATTRS = setOf("jira.projectKey", "jira.versionPrefix")
 
         /** Exact-string FAKE-aggregator artifactId markers. */
         private val FAKE_ARTIFACT_ID_LITERALS: Set<String> = setOf("fake", "dummy", "stub")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/ComponentsRegistryServiceControllerTest.kt
@@ -115,7 +115,7 @@ class ComponentsRegistryServiceControllerTest : MockMvcRegistryTestSupport() {
         expectedComponent.copyright = "companyName1"
         expectedComponent.labels = setOf("Label2")
 
-        Assertions.assertEquals(59, components.components.size)
+        Assertions.assertEquals(60, components.components.size)
         Assertions.assertTrue(expectedComponent in components.components) {
             components.components.toString()
         }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MetricsTest.kt
@@ -51,7 +51,7 @@ class MetricsTest {
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("components.buildsystem.count"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].statistic").value("VALUE"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(57.0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.measurements[0].value").value(58.0))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].tag").value("buildSystem"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.availableTags[0].values").isArray)
             .andExpect(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -528,6 +528,65 @@ class MigrationIntegrationTest {
     }
 
     // =========================================================================
+    // MIG-048: adjacent same-value scalar overrides merge into one row.
+    // =========================================================================
+
+    @Test
+    @DisplayName(
+        "MIG-048: TEST_MERGED_SCALAR_OVERRIDES — two adjacent older blocks that resolve the SAME " +
+            "inherited build.javaVersion emit ONE merged SCALAR_OVERRIDE (,3.0), not one row per block; " +
+            "a value differing only in one block (build.mavenVersion) keeps its own verbatim range",
+    )
+    fun mig048_adjacentSameValueScalarOverridesMerged() {
+        val component = componentRepository.findByComponentKey("TEST_MERGED_SCALAR_OVERRIDES")
+        assertNotNull(component, "TEST_MERGED_SCALAR_OVERRIDES must be migrated")
+
+        val allRows = configurationRepository.findByComponentId(component!!.id!!)
+
+        // Base = the open-upper [3.0,) block (ADR-018 amendment): javaVersion 17.
+        val baseRow = configurationRepository.findBaseByComponentId(component.id!!)
+        assertNotNull(baseRow, "must have a base row")
+        assertEquals("17", baseRow!!.javaVersion, "BASE must carry the open-upper javaVersion")
+
+        // BOTH older blocks ((,2.0) and [2.0,3.0)) resolve the inherited top-level javaVersion 1.8 —
+        // adjacent + same value ⇒ ONE merged override over their union (,3.0). Two per-block rows
+        // ((,2.0) and [2.0,3.0)) would be the unmerged regression shape.
+        val javaOverrides = allRows.filter { it.rowType == "SCALAR_OVERRIDE" && it.overriddenAttribute == "build.javaVersion" }
+        assertEquals(
+            1, javaOverrides.size,
+            "Adjacent same-value javaVersion overrides must merge into one row. " +
+                "Found: ${javaOverrides.map { "${it.versionRange}=${it.javaVersion}" }}",
+        )
+        assertEquals("(,3.0)", javaOverrides.single().versionRange, "merged range must be the union of the two older blocks")
+        assertEquals("1.8", javaOverrides.single().javaVersion)
+
+        // mavenVersion differs from base ONLY in the first block — it must keep its own verbatim
+        // range and must NOT be widened by the javaVersion merge.
+        val mavenOverrides = allRows.filter { it.rowType == "SCALAR_OVERRIDE" && it.overriddenAttribute == "build.mavenVersion" }
+        assertEquals(
+            listOf("(,2.0)"), mavenOverrides.map { it.versionRange },
+            "mavenVersion override must stay on its own declared range",
+        )
+        assertEquals("3.6.3", mavenOverrides.single().mavenVersion)
+
+        // jira.versionPrefix is set only in the newest block too (both older blocks null-clear it,
+        // same value = null), BUT it is a jira uniqueness-pair attribute: computeEffectiveJiraPairs
+        // reconstructs (projectKey, versionPrefix) by EXACT-range grouping of the persisted rows, so
+        // these rows must stay on their verbatim per-block ranges — excluded from the merge.
+        val prefixOverrides = allRows
+            .filter { it.rowType == "SCALAR_OVERRIDE" && it.overriddenAttribute == "jira.versionPrefix" }
+            .sortedBy { it.versionRange }
+        assertEquals(
+            listOf("(,2.0)", "[2.0,3.0)"), prefixOverrides.map { it.versionRange },
+            "jira.versionPrefix rows must stay verbatim per block (uniqueness-pair attr, never merged)",
+        )
+        assertTrue(
+            prefixOverrides.all { it.jiraVersionPrefix == null },
+            "both older blocks null-clear the newest-block prefix",
+        )
+    }
+
+    // =========================================================================
     // MIG-041: §6.3 aggregator handling — component_groups rows + is_fake + component_group_id FK
     // =========================================================================
 

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -524,7 +524,7 @@ the override rows below.
 
 For each declared version-range block in DSL **except the one chosen as the base** (§6.4 — the
 open-upper/newest block; older & historical-left blocks are the ones that survive here) (override/value layer):
-- For each scalar attribute whose value differs from the `ALL_VERSIONS` base row: emit scalar override row (`overridden_attribute = 'aspect.field'`, single column set), on the block's range. Under the 2026-07 base-VALUE amendment these are the OLDER blocks (the newest block equals the base and emits nothing).
+- For each scalar attribute whose value differs from the `ALL_VERSIONS` base row: emit scalar override row (`overridden_attribute = 'aspect.field'`, single column set). Under the 2026-07 base-VALUE amendment these are the OLDER blocks (the newest block equals the base and emits nothing). Ranges are emitted MERGED per (attribute, value) — adjacent/overlapping same-value blocks collapse into one row via `mergeUnion` (MIG-048, `ImportServiceImpl.emitMergedScalarOverrides`); non-adjacent same-value ranges stay separate. EXCEPTION: `jira.projectKey` / `jira.versionPrefix` always keep their verbatim per-block ranges — the jira uniqueness pair is reconstructed from persisted rows by exact-range grouping (`computeEffectiveJiraPairs`), and independently-widened companion rows would tear the pairs apart.
 - For each child-collection change (multi-VCS, distribution_*, requiredTools): emit marker row (`overridden_attribute = '<marker>'`, all typed scalars NULL) + child rows attached. Base VCS/distribution/tools now come from the newest block too.
 
 Override detection deduplicates against the `ALL_VERSIONS` base: a scalar/marker row is emitted only

--- a/docs/registry/version-model-spec-DRAFT.md
+++ b/docs/registry/version-model-spec-DRAFT.md
@@ -78,10 +78,15 @@ migrate(legacy DSL):
   declaredRanges = the block range strings, VERBATIM (incl composites)  // persisted as RANGE_PRESENCE rows
   supported      = ∪ declaredRanges                       || ALL        (no blocks → all versions)
   base(A)        = effective value of the OPEN-UPPER (newest) range   // ALL_VERSIONS row; superseded 2026-07 (was top-level ⊕ Defaults)
-  overrides      = per attribute, derived from the OLDER blocks (newest = base); adjacent same-value MAY be merged.
-                   NOTE: enumeration currently DOES key off override edges, so two adjacent value-identical
-                   OLDER blocks yield two identical views. Preferred fix = clean the redundant blocks in the
-                   source DSL (old CR) / fixtures, NOT a resolver-side collapse. See §compat.
+  overrides      = per attribute, derived from the OLDER blocks (newest = base); adjacent same-value
+                   SCALAR overrides ARE merged at import (MIG-048, ImportServiceImpl.emitMergedScalarOverrides:
+                   ranges grouped per (attribute, value), collapsed via mergeUnion) — with base = newest,
+                   an attribute set only there would otherwise emit one identical row per older block.
+                   Markers stay per declared block (their boundaries anchor enumeration edges).
+                   NOTE: enumeration keys off override edges, so two FULL-twin adjacent blocks (identical
+                   in every attribute incl. markers) would still collapse a view. Preferred fix for full
+                   twins = clean the redundant blocks in the source DSL (old CR) / fixtures, NOT a
+                   resolver-side collapse. See §compat.
   // no synthetic-bounded base
 
 enumerate(component):                                    // v2/v3 range-list endpoints
@@ -124,8 +129,23 @@ Notes:
 
 ## 5. Enumeration is anchored to declared ranges (so per-attribute merge is safe)
 
+> **SUPERSEDED (ADR-018 redesign refinement + MIG-048).** This section describes the FIRST-CUT
+> anchoring (verbatim per-block RANGE_PRESENCE; enumeration iterates declared ranges). The shipped
+> redesign stores coverage MERGED and computes enumeration as the partition of `supported` by
+> override/ownership VALUE-CHANGE edges — so override edges DO drive enumeration now. The merge
+> conclusion survives with a narrower argument: merging adjacent SAME-VALUE scalar overrides removes
+> only an edge between two sub-ranges that resolved identically (a no-op view boundary), so
+> enumeration output is unchanged; marker rows stay per block and keep their edges. Implemented at
+> import by `ImportServiceImpl.emitMergedScalarOverrides` (jira uniqueness-pair attributes excluded —
+> see §migrate() note above and schema-spec §6.5).
+
+*Historical first-cut reasoning below — retained verbatim for the review record; the anchoring it
+describes (verbatim RANGE_PRESENCE iteration) was replaced by the edge-partition redesign per the
+note above.*
+
 The earlier "do not merge" rule is **withdrawn** — it conflated two things the model now keeps
-separate. Enumeration does **not** recompute a partition from override edges; it iterates the
+separate. Enumeration does **not** recompute a partition from override edges *(first-cut; shipped
+enumeration DOES partition by edges)*; it iterates the
 **preserved declared ranges** (RANGE_PRESENCE, stored verbatim — composites included). Therefore:
 
 - Merging adjacent same-value **per-attribute overrides** is **safe** and allowed (cleaner data,
@@ -135,11 +155,11 @@ separate. Enumeration does **not** recompute a partition from override edges; it
   even though the override is merged. No structural diff.
 - Composites (M8) stay **one** RANGE_PRESENCE entry → one enumerated config. No split.
 
-**Required implementation item (P2 / TD-010):** overrides must apply by **containment**
-(`override.range ⊇ R`), not exact equality. Current code applies an override only when
-`parentRange == childRange` (`EntityMappers.kt:293`) — that must become a `containsRange` check
-for both resolve and enumerate. Declared ranges are breakpoint-aligned, so each attribute is
-constant across a declared range and containment is unambiguous.
+**~~Required implementation item (P2 / TD-010)~~ — SHIPPED:** overrides apply by **containment**
+(`override.range ⊇ R`), not exact equality — implemented in `EntityMappers.rangeApplies`
+(structural open-upper guard + sampled containment; see TD-010). The original requirement text is
+kept for the record: exact text equality would silently drop a broad override projected onto a
+narrower enumerated view.
 
 ## 6. Validation rules (migration + v4 write)
 
@@ -165,7 +185,9 @@ constant across a declared range and containment is unambiguous.
   the canonical check).
 - **Full compat baseline** (real versions, ~130k): 0 diffs on resolve **and** enumeration.
 - **Resolve**: identical for real versions (overrides cover them; base = default elsewhere).
-- **Enumeration parity**: `enumerate()` iterates the **preserved declared ranges**
+- **Enumeration parity** *(first-cut wording; shipped: coverage is stored MERGED and enumeration
+  partitions `supported` by value-change edges — see the §5 note and ADR-018 redesign refinement)*:
+  `enumerate()` iterates the **preserved declared ranges**
   (RANGE_PRESENCE, verbatim — composites stay single strings) and resolves each by containment →
   identical range list to legacy, independent of per-attribute merge. Verify: composites (one
   entry), redundant adjacent-identical-value blocks (two entries), and broad-override-over-narrow-
@@ -192,17 +214,16 @@ constant across a declared range and containment is unambiguous.
 
 ## 8. Open decisions (for the reviewer)
 
-1. **Supported storage** *(leaning decided)*: store declared ranges **verbatim** as `RANGE_PRESENCE`
-   rows (composites kept as single strings); `supported = ∪` of them; resolve gate + enumerate both
-   read them. Confirm this is the representation (vs a separate coverage table).
+1. **Supported storage** *(RESOLVED — superseded by the ADR-018 redesign refinement)*: shipped
+   representation stores coverage **MERGED** (`mergeUnion` of declared ranges, maximal contiguous
+   segments; NO rows when the union is all-versions) — not verbatim per-block rows as first drafted.
 2. **Base required-field invariant (P1)**: gated on **audit A2**. If a required BASE field is ever
    per-range-only, **relax the DB CHECK to allow NULL** (preferred, no synthetic base) vs. neutral
    default vs. representative. If A2 finds none → no change needed.
-3. **`containsRange` / TD-010 (P2)** — REQUIRED impl item, not optional: `rangeApplies()` currently
-   returns `parentRange == childRange` (exact text equality, `EntityMappers.kt:315-319`); replace
-   with a containment check (`override.range ⊇ R`) for resolve **and** enumerate. Counterexample
-   today: override on `[1.0,3.0)` over declared ranges `[1.0,2.0)`+`[2.0,3.0)` is silently dropped
-   (text mismatch) → resolves to base instead of the override.
+3. **`containsRange` / TD-010 (P2)** — *SHIPPED*: `rangeApplies()` is containment-based
+   (structural open-upper guard + sampled containment; see TD-010 write-up). Original motivation
+   kept for the record: exact text equality silently dropped an override on `[1.0,3.0)` projected
+   onto declared ranges `[1.0,2.0)`+`[2.0,3.0)` → resolved to base instead of the override.
 4. **V1**: warn-and-allow vs hard-constrain override input to within supported.
 5. **Resolver ordering**: fix lexicographic → numeric now (risk) or as a separate change?
 6. **Lifecycle layer**: confirm deferred; default status at migration when introduced.
@@ -228,12 +249,12 @@ constant across a declared range and containment is unambiguous.
 
 | Area | File:line | Change |
 |---|---|---|
-| Override application (resolve + enumerate) | `EntityMappers.kt:315-319` `rangeApplies()` | exact-match → **containsRange** (TD-010) |
-| Enumeration synthetic-base skip | `EntityMappers.kt:143-150` | replace with verbatim RANGE_PRESENCE enumeration; prove equivalence |
+| Override application (resolve + enumerate) | `EntityMappers.kt` `rangeApplies()` | exact-match → **containsRange** (TD-010) — **SHIPPED** |
+| Enumeration synthetic-base skip | `EntityMappers.kt` | first cut said "verbatim RANGE_PRESENCE enumeration"; **SHIPPED** as edge-partition of MERGED coverage (redesign refinement) |
 | Resolve coverage gate | `EntityMappers.kt:~209` (`base.versionRange != ALL_VERSIONS` union check) + `ComponentCodeRenderer.renderResolved` ~190-204 | gate on `supported` (∪ RANGE_PRESENCE) |
 | Base row build | `ImportServiceImpl.buildBaseConfigRow` + `selectBaseConfig` | base.versionRange = ALL_VERSIONS; value = effective config of the OPEN-UPPER (newest) block (2026-07 amendment, was top-level ⊕ Defaults); drop synthetic-bounded range |
 | Synthetic base decision | `ImportServiceImpl.importModule:~895-904` | remove `isSyntheticBase` bounded-base path; supported = ∪ declared ranges |
-| RANGE_PRESENCE emission | `ImportServiceImpl.emitRangePresenceRow:~970-993` | emit for every declared bounded block (verbatim, incl composites); none when supported = ALL |
+| RANGE_PRESENCE emission | `ImportServiceImpl.emitRangePresenceRow` | first cut said verbatim per block; **SHIPPED**: one row per MERGED contiguous segment (`mergeUnion`); none when supported = ALL |
 | Enumeration ordering | `V4Mappers.kt` `ARTIFACT_MAPPING_ORDER` | lexicographic today (existing bug) — don't introduce a new diff; numeric fix is a separate decision (§8.5) |
 | BASE field invariant | `V1__schema.sql:243` `chk_..._base_build_system` | relax to allow NULL only if audit A2 finds per-range-only required fields |
 | Docs | `schema-spec.md`, `requirements-migration.md`, `requirements-resolver.md` + new **ADR-018** | update during implementation |

--- a/test-common/src/test/resources/components-registry/common/TestComponents.groovy
+++ b/test-common/src/test/resources/components-registry/common/TestComponents.groovy
@@ -1239,3 +1239,36 @@ NON_ARCHIVED_TEST_COMPONENT {
         }
     }
 }
+
+"TEST_MERGED_SCALAR_OVERRIDES" {
+    // MIG-048 fixture (adjacent same-value scalar-override merge): javaVersion is declared
+    // ONLY in the open-upper (newest) block, which seeds the BASE row (ADR-018 amendment).
+    // BOTH older blocks inherit the top-level 1.8, so without merging the import would emit
+    // two ADJACENT identical build.javaVersion overrides ((,2.0) and [2.0,3.0) -> 1.8).
+    // mavenVersion keeps the first block distinct from the second (not a full twin), and
+    // must NOT be swept into the javaVersion merge.
+    componentOwner = "user9"
+    groupId = "org.octopusden.octopus.test.mergedscalars"
+    artifactId = "test-merged-scalars"
+    build {
+        javaVersion = "1.8"
+    }
+
+    "(,2.0)" {
+        build {
+            mavenVersion = "3.6.3"
+        }
+    }
+    "[2.0,3.0)" {
+    }
+    "[3.0,)" {
+        build {
+            javaVersion = "17"
+        }
+        jira {
+            component {
+                versionPrefix = "tmso2"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

With the base row = the open-upper (newest) block (#389 / ADR-018 amendment), an attribute declared **only in the newest block** makes every OLDER block diff identically against the base — they all resolve the same inherited top-level/`Defaults` value — so the import emitted **one identical `SCALAR_OVERRIDE` per older block**. In the portal editor this surfaced as duplicated adjacent chips (e.g. Java Version base = `17` with two contiguous ranges both `→ 1.8`) that are semantically ONE override over the union range. Domain-owner decision: merge them at import.

## How

- `emitScalarOverrides` (per-config) → `emitMergedScalarOverrides`: scalar diffs collected across ALL non-base configs into `(attribute, value) → [declared ranges]`; each group collapses via `VersionRangePartition.mergeUnion` (scheme-aware comparator). Non-adjacent same-value ranges stay separate; defensive verbatim fallback if a union ever collapses to the all-versions shape.
- **Exception — jira uniqueness pair**: `jira.projectKey` / `jira.versionPrefix` always keep verbatim per-block ranges. The `(projectKey, versionPrefix)` pair is reconstructed from persisted rows by **exact-range grouping** (`computeEffectiveJiraPairs`, mirrored by the API-side validator); merging one attribute independently of its companion would tear the pairs apart and corrupt collision detection.
- Markers stay per declared block (their boundaries anchor enumeration edges) — enumeration output is unchanged: a merged scalar edge was by construction a no-op view boundary (same value on both sides). Full-twin adjacent blocks remain a source-DSL cleanup case, per policy.
- Tests: new fixture + `MIG-048` (merged `javaVersion` over the union; `mavenVersion` stays per-block; `jira.versionPrefix` stays TWO verbatim rows). Fixture-count pins bumped. Docs: schema-spec §6.5 + version-model-spec-DRAFT historical/SHIPPED markers.

Full `:components-registry-service-server:dbTest` green (571). Reviewed: Sonnet APPROVE; Codex — Major (jira pair) fixed and re-verified neutralized, doc Minor fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
