### PR TITLE
feat(config): default new-component build system to GRADLE

### DIFF
--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -61,7 +61,7 @@ components-registry:
   # New-component defaults baseline (generic values only). system code and
   # distribution security groups are installation-specific → service-config.
   component-defaults:
-    buildSystem: MAVEN
+    buildSystem: GRADLE
     artifactIdPattern: '[\w-\.]+'
     releasesInDefaultBranch: true
     solution: false


### PR DESCRIPTION
## What
Change the `component-defaults` baseline in `application.yml` from `MAVEN` to `GRADLE` so the portal create-form pre-selects **Gradle** for new components.

## Why
Product decision: Gradle should be the default build system for newly created components. Previously the baseline resolved to `MAVEN` (and service-config sets no `buildSystem` override, so `MAVEN` was the effective default everywhere the config matched the repo).

## Notes
- `gradleVersion: LATEST` is already the build-tool default, so it lines up with the new default. `mavenVersion: "3.9"` stays as the fallback for components switched to Maven.
- Portal side is neutral (`SCRATCH_DEFAULTS.buildSystem` is empty; it surfaces whatever CRS returns) — no portal change needed.
- No tests assert this yml value (`ConfigSyncServiceTest` builds `ComponentDefaults` programmatically), so nothing breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)