### PR TITLE
docs+chore: refresh AGENTS.md/CLAUDE.md, extract compat-gate, trim agent context

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,10 +54,24 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:github.com)"
     ],
+    "deny": [
+      "Read(./**/BOOT-INF/**)",
+      "Read(./**/.gradle/**)",
+      "Read(./**/.kotlin/**)",
+      "Read(./**/.idea/**)",
+      "Read(./**/.idea-copy/**)",
+      "Read(./**/.teamcity/target/**)"
+    ],
     "defaultMode": "dontAsk",
     "additionalDirectories": [
       "/Users/pgorbachev/projects/octopus",
       "/tmp"
     ]
-  }
+  },
+  "claudeMdExcludes": [
+    "**/octopus-components-registry-service-wt/**",
+    "**/octopus-components-management-portal-wt/**",
+    "**/*-wrapper-archive-*/**",
+    "**/*.backup.git/**"
+  ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@ Quality reports index: `build/reports/quality/index.html`
   - ❌ `curl -s "http://..." | python3 -c "import json; ..."`
   - ✅ `curl -s "http://..." -o /tmp/response.json` — then `python3 -c "import json; f=open('/tmp/response.json'); ..."`
 
+## Search & Context Efficiency
+
+- Before a broad search, identify the target **module** (see the table below) and scope the search to its path — don't scan the whole tree.
+- Do **not** read or grep generated/build directories (`build/`, `.gradle/`, `.kotlin/`, `BOOT-INF/`, `.idea/`, `.idea-copy/`, `.teamcity/target/`). All are gitignored, so `rg`/Grep skip them already. Direct `Read` is additionally denied for all of these **except `build/`** in `.claude/settings.json` — `build/` stays readable on purpose because `build/reports/**` (quality + compat summaries) is consulted.
+- Prefer `rg` with an explicit module path over unscoped searches.
+
 ## Modules
 
 | Module | Purpose |
@@ -60,10 +66,12 @@ Quality reports index: `build/reports/quality/index.html`
 | `components-registry-dsl` | Groovy/Kotlin DSL parsing |
 | `components-registry-automation` | CLI automation tools |
 | `components-registry-service-core` | Core DTOs and exceptions |
+| `components-registry-service-light-client` | Lightweight Feign client (Java 8, legacy Jackson) for consumers on older Gradle-plugin toolchains |
 | `components-registry-service-client` | Feign HTTP client |
 | `components-registry-service-server` | Spring Boot REST API (main application) |
-| `components-registry-cli` | `crsctl` — read-only command-line client for the v4 API (Kotlin/JVM fat jar) |
+| `components-registry-compat-test` | API v1/v2/v3 wire-compatibility tests: baseline (prod/`main`) vs candidate (v3). On-demand only — gated on `compat.*.url`; contributes nothing to `build`/`check` |
 | `test-common` | Shared test utilities |
+| `components-registry-cli` | `crsctl` — read-only command-line client for the v4 API (Kotlin/JVM fat jar) |
 
 ### crsctl CLI
 
@@ -150,54 +158,9 @@ Required env vars: `LDAP_USERNAME`, `LDAP_PASSWORD`, `COMPONENTS_REGISTRY_VCS_RO
 
 ## Compatibility Verification (after every read-path / schema change)
 
-**Entry point:** `scripts/local-stands/verify.sh`. This is the single gate any agent working on schema-v2 bug-cluster PRs (B / C / D+E / F+G) MUST run before declaring a fix complete.
+Any change that can alter v1/v2/v3 wire output MUST be validated against a baseline before it's declared complete. **Entry point:** `scripts/local-stands/verify.sh`.
 
-What it does, per flag:
-
-| Flag | When | Behaviour |
-|---|---|---|
-| `--restart` | code-only change (import / mapper / resolver) | port-scoped kill of the candidate JVM, respawn from `$CANDIDATE_WORKTREE` via `candidate.sh`, wait `/actuator/health` UP, run `:components-registry-compat-test:test`. DSL→DB automigrate re-runs through the new code on every restart. |
-| `--reset-db` | edit to `V1__schema.sql` | implies `--restart`, plus `docker compose down -v` so Flyway re-applies the schema from scratch before automigrate. |
-| `--allow-partial-migration` | targeted smoke knowingly excluding failed components | after restart, the gate parses the auto-migrate summary; without this flag, any `failed > 0` makes verify exit `4` (POLLUTED RUN). With it, the gate prints the warning + failed-component list but proceeds. Only use when your test filter skips the failed set. |
-| _(no flag)_ | re-read state | runs compat against the existing stands without touching them. |
-
-**Exit codes:** `0` clean / `2` baseline down or env missing / `3` candidate failed to come up / `4` polluted run / `*` gradle exit code from compat.
-
-**Polluted run — how to recognize one from the diff signature alone:**
-
-If you have a `summary.md` and don't know whether the run was polluted (e.g. you didn't see the verify banner):
-
-- `STATUS_CODE_DIFF` dominated by `200 → 500` (not `200 → 404`) — endpoints crash on missing-component refs.
-- `NULL_VS_EMPTY` on `GET /rest/api/3/components` for many distinct `componentId=` — those components weren't imported.
-- `VALUE_DIFF` count is small or zero while `STRUCTURAL_DIFF` and `STATUS_CODE_DIFF` are huge.
-
-This combination is the characteristic signature of a partially-migrated DB. **Do not classify these diffs as your cluster's regressions** without first ruling out the polluted-state hypothesis — re-run with `--restart` (which always invokes the migration health-check) or grep the candidate log for `Failed to migrate component '`. The no-flag path of `verify.sh` does NOT invoke the health-check (it has no fresh log to look at), so a polluted candidate started by an earlier `--restart` could keep serving stale state until the next restart-flagged run.
-
-**When `--reset-db` surfaces an upstream import regression:** if the gate exits `4` and the failed components are not in *your* cluster (B / C / D+E / F+G), the regression belongs to an earlier merged PR — file it separately, don't fold the fix into your cluster PR. To continue validating *your* cluster while the upstream fix is in flight, use `--allow-partial-migration` together with a smoke filter (`COMPAT_SMOKE_COMPONENTS=` or `--tests`) that excludes the failed components.
-
-**Env contract** (verify.sh fails fast with a clear message if any required var is missing when a restart-flag is used):
-
-```bash
-export CANDIDATE_WORKTREE="$(pwd)"            # subagent's own worktree, so the rebuild uses its code
-export LOCAL_VCS_ROOT="<your DSL clone>"      # path on your machine, never committed
-export SERVICE_CONFIG_DIR="<service-config clone>"  # carries production-only keys absent from dev/ overlays
-export COMPAT_SMOKE_COMPONENTS="<csv>"        # comma-separated real component names, from session/user
-export COMPAT_RMS_URL="<RMS URL>"             # optional but recommended for real-version sampling
-```
-
-All four `COMPAT_*` values are confidential per the open-source rule — they live in env (or a local `/tmp/compat-*-env.sh`), never in committed files or commit messages. `scripts/local-stands/README.md` has the full operator-facing detail.
-
-**One-shot bootstrap** (first time on a clean host, or after `stop-all.sh`): `postgres-up.sh` → `baseline.sh` (one-time `bootJar`, ~2 min) → `candidate.sh` → then `verify.sh` for subsequent iterations. Baseline is `origin/main` (or whatever fat JAR is in `_wt/local-baseline/components-registry-service-server/build/libs/`); `baseline.sh` rebuilds the JAR automatically when any `*.kt`/`*.java`/`*.gradle` in the baseline worktree is newer.
-
-**Git-mode (no-db) stands need no Postgres** (issue #310 / SYS-047): `candidate.sh --mode=vcs` and the TeamCity git-mode stand (`id18`, `CANDIDATE_MODE=git`) boot the candidate with the `no-db` profile, which excludes the JDBC/JPA/Flyway auto-configs — the candidate runs with no database. Skip `postgres-up.sh` for these; only db-mode (`--mode=db` / `id17`) requires Postgres.
-
-**Reading `build/reports/compat/summary.md`:**
-- `Total recorded / Suppressed / Active` counts at the top — exit code is `0` iff active == 0.
-- Diffs are grouped under `### STATUS_CODE_DIFF`, `### STRUCTURAL_DIFF`, `### VALUE_DIFF` headings (plus `### TIMESTAMP_DRIFT` etc. when present).
-- For a typed-layer (`Feign` recursive comparison) diff, the assertion direction is `assertThat(candidate).isEqualTo(baseline)` — `actual` = candidate, `expected` = baseline.
-- An agent owning one cluster (B / C / D+E / F+G) cares only that diffs scoped to their cluster's endpoint+field signature go to zero. Diffs from sibling PRs not yet landed are expected and tracked separately.
-
-The skill `/crs-compat verify` (user-local, not in this repo) wraps `verify.sh` with the same flag semantics; if invoked from the user's session, prefer the skill — it also surfaces `summary.md` cluster digest. If invoked directly (subagent / CI), call `verify.sh`.
+**When touching the read-path / schema / v1-v2-v3 compat surface, read [`docs/registry/compat-gate.md`](docs/registry/compat-gate.md)** — it covers the `verify.sh` flags (`--restart` / `--reset-db` / `--allow-partial-migration`), exit codes, the polluted-run diff signature, the confidential `COMPAT_*` env contract, git-mode (no-db) stands, and how to read `build/reports/compat/summary.md`. For everyday work you don't need it.
 
 ## Design Documentation
 
@@ -209,7 +172,7 @@ Architecture Decision Records and design docs in this repo live in `docs/registr
 - `functional-spec.md` — functional specification
 - `non-functional-spec.md` — performance, availability, async-job SLAs
 - `requirements-{common,migration,resolver}.md` — numbered requirements (`SYS-NNN`, `MIG-NNN`, `RES-NNN` for resolver parity)
-- `adr/` — 15 ADRs (000–014), including ADR-012 (Portal architecture, canonical), ADR-013 (Cutover strategy, Proposed), ADR-014 (Schema v2)
+- `adr/` — 19 ADRs (000–018), including ADR-012 (Portal architecture, canonical), ADR-013 (Cutover strategy, Proposed), ADR-014 (Schema v2), ADR-015 (Employee-service runtime validation), ADR-016 (Admin config-as-code), ADR-017 (Artifact-ownership modes), ADR-018 (Decoupled version model)
 - `tech-debt/` — numbered tech-debt entries (`TD-NNN`)
 
 ## Tech Debt Tracking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # CLAUDE.md
 
-cd /Users/pgorbachev/projects/octopus/octopus-components-registry-service/This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 See [AGENTS.md](AGENTS.md) for project guidance, build commands, architecture, and code style rules.

--- a/docs/registry/compat-gate.md
+++ b/docs/registry/compat-gate.md
@@ -1,0 +1,54 @@
+# Compatibility Verification Gate
+
+> **Read this only when you are touching the read-path / schema / API compatibility surface** (import, mapper, resolver, `V1__schema.sql`, or any v1/v2/v3 endpoint behaviour). For everyday work, `AGENTS.md` links here — you don't need it otherwise.
+
+Any change that can alter v1/v2/v3 wire output must be validated against a baseline before it's declared complete. Historically this gate was the mandatory check for the schema-v2 bug-cluster PRs (B / C / D+E / F+G); the same mechanics apply to any read-path/schema change.
+
+**Entry point:** `scripts/local-stands/verify.sh`.
+
+What it does, per flag:
+
+| Flag | When | Behaviour |
+|---|---|---|
+| `--restart` | code-only change (import / mapper / resolver) | port-scoped kill of the candidate JVM, respawn from `$CANDIDATE_WORKTREE` via `candidate.sh`, wait `/actuator/health` UP, run `:components-registry-compat-test:test`. DSL→DB automigrate re-runs through the new code on every restart. |
+| `--reset-db` | edit to `V1__schema.sql` | implies `--restart`, plus `docker compose down -v` so Flyway re-applies the schema from scratch before automigrate. |
+| `--allow-partial-migration` | targeted smoke knowingly excluding failed components | after restart, the gate parses the auto-migrate summary; without this flag, any `failed > 0` makes verify exit `4` (POLLUTED RUN). With it, the gate prints the warning + failed-component list but proceeds. Only use when your test filter skips the failed set. |
+| _(no flag)_ | re-read state | runs compat against the existing stands without touching them. |
+
+**Exit codes:** `0` clean / `2` baseline down or env missing / `3` candidate failed to come up / `4` polluted run / `*` gradle exit code from compat.
+
+**Polluted run — how to recognize one from the diff signature alone:**
+
+If you have a `summary.md` and don't know whether the run was polluted (e.g. you didn't see the verify banner):
+
+- `STATUS_CODE_DIFF` dominated by `200 → 500` (not `200 → 404`) — endpoints crash on missing-component refs.
+- `NULL_VS_EMPTY` on `GET /rest/api/3/components` for many distinct `componentId=` — those components weren't imported.
+- `VALUE_DIFF` count is small or zero while `STRUCTURAL_DIFF` and `STATUS_CODE_DIFF` are huge.
+
+This combination is the characteristic signature of a partially-migrated DB. **Do not classify these diffs as your cluster's regressions** without first ruling out the polluted-state hypothesis — re-run with `--restart` (which always invokes the migration health-check) or grep the candidate log for `Failed to migrate component '`. The no-flag path of `verify.sh` does NOT invoke the health-check (it has no fresh log to look at), so a polluted candidate started by an earlier `--restart` could keep serving stale state until the next restart-flagged run.
+
+**When `--reset-db` surfaces an upstream import regression:** if the gate exits `4` and the failed components are not in *your* cluster (B / C / D+E / F+G), the regression belongs to an earlier merged PR — file it separately, don't fold the fix into your cluster PR. To continue validating *your* cluster while the upstream fix is in flight, use `--allow-partial-migration` together with a smoke filter (`COMPAT_SMOKE_COMPONENTS=` or `--tests`) that excludes the failed components.
+
+**Env contract** (verify.sh fails fast with a clear message if any required var is missing when a restart-flag is used):
+
+```bash
+export CANDIDATE_WORKTREE="$(pwd)"            # subagent's own worktree, so the rebuild uses its code
+export LOCAL_VCS_ROOT="<your DSL clone>"      # path on your machine, never committed
+export SERVICE_CONFIG_DIR="<service-config clone>"  # carries production-only keys absent from dev/ overlays
+export COMPAT_SMOKE_COMPONENTS="<csv>"        # comma-separated real component names, from session/user
+export COMPAT_RMS_URL="<RMS URL>"             # optional but recommended for real-version sampling
+```
+
+All four `COMPAT_*` values are confidential per the open-source rule — they live in env (or a local `/tmp/compat-*-env.sh`), never in committed files or commit messages. `scripts/local-stands/README.md` has the full operator-facing detail.
+
+**One-shot bootstrap** (first time on a clean host, or after `stop-all.sh`): `postgres-up.sh` → `baseline.sh` (one-time `bootJar`, ~2 min) → `candidate.sh` → then `verify.sh` for subsequent iterations. Baseline is `origin/main` (or whatever fat JAR is in `_wt/local-baseline/components-registry-service-server/build/libs/`); `baseline.sh` rebuilds the JAR automatically when any `*.kt`/`*.java`/`*.gradle` in the baseline worktree is newer.
+
+**Git-mode (no-db) stands need no Postgres** (issue #310 / SYS-047): `candidate.sh --mode=vcs` and the TeamCity git-mode stand (`id18`, `CANDIDATE_MODE=git`) boot the candidate with the `no-db` profile, which excludes the JDBC/JPA/Flyway auto-configs — the candidate runs with no database. Skip `postgres-up.sh` for these; only db-mode (`--mode=db` / `id17`) requires Postgres.
+
+**Reading `build/reports/compat/summary.md`:**
+- `Total recorded / Suppressed / Active` counts at the top — exit code is `0` iff active == 0.
+- Diffs are grouped under `### STATUS_CODE_DIFF`, `### STRUCTURAL_DIFF`, `### VALUE_DIFF` headings (plus `### TIMESTAMP_DRIFT` etc. when present).
+- For a typed-layer (`Feign` recursive comparison) diff, the assertion direction is `assertThat(candidate).isEqualTo(baseline)` — `actual` = candidate, `expected` = baseline.
+- An agent owning one cluster (B / C / D+E / F+G) cares only that diffs scoped to their cluster's endpoint+field signature go to zero. Diffs from sibling PRs not yet landed are expected and tracked separately.
+
+The skill `/crs-compat verify` (user-local, not in this repo) wraps `verify.sh` with the same flag semantics; if invoked from the user's session, prefer the skill — it also surfaces `summary.md` cluster digest. If invoked directly (subagent / CI), call `verify.sh`.


### PR DESCRIPTION
## What

Cleanup of the agent-facing docs and config to reduce context/token load and fix staleness. No source/build/CI changes — docs + `.claude` config only.

### 1. Agent-context config (`.claude/settings.json`)
- `permissions.deny` — block **direct** `Read` of generated dirs (`BOOT-INF`, `.gradle`, `.kotlin`, `.idea`, `.idea-copy`, `.teamcity/target`). These are already gitignored, so search tools skip them; this closes the direct-read path. **`build/` is intentionally NOT denied** — `build/reports/**` (quality + compat summaries) is read legitimately.
- `claudeMdExcludes` — stop the 28 stray `CLAUDE.md` under sibling worktrees / wrapper-archive / `*.backup.git` from loading into context.

### 2. Docs actuality
- **CLAUDE.md** — drop a stray absolute local path (`cd /Users/…/`) accidentally concatenated into the intro line (would have shipped a personal path to `main`).
- **AGENTS.md** — module table **10 → 12** (add `components-registry-service-light-client`, `components-registry-compat-test`); ADR count **15 (000–014) → 19 (000–018)** with 015–018 listed; add a short *Search & Context Efficiency* section.

### 3. Compat-gate extraction
- Move the ~50-line compatibility-verification section out of AGENTS.md into a new **`docs/registry/compat-gate.md`** (content moved byte-for-byte: flags, exit codes, polluted-run signature, `COMPAT_*` env contract, git-mode stands, summary.md reading guide). AGENTS.md keeps a 4-line pointer. AGENTS.md **247 → 206 lines**.

## Verification
- `.claude/settings.json` validated as JSON.
- Independent subagent review (Sonnet): compat content byte-identical after move, link resolves, module names match `settings.gradle`, ADR count matches `ls adr/`, no stray `/Users/` paths remain, no broken links. One flagged nit (dropped ADR-013 "Proposed" status) fixed before push.
- No gradle build run — no build/source/CI inputs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)