### PR TITLE
fix(registry): handle multiple docker image tags in component lookup (port #386 to v3)

### DIFF
--- a/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
+++ b/components-registry-service-client/src/test/kotlin/org/octopusden/octopus/components/registry/client/ComponentRegistryServiceClientTest.kt
@@ -15,6 +15,7 @@ import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsR
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentArtifactConfigurationDTO
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.ComponentV1
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersions
@@ -143,6 +144,9 @@ class ComponentRegistryServiceClientTest : BaseComponentsRegistryServiceTest() {
 
     override fun getComponentArtifactsParameters(component: String): Map<String, ComponentArtifactConfigurationDTO> =
         componentsRegistryClient.getComponentArtifactsParameters(component)
+
+    override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> =
+        componentsRegistryClient.findComponentsByDockerImages(images)
 
     override fun getSupportedGroupIds(): Set<String> = componentsRegistryClient.getSupportedGroupIds()
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentRegistryResolverImpl.kt
@@ -237,14 +237,12 @@ class ComponentRegistryResolverImpl(
     override fun getComponentProductMapping(): Map<String, ProductTypes> = buildToolsResolver.componentProductMapping
 
     override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> {
-        val imageNames = images.map { it.name }.toSet()
-        return buildImageToComponentMap()
-            .filterKeys(imageNames::contains)
-            .mapNotNull { (imgName, component) ->
-                images.find { it.name == imgName }?.let { requiredImage ->
-                    findConfigurationByImage(imgName, requiredImage.tag, component)
-                }
-            }.toSet()
+        val imageToComponentMap = buildImageToComponentMap()
+        return images.mapNotNull { image ->
+            imageToComponentMap[image.name]?.let { component ->
+                findConfigurationByImage(image.name, image.tag, component)
+            }
+        }.toSet()
     }
 
     private fun findConfigurationByImage(

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DatabaseComponentRegistryResolver.kt
@@ -547,14 +547,12 @@ class DatabaseComponentRegistryResolver(
             }.toMap()
 
     override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> {
-        val imageNames = images.map { it.name }.toSet()
-        return buildImageToComponentMap()
-            .filterKeys(imageNames::contains)
-            .mapNotNull { (imgName, component) ->
-                images.find { it.name == imgName }?.let { requiredImage ->
-                    findConfigurationByDockerImage(imgName, requiredImage.tag, component)
-                }
-            }.toSet()
+        val imageToComponentMap = buildImageToComponentMap()
+        return images.mapNotNull { image ->
+            imageToComponentMap[image.name]?.let { component ->
+                findConfigurationByDockerImage(image.name, image.tag, component)
+            }
+        }.toSet()
     }
 
     // ============================================================

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MockMvcRegistryTestSupport.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/MockMvcRegistryTestSupport.kt
@@ -9,11 +9,13 @@ import org.octopusden.octopus.components.registry.core.dto.ArtifactComponentsDTO
 import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentArtifactConfigurationDTO
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.ComponentV1
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponent
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersions
 import org.octopusden.octopus.components.registry.core.dto.DistributionDTO
+import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionDTO
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionRangeDTO
 import org.octopusden.octopus.components.registry.core.dto.ServiceStatusDTO
@@ -349,6 +351,19 @@ abstract class MockMvcRegistryTestSupport : BaseComponentsRegistryServiceTest() 
             .andReturn()
             .response
             .toObject(object : TypeReference<Map<String, ComponentArtifactConfigurationDTO>>() {})
+
+    override fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage> =
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post("/rest/api/3/components/find-by-docker-images")
+                    .accept(APPLICATION_JSON)
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(images)),
+            ).andExpect(status().isOk)
+            .andReturn()
+            .response
+            .toObject(object : TypeReference<Set<ComponentImage>>() {})
 
     protected fun getAndCheckComponents(
         vcsPath: String?,

--- a/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
+++ b/test-common/src/testFixtures/kotlin/org/octopusden/octopus/components/registry/test/BaseComponentsRegistryServiceTest.kt
@@ -18,6 +18,7 @@ import org.octopusden.octopus.components.registry.core.dto.ArtifactDependency
 import org.octopusden.octopus.components.registry.core.dto.BuildParametersDTO
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.ComponentArtifactConfigurationDTO
+import org.octopusden.octopus.components.registry.core.dto.ComponentImage
 import org.octopusden.octopus.components.registry.core.dto.ComponentInfoDTO
 import org.octopusden.octopus.components.registry.core.dto.ComponentRegistryVersion
 import org.octopusden.octopus.components.registry.core.dto.ComponentV1
@@ -29,6 +30,7 @@ import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVers
 import org.octopusden.octopus.components.registry.core.dto.DistributionDTO
 import org.octopusden.octopus.components.registry.core.dto.EscrowDTO
 import org.octopusden.octopus.components.registry.core.dto.EscrowGenerationMode
+import org.octopusden.octopus.components.registry.core.dto.Image
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentDTO
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionDTO
 import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionRangeDTO
@@ -193,6 +195,8 @@ abstract class BaseComponentsRegistryServiceTest {
     protected abstract fun findByArtifactsV3(artifacts: Set<ArtifactDependency>): ArtifactComponentsDTO
 
     protected abstract fun getComponentArtifactsParameters(component: String): Map<String, ComponentArtifactConfigurationDTO>
+
+    protected abstract fun findComponentsByDockerImages(images: Set<Image>): Set<ComponentImage>
 
     /**
      * Expected Jira-version-range fixture. The DSL-loader implementation enumerates one range per
@@ -650,6 +654,35 @@ abstract class BaseComponentsRegistryServiceTest {
                 .resolve(path)
                 .toObject(object : TypeReference<Map<String, ComponentArtifactConfigurationDTO>>() {})
         Assertions.assertEquals(expectedArtifact, actualArtifacts)
+    }
+
+    @Test
+    @DisplayName("RES-026: Find components by docker images resolves each image independently")
+    fun testFindComponentsByDockerImagesMultipleComponents() {
+        val images = setOf(
+            Image("test/versions-api", "1.0"),
+            Image("test-docker-1", "1.0.0"),
+            Image("test-docker-1_1", "1.0.0"),
+            Image("test-docker-1_1", "1.1.0")
+        )
+        val result = findComponentsByDockerImages(images).map {
+            it.component to it.version
+        }.toSet()
+        val expected = setOf(
+            "TESTONE" to "1.0",
+            "TEST_COMPONENT_WITH_DOCKER_1" to "1.0.0",
+            "TEST_COMPONENT_WITH_DOCKER_1_1" to "1.0.0",
+            "TEST_COMPONENT_WITH_DOCKER_1_1" to "1.1.0"
+        )
+        Assertions.assertEquals(expected, result)
+    }
+
+    @Test
+    @DisplayName("RES-027: Find components by docker images returns empty when nothing matches")
+    fun testFindComponentsByDockerImagesNotFound() {
+        val images = setOf(Image("non-existent-image", "latest"))
+        val result = findComponentsByDockerImages(images)
+        Assertions.assertTrue(result.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Why

PR #386 ("Fix handle multiple Docker image tags in component lookup") was merged to `main` (21e0af2) but is **not** in `v3`. As we prepare the v3 → main cutover, this fix must exist in v3 — otherwise the cutover would either conflict on it or, worse, silently drop it.

`findComponentsByDockerImages(images)` iterated over the image-name→component map and recovered the tag with `images.find { it.name == imgName }`, which returns only the **first** image sharing a given name. So requesting several tags of the same image (e.g. `test-docker-1_1:1.0.0` and `test-docker-1_1:1.1.0`) collapsed to a single result.

## What

- Iterate over the requested `images` and look each up by name in the map (mirrors #386).
- **Applied to both v3 resolvers** — `main` has only one, v3 carries two:
  - `ComponentRegistryResolverImpl` (git)
  - `DatabaseComponentRegistryResolver` (DB) — no counterpart on main; would otherwise keep the bug post-cutover.
- Ported the two upstream tests into `BaseComponentsRegistryServiceTest` + the required subclass overrides. Because the server-side override lives in the shared `MockMvcRegistryTestSupport`, the cases run against **both** the git-backed and DB-backed controller tests — broader coverage than upstream.

## TDD

- `test:` commit is RED on v3 (expected 4 image→component pairs, got 3 — the second tag dropped).
- `fix:` commit makes it GREEN in both resolvers.

## Verification

- Targeted `dbTest` RED→GREEN demonstrated.
- Full local build green (all modules, ktlint/detekt): `build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test`.
- Independent subagent review: clean, faithful port; confirmed RES-026/RES-027 pass in both git-backed and DB-backed controller tests.

After this merges, the eventual v3 → main merge is conflict-free on these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)