### PR TITLE
feat(registry): dedicated skipCommitCheck flag replacing the NOT_AVAILABLE sentinel

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentConfigurationDtos.kt
@@ -12,6 +12,16 @@ const val V4_SCALAR_CLEAR_SEMANTICS: String =
         "non-blank = set verbatim. On create, \"\" is treated as null."
 
 /**
+ * Description of the dedicated `skipCommitCheck` flag (Q12), replacing the legacy
+ * `externalRegistry = "NOT_AVAILABLE"` sentinel in v4 storage.
+ */
+const val V4_SKIP_COMMIT_CHECK: String =
+    "When true, commit checks are skipped at release/RC issue-assignment (issues bind to RCs by " +
+        "builds only). Dedicated flag replacing the legacy externalRegistry=\"NOT_AVAILABLE\" sentinel; " +
+        "legacy v1–v3 clients still see externalRegistry=\"NOT_AVAILABLE\" when this is true. Must be " +
+        "false when the effective BASE build system is WHISKEY (rejected 422 otherwise)."
+
+/**
  * One row of `component_configurations`, projected for the v4 editor view.
  *
  * Three editor-visible shapes per schema-spec.md §3 (Model A' override taxonomy):

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentCreateRequest.kt
@@ -63,6 +63,8 @@ data class ComponentCreateRequest(
     val jiraHotfixVersionFormat: String? = null,
     @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val vcsExternalRegistry: String? = null,
+    @field:Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, description = V4_SKIP_COMMIT_CHECK)
+    val skipCommitCheck: Boolean = false,
     val distributionExplicit: Boolean? = null,
     val distributionExternal: Boolean? = null,
     // Accepted for backward compatibility but IGNORED: group membership is

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentDetailResponse.kt
@@ -44,6 +44,9 @@ data class ComponentDetailResponse(
     val jiraDisplayName: String? = null,
     val jiraHotfixVersionFormat: String? = null,
     val vcsExternalRegistry: String? = null,
+    // Dedicated flag (Q12) — the v4 view shows it alongside the real registry; the
+    // legacy v1–v3 surface still folds true back into externalRegistry="NOT_AVAILABLE".
+    val skipCommitCheck: Boolean = false,
     val distributionExplicit: Boolean? = null,
     val distributionExternal: Boolean? = null,
     // Per-component child rows (never per-version-rangeable) ————————————————

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentUpdateRequest.kt
@@ -53,6 +53,9 @@ data class ComponentUpdateRequest(
     val jiraHotfixVersionFormat: String? = null,
     @field:Schema(description = V4_SCALAR_CLEAR_SEMANTICS)
     val vcsExternalRegistry: String? = null,
+    // PATCH boolean: null = "don't touch" (pre-existing convention). true/false sets it.
+    @field:Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED, description = V4_SKIP_COMMIT_CHECK)
+    val skipCommitCheck: Boolean? = null,
     val distributionExplicit: Boolean? = null,
     val distributionExternal: Boolean? = null,
     // Both accepted for backward compatibility but IGNORED (no-op): group membership

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ComponentEntity.kt
@@ -168,6 +168,14 @@ class ComponentEntity(
     @Column(name = "vcs_external_registry", columnDefinition = "TEXT")
     var vcsExternalRegistry: String? = null,
 
+    // Dedicated replacement for the legacy `externalRegistry = "NOT_AVAILABLE"` sentinel
+    // (Q12): when true, commit checks are skipped at release/RC issue-assignment. The
+    // sentinel is NEVER stored — DSL import maps it here (with a NULL vcsExternalRegistry)
+    // and the legacy v1–v3 read re-emits it (flag wins over any real registry). Q13:
+    // must be false when the effective BASE build system is WHISKEY (validated on write).
+    @Column(name = "skip_commit_check", nullable = false)
+    var skipCommitCheck: Boolean = false,
+
     @Column(name = "distribution_explicit")
     var distributionExplicit: Boolean? = null,
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/EntityMappers.kt
@@ -43,6 +43,14 @@ import org.octopusden.releng.versions.VersionRangeFactory
 internal const val ALL_VERSIONS: String = "(,0),[0,)"
 
 /**
+ * Legacy sentinel value for `VCSSettings.externalRegistry` meaning "skip commit checks".
+ * CRS-C stores this intent as the dedicated `ComponentEntity.skipCommitCheck` flag and never
+ * persists the string; the import bridge maps it in and the legacy v1–v3 read / as-code
+ * renderer map it back out, so the DSL and legacy wire contracts are unchanged.
+ */
+internal const val NOT_AVAILABLE_EXTERNAL_REGISTRY: String = "NOT_AVAILABLE"
+
+/**
  * Marker names for child-collection replacement overrides (see schema-spec.md §3.3).
  */
 internal object MarkerAttributes {
@@ -716,8 +724,15 @@ private fun buildEscrowModuleConfig(
             markerOverrides = markerOverrides,
             baseChildren = base.vcsEntries.toList(),
         ) { it.vcsEntries.toList() }
-    if (vcsEntries.isNotEmpty() || component.vcsExternalRegistry != null) {
-        setField(config, "vcsSettings", vcsEntries.toVCSSettings(component.vcsExternalRegistry))
+    // CRS-C legacy bridge: the dedicated skipCommitCheck flag re-materializes the legacy
+    // `externalRegistry = "NOT_AVAILABLE"` sentinel for v1–v3 consumers (Jira plugin / RM),
+    // so the legacy surface is bit-for-bit identical to the pre-flag world. The flag WINS
+    // over any real registry value (they are mutually exclusive by construction — Q13 forbids
+    // the flag on WHISKEY, the only build system that carries a real registry).
+    val effectiveExternalRegistry =
+        if (component.skipCommitCheck) NOT_AVAILABLE_EXTERNAL_REGISTRY else component.vcsExternalRegistry
+    if (vcsEntries.isNotEmpty() || effectiveExternalRegistry != null) {
+        setField(config, "vcsSettings", vcsEntries.toVCSSettings(effectiveExternalRegistry))
     }
 
     // Distribution — composed from four family child collections, each

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/mapper/V4Mappers.kt
@@ -68,6 +68,7 @@ fun ComponentEntity.toDetailResponse(teamcityBaseUrl: String? = null): Component
         jiraDisplayName = this.jiraDisplayName,
         jiraHotfixVersionFormat = this.jiraHotfixVersionFormat,
         vcsExternalRegistry = this.vcsExternalRegistry,
+        skipCommitCheck = this.skipCommitCheck,
         distributionExplicit = this.distributionExplicit,
         distributionExternal = this.distributionExternal,
         group = this.componentGroup?.let { group -> group.toResponse(thisComponentKey = this.componentKey) },

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -300,6 +300,8 @@ class ComponentManagementServiceImpl(
                 jiraHotfixVersionFormat = stripIfHidden("component.jiraHotfixVersionFormat", request.jiraHotfixVersionFormat),
                 // CRS-A: create maps "" → NULL (treated as absent), consistent with the PATCH clear rule.
                 vcsExternalRegistry = stripIfHidden("component.vcsExternalRegistry", request.vcsExternalRegistry?.let(::clearBlankScalar)),
+                // Non-null Boolean with a false default — hidden strips to the default rather than null.
+                skipCommitCheck = if (fieldConfigService.isHidden("component.skipCommitCheck")) false else request.skipCommitCheck,
                 distributionExplicit = stripIfHidden("component.distributionExplicit", request.distributionExplicit),
                 distributionExternal = stripIfHidden("component.distributionExternal", request.distributionExternal),
                 systemCode = canonicalSystem,
@@ -337,6 +339,9 @@ class ComponentManagementServiceImpl(
         // no DB lookup beyond the soft doc-ref existence probe and run against the
         // final in-memory entity state (everything is freshly assigned on create).
         validateMalformedFieldRules(entity)
+
+        // Q13: reject skipCommitCheck on a WHISKEY component (422). Runs on the final state.
+        validateSkipCommitCheckNotWhiskey(entity)
 
         // Flush so the self-excluding 409 collision queries below see the new
         // component's rows and the entity carries an assigned id.
@@ -603,6 +608,12 @@ class ComponentManagementServiceImpl(
             // CRS-A: "" clears the external registry (persist NULL); non-blank sets verbatim.
             if (!fieldConfigService.isHidden("component.vcsExternalRegistry")) entity.vcsExternalRegistry = clearBlankScalar(it)
         }
+        // PATCH boolean: null = don't touch (handled by ?.let). Editable by any component
+        // editor (Q11) — no adminOnly hardcode; the CRS-B gate above already lets field-config
+        // narrow it later. Hidden-strip mirrors the peer component scalars.
+        request.skipCommitCheck?.let {
+            if (!fieldConfigService.isHidden("component.skipCommitCheck")) entity.skipCommitCheck = it
+        }
         request.distributionExplicit?.let {
             if (!fieldConfigService.isHidden("component.distributionExplicit")) entity.distributionExplicit = it
         }
@@ -695,6 +706,17 @@ class ComponentManagementServiceImpl(
                 applyBaseConfigurationPatch(base, patch)
                 base.takeIf { patch.requiredTools != null }
             }
+
+        // Q13: validate the COMBINED post-patch state (flag + base build system are both
+        // applied by now), so switching buildSystem → WHISKEY while the flag is true, or
+        // setting the flag true while WHISKEY, is rejected 422 in the same place. GATED on the
+        // PATCH actually touching the flag or the BASE build system — mirroring the
+        // "grandfathered on update" convention below: an unrelated PATCH (e.g. clientCode-only)
+        // must NOT 422 a pre-existing WHISKEY+flag component that the import bridge admitted
+        // with a warning (import warns rather than hard-fails on that data contradiction).
+        if (request.skipCommitCheck != null || request.baseConfiguration?.build?.buildSystem != null) {
+            validateSkipCommitCheckNotWhiskey(entity)
+        }
 
         // Field overrides (item D): desired-FULL-SET applied in-place on the
         // configuration collection — cascade (orphanRemoval) persists the
@@ -1942,6 +1964,8 @@ class ComponentManagementServiceImpl(
         request.vcsExternalRegistry?.let {
             enforceFieldEditable("component.vcsExternalRegistry", it, entity.vcsExternalRegistry)
         }
+        // Editable by all by default (Q11); gated here only so field-config CAN narrow it later.
+        request.skipCommitCheck?.let { enforceFieldEditable("component.skipCommitCheck", it, entity.skipCommitCheck) }
         request.distributionExplicit?.let { enforceFieldEditable("component.distributionExplicit", it, entity.distributionExplicit) }
         request.distributionExternal?.let { enforceFieldEditable("component.distributionExternal", it, entity.distributionExternal) }
         request.system?.let { enforceFieldEditable("component.system", it, entity.systemCode) }
@@ -2018,6 +2042,8 @@ class ComponentManagementServiceImpl(
         request.jiraDisplayName?.let { enforceFieldEditable("component.jiraDisplayName", it, null) }
         request.jiraHotfixVersionFormat?.let { enforceFieldEditable("component.jiraHotfixVersionFormat", it, null) }
         request.vcsExternalRegistry?.let { enforceFieldEditable("component.vcsExternalRegistry", it, null) }
+        // skipCommitCheck defaults to false on create; only a supplied `true` is a change to gate.
+        request.skipCommitCheck.takeIf { it }?.let { enforceFieldEditable("component.skipCommitCheck", it, null) }
         request.distributionExplicit?.let { enforceFieldEditable("component.distributionExplicit", it, null) }
         request.distributionExternal?.let { enforceFieldEditable("component.distributionExternal", it, null) }
         request.system?.let { enforceFieldEditable("component.system", it, null) }
@@ -2063,6 +2089,28 @@ class ComponentManagementServiceImpl(
             e.gradleExcludeConfigurations?.let { enforceFieldEditable("escrow.gradleExcludeConfigurations", it, null) }
             e.gradleIncludeTestConfigurations?.let { enforceFieldEditable("escrow.gradleIncludeTestConfigurations", it, null) }
             e.buildTask?.let { enforceFieldEditable("escrow.buildTask", it, null) }
+        }
+    }
+
+    /**
+     * CRS-C / Q13: `skipCommitCheck` is mutually exclusive with a WHISKEY effective BASE
+     * build system. A real external registry only ever exists on WHISKEY components, so the
+     * flag (a NOT_AVAILABLE stand-in) and WHISKEY can never coexist meaningfully.
+     *
+     * Validates the COMBINED post-write state (call AFTER the flag and the base build system
+     * are both applied), so it catches every transition uniformly: create with both set,
+     * PATCH flipping the flag true while WHISKEY, and PATCH switching buildSystem → WHISKEY
+     * while the flag is already true. Effective BASE = the BASE configuration row's
+     * `build_system` (per-range build overrides do not relax this component-level flag).
+     */
+    private fun validateSkipCommitCheckNotWhiskey(entity: ComponentEntity) {
+        if (!entity.skipCommitCheck) return
+        val baseBuildSystem = entity.configurations.firstOrNull { it.rowType == "BASE" }?.buildSystem
+        if (baseBuildSystem.equals("WHISKEY", ignoreCase = true)) {
+            throw ResponseStatusException(
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "skipCommitCheck is not applicable when the effective BASE build system is WHISKEY",
+            )
         }
     }
 
@@ -3617,6 +3665,7 @@ class ComponentManagementServiceImpl(
             "jiraDisplayName" to entity.jiraDisplayName,
             "jiraHotfixVersionFormat" to entity.jiraHotfixVersionFormat,
             "vcsExternalRegistry" to entity.vcsExternalRegistry,
+            "skipCommitCheck" to entity.skipCommitCheck,
             "distributionExplicit" to entity.distributionExplicit,
             "distributionExternal" to entity.distributionExternal,
             "labels" to (overrideLabels ?: entity.labelJunctions.map { it.labelCode }.toSet()),

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -58,6 +58,7 @@ import org.octopusden.octopus.components.registry.server.mapper.BUILD_SYSTEM_NAM
 import org.octopusden.octopus.components.registry.server.mapper.numericVersionComparator
 import org.octopusden.octopus.components.registry.server.mapper.ESCROW_GENERATION_MODE_NAMES
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.mapper.NOT_AVAILABLE_EXTERNAL_REGISTRY
 import org.octopusden.octopus.components.registry.server.mapper.PACKAGE_TYPE_NAMES
 import org.octopusden.octopus.components.registry.server.mapper.PRODUCT_TYPE_NAMES
 import org.octopusden.octopus.components.registry.server.mapper.REPOSITORY_TYPE_NAMES
@@ -299,7 +300,12 @@ class ComponentManagementServiceImpl(
                 jiraDisplayName = stripIfHidden("component.jiraDisplayName", request.jiraDisplayName),
                 jiraHotfixVersionFormat = stripIfHidden("component.jiraHotfixVersionFormat", request.jiraHotfixVersionFormat),
                 // CRS-A: create maps "" → NULL (treated as absent), consistent with the PATCH clear rule.
-                vcsExternalRegistry = stripIfHidden("component.vcsExternalRegistry", request.vcsExternalRegistry?.let(::clearBlankScalar)),
+                // CRS-C: reject the legacy NOT_AVAILABLE sentinel — it must never land in the column.
+                vcsExternalRegistry =
+                    stripIfHidden(
+                        "component.vcsExternalRegistry",
+                        request.vcsExternalRegistry?.let(::clearBlankScalar).also(::rejectLegacyExternalRegistrySentinel),
+                    ),
                 // Non-null Boolean with a false default — hidden strips to the default rather than null.
                 skipCommitCheck = if (fieldConfigService.isHidden("component.skipCommitCheck")) false else request.skipCommitCheck,
                 distributionExplicit = stripIfHidden("component.distributionExplicit", request.distributionExplicit),
@@ -551,6 +557,13 @@ class ComponentManagementServiceImpl(
         val oldSecurityChampions = entity.securityChampionUsernames()
         val oldExplicit = entity.distributionExplicit
         val oldExternal = entity.distributionExternal
+        // CRS-C / Q13: snapshot the flag + effective BASE build system BEFORE the patch so the
+        // WHISKEY exclusion is CHANGE-based. A full-form combined Save echoes the whole slice, so a
+        // grandfathered skipCommitCheck=true + WHISKEY row (admitted by the import bridge with a
+        // warning) must tolerate an unchanged echo; only a real transition (flag false→true while
+        // WHISKEY, or buildSystem→WHISKEY while the flag is set) is rejected 422.
+        val oldSkipCommitCheck = entity.skipCommitCheck
+        val oldBaseBuildSystem = entity.configurations.firstOrNull { it.rowType == "BASE" }?.buildSystem
 
         if (isRename) entity.componentKey = normalizedNewKey!!
 
@@ -606,7 +619,10 @@ class ComponentManagementServiceImpl(
         }
         request.vcsExternalRegistry?.let {
             // CRS-A: "" clears the external registry (persist NULL); non-blank sets verbatim.
-            if (!fieldConfigService.isHidden("component.vcsExternalRegistry")) entity.vcsExternalRegistry = clearBlankScalar(it)
+            // CRS-C: reject the legacy NOT_AVAILABLE sentinel — it must never land in the column.
+            val normalized = clearBlankScalar(it)
+            rejectLegacyExternalRegistrySentinel(normalized)
+            if (!fieldConfigService.isHidden("component.vcsExternalRegistry")) entity.vcsExternalRegistry = normalized
         }
         // PATCH boolean: null = don't touch (handled by ?.let). Editable by any component
         // editor (Q11) — no adminOnly hardcode; the CRS-B gate above already lets field-config
@@ -707,14 +723,14 @@ class ComponentManagementServiceImpl(
                 base.takeIf { patch.requiredTools != null }
             }
 
-        // Q13: validate the COMBINED post-patch state (flag + base build system are both
-        // applied by now), so switching buildSystem → WHISKEY while the flag is true, or
-        // setting the flag true while WHISKEY, is rejected 422 in the same place. GATED on the
-        // PATCH actually touching the flag or the BASE build system — mirroring the
-        // "grandfathered on update" convention below: an unrelated PATCH (e.g. clientCode-only)
-        // must NOT 422 a pre-existing WHISKEY+flag component that the import bridge admitted
-        // with a warning (import warns rather than hard-fails on that data contradiction).
-        if (request.skipCommitCheck != null || request.baseConfiguration?.build?.buildSystem != null) {
+        // Q13: validate the COMBINED post-patch state (flag + base build system are both applied by
+        // now). CHANGE-based, not presence-based: only a real transition is rejected — the flag
+        // actually flipping or the BASE build system actually changing. A full-form combined Save
+        // that echoes an unchanged skipCommitCheck=true or buildSystem="WHISKEY" on a grandfathered
+        // row (import admits WHISKEY+sentinel with a warning) is legal, mirroring the CRS-B
+        // change-based write-gate and the "grandfathered on update" convention below.
+        val newBaseBuildSystem = entity.configurations.firstOrNull { it.rowType == "BASE" }?.buildSystem
+        if (entity.skipCommitCheck != oldSkipCommitCheck || newBaseBuildSystem != oldBaseBuildSystem) {
             validateSkipCommitCheckNotWhiskey(entity)
         }
 
@@ -2110,6 +2126,22 @@ class ComponentManagementServiceImpl(
             throw ResponseStatusException(
                 HttpStatus.UNPROCESSABLE_ENTITY,
                 "skipCommitCheck is not applicable when the effective BASE build system is WHISKEY",
+            )
+        }
+    }
+
+    /**
+     * CRS-C: the legacy `NOT_AVAILABLE` sentinel must never be written to `vcs_external_registry`
+     * via v4 — the storage invariant is "real registry names only"; skip-commit intent is expressed
+     * through the dedicated `skipCommitCheck` flag. Reject an explicit sentinel (exact match, after
+     * the CRS-A blank→null normalization) with 422 rather than silently folding it into the flag —
+     * the Portal never sends the sentinel, so this only fires on a misbehaving client.
+     */
+    private fun rejectLegacyExternalRegistrySentinel(normalizedValue: String?) {
+        if (normalizedValue == NOT_AVAILABLE_EXTERNAL_REGISTRY) {
+            throw ResponseStatusException(
+                HttpStatus.UNPROCESSABLE_ENTITY,
+                "vcsExternalRegistry must not be the legacy \"NOT_AVAILABLE\" sentinel; use skipCommitCheck instead",
             )
         }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportExternalRegistryBridge.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportExternalRegistryBridge.kt
@@ -1,0 +1,30 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.NOT_AVAILABLE_EXTERNAL_REGISTRY
+
+/**
+ * CRS-C import bridge for the per-component external registry ⟷ skipCommitCheck fold.
+ *
+ * Sets BOTH `skipCommitCheck` and `vcsExternalRegistry` authoritatively from the DSL value — the
+ * import is the source of truth, so a re-import/resync that changed the sentinel to a real registry
+ * (or dropped it) must not leave a stale flag behind:
+ *  - `"NOT_AVAILABLE"` → `skipCommitCheck = true`, `vcsExternalRegistry = null` (the sentinel is
+ *    never stored);
+ *  - any other value (including `null`) → `skipCommitCheck = false`, `vcsExternalRegistry = value`.
+ *
+ * The WHISKEY + NOT_AVAILABLE data-contradiction warning stays at the call site (it needs the build
+ * system and the component key for the log line).
+ */
+internal fun applyImportedExternalRegistry(
+    entity: ComponentEntity,
+    importedExternalRegistry: String?,
+) {
+    if (importedExternalRegistry == NOT_AVAILABLE_EXTERNAL_REGISTRY) {
+        entity.skipCommitCheck = true
+        entity.vcsExternalRegistry = null
+    } else {
+        entity.skipCommitCheck = false
+        entity.vcsExternalRegistry = importedExternalRegistry
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -35,6 +35,7 @@ import org.octopusden.octopus.components.registry.server.entity.ToolEntity
 import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
 import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.mapper.NOT_AVAILABLE_EXTERNAL_REGISTRY
 import org.octopusden.octopus.components.registry.server.mapper.numericVersionComparator
 import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
@@ -1369,8 +1370,27 @@ class ImportServiceImpl(
                 jira.componentVersionFormat?.hotfixVersionFormat?.takeIf { it.isNotBlank() }
         }
 
-        // vcs.externalRegistry is per-component
-        entity.vcsExternalRegistry = cfg.vcsSettings?.externalRegistry
+        // vcs.externalRegistry is per-component. CRS-C bridge: the legacy
+        // `externalRegistry = "NOT_AVAILABLE"` sentinel is NEVER stored — it becomes the
+        // dedicated skipCommitCheck flag with a NULL registry. Any real registry name imports
+        // as-is (skipCommitCheck stays false).
+        val importedExternalRegistry = cfg.vcsSettings?.externalRegistry
+        if (importedExternalRegistry == NOT_AVAILABLE_EXTERNAL_REGISTRY) {
+            entity.skipCommitCheck = true
+            entity.vcsExternalRegistry = null
+            // Q13: WHISKEY + NOT_AVAILABLE is a data contradiction (a WHISKEY component should
+            // carry a real registry, not the sentinel). Warn but still import — the v4 write path
+            // rejects the combination; existing DSL data is the domain owner's to reconcile.
+            if (cfg.buildSystem == org.octopusden.octopus.escrow.BuildSystem.WHISKEY) {
+                LOG.warn(
+                    "Component '{}': externalRegistry=NOT_AVAILABLE combined with buildSystem=WHISKEY — " +
+                        "imported as skipCommitCheck=true; this pairing is rejected on v4 write and should be reviewed.",
+                    componentKey,
+                )
+            }
+        } else {
+            entity.vcsExternalRegistry = importedExternalRegistry
+        }
 
         // distribution.explicit / distribution.external are per-component; a
         // per-range value that differs from the base is rejected at import

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -35,7 +35,6 @@ import org.octopusden.octopus.components.registry.server.entity.ToolEntity
 import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
 import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
-import org.octopusden.octopus.components.registry.server.mapper.NOT_AVAILABLE_EXTERNAL_REGISTRY
 import org.octopusden.octopus.components.registry.server.mapper.numericVersionComparator
 import org.octopusden.octopus.components.registry.server.repository.ComponentBuildToolBeanRepository
 import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
@@ -1372,24 +1371,20 @@ class ImportServiceImpl(
 
         // vcs.externalRegistry is per-component. CRS-C bridge: the legacy
         // `externalRegistry = "NOT_AVAILABLE"` sentinel is NEVER stored — it becomes the
-        // dedicated skipCommitCheck flag with a NULL registry. Any real registry name imports
-        // as-is (skipCommitCheck stays false).
+        // dedicated skipCommitCheck flag with a NULL registry; any real registry name imports
+        // as-is with the flag off. The helper sets BOTH fields authoritatively so a re-import
+        // that changed/dropped the sentinel can never leave a stale flag.
         val importedExternalRegistry = cfg.vcsSettings?.externalRegistry
-        if (importedExternalRegistry == NOT_AVAILABLE_EXTERNAL_REGISTRY) {
-            entity.skipCommitCheck = true
-            entity.vcsExternalRegistry = null
-            // Q13: WHISKEY + NOT_AVAILABLE is a data contradiction (a WHISKEY component should
-            // carry a real registry, not the sentinel). Warn but still import — the v4 write path
-            // rejects the combination; existing DSL data is the domain owner's to reconcile.
-            if (cfg.buildSystem == org.octopusden.octopus.escrow.BuildSystem.WHISKEY) {
-                LOG.warn(
-                    "Component '{}': externalRegistry=NOT_AVAILABLE combined with buildSystem=WHISKEY — " +
-                        "imported as skipCommitCheck=true; this pairing is rejected on v4 write and should be reviewed.",
-                    componentKey,
-                )
-            }
-        } else {
-            entity.vcsExternalRegistry = importedExternalRegistry
+        applyImportedExternalRegistry(entity, importedExternalRegistry)
+        // Q13: WHISKEY + NOT_AVAILABLE is a data contradiction (a WHISKEY component should carry a
+        // real registry, not the sentinel). Warn but still import — the v4 write path rejects the
+        // combination; existing DSL data is the domain owner's to reconcile.
+        if (entity.skipCommitCheck && cfg.buildSystem == org.octopusden.octopus.escrow.BuildSystem.WHISKEY) {
+            LOG.warn(
+                "Component '{}': externalRegistry=NOT_AVAILABLE combined with buildSystem=WHISKEY — " +
+                    "imported as skipCommitCheck=true; this pairing is rejected on v4 write and should be reviewed.",
+                componentKey,
+            )
         }
 
         // distribution.explicit / distribution.external are per-component; a

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRenderer.kt
@@ -13,6 +13,7 @@ import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntry
 import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
 import org.octopusden.octopus.components.registry.server.mapper.ComponentConfigurationView
 import org.octopusden.octopus.components.registry.server.mapper.MarkerAttributes
+import org.octopusden.octopus.components.registry.server.mapper.NOT_AVAILABLE_EXTERNAL_REGISTRY
 import org.octopusden.octopus.components.registry.server.mapper.extractScalarValue
 import org.octopusden.releng.versions.NumericVersionFactory
 import org.octopusden.releng.versions.VersionRangeFactory
@@ -322,7 +323,14 @@ class ComponentCodeRenderer(
         cb.strList("securityChampion", component.securityChampionUsernames())
         cb.strList("labels", component.labelJunctions.map { it.labelCode })
 
-        writeVcs(cb, vcsEntries, component.vcsExternalRegistry)
+        // CRS-C bridge: emit the DSL literal `externalRegistry = "NOT_AVAILABLE"` for the
+        // dedicated skipCommitCheck flag so the as-code DSL contract is unchanged. Flag wins
+        // over any real registry (mirrors the legacy read; mutually exclusive by Q13).
+        writeVcs(
+            cb,
+            vcsEntries,
+            if (component.skipCommitCheck) NOT_AVAILABLE_EXTERNAL_REGISTRY else component.vcsExternalRegistry,
+        )
         writeBuild(cb, scalars, requiredTools, buildToolBeans)
         writeArtifactIds(cb, ownershipMappings, ownershipExportPatterns)
         writeJira(cb, scalars, component)

--- a/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V1__schema.sql
@@ -67,6 +67,15 @@ CREATE TABLE components (
     -- when present (see EntityMappers.buildJiraComponent).
     jira_hotfix_version_format  VARCHAR(255),
     vcs_external_registry       TEXT,
+    -- Dedicated flag replacing the legacy `externalRegistry = "NOT_AVAILABLE"` sentinel
+    -- in storage: when true, commit checks are skipped at release/RC issue-assignment
+    -- (RC↔issue binding goes by builds only). The sentinel survives ONLY as a legacy
+    -- wire/DSL bridge — DSL import maps NOT_AVAILABLE → skip_commit_check=true with a NULL
+    -- vcs_external_registry, and the legacy v1–v3 read re-emits externalRegistry="NOT_AVAILABLE"
+    -- when this is true (flag wins over any real registry). No CHECK couples it to
+    -- vcs_external_registry: a non-WHISKEY component may legitimately carry both a real
+    -- registry and the flag; the flag-wins rule keeps the legacy surface unambiguous.
+    skip_commit_check           BOOLEAN NOT NULL DEFAULT false,
     -- distribution fields that never vary per-version:
     distribution_explicit       BOOLEAN,
     distribution_external       BOOLEAN,

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -537,6 +537,10 @@
             },
             "type" : "array"
           },
+          "skipCommitCheck" : {
+            "description" : "When true, commit checks are skipped at release/RC issue-assignment (issues bind to RCs by builds only). Dedicated flag replacing the legacy externalRegistry=\"NOT_AVAILABLE\" sentinel; legacy v1–v3 clients still see externalRegistry=\"NOT_AVAILABLE\" when this is true. Must be false when the effective BASE build system is WHISKEY (rejected 422 otherwise).",
+            "type" : "boolean"
+          },
           "solution" : {
             "type" : "boolean"
           },
@@ -661,6 +665,9 @@
             },
             "type" : "array"
           },
+          "skipCommitCheck" : {
+            "type" : "boolean"
+          },
           "solution" : {
             "type" : "boolean"
           },
@@ -697,6 +704,7 @@
           "releaseManager",
           "securityChampion",
           "securityGroups",
+          "skipCommitCheck",
           "teamcityProjects",
           "version"
         ],
@@ -946,6 +954,10 @@
               "$ref" : "#/components/schemas/SecurityGroupRequest"
             },
             "type" : "array"
+          },
+          "skipCommitCheck" : {
+            "description" : "When true, commit checks are skipped at release/RC issue-assignment (issues bind to RCs by builds only). Dedicated flag replacing the legacy externalRegistry=\"NOT_AVAILABLE\" sentinel; legacy v1–v3 clients still see externalRegistry=\"NOT_AVAILABLE\" when this is true. Must be false when the effective BASE build system is WHISKEY (rejected 422 otherwise).",
+            "type" : "boolean"
           },
           "solution" : {
             "type" : "boolean"

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SkipCommitCheckV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SkipCommitCheckV4Test.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.RegistryConfigEntity
+import org.octopusden.octopus.components.registry.server.repository.RegistryConfigRepository
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -55,6 +57,9 @@ class SkipCommitCheckV4Test {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var registryConfigRepository: RegistryConfigRepository
 
     init {
         // application-common.yml's work-dir/groovy-path placeholders resolve against this;
@@ -249,5 +254,73 @@ class SkipCommitCheckV4Test {
                 ?: error("expected an UPDATE audit row carrying skipCommitCheck: $history")
         assertEquals(false, diff.path("old").asBoolean(), "audit old must be the pre-toggle value")
         assertEquals(true, diff.path("new").asBoolean(), "audit new must be the toggled value")
+    }
+
+    // ------------------------------------------------------------------
+    // the legacy NOT_AVAILABLE sentinel must never be stored via v4
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create with vcsExternalRegistry=\"NOT_AVAILABLE\" is rejected 422 (use skipCommitCheck)")
+    fun `create rejects sentinel registry`() {
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        createBody(
+                            unique("scc_sentinel_create"),
+                            """{"build":{"buildSystem":"MAVEN"}}""",
+                            topLevelJson = """"vcsExternalRegistry":"NOT_AVAILABLE",""",
+                        ),
+                    ),
+            ).andExpect(status().isUnprocessableEntity)
+    }
+
+    @Test
+    @DisplayName("PATCH vcsExternalRegistry=\"NOT_AVAILABLE\" is rejected 422 (use skipCommitCheck)")
+    fun `patch rejects sentinel registry`() {
+        val created = create(unique("scc_sentinel_patch"), """{"build":{"buildSystem":"MAVEN"}}""")
+        mvc
+            .perform(
+                patch("/rest/api/4/components/${created["id"].asText()}")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"version":${version(created)},"vcsExternalRegistry":"NOT_AVAILABLE"}"""),
+            ).andExpect(status().isUnprocessableEntity)
+    }
+
+    // ------------------------------------------------------------------
+    // hidden component.skipCommitCheck is stripped on create (→ default false)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("hidden component.skipCommitCheck strips an incoming true on create (saved false)")
+    fun `hidden flag stripped on create`() {
+        try {
+            seedFieldConfig(mapOf("component" to mapOf("skipCommitCheck" to mapOf("visibility" to "hidden"))))
+            val created =
+                create(
+                    unique("scc_hidden"),
+                    """{"build":{"buildSystem":"MAVEN"}}""",
+                    topLevelJson = """"skipCommitCheck":true,""",
+                )
+            assertFalse(
+                created["skipCommitCheck"].asBoolean(),
+                "a hidden skipCommitCheck must be stripped to its false default on create",
+            )
+            assertFalse(getComponent(created["id"].asText())["skipCommitCheck"].asBoolean(), "durable across a fresh read")
+        } finally {
+            seedFieldConfig(emptyMap())
+        }
+    }
+
+    /** Seed the `field-config` cache row directly (mirrors ConfigSyncService's writer). */
+    private fun seedFieldConfig(value: Map<String, Any?>) {
+        val entity =
+            registryConfigRepository.findById("field-config").orElse(RegistryConfigEntity(key = "field-config"))
+        entity.value = value
+        registryConfigRepository.save(entity)
     }
 }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SkipCommitCheckV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/SkipCommitCheckV4Test.kt
@@ -1,0 +1,253 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * CRS-C — v4 write/read surface of the dedicated `skipCommitCheck` flag (Q12) and the Q13
+ * WHISKEY exclusion rule.
+ *
+ * Covers: create/PATCH/read round-trip of the boolean (with the PATCH-null no-op convention),
+ * the default (absent → false), the audit snapshot, and the 422 rejection when the flag would
+ * coexist with an effective BASE build system of WHISKEY — on create AND on every PATCH
+ * transition (flag→true while WHISKEY, buildSystem→WHISKEY while flag true).
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+@Tag("integration")
+class SkipCommitCheckV4Test {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        // application-common.yml's work-dir/groovy-path placeholders resolve against this;
+        // point it at the packaged test fixtures (parent of /expected-data), as the sibling
+        // ft-db integration tests do.
+        val testResourcesPath =
+            Paths.get(SkipCommitCheckV4Test::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun unique(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    private fun uniqueProjectKey() = "PK${UUID.randomUUID().toString().take(8).uppercase().replace("-", "")}"
+
+    private fun createBody(name: String, baseConfigJson: String, topLevelJson: String = ""): String =
+        """{"name":"$name","componentOwner":"owner1",""" +
+            """"group":{"groupKey":"org.example.test","isFake":false},$topLevelJson""" +
+            """"baseConfiguration":$baseConfigJson}"""
+
+    /** POST expecting 201; returns the detail node. */
+    private fun create(name: String, baseConfigJson: String, topLevelJson: String = ""): JsonNode =
+        objectMapper.readTree(
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody(name, baseConfigJson, topLevelJson)),
+                ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString,
+        )
+
+    private fun getComponent(id: String): JsonNode =
+        objectMapper.readTree(
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn().response.contentAsString,
+        )
+
+    /** PATCH expecting 200; returns the detail node. */
+    private fun patch(id: String, version: Long, fieldsJson: String): JsonNode =
+        objectMapper.readTree(
+            mvc
+                .perform(
+                    patch("/rest/api/4/components/$id")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"version":$version,$fieldsJson}"""),
+                ).andExpect(status().isOk)
+                .andReturn().response.contentAsString,
+        )
+
+    private fun version(node: JsonNode): Long = node["version"].asLong()
+
+    private fun JsonNode.baseScalar(aspect: String, field: String): String? =
+        this["configurations"].first { it["rowType"].asText() == "BASE" }[aspect]?.get(field)?.takeUnless { it.isNull }?.asText()
+
+    // ------------------------------------------------------------------
+    // round-trip
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create with skipCommitCheck=true (non-WHISKEY) persists the flag; registry stays independent/null")
+    fun `create true round-trips`() {
+        val created =
+            create(
+                unique("scc_true"),
+                """{"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"${uniqueProjectKey()}"}}""",
+                topLevelJson = """"skipCommitCheck":true,""",
+            )
+        assertTrue(created["skipCommitCheck"].asBoolean(), "create must persist skipCommitCheck=true")
+        assertTrue(created["vcsExternalRegistry"].isNull, "no registry was supplied — stays null (flag is a separate field)")
+        assertTrue(getComponent(created["id"].asText())["skipCommitCheck"].asBoolean(), "durable across a fresh read")
+    }
+
+    @Test
+    @DisplayName("skipCommitCheck defaults to false when absent on create")
+    fun `default false`() {
+        val created = create(unique("scc_default"), """{"build":{"buildSystem":"MAVEN"}}""")
+        assertFalse(created["skipCommitCheck"].asBoolean(), "absent skipCommitCheck defaults to false")
+    }
+
+    @Test
+    @DisplayName("PATCH toggles skipCommitCheck true↔false; null is a no-op")
+    fun `patch toggles and null noop`() {
+        val created = create(unique("scc_toggle"), """{"build":{"buildSystem":"MAVEN"}}""")
+        val id = created["id"].asText()
+        assertFalse(created["skipCommitCheck"].asBoolean())
+
+        val on = patch(id, version(created), """"skipCommitCheck":true""")
+        assertTrue(on["skipCommitCheck"].asBoolean(), "PATCH true sets the flag")
+
+        // null = don't touch: PATCH an unrelated field, flag must survive.
+        val noop = patch(id, version(on), """"clientCode":"C1"""")
+        assertTrue(noop["skipCommitCheck"].asBoolean(), "PATCH with skipCommitCheck absent (null) leaves it unchanged")
+
+        val off = patch(id, version(noop), """"skipCommitCheck":false""")
+        assertFalse(off["skipCommitCheck"].asBoolean(), "PATCH false clears the flag")
+        assertFalse(getComponent(id)["skipCommitCheck"].asBoolean(), "durable across a fresh read")
+    }
+
+    @Test
+    @DisplayName("a WHISKEY component with skipCommitCheck=false is accepted (flag off is always fine)")
+    fun `whiskey flag off ok`() {
+        val created =
+            create(unique("scc_whiskey_off"), """{"build":{"buildSystem":"WHISKEY"}}""")
+        assertFalse(created["skipCommitCheck"].asBoolean())
+        assertEquals("WHISKEY", created.baseScalar("build", "buildSystem"))
+    }
+
+    // ------------------------------------------------------------------
+    // Q13 — WHISKEY exclusion (422)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create WHISKEY + skipCommitCheck=true is rejected 422")
+    fun `create whiskey with flag rejected`() {
+        mvc
+            .perform(
+                post("/rest/api/4/components")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        createBody(
+                            unique("scc_whiskey_true"),
+                            """{"build":{"buildSystem":"WHISKEY"}}""",
+                            topLevelJson = """"skipCommitCheck":true,""",
+                        ),
+                    ),
+            ).andExpect(status().isUnprocessableEntity)
+    }
+
+    @Test
+    @DisplayName("PATCH flag→true on an existing WHISKEY component is rejected 422")
+    fun `patch flag true while whiskey rejected`() {
+        val created = create(unique("scc_whiskey_patch"), """{"build":{"buildSystem":"WHISKEY"}}""")
+        mvc
+            .perform(
+                patch("/rest/api/4/components/${created["id"].asText()}")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"version":${version(created)},"skipCommitCheck":true}"""),
+            ).andExpect(status().isUnprocessableEntity)
+    }
+
+    @Test
+    @DisplayName("PATCH buildSystem→WHISKEY while the flag is already true is rejected 422 (combined post-patch state)")
+    fun `patch buildsystem to whiskey while flag true rejected`() {
+        val created =
+            create(
+                unique("scc_toggle_bs"),
+                """{"build":{"buildSystem":"MAVEN"}}""",
+                topLevelJson = """"skipCommitCheck":true,""",
+            )
+        assertTrue(created["skipCommitCheck"].asBoolean())
+        mvc
+            .perform(
+                patch("/rest/api/4/components/${created["id"].asText()}")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"version":${version(created)},"baseConfiguration":{"build":{"buildSystem":"WHISKEY"}}}""",
+                    ),
+            ).andExpect(status().isUnprocessableEntity)
+    }
+
+    // ------------------------------------------------------------------
+    // audit
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("toggling skipCommitCheck records a false→true audit diff")
+    fun `audit records flag change`() {
+        val created = create(unique("scc_audit"), """{"build":{"buildSystem":"MAVEN"}}""")
+        val id = created["id"].asText()
+        patch(id, version(created), """"skipCommitCheck":true""")
+
+        val history =
+            objectMapper.readTree(
+                mvc
+                    .perform(get("/rest/api/4/audit/Component/$id").with(adminJwt()).param("size", "500"))
+                    .andExpect(status().isOk)
+                    .andReturn().response.contentAsString,
+            )["content"].toList()
+        val diff =
+            history
+                .filter { it["action"].asText() == "UPDATE" }
+                .map { it.path("changeDiff") }
+                .firstOrNull { it.isObject && it.has("skipCommitCheck") }
+                ?.get("skipCommitCheck")
+                ?: error("expected an UPDATE audit row carrying skipCommitCheck: $history")
+        assertEquals(false, diff.path("old").asBoolean(), "audit old must be the pre-toggle value")
+        assertEquals(true, diff.path("new").asBoolean(), "audit new must be the toggled value")
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/mapper/ComponentDetailMapperTest.kt
@@ -90,6 +90,7 @@ class ComponentDetailMapperTest {
         assertNull(response.jiraDisplayName)
         assertNull(response.jiraHotfixVersionFormat)
         assertNull(response.vcsExternalRegistry)
+        assertEquals(false, response.skipCommitCheck)
         assertNull(response.distributionExplicit)
         assertNull(response.distributionExternal)
         assertNull(response.group)
@@ -117,6 +118,9 @@ class ComponentDetailMapperTest {
             it.jiraDisplayName = "Alpha Jira"
             it.jiraHotfixVersionFormat = "\$major.\$minor.x"
             it.vcsExternalRegistry = "ssh://external.git"
+            // skipCommitCheck is a dedicated flag independent of vcsExternalRegistry — the v4
+            // view exposes BOTH the real registry and the flag (unlike the legacy folded surface).
+            it.skipCommitCheck = true
             it.distributionExplicit = true
             it.distributionExternal = false
         }
@@ -135,6 +139,7 @@ class ComponentDetailMapperTest {
         assertEquals("Alpha Jira", response.jiraDisplayName)
         assertEquals("\$major.\$minor.x", response.jiraHotfixVersionFormat)
         assertEquals("ssh://external.git", response.vcsExternalRegistry)
+        assertEquals(true, response.skipCommitCheck)
         assertEquals(true, response.distributionExplicit)
         assertEquals(false, response.distributionExternal)
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportExternalRegistryBridgeTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportExternalRegistryBridgeTest.kt
@@ -1,0 +1,72 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+
+/**
+ * CRS-C — the import external-registry ⟷ skipCommitCheck fold ([applyImportedExternalRegistry]).
+ *
+ * The import is authoritative, so the bridge must set BOTH fields on every call — including the
+ * re-import/resync transitions where a component that previously carried the NOT_AVAILABLE sentinel
+ * (skipCommitCheck=true) now declares a real registry or none. These pre-seed the entity with the
+ * stale state and assert the bridge fully overwrites it (no stuck flag). Plain unit test — `:test`.
+ */
+@Timeout(10, unit = TimeUnit.SECONDS)
+class ImportExternalRegistryBridgeTest {
+
+    private fun entity(
+        skipCommitCheck: Boolean,
+        vcsExternalRegistry: String?,
+    ) = ComponentEntity(componentKey = "c").also {
+        it.skipCommitCheck = skipCommitCheck
+        it.vcsExternalRegistry = vcsExternalRegistry
+    }
+
+    @Test
+    @DisplayName("NOT_AVAILABLE → flag on, registry cleared (sentinel never stored)")
+    fun sentinelSetsFlag() {
+        val e = entity(skipCommitCheck = false, vcsExternalRegistry = "stale")
+        applyImportedExternalRegistry(e, "NOT_AVAILABLE")
+        assertTrue(e.skipCommitCheck)
+        assertNull(e.vcsExternalRegistry, "the sentinel is never stored in the registry column")
+    }
+
+    @Test
+    @DisplayName("re-import transition: was flag=true, DSL now a real registry → flag reset off, registry set")
+    fun realRegistryResetsStaleFlag() {
+        val e = entity(skipCommitCheck = true, vcsExternalRegistry = null)
+        applyImportedExternalRegistry(e, "some-registry")
+        assertFalse(e.skipCommitCheck, "a real registry must reset a previously-set flag")
+        assertEquals("some-registry", e.vcsExternalRegistry)
+    }
+
+    @Test
+    @DisplayName("re-import transition: was flag=true, DSL now has NO external registry → flag reset off, registry null")
+    fun droppedRegistryResetsStaleFlag() {
+        val e = entity(skipCommitCheck = true, vcsExternalRegistry = null)
+        applyImportedExternalRegistry(e, null)
+        assertFalse(e.skipCommitCheck, "dropping the registry must reset a previously-set flag")
+        assertNull(e.vcsExternalRegistry)
+    }
+
+    @Test
+    @DisplayName("re-import transition: was a real registry, DSL now NOT_AVAILABLE → flag on, old registry cleared")
+    fun sentinelClearsPreviousRealRegistry() {
+        val e = entity(skipCommitCheck = false, vcsExternalRegistry = "old-registry")
+        applyImportedExternalRegistry(e, "NOT_AVAILABLE")
+        assertTrue(e.skipCommitCheck)
+        assertNull(e.vcsExternalRegistry)
+    }
+
+    companion object {
+        private fun assertEquals(expected: String?, actual: String?) =
+            org.junit.jupiter.api.Assertions.assertEquals(expected, actual)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/SkipCommitCheckBridgeIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/SkipCommitCheckBridgeIntegrationTest.kt
@@ -147,6 +147,24 @@ class SkipCommitCheckBridgeIntegrationTest {
         assertTrue(updated.skipCommitCheck, "the pre-existing flag is preserved by an unrelated PATCH")
     }
 
+    @Test
+    @Transactional
+    @DisplayName("full-form echo of an unchanged skipCommitCheck=true on a grandfathered WHISKEY row is legal (no 422)")
+    fun `echoing unchanged flag on grandfathered whiskey row is legal`() {
+        migrate(WHISKEY_NA_COMPONENT)
+        val imported = componentManagementService.getComponentByName(WHISKEY_NA_COMPONENT)
+        assertTrue(imported.skipCommitCheck)
+
+        // A combined Save posts the whole Jira slice, echoing skipCommitCheck=true UNCHANGED. The
+        // Q13 gate is change-based, so this must be accepted (not 422) — the flag did not transition.
+        val updated =
+            componentManagementService.updateComponent(
+                imported.id,
+                ComponentUpdateRequest(version = imported.version, skipCommitCheck = true),
+            )
+        assertTrue(updated.skipCommitCheck, "the echoed unchanged flag is preserved and accepted")
+    }
+
     companion object {
         private const val NA_COMPONENT = "sccNotAvailable"
         private const val REAL_COMPONENT = "sccRealRegistry"

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/SkipCommitCheckBridgeIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/SkipCommitCheckBridgeIntegrationTest.kt
@@ -1,0 +1,272 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateRequest
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
+import org.octopusden.octopus.components.registry.server.service.ImportService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * CRS-C — full DSL-import → storage → dual-read bridge, on real imported data.
+ *
+ * Seeds components via the real DSL import from a self-contained copy of the shared `common`
+ * fixture (with three extra component blocks appended), then asserts the whole contract in one
+ * flow:
+ *  - `externalRegistry = "NOT_AVAILABLE"` imports as `skipCommitCheck=true` + a NULL
+ *    `vcsExternalRegistry` (the sentinel is never stored);
+ *  - the legacy v1–v3 resolver still emits `externalRegistry = "NOT_AVAILABLE"` for that component
+ *    (bit-for-bit compat — this is what keeps the "Compat Local Stand" green);
+ *  - v4 read exposes `skipCommitCheck=true` + `vcsExternalRegistry=null`;
+ *  - the reverse: a real registry name imports untouched (flag stays false) and is emitted verbatim
+ *    on both the legacy and v4 surfaces.
+ *
+ * ft-db (H2) profile with a `@DynamicPropertySource`-overridden groovy source, so no Postgres/Git.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@Timeout(120)
+@Tag("integration")
+class SkipCommitCheckBridgeIntegrationTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var importService: ImportService
+
+    @Autowired
+    private lateinit var componentManagementService: ComponentManagementService
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
+
+    @Autowired
+    private lateinit var databaseComponentRegistryResolver: DatabaseComponentRegistryResolver
+
+    private fun migrate(name: String) {
+        val result = importService.migrateComponent(name, dryRun = false)
+        assertTrue(result.success, "migration of '$name' must succeed: ${result.message}")
+    }
+
+    private fun legacyExternalRegistry(name: String): String? =
+        databaseComponentRegistryResolver
+            .getResolvedComponentDefinition(name, VERSION)
+            ?.vcsSettings
+            ?.externalRegistry
+
+    @Test
+    @Transactional
+    @DisplayName("import NOT_AVAILABLE → skipCommitCheck flag + null registry; legacy re-emits NOT_AVAILABLE; v4 shows the flag")
+    fun `not available bridges to flag and back`() {
+        migrate(NA_COMPONENT)
+
+        // storage: sentinel became the flag; registry column is null
+        val entity = componentRepository.findByComponentKey(NA_COMPONENT)!!
+        assertTrue(entity.skipCommitCheck, "NOT_AVAILABLE must import as skipCommitCheck=true")
+        assertNull(entity.vcsExternalRegistry, "the sentinel is never stored in vcs_external_registry")
+
+        // legacy v1–v3 surface: still NOT_AVAILABLE (bit-for-bit compat)
+        assertEquals("NOT_AVAILABLE", legacyExternalRegistry(NA_COMPONENT))
+
+        // v4 surface: the flag is visible, the registry is null
+        val v4 = componentManagementService.getComponentByName(NA_COMPONENT)
+        assertTrue(v4.skipCommitCheck, "v4 must expose skipCommitCheck=true")
+        assertNull(v4.vcsExternalRegistry, "v4 must NOT surface the sentinel as a registry value")
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("import a real registry name → stored + emitted untouched; flag stays false")
+    fun `real registry untouched`() {
+        migrate(REAL_COMPONENT)
+
+        val entity = componentRepository.findByComponentKey(REAL_COMPONENT)!!
+        assertFalse(entity.skipCommitCheck, "a real registry does not set the flag")
+        assertEquals(REAL_REGISTRY, entity.vcsExternalRegistry, "a real registry is stored verbatim")
+
+        assertEquals(REAL_REGISTRY, legacyExternalRegistry(REAL_COMPONENT), "legacy emits the real registry")
+
+        val v4 = componentManagementService.getComponentByName(REAL_COMPONENT)
+        assertFalse(v4.skipCommitCheck)
+        assertEquals(REAL_REGISTRY, v4.vcsExternalRegistry)
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("import a component with no external registry → flag false, registry null")
+    fun `plain component has no flag`() {
+        migrate(PLAIN_COMPONENT)
+
+        val entity = componentRepository.findByComponentKey(PLAIN_COMPONENT)!!
+        assertFalse(entity.skipCommitCheck)
+        assertNull(entity.vcsExternalRegistry)
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("WHISKEY + NOT_AVAILABLE imports (warn, not fail); an unrelated PATCH is grandfathered (no 422)")
+    fun `whiskey with sentinel is grandfathered on unrelated patch`() {
+        // Import admits the contradiction with a WARNING (Q13 is a v4 write-side rule, not an
+        // import hard-fail) — the component lands as skipCommitCheck=true + buildSystem=WHISKEY.
+        migrate(WHISKEY_NA_COMPONENT)
+        val imported = componentManagementService.getComponentByName(WHISKEY_NA_COMPONENT)
+        assertTrue(imported.skipCommitCheck, "NOT_AVAILABLE still bridges to the flag even on WHISKEY")
+
+        // An unrelated PATCH (clientCode only, flag & buildSystem untouched) must NOT be
+        // rejected 422 — the WHISKEY rule is change-based, so pre-existing data is grandfathered.
+        val updated =
+            componentManagementService.updateComponent(
+                imported.id,
+                ComponentUpdateRequest(version = imported.version, clientCode = "GRANDFATHERED"),
+            )
+        assertEquals("GRANDFATHERED", updated.clientCode)
+        assertTrue(updated.skipCommitCheck, "the pre-existing flag is preserved by an unrelated PATCH")
+    }
+
+    companion object {
+        private const val NA_COMPONENT = "sccNotAvailable"
+        private const val REAL_COMPONENT = "sccRealRegistry"
+        private const val PLAIN_COMPONENT = "sccPlain"
+        private const val WHISKEY_NA_COMPONENT = "sccWhiskeyNotAvailable"
+        private const val REAL_REGISTRY = "some-registry"
+        private const val VERSION = "1.0.0"
+
+        private lateinit var workDir: Path
+
+        // Three self-contained component blocks appended to the copied TestComponents.groovy.
+        // Component-own defaults only (no version-range block) → import materializes an
+        // ALL_VERSIONS BASE row, so any version resolves on the legacy read path.
+        private val EXTRA_COMPONENTS =
+            """
+
+            "$NA_COMPONENT" {
+                componentOwner = "user9"
+                groupId = "org.octopusden.octopus.sccna"
+                artifactId = "scc-not-available"
+                buildSystem = MAVEN
+                vcsSettings {
+                    vcsUrl = "ssh://git@example/scc-na.git"
+                    tag = 'scc-na-${'$'}version'
+                    externalRegistry = "NOT_AVAILABLE"
+                }
+                jira {
+                    projectKey = "SCCNA"
+                    majorVersionFormat = '${'$'}major'
+                    releaseVersionFormat = '${'$'}major.${'$'}minor.${'$'}service'
+                }
+            }
+
+            "$REAL_COMPONENT" {
+                componentOwner = "user9"
+                groupId = "org.octopusden.octopus.sccreal"
+                artifactId = "scc-real-registry"
+                buildSystem = MAVEN
+                vcsSettings {
+                    vcsUrl = "ssh://git@example/scc-real.git"
+                    tag = 'scc-real-${'$'}version'
+                    externalRegistry = "$REAL_REGISTRY"
+                }
+                jira {
+                    projectKey = "SCCREAL"
+                    majorVersionFormat = '${'$'}major'
+                    releaseVersionFormat = '${'$'}major.${'$'}minor.${'$'}service'
+                }
+            }
+
+            "$PLAIN_COMPONENT" {
+                componentOwner = "user9"
+                groupId = "org.octopusden.octopus.sccplain"
+                artifactId = "scc-plain"
+                buildSystem = MAVEN
+                vcsSettings {
+                    vcsUrl = "ssh://git@example/scc-plain.git"
+                    tag = 'scc-plain-${'$'}version'
+                }
+                jira {
+                    projectKey = "SCCPLAIN"
+                    majorVersionFormat = '${'$'}major'
+                    releaseVersionFormat = '${'$'}major.${'$'}minor.${'$'}service'
+                }
+            }
+
+            "$WHISKEY_NA_COMPONENT" {
+                componentOwner = "user9"
+                groupId = "org.octopusden.octopus.sccwhna"
+                artifactId = "scc-whiskey-na"
+                buildSystem = WHISKEY
+                vcsSettings {
+                    vcsUrl = "ssh://git@example/scc-whna.git"
+                    tag = 'scc-whna-${'$'}version'
+                    externalRegistry = "NOT_AVAILABLE"
+                }
+                jira {
+                    projectKey = "SCCWHNA"
+                    majorVersionFormat = '${'$'}major'
+                    releaseVersionFormat = '${'$'}major.${'$'}minor.${'$'}service'
+                }
+            }
+            """.trimIndent()
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun configureSource(registry: DynamicPropertyRegistry) {
+            val fixture =
+                Paths
+                    .get(System.getProperty("user.dir"))
+                    .resolve("../test-common/src/test/resources/components-registry/common")
+                    .normalize()
+            workDir = Files.createTempDirectory("skip-commit-bridge")
+            copyTree(fixture, workDir)
+            // Append our self-contained component blocks to the copied TestComponents.groovy.
+            val testComponents = workDir.resolve("TestComponents.groovy")
+            Files.writeString(
+                testComponents,
+                Files.readString(testComponents) + "\n" + EXTRA_COMPONENTS + "\n",
+            )
+            // The @DynamicPropertySource-set data dir is what application-common.yml's
+            // work-dir/groovy-path placeholders resolve against; point them at the temp copy.
+            System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", workDir.parent.toString())
+            registry.add("components-registry.work-dir") { workDir.toString() }
+            registry.add("components-registry.groovy-path") { workDir.toString() }
+            registry.add("pathToConfig") { "file://$workDir" }
+        }
+
+        private fun copyTree(src: Path, dst: Path) {
+            Files.createDirectories(dst)
+            Files.walk(src).use { stream ->
+                stream.forEach { source ->
+                    val target = dst.resolve(src.relativize(source).toString())
+                    if (Files.isDirectory(source)) {
+                        Files.createDirectories(target)
+                    } else {
+                        Files.copy(source, target)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/SkipCommitCheckLegacyReadTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/SkipCommitCheckLegacyReadTest.kt
@@ -1,0 +1,128 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.ComponentEntity
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.repository.DependencyMappingRepository
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+
+/**
+ * CRS-C — legacy-read compatibility bridge for the dedicated `skipCommitCheck` flag.
+ *
+ * The v1–v3 contract (Jira plugin / RM) has no notion of `skipCommitCheck`; it only knows
+ * `VCSSettings.externalRegistry`. This guard pins that the DB-mode resolver re-materializes the
+ * legacy `externalRegistry = "NOT_AVAILABLE"` sentinel whenever the flag is set — bit-for-bit
+ * identical to the pre-flag world — and that the flag WINS over any real registry value (they are
+ * mutually exclusive by construction, Q13). Reverse: with the flag off, a real registry is emitted
+ * untouched.
+ *
+ * Hand-built entity graph driven through `DatabaseComponentRegistryResolver` with a mocked
+ * repository (the `RangeOnlyParityGuardTest` / `DatabaseComponentRegistryResolverTest` pattern) —
+ * no Spring/DB context, so it runs under `:test`.
+ */
+@Timeout(30, unit = TimeUnit.SECONDS)
+class SkipCommitCheckLegacyReadTest {
+
+    private val componentRepository: ComponentRepository = mock(ComponentRepository::class.java)
+    private val dependencyMappingRepository: DependencyMappingRepository =
+        mock(DependencyMappingRepository::class.java)
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+    private lateinit var resolver: DatabaseComponentRegistryResolver
+
+    @BeforeEach
+    fun setUp() {
+        resolver = DatabaseComponentRegistryResolver(
+            componentRepository,
+            dependencyMappingRepository,
+            numericVersionFactory,
+            versionRangeFactory,
+            versionNames,
+        )
+    }
+
+    private fun component(
+        skipCommitCheck: Boolean,
+        externalRegistry: String?,
+    ): ComponentEntity {
+        val comp = ComponentEntity(id = UUID.randomUUID(), componentKey = COMPONENT)
+        comp.skipCommitCheck = skipCommitCheck
+        comp.vcsExternalRegistry = externalRegistry
+        val base = ComponentConfigurationEntity(
+            component = comp,
+            versionRange = ALL_VERSIONS,
+            overriddenAttribute = null,
+            rowType = "BASE",
+            isSyntheticBase = false,
+            buildSystem = "MAVEN",
+            jiraProjectKey = "SCC",
+            deprecated = false,
+        )
+        base.jiraMinorVersionFormat = "\$major"
+        base.jiraReleaseVersionFormat = "\$major.\$minor.\$service"
+        comp.configurations.add(base)
+        return comp
+    }
+
+    private fun stub(comp: ComponentEntity) {
+        `when`(componentRepository.findByComponentKey(comp.componentKey)).thenReturn(comp)
+        `when`(componentRepository.findAll()).thenReturn(mutableListOf(comp))
+    }
+
+    private fun resolvedExternalRegistry(comp: ComponentEntity): String? {
+        stub(comp)
+        val resolved = resolver.getResolvedComponentDefinition(COMPONENT, VERSION)
+        assertNotNull(resolved, "component must resolve at $VERSION")
+        return resolved!!.vcsSettings?.externalRegistry
+    }
+
+    @Test
+    @DisplayName("skipCommitCheck=true (no real registry, no roots) → legacy externalRegistry = NOT_AVAILABLE")
+    fun flagTrueEmitsSentinel() {
+        assertEquals("NOT_AVAILABLE", resolvedExternalRegistry(component(skipCommitCheck = true, externalRegistry = null)))
+    }
+
+    @Test
+    @DisplayName("skipCommitCheck=true WINS over a real registry → legacy externalRegistry = NOT_AVAILABLE")
+    fun flagWinsOverRealRegistry() {
+        assertEquals(
+            "NOT_AVAILABLE",
+            resolvedExternalRegistry(component(skipCommitCheck = true, externalRegistry = "some-registry")),
+        )
+    }
+
+    @Test
+    @DisplayName("skipCommitCheck=false → the real registry value is emitted untouched")
+    fun realRegistryUntouched() {
+        assertEquals(
+            "some-registry",
+            resolvedExternalRegistry(component(skipCommitCheck = false, externalRegistry = "some-registry")),
+        )
+    }
+
+    @Test
+    @DisplayName("skipCommitCheck=false, no registry, no roots → no externalRegistry on the legacy surface")
+    fun noFlagNoRegistry() {
+        assertNull(resolvedExternalRegistry(component(skipCommitCheck = false, externalRegistry = null)))
+    }
+
+    companion object {
+        private const val COMPONENT = "sccComponent"
+        private const val VERSION = "1.0.0"
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/ComponentCodeRendererTest.kt
@@ -351,6 +351,42 @@ class ComponentCodeRendererTest {
     }
 
     @Test
+    @DisplayName("FULL: skipCommitCheck renders the legacy DSL literal externalRegistry = \"NOT_AVAILABLE\"")
+    fun fullSkipCommitCheckRendersSentinel() {
+        val c = component().also { it.skipCommitCheck = true }
+        base(c) { buildSystem = "MAVEN" }
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("vcsSettings {"), out)
+        assertTrue(out.contains("externalRegistry = \"NOT_AVAILABLE\""), out)
+    }
+
+    @Test
+    @DisplayName("FULL: skipCommitCheck wins over a real registry — renders NOT_AVAILABLE, not the real value")
+    fun fullSkipCommitCheckWinsOverRealRegistry() {
+        val c = component().also {
+            it.skipCommitCheck = true
+            it.vcsExternalRegistry = "some-registry"
+        }
+        base(c) { buildSystem = "MAVEN" }
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("externalRegistry = \"NOT_AVAILABLE\""), out)
+        assertFalse(out.contains("some-registry"), out)
+    }
+
+    @Test
+    @DisplayName("FULL: a real registry with the flag off renders the real value verbatim")
+    fun fullRealRegistryNoFlag() {
+        val c = component().also { it.vcsExternalRegistry = "some-registry" }
+        base(c) { buildSystem = "MAVEN" }
+
+        val out = renderer.renderFull(c)
+        assertTrue(out.contains("externalRegistry = \"some-registry\""), out)
+        assertFalse(out.contains("NOT_AVAILABLE"), out)
+    }
+
+    @Test
     @DisplayName("FULL: build markers (requiredTools + buildTools beans) render inside build block")
     fun fullBuildMarkers() {
         val c = component()


### PR DESCRIPTION
## What

Adds a dedicated component-level boolean **`skipCommitCheck`** (Q12) that replaces the legacy `externalRegistry = "NOT_AVAILABLE"` sentinel in v4 storage. `vcs_external_registry` now holds real registry names exclusively; the sentinel survives ONLY as a legacy wire/DSL bridge.

- **DB**: `skip_commit_check BOOLEAN NOT NULL DEFAULT false` on the components baseline (pre-prod convention: V1 edited directly).
- **v4**: create / PATCH (null = no-op) / detail + audit snapshot; OpenAPI regenerated.
- **Bridges** (flag WINS over any real registry, mirroring legacy semantics):
  - DSL import: `externalRegistry="NOT_AVAILABLE"` → `skipCommitCheck=true` + NULL registry; the fold is centralized in `applyImportedExternalRegistry` which sets BOTH fields on every call, so re-import/resync transitions (sentinel→real, sentinel→absent) reset the flag — import stays authoritative.
  - Legacy v1–v3 read: `skipCommitCheck=true` → `VCSSettings.externalRegistry="NOT_AVAILABLE"` — legacy wire output is bit-for-bit identical for existing data (keeps the local-stand compat job green).
  - As-code renderer: flag → DSL literal `externalRegistry = "NOT_AVAILABLE"` (DSL contract unchanged).
- **Q13 validation**: effective BASE buildSystem = WHISKEY ⇒ flag must be false — 422 on create and on every PATCH transition (combined post-write state), change-gated so import-admitted contradictions aren't blocked on unrelated edits. Import logs a WARNING instead of failing; a check of the production DSL found **zero** WHISKEY+NOT_AVAILABLE pairs.
- **Editability**: editable by any component editor (Q11), routed through the field-config gate (default `editable: all`; hidden strips on create too, integrated with the editability wiring merged in #395).

## Verification

- `./gradlew :components-registry-service-server:test` and `:dbTest` — green, full suite, re-run after rebasing onto v3 with #394+#395 merged (one conflict resolved: create-path hidden-strip wrappers × new flag field).
- New suites: `SkipCommitCheckV4Test` (CRUD/validation), `SkipCommitCheckBridgeIntegrationTest` (import → v4 + legacy read round-trips), `SkipCommitCheckLegacyReadTest`, `ComponentCodeRendererTest` additions, `ImportExternalRegistryBridgeTest` (re-import transitions).
- Review trail: 2 Sonnet rounds (fixed: PATCH-time WHISKEY validation gating, import ordering) + coordinator pass (fixed: import else-branch flag reset).

## Coordination

- Portal (P-2a): the Jira-section toggle "Skip Commit Check at Issue Assignment at Release" binds to this field; NOT admin-gated.
- Legacy consumers (Jira releng plugin / RM) need no changes — they keep seeing the sentinel via the read bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
