### PR TITLE
feat(config): field-config editable axis (all|adminOnly|none) + options

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
@@ -38,6 +38,23 @@ class AdminConfigProperties {
         /** `editable` | `readonly` | `hidden`. */
         var visibility: String? = null
 
+        /**
+         * Editability axis (CRS-B), orthogonal to [visibility]: `all` | `adminOnly` | `none`.
+         * Absent = `all`. `adminOnly` requires the writer to hold `EDIT_ANY_COMPONENT`;
+         * `none` is non-editable for everyone. `visibility: readonly` is unified with
+         * `none` in `FieldConfigService.editabilityFor`. Enforced change-based on write
+         * (echoing the unchanged value is always allowed) by `ComponentManagementServiceImpl`.
+         */
+        var editable: String? = null
+
+        /**
+         * Enumerated allowed values surfaced to the Portal as a dropdown (e.g. the
+         * configured External Registry names). Serialized into the read-side blob; the
+         * Portal's `useFieldOptions` already consumes `options` with priority over the
+         * meta endpoints. Server does NOT value-validate writes against this list.
+         */
+        var options: MutableList<String>? = null
+
         /** `Main` | `Extended` | `None`. */
         var searchable: String? = null
         var required: Boolean? = null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/PermissionEvaluator.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/security/PermissionEvaluator.kt
@@ -98,6 +98,14 @@ class PermissionEvaluator(
     fun canImport(): Boolean = hasPermission(IMPORT_DATA)
 
     /**
+     * CRS-B field-config `editable: adminOnly` gate. A caller may write a field marked
+     * `adminOnly` only when they hold [EDIT_ANY_COMPONENT] — the same permission that
+     * bypasses the per-component ownership check in [canEditComponent]. Read server-side
+     * from the requester's permissions; the field-config read blob stays user-agnostic.
+     */
+    fun canEditAdminOnlyFields(): Boolean = hasPermission(EDIT_ANY_COMPONENT)
+
+    /**
      * Edit component-configuration metadata — gates the raw Field-Overrides edit
      * surface (add/edit/delete, incl. marker editing); a power-user / escape-hatch
      * capability. Distinct from CREATE_COMPONENTS (new component creation) and

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -172,7 +172,9 @@ class ComponentManagementServiceImpl(
         // (mirrors EscrowConfigValidator.validateExplicitExternalComponent). The 400 is
         // colon-prefixed so the Portal routes it inline onto the displayName field.
         val normalizedDisplayName = request.displayName?.trim()?.takeIf { it.isNotEmpty() }
-        if (normalizedDisplayName != null) {
+        // Skip the uniqueness probe for a hidden displayName — the value is stripped below
+        // (not persisted), so it must not surface a 4xx (hidden = silent, never rejected).
+        if (normalizedDisplayName != null && !fieldConfigService.isHidden("component.displayName")) {
             require(!componentRepository.existsByDisplayName(normalizedDisplayName)) {
                 "displayName: a component with display name '$normalizedDisplayName' already exists"
             }
@@ -205,7 +207,7 @@ class ComponentManagementServiceImpl(
         // property getter — so we hoist explicitly here rather than
         // sprinkling `!!` or `?.let` at each call site.
         val buildSystemValue: String = buildAspect.buildSystem!!
-        request.productType?.let { validateProductType(it) }
+        request.productType?.let { if (!fieldConfigService.isHidden("component.productType")) validateProductType(it) }
         request.clientCode?.let {
             if (!fieldConfigService.isHidden("component.clientCode")) validateClientCode(it)
         }
@@ -214,7 +216,10 @@ class ComponentManagementServiceImpl(
         }
         baseConfigRequest.versionRange?.let { validateRangeSyntax(it) }
         validateBuildSystem(buildSystemValue)
-        baseConfigRequest.escrow?.generation?.let { validateEscrowGenerationMode(it) }
+        // Hidden escrow.generation is stripped below → don't 4xx on its value here.
+        baseConfigRequest.escrow?.generation?.let {
+            if (!fieldConfigService.isHidden("escrow.generation")) validateEscrowGenerationMode(it)
+        }
         // vcsEntries[].repositoryType / packages[].packageType are validated
         // inside `replaceVcsEntries` / `replacePackages` (covers both base-config
         // and field-override marker paths).
@@ -242,17 +247,27 @@ class ComponentManagementServiceImpl(
         // the FK from `components.system_code → systems(code)` is
         // always satisfied on first write of a newly-introduced (but
         // config-allowed) code.
-        val canonicalSystem = request.system?.trim()?.takeIf { it.isNotEmpty() }?.let {
-            val canon = validateAndCanonicalizeSystemCode(it)
-            ensureSystemExists(canon)
-            canon
-        }
-
-        val parent =
-            request.parentComponentName?.let { parentKey ->
-                componentRepository.findByComponentKey(parentKey)
-                    ?: throw NotFoundException("Parent component '$parentKey' not found")
+        val canonicalSystem = request.system
+            ?.takeUnless { fieldConfigService.isHidden("component.system") }
+            ?.trim()?.takeIf { it.isNotEmpty() }?.let {
+                val canon = validateAndCanonicalizeSystemCode(it)
+                ensureSystemExists(canon)
+                canon
             }
+
+        // CRS-B: hidden component-level fields are silently STRIPPED on create (symmetric with
+        // the PATCH write-site gates) — a hidden field is never persisted and never 4xx. A hidden
+        // parentComponentName is treated as absent (no parent), a hidden canBeParent as its
+        // `false` default. Editability (adminOnly/none) is enforced separately by
+        // enforceEditabilityOnCreate before this point.
+        val effectiveCanBeParent = request.canBeParent && !fieldConfigService.isHidden("component.canBeParent")
+        val parent =
+            request.parentComponentName
+                ?.takeUnless { fieldConfigService.isHidden("component.parentComponentName") }
+                ?.let { parentKey ->
+                    componentRepository.findByComponentKey(parentKey)
+                        ?: throw NotFoundException("Parent component '$parentKey' not found")
+                }
 
         // Parent invariants (create = everything is new): a chosen parent must be
         // marked can-be-parent, and a component that itself can be a parent may
@@ -261,7 +276,7 @@ class ComponentManagementServiceImpl(
             require(parent.canBeParent) {
                 "parentComponentName: parent '${parent.componentKey}' is not marked can-be-parent"
             }
-            require(!request.canBeParent) {
+            require(!effectiveCanBeParent) {
                 "parentComponentName: a component that can be a parent cannot itself have a parent"
             }
         }
@@ -269,32 +284,33 @@ class ComponentManagementServiceImpl(
         val entity =
             ComponentEntity(
                 componentKey = normalizedKey,
-                displayName = normalizedDisplayName,
-                componentOwner = request.componentOwner,
-                productType = request.productType,
-                clientCode = request.clientCode,
+                displayName = stripIfHidden("component.displayName", normalizedDisplayName),
+                componentOwner = stripIfHidden("component.componentOwner", request.componentOwner),
+                productType = stripIfHidden("component.productType", request.productType),
+                clientCode = stripIfHidden("component.clientCode", request.clientCode),
                 archived = request.archived,
-                solution = request.solution,
+                solution = stripIfHidden("component.solution", request.solution),
                 parentComponent = parent,
                 // R1: group = migration-derived aggregator membership only; never assigned via API.
                 componentGroup = null,
-                canBeParent = request.canBeParent,
-                copyright = request.copyright,
-                releasesInDefaultBranch = request.releasesInDefaultBranch,
-                jiraDisplayName = request.jiraDisplayName,
-                jiraHotfixVersionFormat = request.jiraHotfixVersionFormat,
+                canBeParent = effectiveCanBeParent,
+                copyright = stripIfHidden("component.copyright", request.copyright),
+                releasesInDefaultBranch = stripIfHidden("component.releasesInDefaultBranch", request.releasesInDefaultBranch),
+                jiraDisplayName = stripIfHidden("component.jiraDisplayName", request.jiraDisplayName),
+                jiraHotfixVersionFormat = stripIfHidden("component.jiraHotfixVersionFormat", request.jiraHotfixVersionFormat),
                 // CRS-A: create maps "" → NULL (treated as absent), consistent with the PATCH clear rule.
-                vcsExternalRegistry = request.vcsExternalRegistry?.let(::clearBlankScalar),
-                distributionExplicit = request.distributionExplicit,
-                distributionExternal = request.distributionExternal,
+                vcsExternalRegistry = stripIfHidden("component.vcsExternalRegistry", request.vcsExternalRegistry?.let(::clearBlankScalar)),
+                distributionExplicit = stripIfHidden("component.distributionExplicit", request.distributionExplicit),
+                distributionExternal = stripIfHidden("component.distributionExternal", request.distributionExternal),
                 systemCode = canonicalSystem,
             )
 
         // Per-component child collections (cascade = ALL on these — flushed with the parent)
         // Ordered multi-value people — the accessor canonicalizes (trim → drop
         // blank → keep-first dedupe), so create matches patch/import exactly.
-        entity.replaceReleaseManagerUsernames(request.releaseManager)
-        entity.replaceSecurityChampionUsernames(request.securityChampion)
+        // CRS-B: hidden people-lists are silently stripped (symmetric with the PATCH gate).
+        if (!fieldConfigService.isHidden("component.releaseManager")) entity.replaceReleaseManagerUsernames(request.releaseManager)
+        if (!fieldConfigService.isHidden("component.securityChampion")) entity.replaceSecurityChampionUsernames(request.securityChampion)
         addArtifactIds(entity, request.artifactIds)
         addSecurityGroups(entity, request.securityGroups.map { it.groupType to it.groupName })
         addTeamcityProjects(entity, request.teamcityProjects.map { it.projectId })
@@ -474,7 +490,10 @@ class ComponentManagementServiceImpl(
         // base-configuration patch block via `validateRangeSyntax` — no
         // top-level guard needed here.
         request.baseConfiguration?.build?.buildSystem?.let { validateBuildSystem(it) }
-        request.baseConfiguration?.escrow?.generation?.let { validateEscrowGenerationMode(it) }
+        // Hidden escrow.generation is stripped in applyBaseConfigurationPatch → don't 4xx here.
+        request.baseConfiguration?.escrow?.generation?.let {
+            if (!fieldConfigService.isHidden("escrow.generation")) validateEscrowGenerationMode(it)
+        }
         // vcsEntries[].repositoryType / packages[].packageType are validated
         // inside `replaceVcsEntries` / `replacePackages` (see service helpers).
         request.labels?.let { validateLabels(it) }
@@ -495,11 +514,13 @@ class ComponentManagementServiceImpl(
         // `systems("CLASSIC")`. `ensureSystemExists` then auto-creates
         // the master `systems` row so the FK from `components.system_code
         // → systems(code)` is satisfied.
-        val canonicalSystem = request.system?.trim()?.takeIf { it.isNotEmpty() }?.let {
-            val canon = validateAndCanonicalizeSystemCode(it)
-            ensureSystemExists(canon)
-            canon
-        }
+        val canonicalSystem = request.system
+            ?.takeUnless { fieldConfigService.isHidden("component.system") }
+            ?.trim()?.takeIf { it.isNotEmpty() }?.let {
+                val canon = validateAndCanonicalizeSystemCode(it)
+                ensureSystemExists(canon)
+                canon
+            }
 
         // Capture the pre-update label set so the post-sync audit `newValue`
         // (which is computed after `syncLabels` has bypassed the entity's
@@ -553,9 +574,9 @@ class ComponentManagementServiceImpl(
         }
         request.solution?.let { if (!fieldConfigService.isHidden("component.solution")) entity.solution = it }
         request.archived?.let { entity.archived = it }
-        // canBeParent is structural (not field-config-gated). Invariants are
-        // validated below once the final parent/canBeParent state is known.
-        request.canBeParent?.let { entity.canBeParent = it }
+        // canBeParent: editability enforced above; `hidden` silently strips (consistent with
+        // the other field-config-gated scalars). Structural invariants are validated below.
+        request.canBeParent?.let { if (!fieldConfigService.isHidden("component.canBeParent")) entity.canBeParent = it }
         // Ordered multi-value people. `null` = don't touch; a provided list
         // (including empty = clear) replaces the whole ordered child collection.
         request.releaseManager?.let {
@@ -605,14 +626,17 @@ class ComponentManagementServiceImpl(
 
         // Parent. `parentComponentName == null` = don't touch (JSON Merge Patch);
         // `clearParent` is the explicit removal signal (remediates a grandfathered
-        // parent-of-parent row by letting the user drop the parent).
-        if (request.clearParent) {
-            entity.parentComponent = null
-        }
-        request.parentComponentName?.let { parentKey ->
-            entity.parentComponent =
-                componentRepository.findByComponentKey(parentKey)
-                    ?: throw NotFoundException("Parent component '$parentKey' not found")
+        // parent-of-parent row by letting the user drop the parent). Editability is
+        // enforced above; `hidden` silently strips both the set and the clear.
+        if (!fieldConfigService.isHidden("component.parentComponentName")) {
+            if (request.clearParent) {
+                entity.parentComponent = null
+            }
+            request.parentComponentName?.let { parentKey ->
+                entity.parentComponent =
+                    componentRepository.findByComponentKey(parentKey)
+                        ?: throw NotFoundException("Parent component '$parentKey' not found")
+            }
         }
 
         // Parent / canBeParent invariants (single-level — matches the DSL validator):
@@ -860,9 +884,11 @@ class ComponentManagementServiceImpl(
         request: FieldOverrideCreateRequest,
     ): FieldOverrideResponse {
         val component = findComponentOr404(componentId)
-        // CRS-B: introducing an override IS a value change on the overridden attribute
-        // — gate it by the caller's editability for that field. Unknown/marker
-        // attributes resolve to `all` (no-op) and still hit their own validation below.
+        // CRS-B: introducing an override IS a value change on the overridden attribute.
+        // A hidden attribute is masked as unknown (400, no leak); otherwise gate by the
+        // caller's editability. Unknown/marker attributes resolve to `all` (no-op) and
+        // still hit their own validation below.
+        rejectHiddenOverrideAttribute(request.overriddenAttribute)
         enforceOverrideEditable(request.overriddenAttribute)
         // Whitespace normalisation up-front so the DB UNIQUE (which is exact-
         // string) and the duplicate-row lookup agree with the partial-overlap
@@ -967,6 +993,8 @@ class ComponentManagementServiceImpl(
             "Cannot update id $overrideId via field-override endpoint (row_type=${row.rowType})"
         }
         requireNotImportManagedMarker(row, "update")
+        // CRS-B: a hidden attribute is masked as unknown (400) on the standalone endpoint.
+        row.overriddenAttribute?.let { rejectHiddenOverrideAttribute(it) }
 
         val beforeSnapshot = fieldOverrideAuditSnapshot(row)
 
@@ -1038,9 +1066,12 @@ class ComponentManagementServiceImpl(
             "Cannot delete id $overrideId via field-override endpoint (row_type=${row.rowType})"
         }
         requireNotImportManagedMarker(row, "delete")
-        // CRS-B: removing an override changes the effective value on its attribute —
-        // gate it like the combined-save desired-set delete branch (no direct-DELETE bypass).
-        row.overriddenAttribute?.let { enforceOverrideEditable(it) }
+        // CRS-B: a hidden attribute is masked as unknown (400); otherwise removing an override
+        // changes the effective value — gate it like the desired-set delete (no direct-DELETE bypass).
+        row.overriddenAttribute?.let {
+            rejectHiddenOverrideAttribute(it)
+            enforceOverrideEditable(it)
+        }
         val owningComponent = row.component
         val beforeSnapshot = fieldOverrideAuditSnapshot(row)
         configurationRepository.delete(row)
@@ -1138,19 +1169,26 @@ class ComponentManagementServiceImpl(
         val pendingTools = LinkedHashMap<ComponentConfigurationEntity, List<String>>()
 
         // 1) DELETE editable rows omitted from the desired set (orphanRemoval on flush).
+        // CRS-B: hidden-attribute rows are PRESERVED here (never deleted) — like import-managed
+        // markers — so a client that (correctly) omits hidden fields from its slice does not
+        // silently drop them.
         val deletedSnapshots = mutableListOf<Map<String, Any?>>()
-        existing.filter { !isImportManaged(it) && it.id !in keepIds }.forEach { row ->
-            // CRS-B: removing an override changes the effective value on that attribute.
-            row.overriddenAttribute?.let { enforceOverrideEditable(it) }
-            deletedSnapshots += fieldOverrideAuditSnapshot(row)
-            component.configurations.remove(row)
-        }
+        existing
+            .filter { !isImportManaged(it) && !isHiddenOverrideAttribute(it.overriddenAttribute) && it.id !in keepIds }
+            .forEach { row ->
+                // Removing an override changes the effective value on that attribute — gate it.
+                row.overriddenAttribute?.let { enforceOverrideEditable(it) }
+                deletedSnapshots += fieldOverrideAuditSnapshot(row)
+                component.configurations.remove(row)
+            }
 
         // 2) UPDATE existing editable rows referenced by id.
         val updated = mutableListOf<Pair<ComponentConfigurationEntity, Map<String, Any?>>>()
         desired.filter { it.id != null }.forEach { d ->
             val row = byId.getValue(d.id!!)
             if (isImportManaged(row)) return@forEach // preserve; ignore client echo
+            // CRS-B: hidden-attribute rows are stripped — preserved as-is, incoming change ignored.
+            if (isHiddenOverrideAttribute(row.overriddenAttribute)) return@forEach
             require(d.overriddenAttribute == row.overriddenAttribute) {
                 "fieldOverrides: cannot change overriddenAttribute of override '${d.id}' " +
                     "(${row.overriddenAttribute} -> ${d.overriddenAttribute})"
@@ -1169,7 +1207,9 @@ class ComponentManagementServiceImpl(
         // 3) CREATE rows without an id.
         val created = mutableListOf<ComponentConfigurationEntity>()
         desired.filter { it.id == null }.forEach { d ->
-            // CRS-B: a new override is a value change on the overridden attribute.
+            // CRS-B: hidden-attribute create is silently dropped (strip); otherwise a new
+            // override is a value change on the overridden attribute — gate it.
+            if (isHiddenOverrideAttribute(d.overriddenAttribute)) return@forEach
             enforceOverrideEditable(d.overriddenAttribute)
             val row =
                 ComponentConfigurationEntity(
@@ -1799,6 +1839,11 @@ class ComponentManagementServiceImpl(
      * value change on the overridden attribute (`overriddenAttribute` doubles as
      * the field-config path, e.g. `jira.technical`). Callers invoke this only for
      * actual changes (an unchanged desired-set echo is left untouched).
+     *
+     * `hidden` is NOT handled here — the two override entry points treat it differently:
+     * the combined-Save desired-set silently strips hidden-attribute records (consistent
+     * with the base write), while the standalone CRUD endpoints reject them via
+     * [rejectHiddenOverrideAttribute]. Callers apply the hidden rule first.
      */
     private fun enforceOverrideEditable(attribute: String) {
         when (fieldConfigService.editabilityFor(attribute)) {
@@ -1817,6 +1862,40 @@ class ComponentManagementServiceImpl(
             else -> Unit // "all"
         }
     }
+
+    /** True when the override's attribute maps to a field-config `visibility: hidden`. */
+    private fun isHiddenOverrideAttribute(attribute: String?): Boolean =
+        attribute != null && fieldConfigService.isHidden(attribute)
+
+    /**
+     * Standalone field-override CRUD rejects a `hidden` attribute with the SAME 400 as a
+     * genuinely unknown attribute — deliberately NOT distinguishing "hidden" from "does not
+     * exist". Field paths are a public contract, but which fields an installation hides is
+     * not: leaking it here would let a caller enumerate hidden config via the override API.
+     * (The combined-Save desired-set instead silently strips hidden records — see
+     * [applyFieldOverrideDesiredSet].)
+     */
+    private fun rejectHiddenOverrideAttribute(attribute: String) {
+        if (fieldConfigService.isHidden(attribute)) throw unknownOverrideAttribute(attribute)
+    }
+
+    /**
+     * CRS-B create-side hidden strip: returns null when [fieldPath] is `hidden` (so the
+     * value is not persisted), else the value verbatim. Mirrors the component-scalar
+     * `if (!isHidden)` gate the PATCH path applies at each write site; used to keep CREATE
+     * symmetric with PATCH (a hidden field is silently dropped, never persisted, never 4xx).
+     */
+    private fun <T> stripIfHidden(
+        fieldPath: String,
+        value: T?,
+    ): T? = if (fieldConfigService.isHidden(fieldPath)) null else value
+
+    /** The canonical 400 for an unsupported override attribute (also reused to mask hidden ones). */
+    private fun unknownOverrideAttribute(attribute: String): IllegalArgumentException =
+        IllegalArgumentException(
+            "Unknown overriddenAttribute: '$attribute'. " +
+                "Must be a scalar aspect.field path or one of ${MarkerAttributes.ALL}",
+        )
 
     /**
      * Change detection for the editability gate. For strings it delegates to the CRS-A
@@ -1867,6 +1946,15 @@ class ComponentManagementServiceImpl(
         request.system?.let { enforceFieldEditable("component.system", it, entity.systemCode) }
         request.releaseManager?.let { enforceFieldEditable("component.releaseManager", it, entity.releaseManagerUsernames()) }
         request.securityChampion?.let { enforceFieldEditable("component.securityChampion", it, entity.securityChampionUsernames()) }
+        request.canBeParent?.let { enforceFieldEditable("component.canBeParent", it, entity.canBeParent) }
+        request.parentComponentName?.let {
+            enforceFieldEditable("component.parentComponentName", it, entity.parentComponent?.componentKey)
+        }
+        // clearParent is the explicit "remove parent" signal — an actual change only when a
+        // parent currently exists; gate it under the same parentComponentName policy.
+        if (request.clearParent && entity.parentComponent != null) {
+            enforceFieldEditable("component.parentComponentName", null, entity.parentComponent?.componentKey)
+        }
 
         val base = entity.configurations.firstOrNull { it.rowType == "BASE" }
         request.baseConfiguration?.jira?.let { j ->
@@ -1879,11 +1967,36 @@ class ComponentManagementServiceImpl(
             j.versionPrefix?.let { enforceFieldEditable("jira.versionPrefix", it, base?.jiraVersionPrefix) }
             j.versionFormat?.let { enforceFieldEditable("jira.versionFormat", it, base?.jiraVersionFormat) }
         }
+        // Full build/escrow aspect-scalar set — must mirror every path applyBaseConfigurationPatch
+        // actually writes (see ConfigurationRowAccessors.SCALAR_ATTRIBUTE_PATHS). Booleans gate by value.
         request.baseConfiguration?.build?.let { b ->
             b.buildSystem?.let { enforceFieldEditable("build.buildSystem", it, base?.buildSystem) }
             b.javaVersion?.let { enforceFieldEditable("build.javaVersion", it, base?.javaVersion) }
             b.gradleVersion?.let { enforceFieldEditable("build.gradleVersion", it, base?.gradleVersion) }
             b.mavenVersion?.let { enforceFieldEditable("build.mavenVersion", it, base?.mavenVersion) }
+            b.buildFilePath?.let { enforceFieldEditable("build.buildFilePath", it, base?.buildFilePath) }
+            b.deprecated?.let { enforceFieldEditable("build.deprecated", it, base?.deprecated) }
+            b.requiredProject?.let { enforceFieldEditable("build.requiredProject", it, base?.requiredProject) }
+            b.projectVersion?.let { enforceFieldEditable("build.projectVersion", it, base?.projectVersion) }
+            b.systemProperties?.let { enforceFieldEditable("build.systemProperties", it, base?.systemProperties) }
+            b.buildTasks?.let { enforceFieldEditable("build.buildTasks", it, base?.buildTasks) }
+        }
+        request.baseConfiguration?.escrow?.let { e ->
+            e.providedDependencies?.let { enforceFieldEditable("escrow.providedDependencies", it, base?.escrowProvidedDependencies) }
+            e.reusable?.let { enforceFieldEditable("escrow.reusable", it, base?.escrowReusable) }
+            e.generation?.let { enforceFieldEditable("escrow.generation", it, base?.escrowGeneration) }
+            e.diskSpace?.let { enforceFieldEditable("escrow.diskSpace", it, base?.escrowDiskSpace) }
+            e.additionalSources?.let { enforceFieldEditable("escrow.additionalSources", it, base?.escrowAdditionalSources) }
+            e.gradleIncludeConfigurations?.let {
+                enforceFieldEditable("escrow.gradleIncludeConfigurations", it, base?.escrowGradleIncludeConfigurations)
+            }
+            e.gradleExcludeConfigurations?.let {
+                enforceFieldEditable("escrow.gradleExcludeConfigurations", it, base?.escrowGradleExcludeConfigurations)
+            }
+            e.gradleIncludeTestConfigurations?.let {
+                enforceFieldEditable("escrow.gradleIncludeTestConfigurations", it, base?.escrowGradleIncludeTestConfigurations)
+            }
+            e.buildTask?.let { enforceFieldEditable("escrow.buildTask", it, base?.escrowBuildTask) }
         }
     }
 
@@ -1907,6 +2020,13 @@ class ComponentManagementServiceImpl(
         request.distributionExplicit?.let { enforceFieldEditable("component.distributionExplicit", it, null) }
         request.distributionExternal?.let { enforceFieldEditable("component.distributionExternal", it, null) }
         request.system?.let { enforceFieldEditable("component.system", it, null) }
+        request.parentComponentName?.let { enforceFieldEditable("component.parentComponentName", it, null) }
+        // canBeParent is a non-null boolean with a `false` default; only a supplied `true`
+        // (a non-default value) counts as a supplied change on create.
+        if (request.canBeParent) enforceFieldEditable("component.canBeParent", true, null)
+        // People lists: only a supplied NON-EMPTY list is a change (empty ≡ absent → server default).
+        request.releaseManager?.takeIf { it.isNotEmpty() }?.let { enforceFieldEditable("component.releaseManager", it, null) }
+        request.securityChampion?.takeIf { it.isNotEmpty() }?.let { enforceFieldEditable("component.securityChampion", it, null) }
 
         request.baseConfiguration?.jira?.let { j ->
             j.projectKey?.let { enforceFieldEditable("jira.projectKey", it, null) }
@@ -1925,6 +2045,23 @@ class ComponentManagementServiceImpl(
             b.javaVersion?.let { enforceFieldEditable("build.javaVersion", it, null) }
             b.gradleVersion?.let { enforceFieldEditable("build.gradleVersion", it, null) }
             b.mavenVersion?.let { enforceFieldEditable("build.mavenVersion", it, null) }
+            b.buildFilePath?.let { enforceFieldEditable("build.buildFilePath", it, null) }
+            b.deprecated?.let { enforceFieldEditable("build.deprecated", it, null) }
+            b.requiredProject?.let { enforceFieldEditable("build.requiredProject", it, null) }
+            b.projectVersion?.let { enforceFieldEditable("build.projectVersion", it, null) }
+            b.systemProperties?.let { enforceFieldEditable("build.systemProperties", it, null) }
+            b.buildTasks?.let { enforceFieldEditable("build.buildTasks", it, null) }
+        }
+        request.baseConfiguration?.escrow?.let { e ->
+            e.providedDependencies?.let { enforceFieldEditable("escrow.providedDependencies", it, null) }
+            e.reusable?.let { enforceFieldEditable("escrow.reusable", it, null) }
+            e.generation?.let { enforceFieldEditable("escrow.generation", it, null) }
+            e.diskSpace?.let { enforceFieldEditable("escrow.diskSpace", it, null) }
+            e.additionalSources?.let { enforceFieldEditable("escrow.additionalSources", it, null) }
+            e.gradleIncludeConfigurations?.let { enforceFieldEditable("escrow.gradleIncludeConfigurations", it, null) }
+            e.gradleExcludeConfigurations?.let { enforceFieldEditable("escrow.gradleExcludeConfigurations", it, null) }
+            e.gradleIncludeTestConfigurations?.let { enforceFieldEditable("escrow.gradleIncludeTestConfigurations", it, null) }
+            e.buildTask?.let { enforceFieldEditable("escrow.buildTask", it, null) }
         }
     }
 
@@ -1942,40 +2079,61 @@ class ComponentManagementServiceImpl(
         // CRS-A: on create an incoming "" maps to NULL (treated as absent), for
         // consistency with the PATCH clear rule. `?.let(::clearBlankScalar)`
         // keeps null as null, maps "" → null, and sets non-blank verbatim.
+        // CRS-B: an aspect field whose field-config visibility is `hidden` is SILENTLY
+        // STRIPPED (its incoming value is ignored, not persisted and NOT a 4xx) — mirroring
+        // the component-scalar isHidden gate. buildSystem is exempt: it is a required enum,
+        // hiding it is unsupported. Editability (adminOnly/none) is enforced separately.
         request.build?.let { b ->
-            // buildSystem is a required enum (validated) — not clearable; set as-is.
+            // buildSystem is a required enum (validated) — not clearable, not hidden-stripped.
             config.buildSystem = b.buildSystem
-            config.javaVersion = b.javaVersion?.let(::clearBlankScalar)
-            config.mavenVersion = b.mavenVersion?.let(::clearBlankScalar)
-            config.gradleVersion = b.gradleVersion?.let(::clearBlankScalar)
-            config.buildFilePath = b.buildFilePath?.let(::clearBlankScalar)
-            config.deprecated = b.deprecated
-            config.requiredProject = b.requiredProject
-            config.projectVersion = b.projectVersion?.let(::clearBlankScalar)
-            config.systemProperties = b.systemProperties?.let(::clearBlankScalar)
-            config.buildTasks = b.buildTasks?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("build.javaVersion")) config.javaVersion = b.javaVersion?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("build.mavenVersion")) config.mavenVersion = b.mavenVersion?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("build.gradleVersion")) config.gradleVersion = b.gradleVersion?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("build.buildFilePath")) config.buildFilePath = b.buildFilePath?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("build.deprecated")) config.deprecated = b.deprecated
+            if (!fieldConfigService.isHidden("build.requiredProject")) config.requiredProject = b.requiredProject
+            if (!fieldConfigService.isHidden("build.projectVersion")) config.projectVersion = b.projectVersion?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("build.systemProperties")) config.systemProperties = b.systemProperties?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("build.buildTasks")) config.buildTasks = b.buildTasks?.let(::clearBlankScalar)
         }
         request.escrow?.let { e ->
-            config.escrowProvidedDependencies = e.providedDependencies?.let(::clearBlankScalar)
-            config.escrowReusable = e.reusable
-            // escrow.generation is a validated enum mode — not clearable; set as-is.
-            config.escrowGeneration = e.generation
-            config.escrowDiskSpace = e.diskSpace?.let(::clearBlankScalar)
-            config.escrowAdditionalSources = e.additionalSources?.let(::clearBlankScalar)
-            config.escrowGradleIncludeConfigurations = e.gradleIncludeConfigurations?.let(::clearBlankScalar)
-            config.escrowGradleExcludeConfigurations = e.gradleExcludeConfigurations?.let(::clearBlankScalar)
-            config.escrowGradleIncludeTestConfigurations = e.gradleIncludeTestConfigurations
-            config.escrowBuildTask = e.buildTask?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("escrow.providedDependencies")) {
+                config.escrowProvidedDependencies = e.providedDependencies?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("escrow.reusable")) config.escrowReusable = e.reusable
+            if (!fieldConfigService.isHidden("escrow.generation")) config.escrowGeneration = e.generation
+            if (!fieldConfigService.isHidden("escrow.diskSpace")) config.escrowDiskSpace = e.diskSpace?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("escrow.additionalSources")) {
+                config.escrowAdditionalSources = e.additionalSources?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("escrow.gradleIncludeConfigurations")) {
+                config.escrowGradleIncludeConfigurations = e.gradleIncludeConfigurations?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("escrow.gradleExcludeConfigurations")) {
+                config.escrowGradleExcludeConfigurations = e.gradleExcludeConfigurations?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("escrow.gradleIncludeTestConfigurations")) {
+                config.escrowGradleIncludeTestConfigurations = e.gradleIncludeTestConfigurations
+            }
+            if (!fieldConfigService.isHidden("escrow.buildTask")) config.escrowBuildTask = e.buildTask?.let(::clearBlankScalar)
         }
         request.jira?.let { j ->
-            config.jiraProjectKey = j.projectKey?.let(::clearBlankScalar)
-            config.jiraTechnical = j.technical
-            config.jiraMinorVersionFormat = j.minorVersionFormat?.let(::clearBlankScalar)
-            config.jiraReleaseVersionFormat = j.releaseVersionFormat?.let(::clearBlankScalar)
-            config.jiraBuildVersionFormat = j.buildVersionFormat?.let(::clearBlankScalar)
-            config.jiraLineVersionFormat = j.lineVersionFormat?.let(::clearBlankScalar)
-            config.jiraVersionPrefix = j.versionPrefix?.let(::clearBlankScalar)
-            config.jiraVersionFormat = j.versionFormat?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("jira.projectKey")) config.jiraProjectKey = j.projectKey?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("jira.technical")) config.jiraTechnical = j.technical
+            if (!fieldConfigService.isHidden("jira.minorVersionFormat")) {
+                config.jiraMinorVersionFormat = j.minorVersionFormat?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("jira.releaseVersionFormat")) {
+                config.jiraReleaseVersionFormat = j.releaseVersionFormat?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("jira.buildVersionFormat")) {
+                config.jiraBuildVersionFormat = j.buildVersionFormat?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("jira.lineVersionFormat")) {
+                config.jiraLineVersionFormat = j.lineVersionFormat?.let(::clearBlankScalar)
+            }
+            if (!fieldConfigService.isHidden("jira.versionPrefix")) config.jiraVersionPrefix = j.versionPrefix?.let(::clearBlankScalar)
+            if (!fieldConfigService.isHidden("jira.versionFormat")) config.jiraVersionFormat = j.versionFormat?.let(::clearBlankScalar)
             // jiraHotfixVersionFormat per-range write is intentionally not
             // exposed via V4 (no UI need today); DSL import is the only
             // producer of the per-range column.
@@ -2006,39 +2164,66 @@ class ComponentManagementServiceImpl(
         // and `escrow.generation` must be a known mode — both are validated
         // (validateBuildSystem / validateEscrowGenerationMode reject blank), so a
         // "" on those is a 400, not a clear. They keep set-only semantics.
+        // CRS-B: hidden aspect fields are silently stripped (see applyBaseConfigurationCreate).
+        // buildSystem is exempt (required enum). The `if (!isHidden)` sits inside each `?.let`
+        // so an absent field stays a no-op and only a PRESENT value on a visible field is written.
         patch.versionRange?.let { config.versionRange = it }
         patch.build?.let { b ->
             b.buildSystem?.let { config.buildSystem = it }
-            b.javaVersion?.let { config.javaVersion = clearBlankScalar(it) }
-            b.mavenVersion?.let { config.mavenVersion = clearBlankScalar(it) }
-            b.gradleVersion?.let { config.gradleVersion = clearBlankScalar(it) }
-            b.buildFilePath?.let { config.buildFilePath = clearBlankScalar(it) }
-            b.deprecated?.let { config.deprecated = it }
-            b.requiredProject?.let { config.requiredProject = it }
-            b.projectVersion?.let { config.projectVersion = clearBlankScalar(it) }
-            b.systemProperties?.let { config.systemProperties = clearBlankScalar(it) }
-            b.buildTasks?.let { config.buildTasks = clearBlankScalar(it) }
+            b.javaVersion?.let { if (!fieldConfigService.isHidden("build.javaVersion")) config.javaVersion = clearBlankScalar(it) }
+            b.mavenVersion?.let { if (!fieldConfigService.isHidden("build.mavenVersion")) config.mavenVersion = clearBlankScalar(it) }
+            b.gradleVersion?.let { if (!fieldConfigService.isHidden("build.gradleVersion")) config.gradleVersion = clearBlankScalar(it) }
+            b.buildFilePath?.let { if (!fieldConfigService.isHidden("build.buildFilePath")) config.buildFilePath = clearBlankScalar(it) }
+            b.deprecated?.let { if (!fieldConfigService.isHidden("build.deprecated")) config.deprecated = it }
+            b.requiredProject?.let { if (!fieldConfigService.isHidden("build.requiredProject")) config.requiredProject = it }
+            b.projectVersion?.let { if (!fieldConfigService.isHidden("build.projectVersion")) config.projectVersion = clearBlankScalar(it) }
+            b.systemProperties?.let {
+                if (!fieldConfigService.isHidden("build.systemProperties")) config.systemProperties = clearBlankScalar(it)
+            }
+            b.buildTasks?.let { if (!fieldConfigService.isHidden("build.buildTasks")) config.buildTasks = clearBlankScalar(it) }
         }
         patch.escrow?.let { e ->
-            e.providedDependencies?.let { config.escrowProvidedDependencies = clearBlankScalar(it) }
-            e.reusable?.let { config.escrowReusable = it }
-            e.generation?.let { config.escrowGeneration = it }
-            e.diskSpace?.let { config.escrowDiskSpace = clearBlankScalar(it) }
-            e.additionalSources?.let { config.escrowAdditionalSources = clearBlankScalar(it) }
-            e.gradleIncludeConfigurations?.let { config.escrowGradleIncludeConfigurations = clearBlankScalar(it) }
-            e.gradleExcludeConfigurations?.let { config.escrowGradleExcludeConfigurations = clearBlankScalar(it) }
-            e.gradleIncludeTestConfigurations?.let { config.escrowGradleIncludeTestConfigurations = it }
-            e.buildTask?.let { config.escrowBuildTask = clearBlankScalar(it) }
+            e.providedDependencies?.let {
+                if (!fieldConfigService.isHidden("escrow.providedDependencies")) config.escrowProvidedDependencies = clearBlankScalar(it)
+            }
+            e.reusable?.let { if (!fieldConfigService.isHidden("escrow.reusable")) config.escrowReusable = it }
+            e.generation?.let { if (!fieldConfigService.isHidden("escrow.generation")) config.escrowGeneration = it }
+            e.diskSpace?.let { if (!fieldConfigService.isHidden("escrow.diskSpace")) config.escrowDiskSpace = clearBlankScalar(it) }
+            e.additionalSources?.let {
+                if (!fieldConfigService.isHidden("escrow.additionalSources")) config.escrowAdditionalSources = clearBlankScalar(it)
+            }
+            e.gradleIncludeConfigurations?.let {
+                if (!fieldConfigService.isHidden("escrow.gradleIncludeConfigurations")) {
+                    config.escrowGradleIncludeConfigurations = clearBlankScalar(it)
+                }
+            }
+            e.gradleExcludeConfigurations?.let {
+                if (!fieldConfigService.isHidden("escrow.gradleExcludeConfigurations")) {
+                    config.escrowGradleExcludeConfigurations = clearBlankScalar(it)
+                }
+            }
+            e.gradleIncludeTestConfigurations?.let {
+                if (!fieldConfigService.isHidden("escrow.gradleIncludeTestConfigurations")) config.escrowGradleIncludeTestConfigurations = it
+            }
+            e.buildTask?.let { if (!fieldConfigService.isHidden("escrow.buildTask")) config.escrowBuildTask = clearBlankScalar(it) }
         }
         patch.jira?.let { j ->
-            j.projectKey?.let { config.jiraProjectKey = clearBlankScalar(it) }
-            j.technical?.let { config.jiraTechnical = it }
-            j.minorVersionFormat?.let { config.jiraMinorVersionFormat = clearBlankScalar(it) }
-            j.releaseVersionFormat?.let { config.jiraReleaseVersionFormat = clearBlankScalar(it) }
-            j.buildVersionFormat?.let { config.jiraBuildVersionFormat = clearBlankScalar(it) }
-            j.lineVersionFormat?.let { config.jiraLineVersionFormat = clearBlankScalar(it) }
-            j.versionPrefix?.let { config.jiraVersionPrefix = clearBlankScalar(it) }
-            j.versionFormat?.let { config.jiraVersionFormat = clearBlankScalar(it) }
+            j.projectKey?.let { if (!fieldConfigService.isHidden("jira.projectKey")) config.jiraProjectKey = clearBlankScalar(it) }
+            j.technical?.let { if (!fieldConfigService.isHidden("jira.technical")) config.jiraTechnical = it }
+            j.minorVersionFormat?.let {
+                if (!fieldConfigService.isHidden("jira.minorVersionFormat")) config.jiraMinorVersionFormat = clearBlankScalar(it)
+            }
+            j.releaseVersionFormat?.let {
+                if (!fieldConfigService.isHidden("jira.releaseVersionFormat")) config.jiraReleaseVersionFormat = clearBlankScalar(it)
+            }
+            j.buildVersionFormat?.let {
+                if (!fieldConfigService.isHidden("jira.buildVersionFormat")) config.jiraBuildVersionFormat = clearBlankScalar(it)
+            }
+            j.lineVersionFormat?.let {
+                if (!fieldConfigService.isHidden("jira.lineVersionFormat")) config.jiraLineVersionFormat = clearBlankScalar(it)
+            }
+            j.versionPrefix?.let { if (!fieldConfigService.isHidden("jira.versionPrefix")) config.jiraVersionPrefix = clearBlankScalar(it) }
+            j.versionFormat?.let { if (!fieldConfigService.isHidden("jira.versionFormat")) config.jiraVersionFormat = clearBlankScalar(it) }
             // jiraHotfixVersionFormat per-range PATCH is intentionally not
             // exposed via V4; see applyBaseConfigurationCreate above.
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -80,6 +80,7 @@ import org.octopusden.octopus.components.registry.server.repository.LabelReposit
 import org.octopusden.octopus.components.registry.server.repository.SystemRepository
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.octopusden.octopus.components.registry.server.security.PermissionEvaluator
 import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.components.registry.server.service.RenderedComponentCode
@@ -98,8 +99,10 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
 import java.nio.file.Files
 import java.time.Instant
 import java.util.UUID
@@ -133,6 +136,7 @@ class ComponentManagementServiceImpl(
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val currentUserResolver: CurrentUserResolver,
     private val fieldConfigService: FieldConfigService,
+    private val permissionEvaluator: PermissionEvaluator,
     private val teamcityProperties: TeamcityProperties,
     private val versionRangeFactory: VersionRangeFactory,
     private val numericVersionFactory: NumericVersionFactory,
@@ -215,6 +219,9 @@ class ComponentManagementServiceImpl(
         // inside `replaceVcsEntries` / `replacePackages` (covers both base-config
         // and field-override marker paths).
         validateLabels(request.labels)
+        // CRS-B: a supplied (non-null) value for a field the caller may not edit is
+        // rejected up-front; an absent field lets server defaults apply.
+        enforceEditabilityOnCreate(request)
         // Canonicalise once and reuse so the synced junction, the
         // in-memory refresh, and the audit snapshot all see the same
         // trimmed/deduped set — the originally requested set may still
@@ -456,6 +463,11 @@ class ComponentManagementServiceImpl(
             }
         }
         val isRename = normalizedNewKey != null && normalizedNewKey != oldKey
+
+        // CRS-B: reject an attempt to CHANGE a field the caller may not edit BEFORE any
+        // mutation (change-based; unchanged echo is tolerated). Reads the pristine BASE
+        // row for jira/build aspect currents, so it must run ahead of the patch appliers.
+        enforceEditabilityOnUpdate(entity, request)
 
         request.productType?.let { validateProductType(it) }
         // `baseConfiguration.versionRange` is validated downstream inside the
@@ -848,6 +860,10 @@ class ComponentManagementServiceImpl(
         request: FieldOverrideCreateRequest,
     ): FieldOverrideResponse {
         val component = findComponentOr404(componentId)
+        // CRS-B: introducing an override IS a value change on the overridden attribute
+        // — gate it by the caller's editability for that field. Unknown/marker
+        // attributes resolve to `all` (no-op) and still hit their own validation below.
+        enforceOverrideEditable(request.overriddenAttribute)
         // Whitespace normalisation up-front so the DB UNIQUE (which is exact-
         // string) and the duplicate-row lookup agree with the partial-overlap
         // validator below: `[1.0, 2.0)` stored as `[1.0,2.0)` lets the next
@@ -979,6 +995,14 @@ class ComponentManagementServiceImpl(
                 }
             }
 
+        // CRS-B: gate any ACTUAL change (scalar value, markerChildren, or range) to an
+        // override on a non-editable field. Snapshot-diff keeps it change-based across
+        // both scalar and marker attributes — an unchanged echo leaves the snapshot
+        // equal and is allowed (the transaction rolls back on the thrown 403/422).
+        if (fieldOverrideAuditSnapshot(row) != beforeSnapshot) {
+            enforceOverrideEditable(row.overriddenAttribute!!)
+        }
+
         val saved = configurationRepository.save(row)
         if (pendingTools != null) {
             syncRequiredTools(saved.id!!, pendingTools)
@@ -1014,6 +1038,9 @@ class ComponentManagementServiceImpl(
             "Cannot delete id $overrideId via field-override endpoint (row_type=${row.rowType})"
         }
         requireNotImportManagedMarker(row, "delete")
+        // CRS-B: removing an override changes the effective value on its attribute —
+        // gate it like the combined-save desired-set delete branch (no direct-DELETE bypass).
+        row.overriddenAttribute?.let { enforceOverrideEditable(it) }
         val owningComponent = row.component
         val beforeSnapshot = fieldOverrideAuditSnapshot(row)
         configurationRepository.delete(row)
@@ -1113,6 +1140,8 @@ class ComponentManagementServiceImpl(
         // 1) DELETE editable rows omitted from the desired set (orphanRemoval on flush).
         val deletedSnapshots = mutableListOf<Map<String, Any?>>()
         existing.filter { !isImportManaged(it) && it.id !in keepIds }.forEach { row ->
+            // CRS-B: removing an override changes the effective value on that attribute.
+            row.overriddenAttribute?.let { enforceOverrideEditable(it) }
             deletedSnapshots += fieldOverrideAuditSnapshot(row)
             component.configurations.remove(row)
         }
@@ -1128,12 +1157,20 @@ class ComponentManagementServiceImpl(
             }
             val before = fieldOverrideAuditSnapshot(row)
             applyOverrideUpsertPayload(component, row, d, excludeOverrideId = row.id)?.let { pendingTools[row] = it }
+            // CRS-B: gate any actual change (value / markerChildren / range) to an
+            // override on a non-editable field; an unchanged echo (combined Save
+            // re-sends the whole set) leaves the snapshot equal and is left alone.
+            if (fieldOverrideAuditSnapshot(row) != before) {
+                enforceOverrideEditable(d.overriddenAttribute)
+            }
             updated += row to before
         }
 
         // 3) CREATE rows without an id.
         val created = mutableListOf<ComponentConfigurationEntity>()
         desired.filter { it.id == null }.forEach { d ->
+            // CRS-B: a new override is a value change on the overridden attribute.
+            enforceOverrideEditable(d.overriddenAttribute)
             val row =
                 ComponentConfigurationEntity(
                     component = component,
@@ -1702,6 +1739,184 @@ class ComponentManagementServiceImpl(
             throw IllegalArgumentException(
                 "canBeParent: cannot disable can-be-parent while other components reference this as their parent",
             )
+        }
+    }
+
+    // ============================================================
+    // Helpers — field-config editability enforcement (CRS-B)
+    // ============================================================
+
+    /**
+     * CRS-B editability write-gate for a single scalar field, keyed by the
+     * section-prefixed field-config path (e.g. `jira.technical`,
+     * `component.vcsExternalRegistry`).
+     *
+     * **Change-based** — the single most important property: a write is rejected
+     * only when it would actually CHANGE the field. Echoing the current value (or
+     * clearing an already-empty field) is a no-op and is always allowed, because
+     * the Portal's combined Save posts whole section slices; a presence-based
+     * reject would fail every ordinary editor's save. On CREATE the caller passes
+     * `current = null`, so any supplied non-null value counts as a change.
+     *
+     *  - `editable: adminOnly` without `EDIT_ANY_COMPONENT` → 403 (authorization).
+     *  - `editable: none` / `visibility: readonly` (unified) → 422 for everyone.
+     *  - `visibility: hidden` is NOT handled here — it keeps its silent-strip
+     *    behavior at the individual write sites (`isHidden` short-circuits first).
+     *
+     * String values are compared with CRS-A "" ≡ null normalization (blank means
+     * clear); booleans and lists compare by value equality. Comparison is
+     * case-sensitive for strings (a case-only echo of an already-canonicalized
+     * value is treated as a change — erring toward reject, the safe direction).
+     */
+    private fun enforceFieldEditable(
+        fieldPath: String,
+        incoming: Any?,
+        current: Any?,
+    ) {
+        if (fieldConfigService.isHidden(fieldPath)) return
+        if (!isFieldChange(incoming, current)) return
+        when (fieldConfigService.editabilityFor(fieldPath)) {
+            "adminonly" ->
+                if (!permissionEvaluator.canEditAdminOnlyFields()) {
+                    throw ResponseStatusException(
+                        HttpStatus.FORBIDDEN,
+                        "Field '$fieldPath' is editable by administrators only",
+                    )
+                }
+            "none" ->
+                throw ResponseStatusException(
+                    HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Field '$fieldPath' is not editable",
+                )
+            else -> Unit // "all"
+        }
+    }
+
+    /**
+     * Reject a create/modify/delete of a per-range override on a field the caller
+     * may not edit — the same policy as [enforceFieldEditable], but for the
+     * field-override sub-resource where introducing/removing an override IS a
+     * value change on the overridden attribute (`overriddenAttribute` doubles as
+     * the field-config path, e.g. `jira.technical`). Callers invoke this only for
+     * actual changes (an unchanged desired-set echo is left untouched).
+     */
+    private fun enforceOverrideEditable(attribute: String) {
+        when (fieldConfigService.editabilityFor(attribute)) {
+            "adminonly" ->
+                if (!permissionEvaluator.canEditAdminOnlyFields()) {
+                    throw ResponseStatusException(
+                        HttpStatus.FORBIDDEN,
+                        "Field-override on '$attribute' is editable by administrators only",
+                    )
+                }
+            "none" ->
+                throw ResponseStatusException(
+                    HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Field-override on '$attribute' targets a non-editable field",
+                )
+            else -> Unit // "all"
+        }
+    }
+
+    /** Change detection with CRS-A "" ≡ null normalization for strings; value equality otherwise. */
+    private fun isFieldChange(
+        incoming: Any?,
+        current: Any?,
+    ): Boolean {
+        fun norm(v: Any?): Any? = if (v is String) v.trim().ifBlank { null } else v
+        return norm(incoming) != norm(current)
+    }
+
+    /**
+     * CRS-B: enforce editability across every scalar the given PATCH touches, BEFORE
+     * any mutation, comparing incoming against the entity's current value (its BASE
+     * configuration row for jira/build aspect scalars). `null`/absent request fields
+     * are skipped (JSON Merge Patch "don't touch"), so only fields actually present
+     * in the payload are considered — and even then only a real value change is gated.
+     */
+    private fun enforceEditabilityOnUpdate(
+        entity: ComponentEntity,
+        request: ComponentUpdateRequest,
+    ) {
+        request.displayName?.let { enforceFieldEditable("component.displayName", it, entity.displayName) }
+        request.componentOwner?.let { enforceFieldEditable("component.componentOwner", it, entity.componentOwner) }
+        request.productType?.let { enforceFieldEditable("component.productType", it, entity.productType) }
+        request.clientCode?.let { enforceFieldEditable("component.clientCode", it, entity.clientCode) }
+        request.solution?.let { enforceFieldEditable("component.solution", it, entity.solution) }
+        request.copyright?.let { enforceFieldEditable("component.copyright", it, entity.copyright) }
+        request.releasesInDefaultBranch?.let {
+            enforceFieldEditable("component.releasesInDefaultBranch", it, entity.releasesInDefaultBranch)
+        }
+        request.jiraDisplayName?.let { enforceFieldEditable("component.jiraDisplayName", it, entity.jiraDisplayName) }
+        request.jiraHotfixVersionFormat?.let {
+            enforceFieldEditable("component.jiraHotfixVersionFormat", it, entity.jiraHotfixVersionFormat)
+        }
+        request.vcsExternalRegistry?.let {
+            enforceFieldEditable("component.vcsExternalRegistry", it, entity.vcsExternalRegistry)
+        }
+        request.distributionExplicit?.let { enforceFieldEditable("component.distributionExplicit", it, entity.distributionExplicit) }
+        request.distributionExternal?.let { enforceFieldEditable("component.distributionExternal", it, entity.distributionExternal) }
+        request.system?.let { enforceFieldEditable("component.system", it, entity.systemCode) }
+        request.releaseManager?.let { enforceFieldEditable("component.releaseManager", it, entity.releaseManagerUsernames()) }
+        request.securityChampion?.let { enforceFieldEditable("component.securityChampion", it, entity.securityChampionUsernames()) }
+
+        val base = entity.configurations.firstOrNull { it.rowType == "BASE" }
+        request.baseConfiguration?.jira?.let { j ->
+            j.projectKey?.let { enforceFieldEditable("jira.projectKey", it, base?.jiraProjectKey) }
+            j.technical?.let { enforceFieldEditable("jira.technical", it, base?.jiraTechnical) }
+            j.minorVersionFormat?.let { enforceFieldEditable("jira.minorVersionFormat", it, base?.jiraMinorVersionFormat) }
+            j.releaseVersionFormat?.let { enforceFieldEditable("jira.releaseVersionFormat", it, base?.jiraReleaseVersionFormat) }
+            j.buildVersionFormat?.let { enforceFieldEditable("jira.buildVersionFormat", it, base?.jiraBuildVersionFormat) }
+            j.lineVersionFormat?.let { enforceFieldEditable("jira.lineVersionFormat", it, base?.jiraLineVersionFormat) }
+            j.versionPrefix?.let { enforceFieldEditable("jira.versionPrefix", it, base?.jiraVersionPrefix) }
+            j.versionFormat?.let { enforceFieldEditable("jira.versionFormat", it, base?.jiraVersionFormat) }
+        }
+        request.baseConfiguration?.build?.let { b ->
+            b.buildSystem?.let { enforceFieldEditable("build.buildSystem", it, base?.buildSystem) }
+            b.javaVersion?.let { enforceFieldEditable("build.javaVersion", it, base?.javaVersion) }
+            b.gradleVersion?.let { enforceFieldEditable("build.gradleVersion", it, base?.gradleVersion) }
+            b.mavenVersion?.let { enforceFieldEditable("build.mavenVersion", it, base?.mavenVersion) }
+        }
+    }
+
+    /**
+     * CRS-B: create-side editability — a supplied (non-null) value for a field the
+     * caller may not edit is rejected (`current = null`, so any non-blank value is a
+     * change); an absent field lets server defaults apply. Mirrors
+     * [enforceEditabilityOnUpdate] for the fields the create payload carries.
+     */
+    private fun enforceEditabilityOnCreate(request: ComponentCreateRequest) {
+        request.displayName?.let { enforceFieldEditable("component.displayName", it, null) }
+        request.componentOwner?.let { enforceFieldEditable("component.componentOwner", it, null) }
+        request.productType?.let { enforceFieldEditable("component.productType", it, null) }
+        request.clientCode?.let { enforceFieldEditable("component.clientCode", it, null) }
+        request.solution?.let { enforceFieldEditable("component.solution", it, null) }
+        request.copyright?.let { enforceFieldEditable("component.copyright", it, null) }
+        request.releasesInDefaultBranch?.let { enforceFieldEditable("component.releasesInDefaultBranch", it, null) }
+        request.jiraDisplayName?.let { enforceFieldEditable("component.jiraDisplayName", it, null) }
+        request.jiraHotfixVersionFormat?.let { enforceFieldEditable("component.jiraHotfixVersionFormat", it, null) }
+        request.vcsExternalRegistry?.let { enforceFieldEditable("component.vcsExternalRegistry", it, null) }
+        request.distributionExplicit?.let { enforceFieldEditable("component.distributionExplicit", it, null) }
+        request.distributionExternal?.let { enforceFieldEditable("component.distributionExternal", it, null) }
+        request.system?.let { enforceFieldEditable("component.system", it, null) }
+
+        request.baseConfiguration?.jira?.let { j ->
+            j.projectKey?.let { enforceFieldEditable("jira.projectKey", it, null) }
+            j.technical?.let { enforceFieldEditable("jira.technical", it, null) }
+            j.minorVersionFormat?.let { enforceFieldEditable("jira.minorVersionFormat", it, null) }
+            j.releaseVersionFormat?.let { enforceFieldEditable("jira.releaseVersionFormat", it, null) }
+            j.buildVersionFormat?.let { enforceFieldEditable("jira.buildVersionFormat", it, null) }
+            j.lineVersionFormat?.let { enforceFieldEditable("jira.lineVersionFormat", it, null) }
+            j.versionPrefix?.let { enforceFieldEditable("jira.versionPrefix", it, null) }
+            j.versionFormat?.let { enforceFieldEditable("jira.versionFormat", it, null) }
+        }
+        request.baseConfiguration?.build?.let { b ->
+            // buildSystem is required on create; gate it too so a non-editable config is
+            // enforced symmetrically with the PATCH path (no CREATE-only bypass).
+            b.buildSystem?.let { enforceFieldEditable("build.buildSystem", it, null) }
+            b.javaVersion?.let { enforceFieldEditable("build.javaVersion", it, null) }
+            b.gradleVersion?.let { enforceFieldEditable("build.gradleVersion", it, null) }
+            b.mavenVersion?.let { enforceFieldEditable("build.mavenVersion", it, null) }
         }
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1818,12 +1818,20 @@ class ComponentManagementServiceImpl(
         }
     }
 
-    /** Change detection with CRS-A "" ≡ null normalization for strings; value equality otherwise. */
+    /**
+     * Change detection for the editability gate. For strings it delegates to the CRS-A
+     * storage normalizer [clearBlankScalar] so the comparison rule can NEVER drift from what
+     * the write path actually persists (`ifBlank { null }`, NO trim: blank clears to null, a
+     * non-blank value is kept verbatim — surrounding whitespace is significant for format
+     * templates). Trimming here would make a padded echo (`"  x  "` vs stored `"x"`) compare
+     * equal while the write would still persist the padded value — a silent change to a
+     * non-editable field. Booleans/lists compare by value.
+     */
     private fun isFieldChange(
         incoming: Any?,
         current: Any?,
     ): Boolean {
-        fun norm(v: Any?): Any? = if (v is String) v.trim().ifBlank { null } else v
+        fun norm(v: Any?): Any? = if (v is String) clearBlankScalar(v) else v
         return norm(incoming) != norm(current)
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -485,7 +485,8 @@ class ComponentManagementServiceImpl(
         // row for jira/build aspect currents, so it must run ahead of the patch appliers.
         enforceEditabilityOnUpdate(entity, request)
 
-        request.productType?.let { validateProductType(it) }
+        // Hidden productType is stripped at its write site → don't 4xx on its value here.
+        request.productType?.let { if (!fieldConfigService.isHidden("component.productType")) validateProductType(it) }
         // `baseConfiguration.versionRange` is validated downstream inside the
         // base-configuration patch block via `validateRangeSyntax` — no
         // top-level guard needed here.
@@ -3259,6 +3260,9 @@ class ComponentManagementServiceImpl(
      * the 400 inline onto the displayName field.
      */
     private fun validateRequiredDisplayName(entity: ComponentEntity) {
+        // A hidden displayName is silently stripped (persisted null), so its requiredness
+        // must not 4xx — mirrors validateRequiredCopyright's hidden guard above.
+        if (fieldConfigService.isHidden("component.displayName")) return
         if (entity.distributionExplicit != true || entity.distributionExternal != true) return
         require(!entity.displayName.isNullOrBlank()) {
             "displayName: componentDisplayName is required for an explicit+external " +

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
@@ -117,12 +117,25 @@ class ConfigSyncService(
                 }
                 put("visibility", v)
             }
+            entry.editable?.let {
+                val e = it.trim().lowercase()
+                require(e in EDITABILITIES) {
+                    invalid("$section.$field.editable", it, EDITABILITIES)
+                }
+                put("editable", e)
+            }
             entry.searchable?.let {
                 require(it.trim() in SEARCHABLES) {
                     invalid("$section.$field.searchable", it, SEARCHABLES)
                 }
                 put("searchable", it.trim())
             }
+            // Dropdown options (e.g. External Registry names): trimmed, blanks dropped;
+            // an all-blank/empty list is omitted rather than written as `[]`.
+            entry.options
+                ?.mapNotNull { opt -> opt.trim().takeIf { it.isNotBlank() } }
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { put("options", it) }
             entry.required?.let { put("required", it) }
             entry.defaultValue?.let { put("defaultValue", it) }
             // Free-text display overrides — no validation beyond blank-dropping.
@@ -237,6 +250,7 @@ class ConfigSyncService(
         const val FIELD_CONFIG_KEY = "field-config"
         const val COMPONENT_DEFAULTS_KEY = "component-defaults"
         private val VISIBILITIES = setOf("editable", "readonly", "hidden")
+        private val EDITABILITIES = setOf("all", "adminonly", "none")
         private val SEARCHABLES = setOf("Main", "Extended", "None")
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigService.kt
@@ -40,18 +40,7 @@ class FieldConfigService(
     private val registryConfigRepository: RegistryConfigRepository,
 ) {
     fun visibilityFor(fieldPath: String): String {
-        val parts = fieldPath.split('.', limit = 2)
-        if (parts.size != 2) return EDITABLE
-
-        val config = registryConfigRepository.findById(FIELD_CONFIG_KEY).orElse(null) ?: return EDITABLE
-
-        @Suppress("UNCHECKED_CAST")
-        val sectionMap =
-            (config.value as? Map<String, Any?>)?.get(parts[0]) as? Map<String, Any?>
-                ?: return EDITABLE
-
-        @Suppress("UNCHECKED_CAST")
-        val entry = sectionMap[parts[1]] as? Map<String, Any?> ?: return EDITABLE
+        val entry = entryFor(fieldPath) ?: return EDITABLE
 
         // Normalize: trim + lowercase before returning so a typo like
         // `"Hidden"` or `"hidden "` in admin-edited JSON still matches the
@@ -66,9 +55,55 @@ class FieldConfigService(
 
     fun isHidden(fieldPath: String): Boolean = visibilityFor(fieldPath) == HIDDEN
 
+    /**
+     * CRS-B editability policy for a section-prefixed path: `all` | `adminonly` | `none`
+     * (normalized lowercase). User-agnostic — the caller pairs this with the requester's
+     * permissions. `visibility: readonly` is unified with `editable: none`: a readonly
+     * field is non-editable for everyone, so the two synonyms enforce identically.
+     * Everything else (including `visibility: hidden`, which is strip-gated separately
+     * via [isHidden]) resolves to `all` unless an explicit `editable` says otherwise.
+     */
+    fun editabilityFor(fieldPath: String): String {
+        val entry = entryFor(fieldPath) ?: return ALL
+
+        val visibility = (entry["visibility"] as? String)?.trim()?.lowercase()
+        if (visibility == READONLY) return NONE
+
+        val editable =
+            (entry["editable"] as? String)
+                ?.trim()
+                ?.lowercase()
+                ?.takeIf { it.isNotBlank() }
+                ?: return ALL
+        return when (editable) {
+            ADMIN_ONLY, NONE -> editable
+            // "all" or any unrecognized token → fully editable (graceful; the sync-time
+            // validator in ConfigSyncService already rejects unknown tokens loudly).
+            else -> ALL
+        }
+    }
+
+    /** Resolve the raw entry map for a section-prefixed path, or null if unconfigured/malformed. */
+    private fun entryFor(fieldPath: String): Map<String, Any?>? {
+        val parts = fieldPath.split('.', limit = 2)
+        if (parts.size != 2) return null
+
+        val config = registryConfigRepository.findById(FIELD_CONFIG_KEY).orElse(null) ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        val sectionMap = (config.value as? Map<String, Any?>)?.get(parts[0]) as? Map<String, Any?> ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        return sectionMap[parts[1]] as? Map<String, Any?>
+    }
+
     companion object {
         private const val FIELD_CONFIG_KEY = "field-config"
         private const val EDITABLE = "editable"
         private const val HIDDEN = "hidden"
+        private const val READONLY = "readonly"
+        private const val ALL = "all"
+        private const val ADMIN_ONLY = "adminonly"
+        private const val NONE = "none"
     }
 }

--- a/components-registry-service-server/src/main/resources/application.yml
+++ b/components-registry-service-server/src/main/resources/application.yml
@@ -47,13 +47,20 @@ components-registry:
       groupKey:             { visibility: editable, searchable: Extended, required: true }
       distributionExplicit: { visibility: editable, searchable: Extended }
       distributionExternal: { visibility: editable, searchable: Extended }
+      # External Registry (Whiskey) — universal product rule: admin-only edit.
+      # NOTE: the write-side gate reads the `component.vcsExternalRegistry` path
+      # (ComponentManagementServiceImpl), while the Portal display path is
+      # `vcs.externalRegistry`; the enforced entry MUST live here under `component`.
+      # The list of registry NAMES (options) is installation-specific → service-config.
+      vcsExternalRegistry:  { editable: adminOnly }
     build:
       buildSystem:          { visibility: editable, searchable: Main }
       javaVersion:          { visibility: editable, searchable: Extended }
       gradleVersion:        { visibility: editable, searchable: Extended }
     jira:
       projectKey:           { visibility: editable, searchable: Extended }
-      technical:            { visibility: editable, searchable: Extended }
+      # Technical flag drives release automation — admin-only edit (universal rule).
+      technical:            { visibility: editable, searchable: Extended, editable: adminOnly }
     vcs:
       vcsPath:              { visibility: editable, searchable: Extended }
       branch:               { visibility: editable, searchable: Extended }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigPropertiesBindingTest.kt
@@ -59,6 +59,24 @@ class AdminConfigPropertiesBindingTest {
             }
     }
 
+    @Test
+    fun `editable axis and options list bind onto a FieldEntry`() {
+        runner
+            .withPropertyValues(
+                "components-registry.field-config.jira.technical.editable=adminOnly",
+                "components-registry.field-config.component.vcsExternalRegistry.editable=adminOnly",
+                "components-registry.field-config.component.vcsExternalRegistry.options[0]=alpha",
+                "components-registry.field-config.component.vcsExternalRegistry.options[1]=beta",
+            )
+            .run { ctx ->
+                val props = ctx.getBean(AdminConfigProperties::class.java)
+                assertEquals("adminOnly", props.fieldConfig["jira"]?.get("technical")?.editable)
+                val registry = props.fieldConfig["component"]?.get("vcsExternalRegistry")
+                assertEquals("adminOnly", registry?.editable)
+                assertEquals(listOf("alpha", "beta"), registry?.options)
+            }
+    }
+
     // ── component-defaults majorVersionFormat → minorVersionFormat alias ───────
     // service-config still emits the old `majorVersionFormat` YAML key until it is
     // renamed in lockstep; the deprecated write-through setter must bind it to the

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/StrictContractTest.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.components.registry.server.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -83,6 +84,16 @@ class StrictContractTest {
         entity.value = value
         registryConfigRepository.save(entity)
     }
+
+    /**
+     * Start every test with an empty `field-config` cache row. Several tests seed a restrictive
+     * policy (e.g. `component.system: hidden`) mid-test; without this reset the row leaks into
+     * sibling tests (JUnit method order is unspecified) — and, across classes, into this one.
+     * This matters now that CRS-B honors hidden on the CREATE path too (values for hidden fields
+     * are stripped), so a leaked `system: hidden` would drop a create's system value.
+     */
+    @BeforeEach
+    fun resetFieldConfig() = seedFieldConfig(emptyMap())
 
     init {
         val testResourcesPath =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/CheapFieldFormatValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/CheapFieldFormatValidationTest.kt
@@ -38,6 +38,7 @@ import org.octopusden.octopus.components.registry.server.repository.LabelReposit
 import org.octopusden.octopus.components.registry.server.repository.SystemRepository
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.octopusden.octopus.components.registry.server.security.PermissionEvaluator
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
 import org.octopusden.octopus.components.registry.server.util.ComponentCodeRenderer
@@ -108,6 +109,7 @@ class CheapFieldFormatValidationTest {
                 applicationEventPublisher = mock(ApplicationEventPublisher::class.java),
                 currentUserResolver = mock(CurrentUserResolver::class.java),
                 fieldConfigService = fieldConfigService,
+                permissionEvaluator = mock(PermissionEvaluator::class.java),
                 teamcityProperties = mock(TeamcityProperties::class.java),
                 versionRangeFactory = VersionRangeFactory(versionNames),
                 numericVersionFactory = NumericVersionFactory(versionNames),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
@@ -29,6 +29,8 @@ class ConfigSyncServiceTest {
         defaultValue: String? = null,
         label: String? = null,
         description: String? = null,
+        editable: String? = null,
+        options: MutableList<String>? = null,
     ) = AdminConfigProperties.FieldEntry().apply {
         this.visibility = visibility
         this.searchable = searchable
@@ -36,6 +38,8 @@ class ConfigSyncServiceTest {
         this.defaultValue = defaultValue
         this.label = label
         this.description = description
+        this.editable = editable
+        this.options = options
     }
 
     @Test
@@ -138,6 +142,67 @@ class ConfigSyncServiceTest {
             ),
             result.fieldConfig,
         )
+    }
+
+    @Test
+    fun `editable axis normalizes to lowercase and options serialize trimmed`() {
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "jira" to mutableMapOf(
+                    "technical" to fieldEntry(visibility = "editable", editable = " AdminOnly "),
+                ),
+                "component" to mutableMapOf(
+                    "vcsExternalRegistry" to fieldEntry(
+                        editable = "adminOnly",
+                        options = mutableListOf(" alpha ", "beta", "  "),
+                    ),
+                ),
+            )
+        }
+
+        val result = service(props).syncToCache()
+
+        assertEquals(
+            mapOf(
+                "jira" to mapOf(
+                    "technical" to mapOf("visibility" to "editable", "editable" to "adminonly"),
+                ),
+                "component" to mapOf(
+                    // blank option dropped, survivors trimmed
+                    "vcsExternalRegistry" to mapOf("editable" to "adminonly", "options" to listOf("alpha", "beta")),
+                ),
+            ),
+            result.fieldConfig,
+        )
+    }
+
+    @Test
+    fun `all-blank options list is omitted`() {
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "component" to mutableMapOf(
+                    "vcsExternalRegistry" to fieldEntry(editable = "none", options = mutableListOf(" ", "")),
+                ),
+            )
+        }
+
+        val result = service(props).syncToCache()
+
+        assertEquals(
+            mapOf("component" to mapOf("vcsExternalRegistry" to mapOf("editable" to "none"))),
+            result.fieldConfig,
+        )
+    }
+
+    @Test
+    fun `invalid editable aborts the sync`() {
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "jira" to mutableMapOf("technical" to fieldEntry(editable = "sometimes")),
+            )
+        }
+        assertThrows(ConfigValidationException::class.java) { service(props).syncToCache() }
+        verify(repo, never()).save(any())
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
@@ -478,6 +478,46 @@ class FieldConfigEnforcementIntegrationTest {
     }
 
     @Test
+    @DisplayName("adminOnly string: non-admin PADDED echo (\"  x  \" vs stored \"x\") → 403 (whitespace is a change)")
+    fun adminOnlyString_paddedEcho_forbidden() {
+        val created = createOwnedByBob(vcsExternalRegistry = "x")
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("component" to mapOf("vcsExternalRegistry" to mapOf("editable" to "adminOnly")))) {
+            // A padded value is NOT the stored value — the write would persist "  x  " verbatim,
+            // so it must be treated as a change and rejected for a non-admin.
+            patchRaw(editorJwt(), id, """{"version":$version,"vcsExternalRegistry":"  x  "}""")
+                .andExpect(status().isForbidden)
+            assertEquals("x", getComponent(id)["vcsExternalRegistry"].asText())
+        }
+    }
+
+    @Test
+    @DisplayName("adminOnly string: change-detection norm mirrors clearBlankScalar over {\"\",\"  \",\"x\",\"  x  \"}")
+    fun adminOnlyString_normParityWithStorage() {
+        // Stored value is "x". A non-admin echo is allowed iff clearBlankScalar(incoming) ==
+        // clearBlankScalar("x"): only a verbatim "x" is a no-op; "" / "  " (clear→null) and
+        // "  x  " (verbatim, whitespace-significant) are all real changes → 403.
+        val created = createOwnedByBob(vcsExternalRegistry = "x")
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("component" to mapOf("vcsExternalRegistry" to mapOf("editable" to "adminOnly")))) {
+            // Changes (403) — these all leave the transaction rolled back, so `version` stays valid.
+            for (changing in listOf("", "  ", "  x  ")) {
+                patchRaw(editorJwt(), id, """{"version":$version,"vcsExternalRegistry":"$changing"}""")
+                    .andExpect(status().isForbidden)
+            }
+            assertEquals("x", getComponent(id)["vcsExternalRegistry"].asText())
+
+            // No-op echo of the exact stored value → allowed.
+            patchRaw(editorJwt(), id, """{"version":$version,"vcsExternalRegistry":"x"}""")
+                .andExpect(status().is2xxSuccessful)
+        }
+    }
+
+    @Test
     @DisplayName("OVERRIDE DELETE: non-admin deleting a jira.technical override → 403; admin → 204")
     fun override_delete_gated() {
         val created = createOwnedByBob(technical = false)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
@@ -765,6 +765,41 @@ class FieldConfigEnforcementIntegrationTest {
     }
 
     @Test
+    @DisplayName("hidden displayName: explicit+external CREATE with a stripped displayName does NOT 400 on required")
+    fun hiddenDisplayName_explicitExternal_requiredGuard() {
+        withFieldConfig(mapOf("component" to mapOf("displayName" to mapOf("visibility" to "hidden")))) {
+            val g = "org.example.test.${UUID.randomUUID().toString().take(8)}"
+            val resp =
+                adminPost(
+                    """{"name":"crsB_ee_${UUID.randomUUID().toString().take(8)}","componentOwner":"owner1",""" +
+                        """"releaseManager":["rm1"],"securityChampion":["sc1"],""" +
+                        """"displayName":"Should Be Stripped","distributionExplicit":true,"distributionExternal":true,""" +
+                        """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                        """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                        """"mavenArtifacts":[{"groupPattern":"$g","artifactPattern":"art"}]}}""",
+                ).andReturn().response
+            assertEquals(201, resp.status, "explicit+external create must succeed; body=${resp.contentAsString}")
+            val created = objectMapper.readTree(resp.contentAsString)
+            // displayName was stripped (hidden) → persisted empty/null; the required rule was skipped.
+            assertEquals("", created["displayName"].asText(""), "hidden displayName must be stripped, requiredness skipped")
+        }
+    }
+
+    @Test
+    @DisplayName("hidden productType: an invalid value on PATCH is stripped, not validated → 2xx (never 4xx)")
+    fun hiddenProductType_badValueStrippedNotRejected() {
+        val created = createOwnedByBob()
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("component" to mapOf("productType" to mapOf("visibility" to "hidden")))) {
+            // "NOT_A_TYPE" would 400 via validateProductType if not skipped for the hidden field.
+            patchRaw(adminJwt(), id, """{"version":$version,"productType":"NOT_A_TYPE"}""")
+                .andExpect(status().is2xxSuccessful)
+        }
+    }
+
+    @Test
     @DisplayName("hidden escrow.generation: a bad value is stripped, not validated → 2xx (never 4xx)")
     fun hiddenEscrowGeneration_badValueStrippedNotRejected() {
         val created = createBobRaw("""{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":"AUTO"}}""")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
@@ -545,4 +545,237 @@ class FieldConfigEnforcementIntegrationTest {
                 .andExpect(status().isNoContent)
         }
     }
+
+    // ---- helpers for the aspect/parent/people coverage below ----
+
+    private fun JsonNode.baseScalar(aspect: String, field: String): String? =
+        baseRow()[aspect]?.get(field)?.takeUnless { it.isNull }?.asText()
+
+    /** POST a bob-owned component with a caller-supplied baseConfiguration (as admin). */
+    private fun createBobRaw(baseConfig: String = """{"build":{"buildSystem":"MAVEN"}}"""): JsonNode {
+        val body =
+            """{"name":"crsB_${UUID.randomUUID().toString().take(8)}","componentOwner":"bob",""" +
+                """"group":{"groupKey":"org.example.test","isFake":false},"baseConfiguration":$baseConfig}"""
+        return objectMapper.readTree(
+            mvc
+                .perform(post("/rest/api/4/components").with(adminJwt()).contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isCreated)
+                .andReturn().response.contentAsString,
+        )
+    }
+
+    private fun adminPost(bodyJson: String) =
+        mvc.perform(post("/rest/api/4/components").with(adminJwt()).contentType(MediaType.APPLICATION_JSON).content(bodyJson))
+
+    private fun editorPost(bodyJson: String) =
+        mvc.perform(post("/rest/api/4/components").with(editorJwt()).contentType(MediaType.APPLICATION_JSON).content(bodyJson))
+
+    // Finding 1+2 — full aspect-scalar set: hidden strip and adminOnly gating reach build/escrow.
+
+    @Test
+    @DisplayName("hidden aspect field (jira.minorVersionFormat): PATCH change silently STRIPPED, not applied, not 4xx")
+    fun hiddenAspectField_stripOnPatch() {
+        val mvf = "${'$'}major.${'$'}minor"
+        val created = createBobRaw("""{"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"${uniqueProjectKey()}","minorVersionFormat":"$mvf"}}""")
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("jira" to mapOf("minorVersionFormat" to mapOf("visibility" to "hidden")))) {
+            patchRaw(adminJwt(), id, """{"version":$version,"baseConfiguration":{"jira":{"minorVersionFormat":"${'$'}changed"}}}""")
+                .andExpect(status().is2xxSuccessful)
+            assertEquals(mvf, getComponent(id).baseScalar("jira", "minorVersionFormat"), "hidden aspect must be stripped, not changed")
+        }
+    }
+
+    @Test
+    @DisplayName("hidden aspect field (jira.releaseVersionFormat): supplied on CREATE is silently STRIPPED (persists null)")
+    fun hiddenAspectField_stripOnCreate() {
+        withFieldConfig(mapOf("jira" to mapOf("releaseVersionFormat" to mapOf("visibility" to "hidden")))) {
+            val created =
+                createBobRaw("""{"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"${uniqueProjectKey()}","releaseVersionFormat":"${'$'}foo"}}""")
+            assertEquals(null, created.baseScalar("jira", "releaseVersionFormat"), "hidden aspect must be stripped on create")
+        }
+    }
+
+    @Test
+    @DisplayName("adminOnly escrow.diskSpace: non-admin CHANGE → 403; ECHO unchanged → 2xx")
+    fun adminOnlyEscrowDiskSpace_gated() {
+        val created = createBobRaw("""{"build":{"buildSystem":"MAVEN"},"escrow":{"diskSpace":"10G"}}""")
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("escrow" to mapOf("diskSpace" to mapOf("editable" to "adminOnly")))) {
+            patchRaw(editorJwt(), id, """{"version":$version,"baseConfiguration":{"escrow":{"diskSpace":"20G"}}}""")
+                .andExpect(status().isForbidden)
+            assertEquals("10G", getComponent(id).baseScalar("escrow", "diskSpace"))
+            patchRaw(editorJwt(), id, """{"version":$version,"baseConfiguration":{"escrow":{"diskSpace":"10G"}}}""")
+                .andExpect(status().is2xxSuccessful)
+        }
+    }
+
+    @Test
+    @DisplayName("adminOnly build.buildFilePath: non-admin CHANGE → 403")
+    fun adminOnlyBuildFilePath_reject() {
+        val created = createBobRaw("""{"build":{"buildSystem":"MAVEN","buildFilePath":"pom.xml"}}""")
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("build" to mapOf("buildFilePath" to mapOf("editable" to "adminOnly")))) {
+            patchRaw(editorJwt(), id, """{"version":$version,"baseConfiguration":{"build":{"buildFilePath":"build.gradle"}}}""")
+                .andExpect(status().isForbidden)
+            assertEquals("pom.xml", getComponent(id).baseScalar("build", "buildFilePath"))
+        }
+    }
+
+    // Finding 3 — override paths + hidden.
+
+    @Test
+    @DisplayName("OVERRIDE on hidden attribute: standalone create → 400 (masked as unknown, no leak)")
+    fun override_hiddenAttribute_standalone400() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("visibility" to "hidden")))) {
+            // Even admin gets a generic 400 — the standalone API never reveals hidden-ness.
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"overriddenAttribute":"jira.technical","versionRange":"[1.0,2.0)","value":true}"""),
+                ).andExpect(status().isBadRequest)
+        }
+    }
+
+    @Test
+    @DisplayName("OVERRIDE on hidden attribute: combined-save desired-set omitting it PRESERVES the row (strip, not delete)")
+    fun override_hiddenAttribute_desiredSetPreserves() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+
+        // Create the override while the field is visible.
+        mvc
+            .perform(
+                post("/rest/api/4/components/$id/field-overrides")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"overriddenAttribute":"jira.technical","versionRange":"[1.0,2.0)","value":true}"""),
+            ).andExpect(status().isCreated)
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("visibility" to "hidden")))) {
+            val version = getComponent(id)["version"].asLong()
+            // Desired-set = [] would delete all editable overrides; the hidden one must survive.
+            patchRaw(adminJwt(), id, """{"version":$version,"fieldOverrides":[]}""")
+                .andExpect(status().is2xxSuccessful)
+
+            val overrides =
+                objectMapper.readTree(
+                    mvc.perform(get("/rest/api/4/components/$id/field-overrides").with(adminJwt()))
+                        .andExpect(status().isOk).andReturn().response.contentAsString,
+                )
+            assertTrue(
+                overrides.any { it["overriddenAttribute"].asText() == "jira.technical" },
+                "hidden-attribute override must be preserved, not deleted by the desired-set",
+            )
+        }
+    }
+
+    // Finding 4 — create people-list gating.
+
+    @Test
+    @DisplayName("CREATE people: non-admin supplying an adminOnly releaseManager → 403; omitting → 2xx")
+    fun create_people_gated() {
+        withFieldConfig(mapOf("component" to mapOf("releaseManager" to mapOf("editable" to "adminOnly")))) {
+            editorPost(
+                """{"name":"crsB_ppl_${UUID.randomUUID().toString().take(8)}","componentOwner":"bob","releaseManager":["bob"],""" +
+                    """"group":{"groupKey":"org.example.test","isFake":false},"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+            ).andExpect(status().isForbidden)
+
+            editorPost(
+                """{"name":"crsB_ppl_${UUID.randomUUID().toString().take(8)}","componentOwner":"bob",""" +
+                    """"group":{"groupKey":"org.example.test","isFake":false},"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+            ).andExpect(status().isCreated)
+        }
+    }
+
+    // Finding 5 — parentComponentName / canBeParent gating.
+
+    @Test
+    @DisplayName("adminOnly canBeParent: non-admin flipping → 403; echoing unchanged → 2xx")
+    fun adminOnlyCanBeParent_gated() {
+        val created = createOwnedByBob() // canBeParent defaults to false
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("component" to mapOf("canBeParent" to mapOf("editable" to "adminOnly")))) {
+            patchRaw(editorJwt(), id, """{"version":$version,"canBeParent":true}""").andExpect(status().isForbidden)
+            patchRaw(editorJwt(), id, """{"version":$version,"canBeParent":false}""").andExpect(status().is2xxSuccessful)
+        }
+    }
+
+    @Test
+    @DisplayName("adminOnly parentComponentName: non-admin setting a parent → 403")
+    fun adminOnlyParentComponentName_reject() {
+        val parentKey = "crsB_parent_${UUID.randomUUID().toString().take(8)}"
+        adminPost(
+            """{"name":"$parentKey","componentOwner":"owner1","canBeParent":true,""" +
+                """"group":{"groupKey":"org.example.test","isFake":false},"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+        ).andExpect(status().isCreated)
+
+        val child = createOwnedByBob()
+        val id = child["id"].asText()
+        val version = child["version"].asLong()
+
+        withFieldConfig(mapOf("component" to mapOf("parentComponentName" to mapOf("editable" to "adminOnly")))) {
+            patchRaw(editorJwt(), id, """{"version":$version,"parentComponentName":"$parentKey"}""")
+                .andExpect(status().isForbidden)
+        }
+    }
+
+    // Hidden strip on CREATE for component-level fields (symmetry with PATCH).
+
+    @Test
+    @DisplayName("CREATE: hidden component.canBeParent supplied true → silently stripped to false")
+    fun create_hiddenCanBeParent_stripped() {
+        withFieldConfig(mapOf("component" to mapOf("canBeParent" to mapOf("visibility" to "hidden")))) {
+            val created =
+                objectMapper.readTree(
+                    adminPost(
+                        """{"name":"crsB_cbp_${UUID.randomUUID().toString().take(8)}","componentOwner":"owner1","canBeParent":true,""" +
+                            """"group":{"groupKey":"org.example.test","isFake":false},"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+                    ).andExpect(status().isCreated).andReturn().response.contentAsString,
+                )
+            assertEquals(false, created["canBeParent"].asBoolean(), "hidden canBeParent must be stripped to its default")
+        }
+    }
+
+    @Test
+    @DisplayName("CREATE: hidden component.releaseManager supplied → silently stripped (empty)")
+    fun create_hiddenReleaseManager_stripped() {
+        withFieldConfig(mapOf("component" to mapOf("releaseManager" to mapOf("visibility" to "hidden")))) {
+            val created =
+                objectMapper.readTree(
+                    adminPost(
+                        """{"name":"crsB_rm_${UUID.randomUUID().toString().take(8)}","componentOwner":"owner1","releaseManager":["bob"],""" +
+                            """"group":{"groupKey":"org.example.test","isFake":false},"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+                    ).andExpect(status().isCreated).andReturn().response.contentAsString,
+                )
+            assertTrue(created["releaseManager"].isEmpty, "hidden releaseManager must be stripped (not persisted)")
+        }
+    }
+
+    @Test
+    @DisplayName("hidden escrow.generation: a bad value is stripped, not validated → 2xx (never 4xx)")
+    fun hiddenEscrowGeneration_badValueStrippedNotRejected() {
+        val created = createBobRaw("""{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":"AUTO"}}""")
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("escrow" to mapOf("generation" to mapOf("visibility" to "hidden")))) {
+            // "NOTAMODE" would be a 400 if validated; hidden must strip it before validation.
+            patchRaw(adminJwt(), id, """{"version":$version,"baseConfiguration":{"escrow":{"generation":"NOTAMODE"}}}""")
+                .andExpect(status().is2xxSuccessful)
+            assertEquals("AUTO", getComponent(id).baseScalar("escrow", "generation"))
+        }
+    }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
@@ -23,10 +23,14 @@ import org.springframework.http.MediaType
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.RequestPostProcessor
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.nio.file.Paths
+import java.util.UUID
 
 /**
  * Risk-1 mitigation — end-to-end test for [FieldConfigService].
@@ -198,5 +202,307 @@ class FieldConfigEnforcementIntegrationTest {
             updated["displayName"].asText(""),
             "displayName should reflect the patch when field-config marks it editable",
         )
+    }
+
+    // ================================================================
+    // CRS-B — editability axis (all | adminOnly | none) write-enforcement
+    // ================================================================
+
+    private fun uniqueProjectKey() = "PK${UUID.randomUUID().toString().take(8).uppercase().replace("-", "")}"
+
+    /** BASE row of a detail node; its jira.technical boolean. */
+    private fun JsonNode.baseRow(): JsonNode = this["configurations"].first { it["rowType"].asText() == "BASE" }
+
+    private fun JsonNode.jiraTechnical(): Boolean = baseRow()["jira"]["technical"].asBoolean()
+
+    private fun JsonNode.baseJira(field: String): String? =
+        baseRow()["jira"]?.get(field)?.takeUnless { it.isNull }?.asText()
+
+    /**
+     * Create a component OWNED BY the editor "bob" (so `editorJwt()` passes the
+     * per-component edit gate) with a known `jira.technical` + projectKey and an
+     * optional top-level `vcsExternalRegistry`. Created as admin (bypasses all gates).
+     */
+    private fun createOwnedByBob(
+        technical: Boolean = false,
+        projectKey: String = uniqueProjectKey(),
+        vcsExternalRegistry: String? = null,
+    ): JsonNode {
+        val registryFragment = vcsExternalRegistry?.let { """"vcsExternalRegistry":"$it",""" } ?: ""
+        val body =
+            """{"name":"crsB_${UUID.randomUUID().toString().take(8)}","componentOwner":"bob",""" +
+                registryFragment +
+                """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                """"jira":{"projectKey":"$projectKey","technical":$technical}}}"""
+        val response =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body),
+                ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        return objectMapper.readTree(response)
+    }
+
+    private fun patchRaw(
+        who: RequestPostProcessor,
+        id: String,
+        bodyJson: String,
+    ) = mvc.perform(
+        patch("/rest/api/4/components/$id")
+            .with(who)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(bodyJson),
+    )
+
+    /** Seed a field-config, run [block], then reset the row so it can't leak into sibling tests. */
+    private fun withFieldConfig(
+        value: Map<String, Any?>,
+        block: () -> Unit,
+    ) {
+        seedFieldConfig(value)
+        try {
+            block()
+        } finally {
+            seedFieldConfig(emptyMap())
+        }
+    }
+
+    @Test
+    @DisplayName("adminOnly jira.technical: non-admin editor FLIPPING the value → 403")
+    fun adminOnlyTechnical_nonAdminFlip_forbidden() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            patchRaw(
+                editorJwt(), // bob = owner, but lacks EDIT_ANY_COMPONENT
+                id,
+                """{"version":$version,"baseConfiguration":{"jira":{"technical":true}}}""",
+            ).andExpect(status().isForbidden)
+            // Value unchanged (transaction rolled back).
+            assertEquals(false, getComponent(id).jiraTechnical())
+        }
+    }
+
+    @Test
+    @DisplayName("adminOnly jira.technical: non-admin editor ECHOING the unchanged value → 2xx (combined-save tolerance)")
+    fun adminOnlyTechnical_nonAdminEcho_ok() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            patchRaw(
+                editorJwt(),
+                id,
+                // Echo current value (false) — the Portal's combined Save sends the whole slice.
+                """{"version":$version,"baseConfiguration":{"jira":{"technical":false}}}""",
+            ).andExpect(status().is2xxSuccessful)
+        }
+    }
+
+    @Test
+    @DisplayName("adminOnly jira.technical: admin FLIPPING the value → 2xx and persisted")
+    fun adminOnlyTechnical_adminFlip_ok() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            patchRaw(
+                adminJwt(),
+                id,
+                """{"version":$version,"baseConfiguration":{"jira":{"technical":true}}}""",
+            ).andExpect(status().is2xxSuccessful)
+            assertEquals(true, getComponent(id).jiraTechnical())
+        }
+    }
+
+    @Test
+    @DisplayName("readonly jira.projectKey: admin CHANGING → 422; ECHOING unchanged → 2xx")
+    fun readonlyProjectKey_changeRejected_echoOk() {
+        val pk = uniqueProjectKey()
+        val created = createOwnedByBob(projectKey = pk)
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(mapOf("jira" to mapOf("projectKey" to mapOf("visibility" to "readonly")))) {
+            // readonly is unified with editable:none — non-editable even for admin.
+            patchRaw(
+                adminJwt(),
+                id,
+                """{"version":$version,"baseConfiguration":{"jira":{"projectKey":"${uniqueProjectKey()}"}}}""",
+            ).andExpect(status().isUnprocessableEntity)
+            assertEquals(pk, getComponent(id).baseJira("projectKey"))
+
+            // Echo of the unchanged value is tolerated.
+            patchRaw(
+                adminJwt(),
+                id,
+                """{"version":$version,"baseConfiguration":{"jira":{"projectKey":"$pk"}}}""",
+            ).andExpect(status().is2xxSuccessful)
+        }
+    }
+
+    @Test
+    @DisplayName("hidden precedence: a hidden+adminOnly field is silently STRIPPED for a non-admin, never 403")
+    fun hiddenBeatsAdminOnly_stripNotReject() {
+        val created = createOwnedByBob(vcsExternalRegistry = "orig-registry")
+        val id = created["id"].asText()
+        val version = created["version"].asLong()
+
+        withFieldConfig(
+            mapOf("component" to mapOf("vcsExternalRegistry" to mapOf("visibility" to "hidden", "editable" to "adminOnly"))),
+        ) {
+            // Non-admin owner tries to change a hidden field: hidden wins → silent strip, 2xx.
+            patchRaw(
+                editorJwt(),
+                id,
+                """{"version":$version,"vcsExternalRegistry":"changed-registry"}""",
+            ).andExpect(status().is2xxSuccessful)
+            assertEquals(
+                "orig-registry",
+                getComponent(id)["vcsExternalRegistry"].asText(),
+                "hidden field must be stripped (unchanged), not rejected",
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("CREATE: non-admin supplying an adminOnly value (jira.technical) → 403")
+    fun create_nonAdminSuppliesAdminOnly_forbidden() {
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            val body =
+                """{"name":"crsB_create_${UUID.randomUUID().toString().take(8)}","componentOwner":"bob",""" +
+                    """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                    """"jira":{"projectKey":"${uniqueProjectKey()}","technical":true}}}"""
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(editorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body),
+                ).andExpect(status().isForbidden)
+        }
+    }
+
+    @Test
+    @DisplayName("CREATE: non-admin OMITTING the adminOnly field → 2xx (server default applies)")
+    fun create_nonAdminOmitsAdminOnly_ok() {
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            val body =
+                """{"name":"crsB_create_${UUID.randomUUID().toString().take(8)}","componentOwner":"bob",""" +
+                    """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},""" +
+                    """"jira":{"projectKey":"${uniqueProjectKey()}"}}}"""
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(editorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body),
+                ).andExpect(status().isCreated)
+        }
+    }
+
+    @Test
+    @DisplayName("OVERRIDE: non-admin creating a jira.technical override → 403; admin → 201")
+    fun override_adminOnlyField_gated() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            val overrideBody = """{"overriddenAttribute":"jira.technical","versionRange":"[1.0,2.0)","value":true}"""
+
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(editorJwt()) // bob = owner, no EDIT_ANY_COMPONENT
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(overrideBody),
+                ).andExpect(status().isForbidden)
+
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(overrideBody),
+                ).andExpect(status().isCreated)
+        }
+    }
+
+    @Test
+    @DisplayName("OVERRIDE UPDATE: non-admin CHANGING a jira.technical override value → 403; ECHOING it → 2xx")
+    fun override_update_valueChange_gated() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+
+        // Create the override as admin while the field is still editable (unseeded).
+        val overrideResponse =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"overriddenAttribute":"jira.technical","versionRange":"[1.0,2.0)","value":true}"""),
+                ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val overrideId = objectMapper.readTree(overrideResponse)["id"].asText()
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            // Non-admin owner flips the override value → change → 403.
+            mvc
+                .perform(
+                    patch("/rest/api/4/components/$id/field-overrides/$overrideId")
+                        .with(editorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"value":false}"""),
+                ).andExpect(status().isForbidden)
+
+            // Non-admin owner echoes the unchanged value → snapshot-equal → 2xx.
+            mvc
+                .perform(
+                    patch("/rest/api/4/components/$id/field-overrides/$overrideId")
+                        .with(editorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"value":true}"""),
+                ).andExpect(status().is2xxSuccessful)
+        }
+    }
+
+    @Test
+    @DisplayName("OVERRIDE DELETE: non-admin deleting a jira.technical override → 403; admin → 204")
+    fun override_delete_gated() {
+        val created = createOwnedByBob(technical = false)
+        val id = created["id"].asText()
+
+        val overrideResponse =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"overriddenAttribute":"jira.technical","versionRange":"[1.0,2.0)","value":true}"""),
+                ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val overrideId = objectMapper.readTree(overrideResponse)["id"].asText()
+
+        withFieldConfig(mapOf("jira" to mapOf("technical" to mapOf("editable" to "adminOnly")))) {
+            // Direct DELETE by a non-admin must be gated the same as the combined-save path.
+            mvc
+                .perform(delete("/rest/api/4/components/$id/field-overrides/$overrideId").with(editorJwt()))
+                .andExpect(status().isForbidden)
+            // Admin can delete it.
+            mvc
+                .perform(delete("/rest/api/4/components/$id/field-overrides/$overrideId").with(adminJwt()))
+                .andExpect(status().isNoContent)
+        }
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigServiceTest.kt
@@ -54,7 +54,7 @@ class FieldConfigServiceTest {
     }
 
     @Test
-    @DisplayName("readonly field → visibility returned but isHidden=false (server only enforces hidden)")
+    @DisplayName("readonly field → visibility returned, isHidden=false, editabilityFor unifies to none")
     fun readonly_notHidden() {
         val svc =
             service(
@@ -68,6 +68,65 @@ class FieldConfigServiceTest {
 
         assertEquals("readonly", svc.visibilityFor("component.displayName"))
         assertFalse(svc.isHidden("component.displayName"))
+        // CRS-B: readonly is unified with editable:none (non-editable for everyone).
+        assertEquals("none", svc.editabilityFor("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("editabilityFor: unconfigured / absent-editable → all")
+    fun editability_defaultsToAll() {
+        assertEquals("all", service(stored = null).editabilityFor("jira.technical"))
+        assertEquals(
+            "all",
+            service(mapOf("jira" to mapOf("technical" to mapOf("visibility" to "editable"))))
+                .editabilityFor("jira.technical"),
+        )
+    }
+
+    @Test
+    @DisplayName("editabilityFor: explicit adminOnly / none normalized from mixed case + whitespace")
+    fun editability_adminOnlyAndNone() {
+        val svc =
+            service(
+                mapOf(
+                    "jira" to mapOf("technical" to mapOf("editable" to "  AdminOnly ")),
+                    "component" to mapOf("system" to mapOf("editable" to "NONE")),
+                ),
+            )
+        assertEquals("adminonly", svc.editabilityFor("jira.technical"))
+        assertEquals("none", svc.editabilityFor("component.system"))
+    }
+
+    @Test
+    @DisplayName("editabilityFor: explicit editable:none overrides even when visibility=editable")
+    fun editability_noneWithEditableVisibility() {
+        val svc =
+            service(
+                mapOf("jira" to mapOf("technical" to mapOf("visibility" to "editable", "editable" to "none"))),
+            )
+        assertEquals("none", svc.editabilityFor("jira.technical"))
+    }
+
+    @Test
+    @DisplayName("editabilityFor: hidden field (no editable key) still resolves to all — strip is a separate axis")
+    fun editability_hiddenResolvesToAll() {
+        val svc =
+            service(
+                mapOf("component" to mapOf("displayName" to mapOf("visibility" to "hidden"))),
+            )
+        // Hidden is enforced via isHidden (silent strip), not via editabilityFor.
+        assertTrue(svc.isHidden("component.displayName"))
+        assertEquals("all", svc.editabilityFor("component.displayName"))
+    }
+
+    @Test
+    @DisplayName("editabilityFor: unrecognized editable token degrades to all")
+    fun editability_unknownTokenAll() {
+        val svc =
+            service(
+                mapOf("jira" to mapOf("technical" to mapOf("editable" to "mostly"))),
+            )
+        assertEquals("all", svc.editabilityFor("jira.technical"))
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MIG047FieldOverrideWriteGuardTest.kt
@@ -33,6 +33,7 @@ import org.octopusden.octopus.components.registry.server.repository.LabelReposit
 import org.octopusden.octopus.components.registry.server.repository.SystemRepository
 import org.octopusden.octopus.components.registry.server.repository.ToolRepository
 import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
+import org.octopusden.octopus.components.registry.server.security.PermissionEvaluator
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
 import org.octopusden.octopus.components.registry.server.util.ComponentCodeRenderer
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
@@ -98,6 +99,7 @@ class MIG047FieldOverrideWriteGuardTest {
                 applicationEventPublisher = mock(ApplicationEventPublisher::class.java),
                 currentUserResolver = mock(CurrentUserResolver::class.java),
                 fieldConfigService = mock(FieldConfigService::class.java),
+                permissionEvaluator = mock(PermissionEvaluator::class.java),
                 teamcityProperties = mock(TeamcityProperties::class.java),
                 versionRangeFactory = VersionRangeFactory(versionNames),
                 numericVersionFactory = NumericVersionFactory(versionNames),


### PR DESCRIPTION
## What

Adds an **editability axis** to field-config and enforces it server-side.

**Config surface** (`AdminConfigProperties.FieldEntry`): new optional `editable: all | adminOnly | none` (absent = `all`) and `options: [string]` (dropdown values, installation-specific — e.g. External Registry names live in service-config only). Both serialized into the JSONB blob by `ConfigSyncService` with enum validation (422 via `ConfigValidationException` on bad values). The read endpoint (`GET /config/field-config`) stays a **raw user-agnostic blob** — each side computes effective editability itself (portal: entry + current user's permissions; CRS: write enforcement below).

**Write enforcement** (`ComponentManagementServiceImpl`):
- **Change-based** — a write is rejected only when it would actually CHANGE the value; echoing the current value (or null/absent) is always allowed, because the portal's combined Save posts whole section slices. String comparison **structurally reuses** the CRS storage normalizer `clearBlankScalar` (`"" ≡ null`, no trim, verbatim otherwise) so the comparison rule can never drift from what the write path persists.
- `editable: adminOnly` without `EDIT_ANY_COMPONENT` → **403**; `editable: none` and `visibility: readonly` (unified — readonly was previously not server-enforced at all) → **422**. `visibility: hidden` keeps its pre-existing silent-strip and short-circuits first.
- **CREATE**: no current value to compare — a supplied non-null value on a non-editable field is rejected; absent is fine (server defaults apply).
- **Per-range overrides**: all four write paths (create / standalone PATCH / standalone DELETE / desired-set branches) gated by the overridden attribute's editability; update/delete are change-based via the audit-snapshot diff, so an unchanged desired-set echo passes.

**Baseline `application.yml`**: `jira.technical` and `component.vcsExternalRegistry` → `editable: adminOnly` (universal product rule, deliberately NOT in service-config).

## Verification

- `./gradlew :components-registry-service-server:test` — green (incl. `AdminConfigPropertiesBindingTest`, `ConfigSyncServiceTest`, `FieldConfigServiceTest`, `StrictContractTest`).
- `./gradlew :components-registry-service-server:dbTest` — green, full suite (594 tests / 0 failures); `FieldConfigEnforcementIntegrationTest` = 14 cases (adminOnly change/echo/admin, readonly change, hidden `""` strip, create supplied/absent, boolean technical echo vs flip, padded-echo 403, norm-parity with storage).
- Re-run green after rebasing onto v3 post-#394.

## Coordination

- Portal follow-ups (P-1/P-3): read External Registry editability by the **write-side key `component.vcsExternalRegistry`** (display path stays `vcs.externalRegistry`); add `EDIT_ANY_COMPONENT` to frontend `PERMISSIONS`; section slices must omit non-editable fields from PATCH payloads (client-side gating; the server change-based rule is defense-in-depth).
- service-config follow-up: installation-specific `options` for External Registry + `releasesInDefaultBranch: hidden` (separate infra change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
