### PR TITLE
fix(registry): reject visibility:hidden on build.buildSystem at config-sync

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -2202,6 +2202,9 @@ class ComponentManagementServiceImpl(
         // hiding it is unsupported. Editability (adminOnly/none) is enforced separately.
         request.build?.let { b ->
             // buildSystem is a required enum (validated) — not clearable, not hidden-stripped.
+            // This hidden-strip exemption is enforced structurally at config-sync time:
+            // ConfigSyncService.serializeFieldEntry rejects `build.buildSystem: {visibility: hidden}`
+            // (ConfigValidationException), so a hidden buildSystem can never reach this writer.
             config.buildSystem = b.buildSystem
             if (!fieldConfigService.isHidden("build.javaVersion")) config.javaVersion = b.javaVersion?.let(::clearBlankScalar)
             if (!fieldConfigService.isHidden("build.mavenVersion")) config.mavenVersion = b.mavenVersion?.let(::clearBlankScalar)
@@ -2286,6 +2289,9 @@ class ComponentManagementServiceImpl(
         // so an absent field stays a no-op and only a PRESENT value on a visible field is written.
         patch.versionRange?.let { config.versionRange = it }
         patch.build?.let { b ->
+            // buildSystem exemption (required enum) is enforced structurally at config-sync time —
+            // ConfigSyncService.serializeFieldEntry rejects `build.buildSystem: {visibility: hidden}`,
+            // so no hidden-strip guard is needed (or wanted) on this writer.
             b.buildSystem?.let { config.buildSystem = it }
             b.javaVersion?.let { if (!fieldConfigService.isHidden("build.javaVersion")) config.javaVersion = clearBlankScalar(it) }
             b.mavenVersion?.let { if (!fieldConfigService.isHidden("build.mavenVersion")) config.mavenVersion = clearBlankScalar(it) }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
@@ -115,6 +115,14 @@ class ConfigSyncService(
                 require(v in VISIBILITIES) {
                     invalid("$section.$field.visibility", it, VISIBILITIES)
                 }
+                // build.buildSystem is a required enum on every BASE configuration row — it can
+                // never be stripped or absent, so the CREATE/PATCH writers deliberately EXEMPT it
+                // from the hidden-strip (see ComponentManagementServiceImpl.applyBaseConfiguration*).
+                // Hiding it would therefore silently do nothing; reject it structurally here so the
+                // misconfiguration is surfaced loudly. Narrowing to adminOnly/none is still allowed.
+                if (v == "hidden" && "$section.$field" == BUILD_SYSTEM_PATH) {
+                    throw ConfigValidationException("build.buildSystem is a required enum and cannot be hidden")
+                }
                 put("visibility", v)
             }
             entry.editable?.let {
@@ -249,6 +257,8 @@ class ConfigSyncService(
     companion object {
         const val FIELD_CONFIG_KEY = "field-config"
         const val COMPONENT_DEFAULTS_KEY = "component-defaults"
+        /** Required enum on the BASE row — cannot be hidden (see [serializeFieldEntry]). */
+        private const val BUILD_SYSTEM_PATH = "build.buildSystem"
         private val VISIBILITIES = setOf("editable", "readonly", "hidden")
         private val EDITABILITIES = setOf("all", "adminonly", "none")
         private val SEARCHABLES = setOf("Main", "Extended", "None")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
@@ -228,6 +228,34 @@ class ConfigSyncServiceTest {
     }
 
     @Test
+    fun `hidden build_buildSystem aborts the sync - required enum cannot be hidden`() {
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "build" to mutableMapOf("buildSystem" to fieldEntry(visibility = "hidden")),
+            )
+        }
+        val ex = assertThrows(ConfigValidationException::class.java) { service(props).syncToCache() }
+        assertEquals("build.buildSystem is a required enum and cannot be hidden", ex.message)
+        verify(repo, never()).save(any())
+    }
+
+    @Test
+    fun `adminOnly build_buildSystem is allowed - only hidden is forbidden`() {
+        val props = AdminConfigProperties().apply {
+            fieldConfig = mutableMapOf(
+                "build" to mutableMapOf("buildSystem" to fieldEntry(editable = "adminOnly")),
+            )
+        }
+
+        val result = service(props).syncToCache()
+
+        assertEquals(
+            mapOf("build" to mapOf("buildSystem" to mapOf("editable" to "adminonly"))),
+            result.fieldConfig,
+        )
+    }
+
+    @Test
     fun `empty subtrees are not written - cache is preserved (no-clobber)`() {
         service(AdminConfigProperties()).syncToCache()
 


### PR DESCRIPTION
## What

Make hiding `build.buildSystem` a **structural** config error. `ConfigSyncService.serializeFieldEntry` now rejects `build.buildSystem: {visibility: hidden}` with `ConfigValidationException("build.buildSystem is a required enum and cannot be hidden")` — surfaced as 422 by the admin controller and aborting the whole sync before any DB write (no clobber). `adminOnly`/`none` editability narrowing is still allowed.

Also adds KDoc notes at both buildSystem write sites in `ComponentManagementServiceImpl` (`applyBaseConfigurationCreate` + `applyBaseConfigurationPatch`) cross-referencing the new validation.

## Why

Post-merge follow-up on #397 (Codex): the three gate/validation reorderings were confirmed clean; the one remaining observation was that the hidden-strip does not cover `build.buildSystem`. That is a **deliberate** exemption — `build.buildSystem` is a required enum on every BASE configuration row, so the CREATE/PATCH writers intentionally never strip it. But leaving hiding it as a silent no-op is a footgun: a `visibility: hidden` on it would be accepted and simply do nothing. This makes the exemption explicit and loud instead of silent.

## Verification

- TDD: added `ConfigSyncServiceTest` coverage — hidden buildSystem → `ConfigValidationException` with the exact message and no repo save; adminOnly buildSystem → serializes fine (guards against over-forbidding). The hidden test fails before the fix, passes after; the adminOnly test passes throughout.
- Full `./gradlew :components-registry-service-server:test :components-registry-service-server:dbTest` green.
- Sonnet review pass: clean (no findings) — confirmed the `section.field` path format matches `FieldConfigService`'s convention, the sync aborts with no partial DB write, and `ConfigValidationException` maps to 422 consistently with the existing enum-validation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)