### PR TITLE
feat(registry): v4 "" = clear semantics for aspect string scalars

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
@@ -4,6 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 /**
+ * CRS-A tri-state clear contract shared by every write-side aspect string
+ * scalar (build/escrow/jira) and the top-level `vcsExternalRegistry`.
+ */
+const val V4_SCALAR_CLEAR_SEMANTICS: String =
+    "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; " +
+        "non-blank = set verbatim. On create, \"\" is treated as null."
+
+/**
  * One row of `component_configurations`, projected for the v4 editor view.
  *
  * Three editor-visible shapes per schema-spec.md §3 (Model A' override taxonomy):
@@ -175,38 +183,67 @@ data class BaseConfigurationRequest(
 )
 
 data class BuildAspectRequest(
+    // buildSystem is a required, validated enum — not subject to the clear rule.
     val buildSystem: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val javaVersion: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val mavenVersion: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val gradleVersion: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val buildFilePath: String? = null,
     val deprecated: Boolean? = null,
     val requiredProject: Boolean? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val projectVersion: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val systemProperties: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val buildTasks: String? = null,
 )
 
 data class EscrowAspectRequest(
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val providedDependencies: String? = null,
     val reusable: Boolean? = null,
+    // generation is a validated enum mode — not subject to the clear rule.
     val generation: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val diskSpace: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val additionalSources: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val gradleIncludeConfigurations: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val gradleExcludeConfigurations: String? = null,
     val gradleIncludeTestConfigurations: Boolean? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val buildTask: String? = null,
 )
 
 data class JiraAspectRequest(
+    @field:Schema(
+        description = "$V4_SCALAR_CLEAR_SEMANTICS Clearing it removes the component's Jira association " +
+            "(no Jira version coordinates are computed) and drops its (projectKey, versionPrefix) uniqueness claim.",
+    )
     val projectKey: String? = null,
     val technical: Boolean? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val minorVersionFormat: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val releaseVersionFormat: String? = null,
+    @field:Schema(
+        description = "$V4_SCALAR_CLEAR_SEMANTICS When cleared, the build version format falls back to the release version format.",
+    )
     val buildVersionFormat: String? = null,
+    @field:Schema(
+        description = "$V4_SCALAR_CLEAR_SEMANTICS When cleared, the line version format falls back to the minor version format.",
+    )
     val lineVersionFormat: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val versionPrefix: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val versionFormat: String? = null,
     // Intentionally NOT exposing per-range hotfixVersionFormat as a V4
     // editor-write field — DSL import is currently the only producer in

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
@@ -61,6 +61,7 @@ data class ComponentCreateRequest(
     val labels: Set<String> = emptySet(),
     val jiraDisplayName: String? = null,
     val jiraHotfixVersionFormat: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val vcsExternalRegistry: String? = null,
     val distributionExplicit: Boolean? = null,
     val distributionExternal: Boolean? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -51,6 +51,7 @@ data class ComponentUpdateRequest(
     val labels: Set<String>? = null,
     val jiraDisplayName: String? = null,
     val jiraHotfixVersionFormat: String? = null,
+    @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val vcsExternalRegistry: String? = null,
     val distributionExplicit: Boolean? = null,
     val distributionExternal: Boolean? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/FieldOverrideRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/FieldOverrideRequest.kt
@@ -1,7 +1,18 @@
 package org.octopusden.octopus.components.registry.server.dto.v4
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.UUID
+
+/**
+ * CRS-A note shared by the write-side override `value` fields: a blank string
+ * for a string-typed scalar attribute is rejected (400). Unlike a BASE scalar,
+ * an override row has no "clear" — use DELETE /field-overrides/{id}.
+ */
+private const val OVERRIDE_VALUE_BLANK_NOTE: String =
+    "For a string-typed scalar attribute a blank value (\"\" or whitespace) is rejected (400): " +
+        "an override row stores its value verbatim and has no clear semantics — use " +
+        "DELETE /field-overrides/{id} to remove it."
 
 /**
  * Create body for one override row in `component_configurations`. The request
@@ -24,6 +35,7 @@ import java.util.UUID
 data class FieldOverrideCreateRequest(
     val overriddenAttribute: String,
     val versionRange: String,
+    @field:Schema(description = OVERRIDE_VALUE_BLANK_NOTE)
     val value: Any? = null,
     val markerChildren: MarkerChildrenPayload? = null,
 )
@@ -46,6 +58,7 @@ data class FieldOverrideUpsertRequest(
     val id: UUID? = null,
     val overriddenAttribute: String,
     val versionRange: String,
+    @field:Schema(description = OVERRIDE_VALUE_BLANK_NOTE)
     val value: Any? = null,
     val markerChildren: MarkerChildrenPayload? = null,
 )
@@ -69,6 +82,7 @@ data class FieldOverrideUpdateRequest(
      * DSL override range sets a scalar to null, clearing an inherited base value). See
      * `ConfigurationRowAccessors.kt` for the full null-handling contract across all four paths.
      */
+    @field:Schema(description = OVERRIDE_VALUE_BLANK_NOTE)
     val value: Any? = null,
     val markerChildren: MarkerChildrenPayload? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/ConfigurationRowAccessors.kt
@@ -111,8 +111,16 @@ internal fun ComponentConfigurationEntity.extractScalarValue(): Any? =
 
 /**
  * Set the single typed column corresponding to `attributePath` from a JSON
- * primitive value. Throws [IllegalArgumentException] when the path is unknown
- * or the value is the wrong type — the service maps that to a 400.
+ * primitive value. Throws [IllegalArgumentException] when the path is unknown,
+ * the value is the wrong type, or (CRS-A) a string-scalar value is blank — the
+ * service maps that to a 400.
+ *
+ * **Blank string override (CRS-A):** a `""`/whitespace value for a string-typed
+ * scalar attribute is rejected. On the BASE row `""` means "clear to NULL", but
+ * an override row stores its value verbatim, and a non-null `""` would defeat
+ * the resolver's `?:` format fallbacks. Overrides have no "clear" operation —
+ * removal is `DELETE /field-overrides/{id}`. (`null` is likewise rejected on
+ * create; see the table below.)
  *
  * Mutates the receiver in place; clears every other scalar column first so
  * the row keeps the "exactly one column non-NULL" invariant required by
@@ -204,7 +212,17 @@ private fun requireString(
     value: Any,
 ): String =
     when (value) {
-        is String -> value
+        is String -> {
+            // CRS-A: a blank ("" / whitespace) scalar override is meaningless. Unlike
+            // a base scalar (where "" = clear to NULL), a non-null "" stored on an
+            // override row would be echoed verbatim by the resolver and defeat its
+            // `?:` format fallbacks — the exact trap base-row clear semantics avoid.
+            // There is no "clear via override": use DELETE /field-overrides/{id}.
+            require(value.isNotBlank()) {
+                "Attribute '$path' must not be blank — use DELETE /field-overrides/{id} to remove the override"
+            }
+            value
+        }
         is Number -> value.toString()
         else -> throw IllegalArgumentException("Attribute '$path' expects a string value; got ${value::class.simpleName}")
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -276,7 +276,8 @@ class ComponentManagementServiceImpl(
                 releasesInDefaultBranch = request.releasesInDefaultBranch,
                 jiraDisplayName = request.jiraDisplayName,
                 jiraHotfixVersionFormat = request.jiraHotfixVersionFormat,
-                vcsExternalRegistry = request.vcsExternalRegistry,
+                // CRS-A: create maps "" → NULL (treated as absent), consistent with the PATCH clear rule.
+                vcsExternalRegistry = request.vcsExternalRegistry?.let(::clearBlankScalar),
                 distributionExplicit = request.distributionExplicit,
                 distributionExternal = request.distributionExternal,
                 systemCode = canonicalSystem,
@@ -565,7 +566,8 @@ class ComponentManagementServiceImpl(
             if (!fieldConfigService.isHidden("component.jiraHotfixVersionFormat")) entity.jiraHotfixVersionFormat = it
         }
         request.vcsExternalRegistry?.let {
-            if (!fieldConfigService.isHidden("component.vcsExternalRegistry")) entity.vcsExternalRegistry = it
+            // CRS-A: "" clears the external registry (persist NULL); non-blank sets verbatim.
+            if (!fieldConfigService.isHidden("component.vcsExternalRegistry")) entity.vcsExternalRegistry = clearBlankScalar(it)
         }
         request.distributionExplicit?.let {
             if (!fieldConfigService.isHidden("component.distributionExplicit")) entity.distributionExplicit = it
@@ -1714,38 +1716,43 @@ class ComponentManagementServiceImpl(
     ) {
         if (request == null) return
         request.versionRange?.let { config.versionRange = it }
+        // CRS-A: on create an incoming "" maps to NULL (treated as absent), for
+        // consistency with the PATCH clear rule. `?.let(::clearBlankScalar)`
+        // keeps null as null, maps "" → null, and sets non-blank verbatim.
         request.build?.let { b ->
+            // buildSystem is a required enum (validated) — not clearable; set as-is.
             config.buildSystem = b.buildSystem
-            config.javaVersion = b.javaVersion
-            config.mavenVersion = b.mavenVersion
-            config.gradleVersion = b.gradleVersion
-            config.buildFilePath = b.buildFilePath
+            config.javaVersion = b.javaVersion?.let(::clearBlankScalar)
+            config.mavenVersion = b.mavenVersion?.let(::clearBlankScalar)
+            config.gradleVersion = b.gradleVersion?.let(::clearBlankScalar)
+            config.buildFilePath = b.buildFilePath?.let(::clearBlankScalar)
             config.deprecated = b.deprecated
             config.requiredProject = b.requiredProject
-            config.projectVersion = b.projectVersion
-            config.systemProperties = b.systemProperties
-            config.buildTasks = b.buildTasks
+            config.projectVersion = b.projectVersion?.let(::clearBlankScalar)
+            config.systemProperties = b.systemProperties?.let(::clearBlankScalar)
+            config.buildTasks = b.buildTasks?.let(::clearBlankScalar)
         }
         request.escrow?.let { e ->
-            config.escrowProvidedDependencies = e.providedDependencies
+            config.escrowProvidedDependencies = e.providedDependencies?.let(::clearBlankScalar)
             config.escrowReusable = e.reusable
+            // escrow.generation is a validated enum mode — not clearable; set as-is.
             config.escrowGeneration = e.generation
-            config.escrowDiskSpace = e.diskSpace
-            config.escrowAdditionalSources = e.additionalSources
-            config.escrowGradleIncludeConfigurations = e.gradleIncludeConfigurations
-            config.escrowGradleExcludeConfigurations = e.gradleExcludeConfigurations
+            config.escrowDiskSpace = e.diskSpace?.let(::clearBlankScalar)
+            config.escrowAdditionalSources = e.additionalSources?.let(::clearBlankScalar)
+            config.escrowGradleIncludeConfigurations = e.gradleIncludeConfigurations?.let(::clearBlankScalar)
+            config.escrowGradleExcludeConfigurations = e.gradleExcludeConfigurations?.let(::clearBlankScalar)
             config.escrowGradleIncludeTestConfigurations = e.gradleIncludeTestConfigurations
-            config.escrowBuildTask = e.buildTask
+            config.escrowBuildTask = e.buildTask?.let(::clearBlankScalar)
         }
         request.jira?.let { j ->
-            config.jiraProjectKey = j.projectKey
+            config.jiraProjectKey = j.projectKey?.let(::clearBlankScalar)
             config.jiraTechnical = j.technical
-            config.jiraMinorVersionFormat = j.minorVersionFormat
-            config.jiraReleaseVersionFormat = j.releaseVersionFormat
-            config.jiraBuildVersionFormat = j.buildVersionFormat
-            config.jiraLineVersionFormat = j.lineVersionFormat
-            config.jiraVersionPrefix = j.versionPrefix
-            config.jiraVersionFormat = j.versionFormat
+            config.jiraMinorVersionFormat = j.minorVersionFormat?.let(::clearBlankScalar)
+            config.jiraReleaseVersionFormat = j.releaseVersionFormat?.let(::clearBlankScalar)
+            config.jiraBuildVersionFormat = j.buildVersionFormat?.let(::clearBlankScalar)
+            config.jiraLineVersionFormat = j.lineVersionFormat?.let(::clearBlankScalar)
+            config.jiraVersionPrefix = j.versionPrefix?.let(::clearBlankScalar)
+            config.jiraVersionFormat = j.versionFormat?.let(::clearBlankScalar)
             // jiraHotfixVersionFormat per-range write is intentionally not
             // exposed via V4 (no UI need today); DSL import is the only
             // producer of the per-range column.
@@ -1769,39 +1776,46 @@ class ComponentManagementServiceImpl(
         config: ComponentConfigurationEntity,
         patch: BaseConfigurationRequest,
     ) {
+        // CRS-A tri-state for free-text string scalars: null/absent = no-op (the
+        // `?.let` skips it), "" = clear to NULL (clearBlankScalar), non-blank = set
+        // verbatim. Booleans keep the plain `?.let` (no clear semantic). The two
+        // enum-validated scalars are NOT clearable: `build.buildSystem` is required
+        // and `escrow.generation` must be a known mode — both are validated
+        // (validateBuildSystem / validateEscrowGenerationMode reject blank), so a
+        // "" on those is a 400, not a clear. They keep set-only semantics.
         patch.versionRange?.let { config.versionRange = it }
         patch.build?.let { b ->
             b.buildSystem?.let { config.buildSystem = it }
-            b.javaVersion?.let { config.javaVersion = it }
-            b.mavenVersion?.let { config.mavenVersion = it }
-            b.gradleVersion?.let { config.gradleVersion = it }
-            b.buildFilePath?.let { config.buildFilePath = it }
+            b.javaVersion?.let { config.javaVersion = clearBlankScalar(it) }
+            b.mavenVersion?.let { config.mavenVersion = clearBlankScalar(it) }
+            b.gradleVersion?.let { config.gradleVersion = clearBlankScalar(it) }
+            b.buildFilePath?.let { config.buildFilePath = clearBlankScalar(it) }
             b.deprecated?.let { config.deprecated = it }
             b.requiredProject?.let { config.requiredProject = it }
-            b.projectVersion?.let { config.projectVersion = it }
-            b.systemProperties?.let { config.systemProperties = it }
-            b.buildTasks?.let { config.buildTasks = it }
+            b.projectVersion?.let { config.projectVersion = clearBlankScalar(it) }
+            b.systemProperties?.let { config.systemProperties = clearBlankScalar(it) }
+            b.buildTasks?.let { config.buildTasks = clearBlankScalar(it) }
         }
         patch.escrow?.let { e ->
-            e.providedDependencies?.let { config.escrowProvidedDependencies = it }
+            e.providedDependencies?.let { config.escrowProvidedDependencies = clearBlankScalar(it) }
             e.reusable?.let { config.escrowReusable = it }
             e.generation?.let { config.escrowGeneration = it }
-            e.diskSpace?.let { config.escrowDiskSpace = it }
-            e.additionalSources?.let { config.escrowAdditionalSources = it }
-            e.gradleIncludeConfigurations?.let { config.escrowGradleIncludeConfigurations = it }
-            e.gradleExcludeConfigurations?.let { config.escrowGradleExcludeConfigurations = it }
+            e.diskSpace?.let { config.escrowDiskSpace = clearBlankScalar(it) }
+            e.additionalSources?.let { config.escrowAdditionalSources = clearBlankScalar(it) }
+            e.gradleIncludeConfigurations?.let { config.escrowGradleIncludeConfigurations = clearBlankScalar(it) }
+            e.gradleExcludeConfigurations?.let { config.escrowGradleExcludeConfigurations = clearBlankScalar(it) }
             e.gradleIncludeTestConfigurations?.let { config.escrowGradleIncludeTestConfigurations = it }
-            e.buildTask?.let { config.escrowBuildTask = it }
+            e.buildTask?.let { config.escrowBuildTask = clearBlankScalar(it) }
         }
         patch.jira?.let { j ->
-            j.projectKey?.let { config.jiraProjectKey = it }
+            j.projectKey?.let { config.jiraProjectKey = clearBlankScalar(it) }
             j.technical?.let { config.jiraTechnical = it }
-            j.minorVersionFormat?.let { config.jiraMinorVersionFormat = it }
-            j.releaseVersionFormat?.let { config.jiraReleaseVersionFormat = it }
-            j.buildVersionFormat?.let { config.jiraBuildVersionFormat = it }
-            j.lineVersionFormat?.let { config.jiraLineVersionFormat = it }
-            j.versionPrefix?.let { config.jiraVersionPrefix = it }
-            j.versionFormat?.let { config.jiraVersionFormat = it }
+            j.minorVersionFormat?.let { config.jiraMinorVersionFormat = clearBlankScalar(it) }
+            j.releaseVersionFormat?.let { config.jiraReleaseVersionFormat = clearBlankScalar(it) }
+            j.buildVersionFormat?.let { config.jiraBuildVersionFormat = clearBlankScalar(it) }
+            j.lineVersionFormat?.let { config.jiraLineVersionFormat = clearBlankScalar(it) }
+            j.versionPrefix?.let { config.jiraVersionPrefix = clearBlankScalar(it) }
+            j.versionFormat?.let { config.jiraVersionFormat = clearBlankScalar(it) }
             // jiraHotfixVersionFormat per-range PATCH is intentionally not
             // exposed via V4; see applyBaseConfigurationCreate above.
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/V4ScalarClearSemantics.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/V4ScalarClearSemantics.kt
@@ -1,0 +1,18 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+/**
+ * CRS-A — v4 write-side clear semantics for aspect string scalars
+ * (`build` / `escrow` / `jira`) and the top-level `vcsExternalRegistry`.
+ *
+ * Applied AFTER the caller's `?.let`, which already handles the null/absent
+ * (no-op) case. What remains is a two-way decision on a present value:
+ *  - `""` or whitespace-only (blank after trim) → clear the column (persist NULL),
+ *  - non-blank → set verbatim (no trimming).
+ *
+ * `""` was never emitted by any v4 client before this rule, so promoting it
+ * from "store the empty string" to "clear" is safe. Storing NULL (not "") also
+ * keeps the resolver's `?:` format fallbacks working — an empty string is
+ * non-null and would defeat them (see ClearedFormatFallbackResolverTest). The
+ * tri-state is documented on the affected OpenAPI field descriptions.
+ */
+internal fun clearBlankScalar(incoming: String): String? = incoming.ifBlank { null }

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -1173,6 +1173,7 @@
             "type" : "string"
           },
           "value" : {
+            "description" : "For a string-typed scalar attribute a blank value (\"\" or whitespace) is rejected (400): an override row stores its value verbatim and has no clear semantics — use DELETE /field-overrides/{id} to remove it.",
             "type" : "object"
           },
           "versionRange" : {
@@ -1235,6 +1236,7 @@
             "$ref" : "#/components/schemas/MarkerChildrenPayload"
           },
           "value" : {
+            "description" : "For a string-typed scalar attribute a blank value (\"\" or whitespace) is rejected (400): an override row stores its value verbatim and has no clear semantics — use DELETE /field-overrides/{id} to remove it.",
             "type" : "object"
           },
           "versionRange" : {
@@ -1256,6 +1258,7 @@
             "type" : "string"
           },
           "value" : {
+            "description" : "For a string-typed scalar attribute a blank value (\"\" or whitespace) is rejected (400): an override row stores its value verbatim and has no clear semantics — use DELETE /field-overrides/{id} to remove it.",
             "type" : "object"
           },
           "versionRange" : {

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -220,33 +220,40 @@
       "BuildAspectRequest" : {
         "properties" : {
           "buildFilePath" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "buildSystem" : {
             "type" : "string"
           },
           "buildTasks" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "deprecated" : {
             "type" : "boolean"
           },
           "gradleVersion" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "javaVersion" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "mavenVersion" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "projectVersion" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "requiredProject" : {
             "type" : "boolean"
           },
           "systemProperties" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           }
         },
@@ -543,6 +550,7 @@
             "type" : "array"
           },
           "vcsExternalRegistry" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           }
         },
@@ -952,6 +960,7 @@
             "type" : "array"
           },
           "vcsExternalRegistry" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "version" : {
@@ -1088,27 +1097,33 @@
       "EscrowAspectRequest" : {
         "properties" : {
           "additionalSources" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "buildTask" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "diskSpace" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "generation" : {
             "type" : "string"
           },
           "gradleExcludeConfigurations" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "gradleIncludeConfigurations" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "gradleIncludeTestConfigurations" : {
             "type" : "boolean"
           },
           "providedDependencies" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "reusable" : {
@@ -1497,27 +1512,34 @@
       "JiraAspectRequest" : {
         "properties" : {
           "buildVersionFormat" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null. When cleared, the build version format falls back to the release version format.",
             "type" : "string"
           },
           "lineVersionFormat" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null. When cleared, the line version format falls back to the minor version format.",
             "type" : "string"
           },
           "minorVersionFormat" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "projectKey" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null. Clearing it removes the component's Jira association (no Jira version coordinates are computed) and drops its (projectKey, versionPrefix) uniqueness claim.",
             "type" : "string"
           },
           "releaseVersionFormat" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "technical" : {
             "type" : "boolean"
           },
           "versionFormat" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           },
           "versionPrefix" : {
+            "description" : "Write tri-state: omit or null = leave unchanged; \"\" (or blank) = clear to null; non-blank = set verbatim. On create, \"\" is treated as null.",
             "type" : "string"
           }
         },

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4ClearSemanticsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4ClearSemanticsTest.kt
@@ -195,18 +195,24 @@ class V4ClearSemanticsTest {
         val created =
             create(
                 unique("clear_build"),
-                """{"build":{"buildSystem":"MAVEN","javaVersion":"17","mavenVersion":"3.9","buildFilePath":"pom.xml"}}""",
+                """{"build":{"buildSystem":"MAVEN","javaVersion":"17","mavenVersion":"3.9","buildFilePath":"pom.xml",""" +
+                    """"gradleVersion":"8.6","projectVersion":"1.0","systemProperties":"-Dfoo=bar","buildTasks":"clean build"}}""",
             )
         val id = created["id"].asText()
         val patched =
             patch(
                 id, version(created),
-                """"baseConfiguration":{"build":{"buildSystem":"MAVEN","javaVersion":"","mavenVersion":"","buildFilePath":""}}""",
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN","javaVersion":"","mavenVersion":"","buildFilePath":"",""" +
+                    """"gradleVersion":"","projectVersion":"","systemProperties":"","buildTasks":""}}""",
             )
         assertEquals("MAVEN", patched.baseScalar("build", "buildSystem"), "non-blank value stays set")
         assertNull(patched.baseScalar("build", "javaVersion"))
         assertNull(patched.baseScalar("build", "mavenVersion"))
         assertNull(patched.baseScalar("build", "buildFilePath"))
+        assertNull(patched.baseScalar("build", "gradleVersion"))
+        assertNull(patched.baseScalar("build", "projectVersion"))
+        assertNull(patched.baseScalar("build", "systemProperties"))
+        assertNull(patched.baseScalar("build", "buildTasks"))
     }
 
     // ------------------------------------------------------------------
@@ -220,7 +226,8 @@ class V4ClearSemanticsTest {
             create(
                 unique("clear_escrow"),
                 """{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":"AUTO","diskSpace":"500M",""" +
-                    """"buildTask":"clean build","providedDependencies":"org.foo:bar"}}""",
+                    """"buildTask":"clean build","providedDependencies":"org.foo:bar","additionalSources":"src/extra",""" +
+                    """"gradleIncludeConfigurations":"runtimeClasspath","gradleExcludeConfigurations":"testRuntime"}}""",
             )
         val id = created["id"].asText()
         // generation is a validated enum (not free-text) — echo it unchanged; the
@@ -228,12 +235,16 @@ class V4ClearSemanticsTest {
         val patched =
             patch(
                 id, version(created),
-                """"baseConfiguration":{"escrow":{"generation":"AUTO","diskSpace":"","buildTask":"","providedDependencies":""}}""",
+                """"baseConfiguration":{"escrow":{"generation":"AUTO","diskSpace":"","buildTask":"","providedDependencies":"",""" +
+                    """"additionalSources":"","gradleIncludeConfigurations":"","gradleExcludeConfigurations":""}}""",
             )
         assertEquals("AUTO", patched.baseScalar("escrow", "generation"), "the validated generation enum stays set")
         assertNull(patched.baseScalar("escrow", "diskSpace"))
         assertNull(patched.baseScalar("escrow", "buildTask"))
         assertNull(patched.baseScalar("escrow", "providedDependencies"))
+        assertNull(patched.baseScalar("escrow", "additionalSources"))
+        assertNull(patched.baseScalar("escrow", "gradleIncludeConfigurations"))
+        assertNull(patched.baseScalar("escrow", "gradleExcludeConfigurations"))
     }
 
     // ------------------------------------------------------------------
@@ -279,6 +290,33 @@ class V4ClearSemanticsTest {
             "\$major.\$minor.\$service",
             patched.baseScalar("jira", "releaseVersionFormat"),
             "an absent scalar must be left unchanged (null = don't touch)",
+        )
+    }
+
+    @Test
+    @DisplayName("PATCH with an EXPLICIT JSON null scalar is likewise a no-op (distinct from \"\")")
+    fun `explicit json null scalar is a no-op`() {
+        val pk = uniqueProjectKey()
+        val created =
+            create(
+                unique("noop_explicit_null"),
+                """{"build":{"buildSystem":"MAVEN","javaVersion":"17"},""" +
+                    """"jira":{"projectKey":"$pk","releaseVersionFormat":"${'$'}major.${'$'}minor.${'$'}service"}}""",
+            )
+        val id = created["id"].asText()
+        // Explicit JSON nulls (NOT absent fields) — the tri-state's null branch must
+        // leave both values untouched, in contrast to "" which would clear them.
+        val patched =
+            patch(
+                id, version(created),
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN","javaVersion":null},""" +
+                    """"jira":{"projectKey":"$pk","releaseVersionFormat":null}}""",
+            )
+        assertEquals("17", patched.baseScalar("build", "javaVersion"), "explicit null must not clear")
+        assertEquals(
+            "\$major.\$minor.\$service",
+            patched.baseScalar("jira", "releaseVersionFormat"),
+            "explicit null must not clear",
         )
     }
 
@@ -373,6 +411,64 @@ class V4ClearSemanticsTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"pom.xml"}"""),
             ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
+    @DisplayName("blank override value is rejected on standalone PATCH and on the component-PATCH desired-set too")
+    fun `blank override value is rejected on update paths`() {
+        val created = create(unique("override_blank_upd"), """{"build":{"buildSystem":"MAVEN"}}""")
+        val id = created["id"].asText()
+
+        // Seed a valid override, keep its id for the standalone PATCH path.
+        val overrideId =
+            objectMapper
+                .readTree(
+                    mvc
+                        .perform(
+                            post("/rest/api/4/components/$id/field-overrides")
+                                .with(adminJwt())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                    """{"overriddenAttribute":"jira.buildVersionFormat",""" +
+                                        """"versionRange":"[1.0,2.0)","value":"${'$'}major.${'$'}minor"}""",
+                                ),
+                        ).andExpect(status().is2xxSuccessful)
+                        .andReturn().response.contentAsString,
+                )["id"].asText()
+
+        // Standalone PATCH of the override with a blank value → 400 (same guard as POST).
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id/field-overrides/$overrideId")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"value":"   "}"""),
+            ).andExpect(status().isBadRequest)
+
+        // Component-PATCH desired-set branch: a blank value inside fieldOverrides → 400,
+        // and the PATCH must not partially apply.
+        val versionNow = version(getComponent(id))
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"version":$versionNow,"fieldOverrides":[{"overriddenAttribute":"jira.buildVersionFormat",""" +
+                            """"versionRange":"[1.0,2.0)","value":""}]}""",
+                    ),
+            ).andExpect(status().isBadRequest)
+
+        // The seeded override survives both rejected writes unchanged.
+        val overrides =
+            objectMapper.readTree(
+                mvc
+                    .perform(get("/rest/api/4/components/$id/field-overrides").with(adminJwt()))
+                    .andExpect(status().isOk)
+                    .andReturn().response.contentAsString,
+            )
+        val row = overrides.first { it["id"].asText() == overrideId }
+        assertEquals("\$major.\$minor", row["value"].asText(), "rejected blank writes must not alter the override")
     }
 
     // ------------------------------------------------------------------

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4ClearSemanticsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4ClearSemanticsTest.kt
@@ -1,0 +1,332 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * CRS-A — v4 write-side clear semantics for aspect string scalars.
+ *
+ * Tri-state contract for the string scalars of the base configuration's
+ * `build` / `escrow` / `jira` aspects, plus the top-level `vcsExternalRegistry`:
+ *   - `null` / absent  → no-op (leave the column unchanged),
+ *   - `""` (or blank)  → clear the column (persist NULL),
+ *   - non-blank        → set verbatim.
+ *
+ * Before this change the write path used `?.let { X = it }`, so a `""` was
+ * stored verbatim as an empty string and `null` was the only "don't touch"
+ * signal — there was no way to clear a scalar from the editor. These round-trips
+ * seed a component via the v4 POST endpoint, PATCH the fields to `""`, and read
+ * them back as NULL. Also pins that create maps `""` to NULL, that `null`
+ * remains a no-op, and that a cleared value audits as old→null.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+@Tag("integration")
+class V4ClearSemanticsTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(V4ClearSemanticsTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun unique(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    // A unique jira project key so the (projectKey, versionPrefix) uniqueness rule
+    // never collides with a sibling test or fixture data.
+    private fun uniqueProjectKey() = "PK${UUID.randomUUID().toString().take(8).uppercase().replace("-", "")}"
+
+    /** POST a component with the given raw baseConfiguration + top-level JSON fragments; returns the detail node. */
+    private fun create(name: String, baseConfigJson: String, topLevelJson: String = ""): JsonNode {
+        val body =
+            """{"name":"$name","componentOwner":"owner1",""" +
+                """"group":{"groupKey":"org.example.test","isFake":false},$topLevelJson""" +
+                """"baseConfiguration":$baseConfigJson}"""
+        val response =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body),
+                ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        return objectMapper.readTree(response)
+    }
+
+    private fun getComponent(id: String): JsonNode =
+        objectMapper.readTree(
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn().response.contentAsString,
+        )
+
+    private fun patch(id: String, version: Long, fieldsJson: String): JsonNode =
+        objectMapper.readTree(
+            mvc
+                .perform(
+                    patch("/rest/api/4/components/$id")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"version":$version,$fieldsJson}"""),
+                ).andExpect(status().isOk)
+                .andReturn().response.contentAsString,
+        )
+
+    /** The BASE configuration row of a detail node. */
+    private fun JsonNode.baseRow(): JsonNode =
+        this["configurations"].first { it["rowType"].asText() == "BASE" }
+
+    /** A scalar under `configurations[BASE].<aspect>.<field>`, or null when JSON null/absent. */
+    private fun JsonNode.baseScalar(aspect: String, field: String): String? =
+        baseRow()[aspect]?.get(field)?.takeUnless { it.isNull }?.asText()
+
+    private fun version(node: JsonNode): Long = node["version"].asLong()
+
+    // ------------------------------------------------------------------
+    // jira aspect string scalars
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH jira scalars to \"\" clears them to NULL (read back as null)")
+    fun `jira scalars clear via empty string`() {
+        val pk = uniqueProjectKey()
+        val created =
+            create(
+                unique("clear_jira"),
+                """{"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"$pk","versionPrefix":"pfx",""" +
+                    """"minorVersionFormat":"${'$'}major.${'$'}minor","releaseVersionFormat":"${'$'}major.${'$'}minor.${'$'}service",""" +
+                    """"buildVersionFormat":"${'$'}major.${'$'}minor.${'$'}service.${'$'}fix","lineVersionFormat":"Line.${'$'}major.${'$'}minor",""" +
+                    """"versionFormat":"${'$'}versionPrefix-${'$'}baseVersionFormat"}}""",
+            )
+        val id = created["id"].asText()
+        // Sanity: everything set on create.
+        assertEquals(pk, created.baseScalar("jira", "projectKey"))
+        assertEquals("pfx", created.baseScalar("jira", "versionPrefix"))
+
+        val patched =
+            patch(
+                id, version(created),
+                """"baseConfiguration":{"jira":{"projectKey":"","versionPrefix":"","minorVersionFormat":"",""" +
+                    """"releaseVersionFormat":"","buildVersionFormat":"","lineVersionFormat":"","versionFormat":""}}""",
+            )
+
+        listOf(
+            "projectKey", "versionPrefix", "minorVersionFormat", "releaseVersionFormat",
+            "buildVersionFormat", "lineVersionFormat", "versionFormat",
+        ).forEach { field ->
+            assertNull(patched.baseScalar("jira", field), "jira.$field must be cleared to null, was ${patched.baseScalar("jira", field)}")
+        }
+        // Durable across a fresh read.
+        assertNull(getComponent(id).baseScalar("jira", "buildVersionFormat"))
+    }
+
+    @Test
+    @DisplayName("clearing jira.buildVersionFormat via \"\" leaves releaseVersionFormat intact (fallback precondition)")
+    fun `clearing build format leaves release format`() {
+        val created =
+            create(
+                unique("clear_buildfmt"),
+                """{"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"${uniqueProjectKey()}",""" +
+                    """"releaseVersionFormat":"${'$'}major.${'$'}minor.${'$'}service","buildVersionFormat":"${'$'}major.${'$'}minor.${'$'}service.${'$'}fix"}}""",
+            )
+        val id = created["id"].asText()
+        val patched = patch(id, version(created), """"baseConfiguration":{"jira":{"buildVersionFormat":""}}""")
+        assertNull(patched.baseScalar("jira", "buildVersionFormat"), "buildVersionFormat must be cleared")
+        assertEquals(
+            "\$major.\$minor.\$service",
+            patched.baseScalar("jira", "releaseVersionFormat"),
+            "releaseVersionFormat must be untouched — its value is what a cleared buildVersionFormat falls back to",
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // build aspect string scalars
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH build scalars to \"\" clears them to NULL")
+    fun `build scalars clear via empty string`() {
+        val created =
+            create(
+                unique("clear_build"),
+                """{"build":{"buildSystem":"MAVEN","javaVersion":"17","mavenVersion":"3.9","buildFilePath":"pom.xml"}}""",
+            )
+        val id = created["id"].asText()
+        val patched =
+            patch(
+                id, version(created),
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN","javaVersion":"","mavenVersion":"","buildFilePath":""}}""",
+            )
+        assertEquals("MAVEN", patched.baseScalar("build", "buildSystem"), "non-blank value stays set")
+        assertNull(patched.baseScalar("build", "javaVersion"))
+        assertNull(patched.baseScalar("build", "mavenVersion"))
+        assertNull(patched.baseScalar("build", "buildFilePath"))
+    }
+
+    // ------------------------------------------------------------------
+    // escrow aspect string scalars
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH free-text escrow scalars to \"\" clears them; the validated generation enum is left intact")
+    fun `escrow scalars clear via empty string`() {
+        val created =
+            create(
+                unique("clear_escrow"),
+                """{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":"AUTO","diskSpace":"500M",""" +
+                    """"buildTask":"clean build","providedDependencies":"org.foo:bar"}}""",
+            )
+        val id = created["id"].asText()
+        // generation is a validated enum (not free-text) — echo it unchanged; the
+        // free-text scalars carry "" to clear.
+        val patched =
+            patch(
+                id, version(created),
+                """"baseConfiguration":{"escrow":{"generation":"AUTO","diskSpace":"","buildTask":"","providedDependencies":""}}""",
+            )
+        assertEquals("AUTO", patched.baseScalar("escrow", "generation"), "the validated generation enum stays set")
+        assertNull(patched.baseScalar("escrow", "diskSpace"))
+        assertNull(patched.baseScalar("escrow", "buildTask"))
+        assertNull(patched.baseScalar("escrow", "providedDependencies"))
+    }
+
+    // ------------------------------------------------------------------
+    // top-level vcsExternalRegistry
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH vcsExternalRegistry to \"\" clears it to NULL")
+    fun `vcsExternalRegistry clears via empty string`() {
+        val created =
+            create(
+                unique("clear_vcsreg"),
+                """{"build":{"buildSystem":"MAVEN"}}""",
+                topLevelJson = """"vcsExternalRegistry":"some-registry",""",
+            )
+        val id = created["id"].asText()
+        assertEquals("some-registry", created["vcsExternalRegistry"].asText())
+
+        val patched = patch(id, version(created), """"vcsExternalRegistry":""""")
+        assertTrue(patched["vcsExternalRegistry"].isNull, "vcsExternalRegistry must be cleared to null")
+        assertTrue(getComponent(id)["vcsExternalRegistry"].isNull, "clear must be durable across a fresh read")
+    }
+
+    // ------------------------------------------------------------------
+    // null / absent remains a no-op (regression guard for the existing contract)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("PATCH with null scalar is still a no-op (leaves the value unchanged)")
+    fun `null scalar is a no-op`() {
+        val pk = uniqueProjectKey()
+        val pk2 = uniqueProjectKey()
+        val created =
+            create(
+                unique("noop_jira"),
+                """{"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"$pk","releaseVersionFormat":"${'$'}major.${'$'}minor.${'$'}service"}}""",
+            )
+        val id = created["id"].asText()
+        // PATCH an unrelated field; jira.releaseVersionFormat is absent → must be preserved.
+        val patched = patch(id, version(created), """"baseConfiguration":{"jira":{"projectKey":"$pk2"}}""")
+        assertEquals(pk2, patched.baseScalar("jira", "projectKey"))
+        assertEquals(
+            "\$major.\$minor.\$service",
+            patched.baseScalar("jira", "releaseVersionFormat"),
+            "an absent scalar must be left unchanged (null = don't touch)",
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // create maps "" to null (consistency with PATCH clear)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create maps \"\" scalars to NULL (treated as absent)")
+    fun `create maps empty string to null`() {
+        val pk = uniqueProjectKey()
+        val created =
+            create(
+                unique("create_empty"),
+                """{"build":{"buildSystem":"MAVEN","javaVersion":""},"jira":{"projectKey":"$pk","versionPrefix":""}}""",
+                topLevelJson = """"vcsExternalRegistry":"",""",
+            )
+        assertNull(created.baseScalar("build", "javaVersion"), "create must map build.javaVersion \"\" to null")
+        assertNull(created.baseScalar("jira", "versionPrefix"), "create must map jira.versionPrefix \"\" to null")
+        assertTrue(created["vcsExternalRegistry"].isNull, "create must map vcsExternalRegistry \"\" to null")
+        assertEquals(pk, created.baseScalar("jira", "projectKey"), "non-blank stays set")
+    }
+
+    // ------------------------------------------------------------------
+    // audit records old -> null on clear
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("clearing a scalar via \"\" records an old->null audit diff")
+    fun `clear audits old to null`() {
+        val created =
+            create(
+                unique("audit_clear"),
+                """{"build":{"buildSystem":"MAVEN","mavenVersion":"3.9"}}""",
+            )
+        val id = created["id"].asText()
+        patch(id, version(created), """"baseConfiguration":{"build":{"buildSystem":"MAVEN","mavenVersion":""}}""")
+
+        val history =
+            objectMapper.readTree(
+                mvc
+                    .perform(get("/rest/api/4/audit/Component/$id").with(adminJwt()).param("size", "500"))
+                    .andExpect(status().isOk)
+                    .andReturn().response.contentAsString,
+            )["content"].toList()
+        val diff =
+            history
+                .filter { it["action"].asText() == "UPDATE" }
+                .map { it.path("changeDiff") }
+                .firstOrNull { it.isObject && it.has("build.mavenVersion") }
+                ?.get("build.mavenVersion")
+                ?: error("expected an UPDATE audit row carrying build.mavenVersion: $history")
+        assertEquals("3.9", diff.path("old").asText(), "audit old must be the pre-clear value")
+        assertTrue(diff.path("new").isNull, "audit new must be null on clear, was ${diff.path("new")}")
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4ClearSemanticsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4ClearSemanticsTest.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.RegistryConfigEntity
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -62,6 +64,9 @@ class V4ClearSemanticsTest {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var registryConfigRepository: RegistryConfigRepository
 
     init {
         val testResourcesPath =
@@ -328,5 +333,147 @@ class V4ClearSemanticsTest {
                 ?: error("expected an UPDATE audit row carrying build.mavenVersion: $history")
         assertEquals("3.9", diff.path("old").asText(), "audit old must be the pre-clear value")
         assertTrue(diff.path("new").isNull, "audit new must be null on clear, was ${diff.path("new")}")
+    }
+
+    // ------------------------------------------------------------------
+    // P2: per-range scalar override with a blank string value is REJECTED 400
+    // (an override row stores its value verbatim — no clear semantics; DELETE
+    // removes it). Contrast with the BASE row where "" clears (tested above).
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("per-range string scalar override with a blank value is rejected 400 (base \"\" clears, override \"\" does not)")
+    fun `blank override value is rejected`() {
+        val created = create(unique("override_blank"), """{"build":{"buildSystem":"MAVEN"}}""")
+        val id = created["id"].asText()
+
+        // "" for a string-typed scalar override → 400 (not stored, not a clear).
+        mvc
+            .perform(
+                post("/rest/api/4/components/$id/field-overrides")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"overriddenAttribute":"jira.buildVersionFormat","versionRange":"[1.0,2.0)","value":""}"""),
+            ).andExpect(status().isBadRequest)
+
+        // whitespace-only is likewise blank → 400.
+        mvc
+            .perform(
+                post("/rest/api/4/components/$id/field-overrides")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"   "}"""),
+            ).andExpect(status().isBadRequest)
+
+        // sanity: a non-blank override value is still accepted.
+        mvc
+            .perform(
+                post("/rest/api/4/components/$id/field-overrides")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0)","value":"pom.xml"}"""),
+            ).andExpect(status().is2xxSuccessful)
+    }
+
+    // ------------------------------------------------------------------
+    // P3.1: the two enum-validated scalars are NOT clearable via "" — 400 in
+    // both create and PATCH flows (they are excluded from the clear rule).
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create with build.buildSystem or escrow.generation = \"\" is rejected 400 (validated enums)")
+    fun `create rejects blank enum scalars`() {
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"name":"${unique("cr_bs")}","componentOwner":"owner1",""" +
+                            """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                            """"baseConfiguration":{"build":{"buildSystem":""}}}""",
+                    ),
+            ).andExpect(status().isBadRequest)
+
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"name":"${unique("cr_gen")}","componentOwner":"owner1",""" +
+                            """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                            """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":""}}}""",
+                    ),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("PATCH build.buildSystem or escrow.generation = \"\" is rejected 400 (validated enums)")
+    fun `patch rejects blank enum scalars`() {
+        val created =
+            create(unique("patch_enum"), """{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":"AUTO"}}""")
+        val id = created["id"].asText()
+
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"version":${version(created)},"baseConfiguration":{"build":{"buildSystem":""}}}"""),
+            ).andExpect(status().isBadRequest)
+
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"version":${version(created)},"baseConfiguration":{"escrow":{"generation":""}}}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    // ------------------------------------------------------------------
+    // P3.2: a field-config-hidden scalar ignores an incoming "" entirely —
+    // the hidden gate strips the write before the clear rule runs, so "" is
+    // NOT a clear (the value is preserved).
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("hidden vcsExternalRegistry ignores an incoming \"\" (no clear — value preserved)")
+    fun `hidden field ignores empty string`() {
+        // create sets the value (create does not gate on hidden); PATCH does.
+        val created =
+            create(
+                unique("hidden_vcsreg"),
+                """{"build":{"buildSystem":"MAVEN"}}""",
+                topLevelJson = """"vcsExternalRegistry":"keep-me",""",
+            )
+        val id = created["id"].asText()
+        assertEquals("keep-me", created["vcsExternalRegistry"].asText())
+
+        try {
+            // Mark component.vcsExternalRegistry hidden via the field-config cache row.
+            seedFieldConfig(
+                mapOf("component" to mapOf("vcsExternalRegistry" to mapOf("visibility" to "hidden"))),
+            )
+            // PATCH "" — would clear if visible; hidden gate must strip it (no clear).
+            patch(id, version(created), """"vcsExternalRegistry":""""")
+            assertEquals(
+                "keep-me",
+                getComponent(id)["vcsExternalRegistry"].asText(),
+                "hidden field must ignore the incoming \"\" — the clear must NOT happen",
+            )
+        } finally {
+            // Reset so the persistent field-config row doesn't leak into sibling tests.
+            seedFieldConfig(emptyMap())
+        }
+    }
+
+    /** Seed the `field-config` cache row directly (mirrors ConfigSyncService's writer). */
+    private fun seedFieldConfig(value: Map<String, Any?>) {
+        val entity =
+            registryConfigRepository.findById("field-config").orElse(RegistryConfigEntity(key = "field-config"))
+        entity.value = value
+        registryConfigRepository.save(entity)
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ClearBlankScalarTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ClearBlankScalarTest.kt
@@ -1,0 +1,35 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * CRS-A — the single contract point for the v4 aspect-scalar clear rule. The
+ * caller's `?.let` has already dropped the null/absent (no-op) case, so this
+ * function only decides blank→clear vs non-blank→set-verbatim.
+ */
+class ClearBlankScalarTest {
+    @Test
+    @DisplayName("empty string clears (-> null)")
+    fun `empty clears`() {
+        assertNull(clearBlankScalar(""))
+    }
+
+    @Test
+    @DisplayName("whitespace-only clears (-> null): blank after trim")
+    fun `whitespace clears`() {
+        assertNull(clearBlankScalar("   "))
+        assertNull(clearBlankScalar("\t\n"))
+    }
+
+    @Test
+    @DisplayName("non-blank is set verbatim — NOT trimmed")
+    fun `non-blank kept verbatim`() {
+        assertEquals("MAVEN", clearBlankScalar("MAVEN"))
+        assertEquals("\$major.\$minor", clearBlankScalar("\$major.\$minor"))
+        // No trimming of a non-blank value: surrounding spaces are preserved.
+        assertEquals("  x  ", clearBlankScalar("  x  "))
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ClearedFormatFallbackResolverTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ClearedFormatFallbackResolverTest.kt
@@ -1,0 +1,101 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * CRS-A — motivation guard for the clear rule at the resolver layer.
+ *
+ * The version-format resolver falls back with a Kotlin `?:` chain
+ * (`buildFmt = jiraBuildVersionFormat ?: releaseFmt`). That chain only fires
+ * on a genuine NULL: an empty-string column is non-null, so it would defeat the
+ * fallback and yield an empty format string. This is exactly why CRS-A converts
+ * a `""` clear to NULL on the write side rather than storing the empty string.
+ *
+ * These tests read the entity columns directly through the resolver:
+ *   - a cleared (NULL) `jiraBuildVersionFormat` falls back to the release format;
+ *   - a would-be `""` column does NOT fall back (the hazard the write rule avoids).
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class ClearedFormatFallbackResolverTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    private fun seed(key: String, buildFormat: String?): ComponentEntity {
+        val comp = ComponentEntity(id = UUID.randomUUID(), componentKey = key)
+        val base =
+            ComponentConfigurationEntity(
+                component = comp,
+                versionRange = ALL_VERSIONS,
+                overriddenAttribute = null,
+                rowType = "BASE",
+                deprecated = false,
+            )
+        base.jiraProjectKey = "PK"
+        base.jiraReleaseVersionFormat = "\$major.\$minor.\$service"
+        base.jiraBuildVersionFormat = buildFormat
+        comp.configurations.add(base)
+        `when`(componentRepository.findByComponentKey(key)).thenReturn(comp)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(comp))
+        return comp
+    }
+
+    @Test
+    @DisplayName("cleared (NULL) buildVersionFormat falls back to the release format")
+    fun `null build format falls back to release`() {
+        seed("CLEARED_NULL_BUILD_FMT", buildFormat = null)
+        val cfg = resolver.getResolvedComponentDefinition("CLEARED_NULL_BUILD_FMT", "1.2.3")
+        assertNotNull(cfg)
+        assertEquals(
+            "\$major.\$minor.\$service",
+            cfg!!.jiraConfiguration?.componentVersionFormat?.buildVersionFormat,
+            "a cleared (null) buildVersionFormat must fall back to releaseVersionFormat",
+        )
+    }
+
+    @Test
+    @DisplayName("empty-string buildVersionFormat does NOT fall back — the hazard the write-side clear rule avoids")
+    fun `empty build format does not fall back`() {
+        seed("EMPTY_BUILD_FMT", buildFormat = "")
+        val cfg = resolver.getResolvedComponentDefinition("EMPTY_BUILD_FMT", "1.2.3")
+        assertNotNull(cfg)
+        assertEquals(
+            "",
+            cfg!!.jiraConfiguration?.componentVersionFormat?.buildVersionFormat,
+            "an empty-string column stays empty (non-null defeats `?:` fallback) — hence write-side stores NULL",
+        )
+    }
+}


### PR DESCRIPTION
## What

Adds a **tri-state write contract** for the free-text string scalars of the v4 base configuration (`build` / `escrow` / `jira` aspects) plus the top-level `vcsExternalRegistry`, applied on **both create and PATCH**:

- `null` / absent → **no-op** (leave the column unchanged);
- `""` (or whitespace / blank) → **clear** the column (persist `NULL`);
- non-blank → **set** verbatim (no trimming).

Previously the write path used `?.let { X = it }`, so a `""` was stored verbatim as an empty string and `null` was the only "don't touch" signal — there was no way to clear a scalar from the editor. A single contract point `clearBlankScalar()` implements the rule; on create an incoming `""` maps to `null` (treated as absent) for the same fields.

## Deliberate decisions

1. **`build.buildSystem` and `escrow.generation` are excluded** from the clear rule. They are validated enums (`validateBuildSystem` / `validateEscrowGenerationMode` already reject blank → `""` is a 400), and `buildSystem` is effectively required. They keep **set-only** semantics.
2. **Per-range override blank value is now rejected (400).** On a `SCALAR_OVERRIDE` row the value is stored verbatim, so a literal `""` would be echoed by the resolver and defeat its `?:` format fallbacks — the exact trap the base-row clear semantics avoid. Overrides have no "clear" operation; removal is `DELETE /field-overrides/{id}`. Enforced in `requireString`, covering all three v4 override write paths (create / update / combined-save upsert). The Groovy import path uses a separate function (`applyScalarValueToRow`) and is unaffected — it still emits its null-clear rows.

`jira.projectKey` **is** included as clearable — verified safe: the `(projectKey, versionPrefix)` uniqueness check ignores blank keys (`computeEffectiveJiraPairs` → `isNotBlank`), the resolve path (`buildJiraComponent`) returns a null `JiraComponent` gracefully, the column is nullable, and there is no server-side required check. Clearing it means "component with no Jira project".

Out of scope (unchanged): top-level `jiraDisplayName` / `jiraHotfixVersionFormat` (existing null-clear contract), booleans, and the import-only per-range null-clear path.

Audit already records `old → null` on a clear (before/after section snapshot in `updateComponent`); covered by a test.

## Verification

- `./gradlew :components-registry-service-server:test` → **BUILD SUCCESSFUL** (includes `OpenApiV4SpecTest` drift gate and `StrictContractTest`).
- `./gradlew :components-registry-service-server:dbTest` → **BUILD SUCCESSFUL** (all `@Tag("integration")`, 0 failures).
- `./gradlew :components-registry-service-server:generateOpenApiDocs` → committed `openapi/v4.json` regenerated (tri-state field descriptions + override `value` notes).
- New tests: `ClearBlankScalarTest` + `ClearedFormatFallbackResolverTest` (unit — a cleared `null` build format falls back to the release format; a `""` column would **not**, motivating the rule); `V4ClearSemanticsTest` (12 dbTest round-trips: per-group set → clear via `""` → read `null`; create `""` → `null`; `null` no-op; audit `old → null`; blank override → 400; excluded-enum `""` → 400 on create + PATCH; hidden field ignores `""`).

## Coordination (portal follow-up, P-1)

When the portal migrates its aspect-scalar clears from `null` to `""` (`useBuildSection` / `useEscrowSection` / `useJiraSection` / `useVcsSection`, dropping the `clearedScalarNoop` annotation): it must **keep sending `null`, not `""`, for the two excluded enum fields** (`build.buildSystem`, `escrow.generation`) — `""` there is a 400. Their `clearedScalarNoop` warning stays truthful. Also recommended: add a symmetric blank guard to `FieldOverrideInline.tsx` `handleUpdate` (the create path already guards blank; the edit path does not, so editing an override value to empty would now surface the 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)