### PR TITLE
refactor(registry): rename v4 jira majorVersionFormat → minorVersionFormat

### DIFF
--- a/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Component.kt
+++ b/components-registry-cli/src/main/kotlin/org/octopusden/octopus/components/registry/cli/model/Component.kt
@@ -121,7 +121,7 @@ data class JiraAspectResponse(
     val buildVersionFormat: String? = null,
     val hotfixVersionFormat: String? = null,
     val lineVersionFormat: String? = null,
-    val majorVersionFormat: String? = null,
+    val minorVersionFormat: String? = null,
     val projectKey: String? = null,
     val releaseVersionFormat: String? = null,
     val technical: Boolean? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
@@ -95,7 +95,23 @@ class AdminConfigProperties {
         var componentVersionFormat: ComponentVersionFormat? = null
 
         class ComponentVersionFormat {
-            var majorVersionFormat: String? = null
+            var minorVersionFormat: String? = null
+
+            /**
+             * External-config compatibility alias for the renamed [minorVersionFormat].
+             * Spring binds `...componentVersionFormat.majorVersionFormat` (still emitted by
+             * service-config until it is renamed in lockstep) here; the setter writes through
+             * to [minorVersionFormat] only when the latter has not already been bound, so
+             * `minorVersionFormat` wins when both keys are present regardless of binding order.
+             * Remove this alias once service-config no longer emits `majorVersionFormat`.
+             */
+            @Deprecated("Use minorVersionFormat; retained for service-config binding compatibility")
+            var majorVersionFormat: String?
+                get() = minorVersionFormat
+                set(value) {
+                    if (minorVersionFormat == null) minorVersionFormat = value
+                }
+
             var releaseVersionFormat: String? = null
             var buildVersionFormat: String? = null
             var lineVersionFormat: String? = null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
@@ -90,7 +90,7 @@ data class EscrowAspectResponse(
 data class JiraAspectResponse(
     val projectKey: String? = null,
     val technical: Boolean? = null,
-    val majorVersionFormat: String? = null,
+    val minorVersionFormat: String? = null,
     val releaseVersionFormat: String? = null,
     val buildVersionFormat: String? = null,
     val lineVersionFormat: String? = null,
@@ -202,7 +202,7 @@ data class EscrowAspectRequest(
 data class JiraAspectRequest(
     val projectKey: String? = null,
     val technical: Boolean? = null,
-    val majorVersionFormat: String? = null,
+    val minorVersionFormat: String? = null,
     val releaseVersionFormat: String? = null,
     val buildVersionFormat: String? = null,
     val lineVersionFormat: String? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentConfigurationEntity.kt
@@ -155,8 +155,8 @@ class ComponentConfigurationEntity(
     @Column(name = "jira_technical")
     var jiraTechnical: Boolean? = null,
 
-    @Column(name = "jira_major_version_format")
-    var jiraMajorVersionFormat: String? = null,
+    @Column(name = "jira_minor_version_format")
+    var jiraMinorVersionFormat: String? = null,
 
     @Column(name = "jira_release_version_format")
     var jiraReleaseVersionFormat: String? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
@@ -52,7 +52,7 @@ internal val SCALAR_ATTRIBUTE_PATHS: Set<String> =
         "escrow.buildTask",
         "jira.projectKey",
         "jira.technical",
-        "jira.majorVersionFormat",
+        "jira.minorVersionFormat",
         "jira.releaseVersionFormat",
         "jira.buildVersionFormat",
         "jira.lineVersionFormat",
@@ -99,7 +99,7 @@ internal fun ComponentConfigurationEntity.extractScalarValue(): Any? =
         "escrow.buildTask" -> escrowBuildTask
         "jira.projectKey" -> jiraProjectKey
         "jira.technical" -> jiraTechnical
-        "jira.majorVersionFormat" -> jiraMajorVersionFormat
+        "jira.minorVersionFormat" -> jiraMinorVersionFormat
         "jira.releaseVersionFormat" -> jiraReleaseVersionFormat
         "jira.buildVersionFormat" -> jiraBuildVersionFormat
         "jira.lineVersionFormat" -> jiraLineVersionFormat
@@ -157,7 +157,7 @@ internal fun ComponentConfigurationEntity.applyScalarValue(
         "escrow.buildTask" -> escrowBuildTask = requireString(attributePath, value)
         "jira.projectKey" -> jiraProjectKey = requireString(attributePath, value)
         "jira.technical" -> jiraTechnical = requireBoolean(attributePath, value)
-        "jira.majorVersionFormat" -> jiraMajorVersionFormat = requireString(attributePath, value)
+        "jira.minorVersionFormat" -> jiraMinorVersionFormat = requireString(attributePath, value)
         "jira.releaseVersionFormat" -> jiraReleaseVersionFormat = requireString(attributePath, value)
         "jira.buildVersionFormat" -> jiraBuildVersionFormat = requireString(attributePath, value)
         "jira.lineVersionFormat" -> jiraLineVersionFormat = requireString(attributePath, value)
@@ -190,7 +190,7 @@ private fun ComponentConfigurationEntity.clearAllScalarColumns() {
     escrowBuildTask = null
     jiraProjectKey = null
     jiraTechnical = null
-    jiraMajorVersionFormat = null
+    jiraMinorVersionFormat = null
     jiraReleaseVersionFormat = null
     jiraBuildVersionFormat = null
     jiraLineVersionFormat = null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -881,7 +881,7 @@ internal class ComponentConfigurationView {
 
     var jiraProjectKey: String? = null
     var jiraTechnical: Boolean? = null
-    var jiraMajorVersionFormat: String? = null
+    var jiraMinorVersionFormat: String? = null
     var jiraReleaseVersionFormat: String? = null
     var jiraBuildVersionFormat: String? = null
     var jiraLineVersionFormat: String? = null
@@ -937,7 +937,7 @@ internal class ComponentConfigurationView {
 
             "jira.projectKey" -> jiraProjectKey = override.jiraProjectKey
             "jira.technical" -> jiraTechnical = override.jiraTechnical
-            "jira.majorVersionFormat" -> jiraMajorVersionFormat = override.jiraMajorVersionFormat
+            "jira.minorVersionFormat" -> jiraMinorVersionFormat = override.jiraMinorVersionFormat
             "jira.releaseVersionFormat" -> jiraReleaseVersionFormat = override.jiraReleaseVersionFormat
             "jira.buildVersionFormat" -> jiraBuildVersionFormat = override.jiraBuildVersionFormat
             "jira.lineVersionFormat" -> jiraLineVersionFormat = override.jiraLineVersionFormat
@@ -1077,7 +1077,7 @@ internal class ComponentConfigurationView {
 
                 jiraProjectKey = base.jiraProjectKey
                 jiraTechnical = base.jiraTechnical
-                jiraMajorVersionFormat = base.jiraMajorVersionFormat
+                jiraMinorVersionFormat = base.jiraMinorVersionFormat
                 jiraReleaseVersionFormat = base.jiraReleaseVersionFormat
                 jiraBuildVersionFormat = base.jiraBuildVersionFormat
                 jiraLineVersionFormat = base.jiraLineVersionFormat
@@ -1195,7 +1195,7 @@ private fun buildJiraComponent(
 ): JiraComponent? {
     val projectKey = merged.jiraProjectKey ?: return null
 
-    val majorFmt = merged.jiraMajorVersionFormat ?: "\$major"
+    val majorFmt = merged.jiraMinorVersionFormat ?: "\$major"
     val releaseFmt = merged.jiraReleaseVersionFormat ?: "\$major.\$minor"
     val buildFmt = merged.jiraBuildVersionFormat ?: releaseFmt
     val lineFmt = merged.jiraLineVersionFormat ?: majorFmt

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -288,7 +288,7 @@ private fun ComponentConfigurationEntity.jiraAspectResponse(): JiraAspectRespons
     JiraAspectResponse(
         projectKey = jiraProjectKey,
         technical = jiraTechnical,
-        majorVersionFormat = jiraMajorVersionFormat,
+        minorVersionFormat = jiraMinorVersionFormat,
         releaseVersionFormat = jiraReleaseVersionFormat,
         buildVersionFormat = jiraBuildVersionFormat,
         lineVersionFormat = jiraLineVersionFormat,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1740,7 +1740,7 @@ class ComponentManagementServiceImpl(
         request.jira?.let { j ->
             config.jiraProjectKey = j.projectKey
             config.jiraTechnical = j.technical
-            config.jiraMajorVersionFormat = j.majorVersionFormat
+            config.jiraMinorVersionFormat = j.minorVersionFormat
             config.jiraReleaseVersionFormat = j.releaseVersionFormat
             config.jiraBuildVersionFormat = j.buildVersionFormat
             config.jiraLineVersionFormat = j.lineVersionFormat
@@ -1796,7 +1796,7 @@ class ComponentManagementServiceImpl(
         patch.jira?.let { j ->
             j.projectKey?.let { config.jiraProjectKey = it }
             j.technical?.let { config.jiraTechnical = it }
-            j.majorVersionFormat?.let { config.jiraMajorVersionFormat = it }
+            j.minorVersionFormat?.let { config.jiraMinorVersionFormat = it }
             j.releaseVersionFormat?.let { config.jiraReleaseVersionFormat = it }
             j.buildVersionFormat?.let { config.jiraBuildVersionFormat = it }
             j.lineVersionFormat?.let { config.jiraLineVersionFormat = it }
@@ -3251,7 +3251,7 @@ class ComponentManagementServiceImpl(
             "escrow.buildTask" to base?.escrowBuildTask,
             "jira.projectKey" to base?.jiraProjectKey,
             "jira.technical" to base?.jiraTechnical,
-            "jira.majorVersionFormat" to base?.jiraMajorVersionFormat,
+            "jira.minorVersionFormat" to base?.jiraMinorVersionFormat,
             "jira.releaseVersionFormat" to base?.jiraReleaseVersionFormat,
             "jira.buildVersionFormat" to base?.jiraBuildVersionFormat,
             "jira.lineVersionFormat" to base?.jiraLineVersionFormat,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
@@ -176,7 +176,7 @@ class ConfigSyncService(
                     jira.technical?.let { put("technical", it) }
                     jira.componentVersionFormat?.let { cvf ->
                         buildMap<String, Any?> {
-                            cvf.majorVersionFormat?.let { put("majorVersionFormat", it) }
+                            cvf.minorVersionFormat?.let { put("minorVersionFormat", it) }
                             cvf.releaseVersionFormat?.let { put("releaseVersionFormat", it) }
                             cvf.buildVersionFormat?.let { put("buildVersionFormat", it) }
                             cvf.lineVersionFormat?.let { put("lineVersionFormat", it) }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -1584,7 +1584,7 @@ class ImportServiceImpl(
             row.jiraProjectKey = jira.projectKey
             row.jiraTechnical = jira.isTechnical.takeIf { it }
             jira.componentVersionFormat?.let { cvf ->
-                row.jiraMajorVersionFormat = cvf.majorVersionFormat
+                row.jiraMinorVersionFormat = cvf.majorVersionFormat
                 row.jiraReleaseVersionFormat = cvf.releaseVersionFormat
                 row.jiraBuildVersionFormat = cvf.buildVersionFormat
                 row.jiraLineVersionFormat = cvf.lineVersionFormat
@@ -2130,7 +2130,7 @@ class ImportServiceImpl(
 
         diffScalar("jira.projectKey", base.jiraProjectKey, override.jiraProjectKey)
         diffScalar("jira.technical", base.jiraTechnical, override.jiraTechnical)
-        diffScalar("jira.majorVersionFormat", base.jiraMajorVersionFormat, override.jiraMajorVersionFormat)
+        diffScalar("jira.minorVersionFormat", base.jiraMinorVersionFormat, override.jiraMinorVersionFormat)
         diffScalar("jira.releaseVersionFormat", base.jiraReleaseVersionFormat, override.jiraReleaseVersionFormat)
         diffScalar("jira.buildVersionFormat", base.jiraBuildVersionFormat, override.jiraBuildVersionFormat)
         diffScalar("jira.lineVersionFormat", base.jiraLineVersionFormat, override.jiraLineVersionFormat)
@@ -2177,7 +2177,7 @@ class ImportServiceImpl(
             "escrow.additionalSources" -> row.escrowAdditionalSources = value?.toString()
             "jira.projectKey" -> row.jiraProjectKey = value?.toString()
             "jira.technical" -> row.jiraTechnical = value as? Boolean ?: value?.toString()?.toBooleanStrictOrNull()
-            "jira.majorVersionFormat" -> row.jiraMajorVersionFormat = value?.toString()
+            "jira.minorVersionFormat" -> row.jiraMinorVersionFormat = value?.toString()
             "jira.releaseVersionFormat" -> row.jiraReleaseVersionFormat = value?.toString()
             "jira.buildVersionFormat" -> row.jiraBuildVersionFormat = value?.toString()
             "jira.lineVersionFormat" -> row.jiraLineVersionFormat = value?.toString()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
@@ -461,7 +461,7 @@ class ComponentCodeRenderer(
             }
         val hasContent =
             listOf(
-                s.jiraProjectKey, s.jiraMajorVersionFormat, s.jiraReleaseVersionFormat, s.jiraBuildVersionFormat,
+                s.jiraProjectKey, s.jiraMinorVersionFormat, s.jiraReleaseVersionFormat, s.jiraBuildVersionFormat,
                 s.jiraLineVersionFormat, s.jiraVersionPrefix, s.jiraVersionFormat, effectiveHotfix,
                 component.jiraDisplayName,
             ).any { it != null } || s.jiraTechnical != null
@@ -470,7 +470,7 @@ class ComponentCodeRenderer(
         cb.str("projectKey", s.jiraProjectKey)
         cb.str("displayName", component.jiraDisplayName)
         cb.bool("technical", s.jiraTechnical)
-        cb.str("majorVersionFormat", s.jiraMajorVersionFormat)
+        cb.str("majorVersionFormat", s.jiraMinorVersionFormat)
         cb.str("releaseVersionFormat", s.jiraReleaseVersionFormat)
         cb.str("buildVersionFormat", s.jiraBuildVersionFormat)
         cb.str("lineVersionFormat", s.jiraLineVersionFormat)

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -72,7 +72,7 @@ components-registry:
     jira:
       technical: false
       componentVersionFormat:
-        majorVersionFormat: '$major.$minor'
+        minorVersionFormat: '$major.$minor'
         releaseVersionFormat: '$major.$minor.$service'
         hotfixVersionFormat: '$major.$minor.$service-$fix'
     distribution:

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -153,7 +153,7 @@ CREATE TABLE component_configurations (
     -- JIRA aspect (per-version overridable fields):
     jira_project_key                            VARCHAR(50),
     jira_technical                              BOOLEAN,
-    jira_major_version_format                   VARCHAR(255),
+    jira_minor_version_format                   VARCHAR(255),
     jira_release_version_format                 VARCHAR(255),
     jira_build_version_format                   VARCHAR(255),
     jira_line_version_format                    VARCHAR(255),
@@ -220,7 +220,7 @@ CREATE TABLE component_configurations (
         AND escrow_gradle_exclude_configurations IS NULL
         AND escrow_gradle_include_test_configurations IS NULL
         AND jira_project_key IS NULL AND jira_technical IS NULL
-        AND jira_major_version_format IS NULL AND jira_release_version_format IS NULL
+        AND jira_minor_version_format IS NULL AND jira_release_version_format IS NULL
         AND jira_build_version_format IS NULL AND jira_line_version_format IS NULL
         AND jira_version_prefix IS NULL AND jira_version_format IS NULL
         AND jira_hotfix_version_format IS NULL

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -1502,7 +1502,7 @@
           "lineVersionFormat" : {
             "type" : "string"
           },
-          "majorVersionFormat" : {
+          "minorVersionFormat" : {
             "type" : "string"
           },
           "projectKey" : {
@@ -1534,7 +1534,7 @@
           "lineVersionFormat" : {
             "type" : "string"
           },
-          "majorVersionFormat" : {
+          "minorVersionFormat" : {
             "type" : "string"
           },
           "projectKey" : {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesAliasTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesAliasTest.kt
@@ -1,0 +1,41 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the rollout behavior of the deprecated `majorVersionFormat` compatibility
+ * alias on [AdminConfigProperties.Jira.ComponentVersionFormat]. service-config still
+ * emits `...componentVersionFormat.majorVersionFormat` until it is renamed in lockstep,
+ * so binding that key must populate the renamed [minorVersionFormat]; when both keys are
+ * present `minorVersionFormat` wins regardless of Spring's (unspecified) binding order.
+ */
+@Suppress("DEPRECATION")
+class AdminConfigPropertiesAliasTest {
+
+    private fun cvf() = AdminConfigProperties.Jira.ComponentVersionFormat()
+
+    @Test
+    fun `legacy majorVersionFormat binds through to minorVersionFormat`() {
+        val c = cvf().apply { majorVersionFormat = "\$major.\$minor" }
+        assertEquals("\$major.\$minor", c.minorVersionFormat)
+    }
+
+    @Test
+    fun `minorVersionFormat wins when bound before legacy majorVersionFormat`() {
+        val c = cvf().apply {
+            minorVersionFormat = "new"
+            majorVersionFormat = "legacy"
+        }
+        assertEquals("new", c.minorVersionFormat)
+    }
+
+    @Test
+    fun `minorVersionFormat wins when bound after legacy majorVersionFormat`() {
+        val c = cvf().apply {
+            majorVersionFormat = "legacy"
+            minorVersionFormat = "new"
+        }
+        assertEquals("new", c.minorVersionFormat)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
@@ -58,4 +58,38 @@ class AdminConfigPropertiesBindingTest {
                 assertNull(props.fieldConfig["distribution"]?.get("maven")?.label)
             }
     }
+
+    // ── component-defaults majorVersionFormat → minorVersionFormat alias ───────
+    // service-config still emits the old `majorVersionFormat` YAML key until it is
+    // renamed in lockstep; the deprecated write-through setter must bind it to the
+    // renamed `minorVersionFormat`, and `minorVersionFormat` must win when both
+    // keys are present (regardless of binder property order). This exercises the
+    // real Spring relaxed binder, not just the Kotlin setter.
+
+    @Test
+    fun `legacy majorVersionFormat YAML key binds through to minorVersionFormat`() {
+        runner
+            .withPropertyValues(
+                "components-registry.component-defaults.jira.componentVersionFormat.majorVersionFormat=legacy",
+            )
+            .run { ctx ->
+                val cvf = ctx.getBean(AdminConfigProperties::class.java)
+                    .componentDefaults.jira?.componentVersionFormat
+                assertEquals("legacy", cvf?.minorVersionFormat)
+            }
+    }
+
+    @Test
+    fun `minorVersionFormat wins when both YAML keys are bound`() {
+        runner
+            .withPropertyValues(
+                "components-registry.component-defaults.jira.componentVersionFormat.majorVersionFormat=legacy",
+                "components-registry.component-defaults.jira.componentVersionFormat.minorVersionFormat=new",
+            )
+            .run { ctx ->
+                val cvf = ctx.getBean(AdminConfigProperties::class.java)
+                    .componentDefaults.jira?.componentVersionFormat
+                assertEquals("new", cvf?.minorVersionFormat)
+            }
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/migration/MigrationIntegrationTest.kt
@@ -456,7 +456,7 @@ class MigrationIntegrationTest {
         assertNull(presence.escrowGradleExcludeConfigurations)
         assertNull(presence.escrowGradleIncludeTestConfigurations)
         assertNull(presence.jiraProjectKey); assertNull(presence.jiraTechnical)
-        assertNull(presence.jiraMajorVersionFormat); assertNull(presence.jiraReleaseVersionFormat)
+        assertNull(presence.jiraMinorVersionFormat); assertNull(presence.jiraReleaseVersionFormat)
         assertNull(presence.jiraBuildVersionFormat); assertNull(presence.jiraLineVersionFormat)
         assertNull(presence.jiraVersionPrefix); assertNull(presence.jiraVersionFormat)
         assertNull(presence.jiraHotfixVersionFormat)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
@@ -186,7 +186,7 @@ class ConfigSyncServiceTest {
                     projectKey = "PROJ"
                     technical = false
                     componentVersionFormat = AdminConfigProperties.Jira.ComponentVersionFormat().apply {
-                        majorVersionFormat = "\$major.\$minor"
+                        minorVersionFormat = "\$major.\$minor"
                     }
                 }
                 distribution = AdminConfigProperties.Distribution().apply {
@@ -207,7 +207,7 @@ class ConfigSyncServiceTest {
                 "jira" to mapOf(
                     "projectKey" to "PROJ",
                     "technical" to false,
-                    "componentVersionFormat" to mapOf("majorVersionFormat" to "\$major.\$minor"),
+                    "componentVersionFormat" to mapOf("minorVersionFormat" to "\$major.\$minor"),
                 ),
                 "distribution" to mapOf("explicit" to false, "securityGroups" to mapOf("read" to "Prod")),
             ),
@@ -281,7 +281,7 @@ class ConfigSyncServiceTest {
                     displayName = "Proj"
                     technical = false
                     componentVersionFormat = AdminConfigProperties.Jira.ComponentVersionFormat().apply {
-                        majorVersionFormat = "\$major.\$minor"
+                        minorVersionFormat = "\$major.\$minor"
                         releaseVersionFormat = "\$major.\$minor.\$service"
                         buildVersionFormat = "\$major.\$minor.\$service-\$build"
                         lineVersionFormat = "\$major.\$minor"
@@ -352,7 +352,7 @@ class ConfigSyncServiceTest {
                     "displayName" to "Proj",
                     "technical" to false,
                     "componentVersionFormat" to mapOf(
-                        "majorVersionFormat" to "\$major.\$minor",
+                        "minorVersionFormat" to "\$major.\$minor",
                         "releaseVersionFormat" to "\$major.\$minor.\$service",
                         "buildVersionFormat" to "\$major.\$minor.\$service-\$build",
                         "lineVersionFormat" to "\$major.\$minor",

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeOnlyParityGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/RangeOnlyParityGuardTest.kt
@@ -132,7 +132,7 @@ class RangeOnlyParityGuardTest {
             jiraProjectKey = "GUARD",
             deprecated = false,
         )
-        base.jiraMajorVersionFormat = "\$major"
+        base.jiraMinorVersionFormat = "\$major"
         base.jiraReleaseVersionFormat = "\$major.\$minor.\$service"
         base.vcsEntries.add(
             VcsSettingsEntryEntity(

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
@@ -202,7 +202,7 @@ class ComponentCodeRendererTest {
         base(c) {
             buildSystem = "MAVEN"
             jiraProjectKey = "BS"
-            jiraMajorVersionFormat = "\$major"
+            jiraMinorVersionFormat = "\$major"
         }
 
         val expected =

--- a/docs/features/doc-support/doc-improvement-concept.md
+++ b/docs/features/doc-support/doc-improvement-concept.md
@@ -302,7 +302,7 @@ DONE!
      ```
 
 3. **Use `majorVersion` (not `lineVersion`):**
-   - Keep consistent with existing `majorVersionFormat` terminology in jira section
+   - The doc-link field names the major version line it documents (e.g. `3.x`); it is unrelated to the Jira version-format templates (`jira.minorVersionFormat` / `jira.lineVersionFormat`) and keeps its own name
    - Rename would be confusing across the codebase
 
 4. **Validation: single doc component per version:**

--- a/docs/registry/requirements-migration.md
+++ b/docs/registry/requirements-migration.md
@@ -500,7 +500,7 @@ jira {
 - Component does NOT explicitly define jira version formats in its DSL file
 
 **Acceptance criteria:**
-1. After migration `GET /rest/api/4/components/{id}` returns `jira.majorVersionFormat = "$major.$minor"`
+1. After migration `GET /rest/api/4/components/{id}` returns `jira.minorVersionFormat = "$major.$minor"` (the DSL `majorVersionFormat` maps to the v4 `minorVersionFormat`)
 2. `jira.releaseVersionFormat = "$major.$minor.$service"`
 3. `jira.hotfixVersionFormat = "$major.$minor.$service-$fix"`
 4. `jira.customer.versionFormat = "$versionPrefix-$baseVersionFormat"`

--- a/docs/registry/schema-spec.md
+++ b/docs/registry/schema-spec.md
@@ -225,7 +225,7 @@ Per-(component, version_range) typed rows; the spine of Model A'.
 | Jira aspect | | | |
 | `jira_project_key` | VARCHAR(50) | | |
 | `jira_technical` | BOOLEAN | | |
-| `jira_major_version_format` | VARCHAR(255) | | |
+| `jira_minor_version_format` | VARCHAR(255) | | |
 | `jira_release_version_format` | VARCHAR(255) | | |
 | `jira_build_version_format` | VARCHAR(255) | | |
 | `jira_line_version_format` | VARCHAR(255) | | |


### PR DESCRIPTION
## What

Renames the Jira version-format field **`majorVersionFormat` → `minorVersionFormat` on the v4 surface only**. The field is semantically a *minor*-level template (`$major.$minor`); the real "major version" notion is the version *line*.

**Renamed (v4):** DB column `jira_minor_version_format` (V1 baseline + CHECK), `ComponentConfigurationEntity`, v4 DTOs (`JiraAspectRequest/Response`), `ConfigurationRowAccessors`, `V4Mappers`, `EntityMappers` (incl. `ComponentConfigurationView`), `ImportServiceImpl` + `ComponentManagementServiceImpl` write/patch/**audit**, the override attribute path `"jira.minorVersionFormat"`, the component-defaults blob (`ConfigSyncService`), `application.yml`, and the regenerated `openapi/v4.json`.

**Kept `majorVersionFormat` (legacy/DSL — unchanged contract):** `ComponentVersionFormatDTO` (v1–v3), the Groovy DSL property + all `*.groovy` fixtures, the resolver model, v1–v3 controllers, CLI model.

**Bridges (deliberate):**
- DSL → DB import: `row.jiraMinorVersionFormat = cvf.majorVersionFormat`.
- Resolve path: `ComponentConfigurationView` reads the renamed column into the legacy `ComponentVersionFormat` major slot.
- `ComponentCodeRenderer` still emits the DSL literal `majorVersionFormat` from the renamed property.

**Compatibility alias:** `AdminConfigProperties.Jira.ComponentVersionFormat` keeps a deprecated `majorVersionFormat` write-through setter (minor wins) so external `service-config` keeps binding until it is renamed in lockstep. Pinned by `AdminConfigPropertiesAliasTest`.

## Verification
- `:components-registry-service-server:test` (incl. `OpenApiV4SpecTest` drift gate) — green
- `:components-registry-service-server:dbTest` (migration + DSL→DB bridge + audit) — green

## Coordination / follow-ups
- **service-config `component-defaults` (lockstep):** rename the external `…componentVersionFormat.majorVersionFormat` key → `minorVersionFormat`, then drop the alias here.
- **Portal** vendors this `v4.json` — its PR must land after this merges (spec pin bump).
- **v4 `GET /config/component-defaults`** now emits `minorVersionFormat` (downstream-visible for anyone scraping that blob).
- Legacy v1/v3 DTO `minorVersionFormat` synonym is a **separate, to-be-agreed** task (see linked issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)