### PR TITLE
fix(registry): enforce editability gate / hidden-strip before value validation

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -208,6 +208,11 @@ class ComponentManagementServiceImpl(
         // property getter — so we hoist explicitly here rather than
         // sprinkling `!!` or `?.let` at each call site.
         val buildSystemValue: String = buildAspect.buildSystem!!
+        // CRS-B: a supplied (non-null) value for a field the caller may not edit is
+        // rejected up-front; an absent field lets server defaults apply. Runs BEFORE the
+        // value validators below so an INVALID value on a non-editable field surfaces the
+        // editability error (403/422), not a value-400 — the gate must win the ordering.
+        enforceEditabilityOnCreate(request)
         request.productType?.let { if (!fieldConfigService.isHidden("component.productType")) validateProductType(it) }
         request.clientCode?.let {
             if (!fieldConfigService.isHidden("component.clientCode")) validateClientCode(it)
@@ -225,9 +230,6 @@ class ComponentManagementServiceImpl(
         // inside `replaceVcsEntries` / `replacePackages` (covers both base-config
         // and field-override marker paths).
         validateLabels(request.labels)
-        // CRS-B: a supplied (non-null) value for a field the caller may not edit is
-        // rejected up-front; an absent field lets server defaults apply.
-        enforceEditabilityOnCreate(request)
         // Canonicalise once and reuse so the synced junction, the
         // in-memory refresh, and the audit snapshot all see the same
         // trimmed/deduped set — the originally requested set may still
@@ -474,8 +476,13 @@ class ComponentManagementServiceImpl(
         // now a non-null one means the same.
         //
         // `clearParent` (remove the parent) and `parentComponentName` (set a parent)
-        // are mutually exclusive — accepting both would silently drop one.
-        require(!(request.clearParent && request.parentComponentName != null)) {
+        // are mutually exclusive — accepting both would silently drop one. Skip the
+        // conflict guard when the field is hidden: both signals are stripped silently
+        // downstream (see the parent block below), so a hidden field must never 4xx.
+        require(
+            fieldConfigService.isHidden("component.parentComponentName") ||
+                !(request.clearParent && request.parentComponentName != null),
+        ) {
             "parentComponentName: clearParent and parentComponentName are mutually exclusive"
         }
 
@@ -1037,28 +1044,32 @@ class ComponentManagementServiceImpl(
 
         val beforeSnapshot = fieldOverrideAuditSnapshot(row)
 
-        request.versionRange?.let {
-            val canonicalRange = normalizeRange(it)
-            validateFieldOverrideRange(
-                range = canonicalRange,
-                component = row.component,
-                attribute = row.overriddenAttribute!!,
-                excludeOverrideId = row.id,
-            )
-            row.versionRange = canonicalRange
-        }
-
+        // Gate-before-validation: an INVALID range/value on a non-editable override must
+        // surface the editability error (403/422), not a value-400. The successful
+        // valid-value path is still gated change-based by the snapshot diff below.
         val pendingTools: List<String>? =
-            when {
-                row.overriddenAttribute in MarkerAttributes.ALL -> {
-                    require(request.value == null) { "Marker override does not accept a scalar value" }
-                    request.markerChildren?.let { applyMarkerChildren(row, row.overriddenAttribute!!, it) }
+            gatingEditabilityOnInvalidPayload(row.overriddenAttribute!!) {
+                request.versionRange?.let {
+                    val canonicalRange = normalizeRange(it)
+                    validateFieldOverrideRange(
+                        range = canonicalRange,
+                        component = row.component,
+                        attribute = row.overriddenAttribute!!,
+                        excludeOverrideId = row.id,
+                    )
+                    row.versionRange = canonicalRange
                 }
+                when {
+                    row.overriddenAttribute in MarkerAttributes.ALL -> {
+                        require(request.value == null) { "Marker override does not accept a scalar value" }
+                        request.markerChildren?.let { applyMarkerChildren(row, row.overriddenAttribute!!, it) }
+                    }
 
-                else -> {
-                    require(request.markerChildren == null) { "Scalar override does not accept markerChildren" }
-                    request.value?.let { row.applyScalarValue(row.overriddenAttribute!!, it) }
-                    null
+                    else -> {
+                        require(request.markerChildren == null) { "Scalar override does not accept markerChildren" }
+                        request.value?.let { row.applyScalarValue(row.overriddenAttribute!!, it) }
+                        null
+                    }
                 }
             }
 
@@ -1233,7 +1244,12 @@ class ComponentManagementServiceImpl(
                     "(${row.overriddenAttribute} -> ${d.overriddenAttribute})"
             }
             val before = fieldOverrideAuditSnapshot(row)
-            applyOverrideUpsertPayload(component, row, d, excludeOverrideId = row.id)?.let { pendingTools[row] = it }
+            // Gate-before-validation: an INVALID range/value on a non-editable override
+            // yields the editability error (403/422), not a value-400. A valid change is
+            // still gated change-based by the snapshot diff below.
+            gatingEditabilityOnInvalidPayload(d.overriddenAttribute) {
+                applyOverrideUpsertPayload(component, row, d, excludeOverrideId = row.id)
+            }?.let { pendingTools[row] = it }
             // CRS-B: gate any actual change (value / markerChildren / range) to an
             // override on a non-editable field; an unchanged echo (combined Save
             // re-sends the whole set) leaves the snapshot equal and is left alone.
@@ -1901,6 +1917,26 @@ class ComponentManagementServiceImpl(
             else -> Unit // "all"
         }
     }
+
+    /**
+     * Run [applyPayload] — which mutates an override row and may throw a value-400
+     * (ConfigurationRowAccessors.requireString / requireBuildSystem / range checks) —
+     * but make the editability gate take precedence: if application fails on a
+     * non-editable [attribute], the caller sees the 403/422 editability error, NOT the
+     * value-400. An editable caller still gets the original 400. The callers keep their
+     * own change-based snapshot-diff gate on the SUCCESSFUL, valid-value path (an
+     * unchanged echo applies cleanly, diffs equal, and is left untouched).
+     */
+    private inline fun <T> gatingEditabilityOnInvalidPayload(
+        attribute: String,
+        applyPayload: () -> T,
+    ): T =
+        try {
+            applyPayload()
+        } catch (e: IllegalArgumentException) {
+            enforceOverrideEditable(attribute)
+            throw e
+        }
 
     /** True when the override's attribute maps to a field-config `visibility: hidden`. */
     private fun isHiddenOverrideAttribute(attribute: String?): Boolean =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/FieldConfigEnforcementIntegrationTest.kt
@@ -813,4 +813,97 @@ class FieldConfigEnforcementIntegrationTest {
             assertEquals("AUTO", getComponent(id).baseScalar("escrow", "generation"))
         }
     }
+
+    // ================================================================
+    // Gate-before-validation ordering: an INVALID value on a NON-EDITABLE
+    // field must surface the editability error (403/422), NOT a value-400.
+    // ================================================================
+
+    @Test
+    @DisplayName("CREATE: non-admin supplying an INVALID value on an adminOnly field → 403 (editability precedes value validation)")
+    fun create_nonAdminInvalidValueOnAdminOnly_forbiddenNotBadRequest() {
+        withFieldConfig(mapOf("component" to mapOf("productType" to mapOf("editable" to "adminOnly")))) {
+            // "NOT_A_TYPE" is not a valid productType — validateProductType would 400 if it ran
+            // first. The editability gate must win: a non-admin may not supply this field at all.
+            val body =
+                """{"name":"crsB_create_${UUID.randomUUID().toString().take(8)}","componentOwner":"bob","productType":"NOT_A_TYPE",""" +
+                    """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                    """"baseConfiguration":{"build":{"buildSystem":"MAVEN"},"jira":{"projectKey":"${uniqueProjectKey()}"}}}"""
+            editorPost(body).andExpect(status().isForbidden)
+        }
+    }
+
+    @Test
+    @DisplayName("OVERRIDE UPDATE (standalone): non-admin sending an INVALID value on an adminOnly override → 403 (not 400)")
+    fun override_update_invalidValueOnAdminOnly_forbiddenNotBadRequest() {
+        val created = createBobRaw("""{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":"AUTO"}}""")
+        val id = created["id"].asText()
+
+        // Create the scalar override as admin while escrow.generation is still editable.
+        val overrideResponse =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"overriddenAttribute":"escrow.generation","versionRange":"[1.0,2.0)","value":"MANUAL"}"""),
+                ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val overrideId = objectMapper.readTree(overrideResponse)["id"].asText()
+
+        withFieldConfig(mapOf("escrow" to mapOf("generation" to mapOf("editable" to "adminOnly")))) {
+            // "NOTAMODE" would 400 via requireEscrowGenerationMode if applied before the gate.
+            mvc
+                .perform(
+                    patch("/rest/api/4/components/$id/field-overrides/$overrideId")
+                        .with(editorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"value":"NOTAMODE"}"""),
+                ).andExpect(status().isForbidden)
+        }
+    }
+
+    @Test
+    @DisplayName("COMBINED SAVE desired-set: non-admin sending an INVALID override value on an adminOnly field → 403 (not 400)")
+    fun desiredSet_invalidValueOnAdminOnly_forbiddenNotBadRequest() {
+        val created = createBobRaw("""{"build":{"buildSystem":"MAVEN"},"escrow":{"generation":"AUTO"}}""")
+        val id = created["id"].asText()
+
+        val overrideResponse =
+            mvc
+                .perform(
+                    post("/rest/api/4/components/$id/field-overrides")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"overriddenAttribute":"escrow.generation","versionRange":"[1.0,2.0)","value":"MANUAL"}"""),
+                ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val overrideId = objectMapper.readTree(overrideResponse)["id"].asText()
+
+        withFieldConfig(mapOf("escrow" to mapOf("generation" to mapOf("editable" to "adminOnly")))) {
+            val version = getComponent(id)["version"].asLong()
+            patchRaw(
+                editorJwt(),
+                id,
+                """{"version":$version,"fieldOverrides":[""" +
+                    """{"id":"$overrideId","overriddenAttribute":"escrow.generation","versionRange":"[1.0,2.0)","value":"NOTAMODE"}]}""",
+            ).andExpect(status().isForbidden)
+        }
+    }
+
+    @Test
+    @DisplayName("hidden parentComponentName: PATCH with clearParent + parentComponentName → silently stripped, not a 400 conflict")
+    fun hiddenParent_clearAndSetConflict_strippedNotBadRequest() {
+        val child = createOwnedByBob()
+        val id = child["id"].asText()
+        val version = child["version"].asLong()
+
+        withFieldConfig(mapOf("component" to mapOf("parentComponentName" to mapOf("visibility" to "hidden")))) {
+            // Both clearParent and parentComponentName target a hidden field → both stripped
+            // silently. The mutual-exclusion conflict-400 must NOT fire (hidden = never 4xx).
+            // "no-such-parent" would otherwise 404 on lookup if the set were not stripped.
+            patchRaw(adminJwt(), id, """{"version":$version,"clearParent":true,"parentComponentName":"no-such-parent"}""")
+                .andExpect(status().is2xxSuccessful)
+        }
+    }
 }


### PR DESCRIPTION
## What

Enforce the **editability-gate / hidden-strip before value validation** ordering across the v4 write paths in `ComponentManagementServiceImpl`, so the error contract holds: an invalid value on a non-editable field must yield the editability error (403/422), not a validation-400; a hidden field must strip silently, not 400.

Three ordering fixes:

1. **CREATE** — `enforceEditabilityOnCreate` now runs ahead of the value validators (`validateProductType` / `validateBuildSystem` / `validateEscrowGenerationMode` / …). A non-admin supplying an invalid value on an `adminOnly`/`none` field now gets 403/422 instead of 400. Structural presence checks (`baseConfiguration` / `build` / `buildSystem` required) still run first.
2. **Override updates** — both the standalone `updateFieldOverride` and the combined-save desired-set update branch (`applyFieldOverrideDesiredSet`) wrap payload application in a new helper `gatingEditabilityOnInvalidPayload(attribute) { … }`. On an `IllegalArgumentException` (ConfigurationRowAccessors `requireString`/`requireBuildSystem`/`requireEscrowGenerationMode` and range checks) it enforces override editability first (403/422 for a non-editable attribute) and only then rethrows the original 400 for an editable caller. The existing change-based snapshot-diff gate on the valid-value path is untouched, so an **unchanged echo is still tolerated** (combined-save re-sends the whole slice).
3. **PATCH** — the `clearParent` + `parentComponentName` mutual-exclusion conflict-400 is now guarded with `isHidden("component.parentComponentName")`, so a hidden parent edit is stripped silently downstream (the parent-mutation block already skips when hidden) instead of raising a 400.

## Why

Codex flagged three spots where value validation (or the parent conflict guard) fired before the editability/hidden gate, leaking the wrong status code and, for hidden fields, a 4xx where the contract requires a silent strip.

## Verification

- New TDD coverage in `FieldConfigEnforcementIntegrationTest` for each path (create invalid-value-on-adminOnly → 403; standalone override update invalid-value → 403; desired-set update invalid-value → 403; hidden parent clear+set conflict → 2xx stripped). All four fail before the fix, pass after.
- Full `./gradlew :components-registry-service-server:test :components-registry-service-server:dbTest` green.
- Sonnet review pass: clean (no findings) — confirmed all wrapped appliers throw only `IllegalArgumentException`, disjoint from the gate's `ResponseStatusException`, so the catch is complete and cannot mask the editable caller's 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)