### PR TITLE
feat(versions): live version-format preview endpoint (POST /rest/api/4/versions/preview)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiV4Config.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiV4Config.kt
@@ -39,6 +39,8 @@ class OpenApiV4Config {
                 "/rest/api/4/info",
                 // MigrationStatusControllerV4 — anonymous migration-activity probe (SYS-055).
                 "/rest/api/4/migration-status",
+                // VersionsControllerV4 — stateless version-format preview (SYS-059).
+                "/rest/api/4/versions/**",
                 // AuthController at /auth/me — outside /rest/api/4.
                 "/auth/**",
             )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/VersionsControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/VersionsControllerV4.kt
@@ -1,0 +1,59 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewRequest
+import org.octopusden.octopus.components.registry.server.service.VersionPreviewService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * SYS-059: live version-format preview.
+ *
+ * `POST /rest/api/4/versions/preview` renders the six version coordinates of a
+ * [DetailedComponentVersion] from **ad-hoc** Jira formats (base + per-range
+ * overrides) supplied in the body, driven by an input version — with no
+ * persistence and no component lookup. It lets the Portal editor show a live,
+ * version-accurate preview of the *unsaved* config instead of the saved-config
+ * `detailed-version` call.
+ *
+ * Not `@ConditionalOnDatabaseEnabled`: rendering only needs the always-present
+ * `VersionNames` / formatter beans, so preview works in both git and DB modes.
+ *
+ * Authorization: gated by the authenticated `rest/api/4` catch-all in
+ * [org.octopusden.octopus.components.registry.server.config.WebSecurityConfig].
+ * The endpoint touches no persisted data, so it needs no finer method-level
+ * permission — any authenticated caller may preview formatting math over its own
+ * payload.
+ */
+@RestController
+@RequestMapping("rest/api/4/versions")
+class VersionsControllerV4(
+    private val versionPreviewService: VersionPreviewService,
+) {
+    @Operation(
+        summary = "Preview version coordinates from ad-hoc formats",
+        description = "Renders a DetailedComponentVersion for the given input version from base + per-range " +
+            "override formats, without persisting or looking up a component.",
+    )
+    @PostMapping(
+        "preview",
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun preview(
+        @RequestBody request: VersionPreviewRequest,
+    ): DetailedComponentVersion {
+        LOG.info("Preview version coordinates for '{}' ({} override(s))", request.version, request.overrides.size)
+        return versionPreviewService.preview(request)
+    }
+
+    companion object {
+        private val LOG: Logger = LoggerFactory.getLogger(VersionsControllerV4::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/VersionsControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/VersionsControllerV4.kt
@@ -49,7 +49,9 @@ class VersionsControllerV4(
     fun preview(
         @RequestBody request: VersionPreviewRequest,
     ): DetailedComponentVersion {
-        LOG.info("Preview version coordinates for '{}' ({} override(s))", request.version, request.overrides.size)
+        // DEBUG, not INFO: the editor calls this on every keystroke (debounced),
+        // so per-request INFO would flood prod logs.
+        LOG.debug("Preview version coordinates for '{}' ({} override(s))", request.version, request.overrides.size)
         return versionPreviewService.preview(request)
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/VersionPreviewDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/VersionPreviewDtos.kt
@@ -47,7 +47,11 @@ data class VersionPreviewFormats(
     override val buildVersionFormat: String? = null,
     @field:Schema(description = "Falls back to the minor version format when blank.")
     override val lineVersionFormat: String? = null,
-    @field:Schema(description = "When present (non-blank), a hotfix coordinate is rendered in the response.")
+    @field:Schema(
+        description = "Hotfix version format. A hotfix coordinate is rendered only when the request's " +
+            "hotfixEnabled is true; this format then shapes it. When hotfixEnabled is true but this is omitted, a " +
+            "degenerate empty hotfix coordinate is rendered (matching detailed-version). Ignored when hotfixEnabled is false.",
+    )
     override val hotfixVersionFormat: String? = null,
     @field:Schema(description = "Custom-component version prefix (e.g. \"acme\"). Requires versionFormat when set.")
     override val versionPrefix: String? = null,
@@ -82,8 +86,9 @@ data class VersionPreviewRequest(
     val technical: Boolean = false,
     @field:Schema(
         description = "Whether hotfix versioning is enabled for the component (in the persisted path this derives " +
-            "from a configured hotfix VCS branch, NOT from the presence of a hotfix format). A hotfix coordinate is " +
-            "rendered only when this is true AND a hotfixVersionFormat resolves for the version.",
+            "from a configured hotfix VCS branch, NOT from the presence of a hotfix format). When true, a hotfix " +
+            "coordinate is rendered — shaped by hotfixVersionFormat, or a degenerate empty coordinate when no format " +
+            "resolves (matching detailed-version). When false, no hotfix coordinate is rendered regardless of the format.",
     )
     val hotfixEnabled: Boolean = false,
     val base: VersionPreviewFormats,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/VersionPreviewDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/VersionPreviewDtos.kt
@@ -1,0 +1,92 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * SYS-059: request/response DTOs for the stateless version-format preview
+ * (`POST /rest/api/4/versions/preview`).
+ *
+ * The Portal editor posts the **unsaved** effective Jira formats — a [base]
+ * block plus per-range [overrides] — together with an input [version]. The
+ * server resolves which range the version falls into, renders the six version
+ * coordinates with the SAME formatter / `VersionNames` the persisted
+ * `detailed-version` path uses, and returns a
+ * [org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion].
+ * No persistence, no component lookup, no `buildSystem` (padding / library
+ * computation is driven purely by the format templates + `VersionNames`).
+ *
+ * Field naming mirrors the v4 write contract
+ * ([JiraAspectRequest]): `minorVersionFormat` is the "$major.$minor"-shaped
+ * format the resolver models internally as `majorVersionFormat`.
+ */
+
+/**
+ * The set of Jira format fields shared by [VersionPreviewFormats] (the base
+ * block) and [VersionPreviewOverride] (a per-range override). Modelled as an
+ * interface so range-vs-base merging is one generic overlay: for each field the
+ * override value wins when present (non-null), otherwise the base value is used.
+ * A `null` field on an override therefore means "inherit the base"; an empty
+ * string means "explicitly blank" (mirrors line/release per the formatter's
+ * blank-format fallback), matching how the editor already emits `''`/`null`.
+ */
+interface JiraPreviewFormatFields {
+    val minorVersionFormat: String?
+    val releaseVersionFormat: String?
+    val buildVersionFormat: String?
+    val lineVersionFormat: String?
+    val hotfixVersionFormat: String?
+    val versionPrefix: String?
+    val versionFormat: String?
+}
+
+@Schema(description = "Effective BASE Jira version formats (the editor's section draft).")
+data class VersionPreviewFormats(
+    override val minorVersionFormat: String? = null,
+    override val releaseVersionFormat: String? = null,
+    @field:Schema(description = "Falls back to the release version format when blank.")
+    override val buildVersionFormat: String? = null,
+    @field:Schema(description = "Falls back to the minor version format when blank.")
+    override val lineVersionFormat: String? = null,
+    @field:Schema(description = "When present (non-blank), a hotfix coordinate is rendered in the response.")
+    override val hotfixVersionFormat: String? = null,
+    @field:Schema(description = "Custom-component version prefix (e.g. \"acme\"). Requires versionFormat when set.")
+    override val versionPrefix: String? = null,
+    @field:Schema(description = "Custom-component wrapper format, e.g. \"\$versionPrefix-\$baseVersionFormat\".")
+    override val versionFormat: String? = null,
+) : JiraPreviewFormatFields
+
+@Schema(
+    description = "A per-range format override. Only the fields that differ from the base need to be set; " +
+        "a null field inherits the base. Applied when the input version falls inside versionRange.",
+)
+data class VersionPreviewOverride(
+    @field:Schema(description = "Maven-style version range, e.g. \"(,1.0.107)\" or \"[1.0,2.0)\".", example = "(,1.0.107)")
+    val versionRange: String,
+    override val minorVersionFormat: String? = null,
+    override val releaseVersionFormat: String? = null,
+    override val buildVersionFormat: String? = null,
+    override val lineVersionFormat: String? = null,
+    override val hotfixVersionFormat: String? = null,
+    override val versionPrefix: String? = null,
+    override val versionFormat: String? = null,
+) : JiraPreviewFormatFields
+
+@Schema(
+    description = "Stateless version-format preview request: render the six version coordinates for `version` " +
+        "from ad-hoc formats (base + per-range overrides) without persisting or looking up a component.",
+)
+data class VersionPreviewRequest(
+    @field:Schema(description = "The input version that drives range selection and rendering.", example = "1.0.50")
+    val version: String,
+    @field:Schema(description = "Whether the component is technical. Carried for parity; does not affect rendering.")
+    val technical: Boolean = false,
+    @field:Schema(
+        description = "Whether hotfix versioning is enabled for the component (in the persisted path this derives " +
+            "from a configured hotfix VCS branch, NOT from the presence of a hotfix format). A hotfix coordinate is " +
+            "rendered only when this is true AND a hotfixVersionFormat resolves for the version.",
+    )
+    val hotfixEnabled: Boolean = false,
+    val base: VersionPreviewFormats,
+    @field:Schema(description = "Per-range format overrides. First range that contains the version wins; base otherwise.")
+    val overrides: List<VersionPreviewOverride> = emptyList(),
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/VersionPreviewService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/VersionPreviewService.kt
@@ -1,0 +1,18 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewRequest
+
+/**
+ * SYS-059: stateless renderer for the Jira version-format preview.
+ *
+ * Given ad-hoc formats (base + per-range overrides) and an input version, it
+ * resolves the applicable range, materialises the effective
+ * `ComponentVersionFormat`, and reuses the persisted-path render seam
+ * (`Mapper<JiraComponentVersion, DetailedComponentVersion>`) so preview output
+ * is byte-for-byte the same as `detailed-version` for the same effective config
+ * and version. No persistence, no component lookup.
+ */
+interface VersionPreviewService {
+    fun preview(request: VersionPreviewRequest): DetailedComponentVersion
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImpl.kt
@@ -1,0 +1,135 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.dto.v4.JiraPreviewFormatFields
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewRequest
+import org.octopusden.octopus.components.registry.server.mapper.Mapper
+import org.octopusden.octopus.components.registry.server.service.VersionPreviewService
+import org.octopusden.octopus.releng.JiraComponentVersionFormatter
+import org.octopusden.octopus.releng.dto.ComponentInfo
+import org.octopusden.octopus.releng.dto.ComponentVersion
+import org.octopusden.octopus.releng.dto.JiraComponent
+import org.octopusden.octopus.releng.dto.JiraComponentVersion
+import org.octopusden.releng.versions.ComponentVersionFormat
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+import org.octopusden.releng.versions.VersionRangeFactory
+import org.springframework.stereotype.Service
+
+@Service
+class VersionPreviewServiceImpl(
+    versionNames: VersionNames,
+    private val detailedComponentVersionMapper: Mapper<JiraComponentVersion, DetailedComponentVersion>,
+) : VersionPreviewService {
+    // Instance-global VersionNames (server-owned): the same beans the persisted
+    // render path binds, so preview padding / custom-var expansion matches.
+    private val formatter = JiraComponentVersionFormatter(versionNames)
+    private val numericVersionFactory = NumericVersionFactory(versionNames)
+    private val versionRangeFactory = VersionRangeFactory(versionNames)
+
+    override fun preview(request: VersionPreviewRequest): DetailedComponentVersion {
+        val version = request.version.trim()
+        require(version.isNotBlank()) { "version must not be blank" }
+        val numericVersion = numericVersionFactory.create(version)
+        require(numericVersion.itemsCount > 0) {
+            "version '$version' is not a parseable numeric version"
+        }
+
+        // Range selection: the first override whose range contains the input
+        // version wins; the base applies when none matches. Range strings are
+        // validated here — a malformed range throws IllegalArgumentException
+        // (→ 400 via ControllerExceptionHandler).
+        val matched =
+            request.overrides.firstOrNull { override ->
+                versionRangeFactory.create(override.versionRange).containsVersion(numericVersion)
+            }
+        val base = request.base
+
+        // Effective format = base overlaid with the matched override's present
+        // (non-null) fields.
+        fun effective(select: JiraPreviewFormatFields.() -> String?): String? = matched?.select() ?: base.select()
+
+        val prefix = effective { versionPrefix }
+        val wrapperFormat = effective { versionFormat }
+        require(prefix.isNullOrBlank() || !wrapperFormat.isNullOrBlank()) {
+            "versionFormat is required when versionPrefix is set"
+        }
+
+        // minor (modelled as majorVersionFormat) and release are the roots. The
+        // persisted DB path (EntityMappers.buildJiraComponent) defaults a blank
+        // minor/release to "$major" / "$major.$minor"; mirror that here rather
+        // than reject, so an editor draft relying on those defaults previews the
+        // same output detailed-version would produce.
+        val minorFormat = effective { minorVersionFormat }.orElse(DEFAULT_MINOR_FORMAT)
+        val releaseFormat = effective { releaseVersionFormat }.orElse(DEFAULT_RELEASE_FORMAT)
+        // Mirror semantics (the resolver relies on Defaults.groovy / the formatter
+        // getters for these): a blank line mirrors minor, a blank build mirrors
+        // release. The mapper reads these fields verbatim, so they must be
+        // non-null even when the caller omits them.
+        val lineFormat = effective { lineVersionFormat }.orElse(minorFormat)
+        val buildFormat = effective { buildVersionFormat }.orElse(releaseFormat)
+        // The persisted buildJiraComponent stores "" (never null) for a missing
+        // hotfix format, so a hotfix-eligible component with no format still renders
+        // a (degenerate, empty) hotfix coordinate. Match that for exact parity;
+        // when not eligible the value is irrelevant (no coordinate is rendered).
+        val hotfixFormat = effective { hotfixVersionFormat } ?: if (request.hotfixEnabled) "" else null
+
+        val componentVersionFormat =
+            ComponentVersionFormat.create(
+                minorFormat,
+                releaseFormat,
+                buildFormat,
+                lineFormat,
+                hotfixFormat,
+            )
+        // Custom-component (prefix) path only kicks in when a prefix is present;
+        // otherwise the standard format path renders without a wrapper.
+        val componentInfo = if (!prefix.isNullOrBlank()) ComponentInfo(prefix, wrapperFormat) else null
+        val jiraComponent =
+            JiraComponent(
+                PREVIEW_PROJECT_KEY,
+                null,
+                componentVersionFormat,
+                componentInfo,
+                request.technical,
+                // Hotfix eligibility is VCS-branch-derived in the persisted path
+                // (isHotFixEnabled(vcsSettings)), NOT format-derived — so the caller
+                // supplies it. A hotfix coordinate then renders only when this is
+                // true AND a hotfix format resolves (see JiraComponentVersion.getHotfixVersion).
+                request.hotfixEnabled,
+            )
+
+        // Canonicalise the input exactly as getJiraComponentVersion does
+        // (strict=false): pick the format the version matches and re-render it,
+        // then drive ALL coordinates from that clean version. Skipping this would
+        // diverge from detailed-version whenever the raw version does not
+        // round-trip through the matched format. A version matching no format
+        // yields null → 404, mirroring the resolver's not-found.
+        val cleanVersion =
+            formatter.normalizeVersion(jiraComponent, version, false, request.hotfixEnabled)
+                ?: throw NotFoundException("Version '$version' does not match any of the supplied formats")
+
+        val jiraComponentVersion =
+            JiraComponentVersion(
+                ComponentVersion.create(PREVIEW_COMPONENT_NAME, cleanVersion),
+                jiraComponent,
+                formatter,
+            )
+        return detailedComponentVersionMapper.convert(jiraComponentVersion)
+    }
+
+    // A blank/null format falls back to the given format.
+    private fun String?.orElse(fallback: String): String = if (this.isNullOrBlank()) fallback else this
+
+    companion object {
+        // Placeholder identity — preview neither persists nor looks up a
+        // component, and the rendered coordinates are independent of the name.
+        private const val PREVIEW_PROJECT_KEY = "PREVIEW"
+        private const val PREVIEW_COMPONENT_NAME = "preview"
+
+        // Match the persisted DB-path defaults in EntityMappers.buildJiraComponent.
+        private const val DEFAULT_MINOR_FORMAT = "\$major"
+        private const val DEFAULT_RELEASE_FORMAT = "\$major.\$minor"
+    }
+}

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -2404,7 +2404,7 @@
             "type" : "string"
           },
           "hotfixVersionFormat" : {
-            "description" : "When present (non-blank), a hotfix coordinate is rendered in the response.",
+            "description" : "Hotfix version format. A hotfix coordinate is rendered only when the request's hotfixEnabled is true; this format then shapes it. When hotfixEnabled is true but this is omitted, a degenerate empty hotfix coordinate is rendered (matching detailed-version). Ignored when hotfixEnabled is false.",
             "type" : "string"
           },
           "lineVersionFormat" : {
@@ -2470,7 +2470,7 @@
             "$ref" : "#/components/schemas/VersionPreviewFormats"
           },
           "hotfixEnabled" : {
-            "description" : "Whether hotfix versioning is enabled for the component (in the persisted path this derives from a configured hotfix VCS branch, NOT from the presence of a hotfix format). A hotfix coordinate is rendered only when this is true AND a hotfixVersionFormat resolves for the version.",
+            "description" : "Whether hotfix versioning is enabled for the component (in the persisted path this derives from a configured hotfix VCS branch, NOT from the presence of a hotfix format). When true, a hotfix coordinate is rendered — shaped by hotfixVersionFormat, or a degenerate empty coordinate when no format resolves (matching detailed-version). When false, no hotfix coordinate is rendered regardless of the format.",
             "type" : "boolean"
           },
           "overrides" : {

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -771,6 +771,33 @@
         ],
         "type" : "object"
       },
+      "ComponentRegistryVersion" : {
+        "properties" : {
+          "jiraVersion" : {
+            "type" : "string"
+          },
+          "type" : {
+            "enum" : [
+              "LINE",
+              "MINOR",
+              "BUILD",
+              "RELEASE",
+              "RC",
+              "HOTFIX"
+            ],
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "jiraVersion",
+          "type",
+          "version"
+        ],
+        "type" : "object"
+      },
       "ComponentSummaryResponse" : {
         "properties" : {
           "archived" : {
@@ -982,6 +1009,40 @@
         },
         "required" : [
           "version"
+        ],
+        "type" : "object"
+      },
+      "DetailedComponentVersion" : {
+        "properties" : {
+          "buildVersion" : {
+            "$ref" : "#/components/schemas/ComponentRegistryVersion"
+          },
+          "component" : {
+            "type" : "string"
+          },
+          "hotfixVersion" : {
+            "$ref" : "#/components/schemas/ComponentRegistryVersion"
+          },
+          "lineVersion" : {
+            "$ref" : "#/components/schemas/ComponentRegistryVersion"
+          },
+          "minorVersion" : {
+            "$ref" : "#/components/schemas/ComponentRegistryVersion"
+          },
+          "rcVersion" : {
+            "$ref" : "#/components/schemas/ComponentRegistryVersion"
+          },
+          "releaseVersion" : {
+            "$ref" : "#/components/schemas/ComponentRegistryVersion"
+          }
+        },
+        "required" : [
+          "buildVersion",
+          "component",
+          "lineVersion",
+          "minorVersion",
+          "rcVersion",
+          "releaseVersion"
         ],
         "type" : "object"
       },
@@ -2332,6 +2393,109 @@
           "id",
           "sortOrder",
           "vcsPath"
+        ],
+        "type" : "object"
+      },
+      "VersionPreviewFormats" : {
+        "description" : "Effective BASE Jira version formats (the editor's section draft).",
+        "properties" : {
+          "buildVersionFormat" : {
+            "description" : "Falls back to the release version format when blank.",
+            "type" : "string"
+          },
+          "hotfixVersionFormat" : {
+            "description" : "When present (non-blank), a hotfix coordinate is rendered in the response.",
+            "type" : "string"
+          },
+          "lineVersionFormat" : {
+            "description" : "Falls back to the minor version format when blank.",
+            "type" : "string"
+          },
+          "minorVersionFormat" : {
+            "type" : "string"
+          },
+          "releaseVersionFormat" : {
+            "type" : "string"
+          },
+          "versionFormat" : {
+            "description" : "Custom-component wrapper format, e.g. \"$versionPrefix-$baseVersionFormat\".",
+            "type" : "string"
+          },
+          "versionPrefix" : {
+            "description" : "Custom-component version prefix (e.g. \"acme\"). Requires versionFormat when set.",
+            "type" : "string"
+          }
+        },
+        "type" : "object"
+      },
+      "VersionPreviewOverride" : {
+        "description" : "A per-range format override. Only the fields that differ from the base need to be set; a null field inherits the base. Applied when the input version falls inside versionRange.",
+        "properties" : {
+          "buildVersionFormat" : {
+            "type" : "string"
+          },
+          "hotfixVersionFormat" : {
+            "type" : "string"
+          },
+          "lineVersionFormat" : {
+            "type" : "string"
+          },
+          "minorVersionFormat" : {
+            "type" : "string"
+          },
+          "releaseVersionFormat" : {
+            "type" : "string"
+          },
+          "versionFormat" : {
+            "type" : "string"
+          },
+          "versionPrefix" : {
+            "type" : "string"
+          },
+          "versionRange" : {
+            "description" : "Maven-style version range, e.g. \"(,1.0.107)\" or \"[1.0,2.0)\".",
+            "example" : "(,1.0.107)",
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "versionRange"
+        ],
+        "type" : "object"
+      },
+      "VersionPreviewRequest" : {
+        "description" : "Stateless version-format preview request: render the six version coordinates for `version` from ad-hoc formats (base + per-range overrides) without persisting or looking up a component.",
+        "properties" : {
+          "base" : {
+            "$ref" : "#/components/schemas/VersionPreviewFormats"
+          },
+          "hotfixEnabled" : {
+            "description" : "Whether hotfix versioning is enabled for the component (in the persisted path this derives from a configured hotfix VCS branch, NOT from the presence of a hotfix format). A hotfix coordinate is rendered only when this is true AND a hotfixVersionFormat resolves for the version.",
+            "type" : "boolean"
+          },
+          "overrides" : {
+            "description" : "Per-range format overrides. First range that contains the version wins; base otherwise.",
+            "items" : {
+              "$ref" : "#/components/schemas/VersionPreviewOverride"
+            },
+            "type" : "array"
+          },
+          "technical" : {
+            "description" : "Whether the component is technical. Carried for parity; does not affect rendering.",
+            "type" : "boolean"
+          },
+          "version" : {
+            "description" : "The input version that drives range selection and rendering.",
+            "example" : "1.0.50",
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "base",
+          "hotfixEnabled",
+          "overrides",
+          "technical",
+          "version"
         ],
         "type" : "object"
       }
@@ -7967,6 +8131,108 @@
         },
         "tags" : [
           "migration-status-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/versions/preview" : {
+      "post" : {
+        "description" : "Renders a DetailedComponentVersion for the given input version from base + per-range override formats, without persisting or looking up a component.",
+        "operationId" : "preview",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VersionPreviewRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DetailedComponentVersion"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "summary" : "Preview version coordinates from ad-hoc formats",
+        "tags" : [
+          "versions-controller-v-4"
         ]
       }
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/VersionsControllerV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/VersionsControllerV4Test.kt
@@ -1,0 +1,203 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.core.dto.DetailedComponentVersion
+import org.octopusden.octopus.components.registry.core.dto.JiraComponentVersionDTO
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewFormats
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewOverride
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewRequest
+import org.octopusden.octopus.components.registry.server.support.viewerJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * SYS-059: `POST /rest/api/4/versions/preview` renders a DetailedComponentVersion
+ * from ad-hoc formats. Exercised through the full SpringBootTest context so the
+ * real WebSecurityConfig gates the endpoint (authenticated-only under the
+ * `rest/api/4` catch-all).
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "test")
+@Tag("integration")
+class VersionsControllerV4Test {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    @DisplayName("SYS-059: authenticated preview returns 200 with rendered coordinates")
+    fun `SYS-059 authenticated preview returns rendered coordinates`() {
+        val request =
+            VersionPreviewRequest(
+                version = "1.2.3",
+                base =
+                    VersionPreviewFormats(
+                        minorVersionFormat = "\$major.\$minor",
+                        releaseVersionFormat = "\$major.\$minor.\$service",
+                        lineVersionFormat = "\$major.\$minor",
+                    ),
+                overrides =
+                    listOf(
+                        VersionPreviewOverride(
+                            versionRange = "(,1.0.107)",
+                            releaseVersionFormat = "\$major.\$minor.\$service-\$fix",
+                        ),
+                    ),
+            )
+
+        mvc
+            .perform(
+                post("/rest/api/4/versions/preview")
+                    .with(viewerJwt())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request)),
+            ).andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            // 1.2.3 is outside (,1.0.107) → base release format applies.
+            .andExpect(jsonPath("$.releaseVersion.version").value("1.2.3"))
+            .andExpect(jsonPath("$.minorVersion.version").value("1.2"))
+            .andExpect(jsonPath("$.rcVersion.version").value("1.2.3_RC"))
+    }
+
+    @Test
+    @DisplayName("SYS-059: an unauthenticated preview is rejected with 401")
+    fun `SYS-059 unauthenticated preview is 401`() {
+        val request =
+            VersionPreviewRequest(
+                version = "1.2.3",
+                base = VersionPreviewFormats(minorVersionFormat = "\$major.\$minor", releaseVersionFormat = "\$major.\$minor.\$service"),
+            )
+
+        mvc
+            .perform(
+                post("/rest/api/4/versions/preview")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request)),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("SYS-059: a non-numeric version is rejected with 400")
+    fun `SYS-059 invalid version is 400`() {
+        val request =
+            VersionPreviewRequest(
+                version = "not-a-version",
+                base = VersionPreviewFormats(minorVersionFormat = "\$major.\$minor", releaseVersionFormat = "\$major.\$minor.\$service"),
+            )
+
+        mvc
+            .perform(
+                post("/rest/api/4/versions/preview")
+                    .with(viewerJwt())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(request)),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("SYS-059: preview output equals detailed-version for the same effective config (SUB@3.0.0)")
+    fun `SYS-059 preview matches detailed-version for a real component`() {
+        // Parity guard: read the resolved Jira formats of a real seeded component
+        // (SUB @ 3.0.0 — exercises a custom version prefix AND hotfix) from the v2
+        // jira-component endpoint, feed them verbatim into the preview, and assert
+        // the rendered coordinates match GET .../detailed-version for that version.
+        val component = "SUB"
+        val version = "3.0.0"
+
+        val reference = getJson("/rest/api/2/components/$component/versions/$version/detailed-version", DetailedComponentVersion::class.java)
+        val jira = getJson("/rest/api/2/components/$component/versions/$version/jira-component", JiraComponentVersionDTO::class.java).component
+        val cvf = jira.componentVersionFormat
+
+        val request =
+            VersionPreviewRequest(
+                version = version,
+                technical = jira.technical,
+                // Eligibility is VCS-derived in the persisted path; the seeded SUB
+                // has a hotfix branch, so detailed-version renders a hotfix coordinate.
+                hotfixEnabled = reference.hotfixVersion != null,
+                base =
+                    VersionPreviewFormats(
+                        minorVersionFormat = cvf.majorVersionFormat,
+                        releaseVersionFormat = cvf.releaseVersionFormat,
+                        buildVersionFormat = cvf.buildVersionFormat,
+                        lineVersionFormat = cvf.lineVersionFormat,
+                        hotfixVersionFormat = cvf.hotfixVersionFormat,
+                        versionPrefix = jira.componentInfo.versionPrefix,
+                        versionFormat = jira.componentInfo.versionFormat,
+                    ),
+            )
+
+        val preview =
+            objectMapper.readValue(
+                mvc
+                    .perform(
+                        post("/rest/api/4/versions/preview")
+                            .with(viewerJwt())
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(request)),
+                    ).andExpect(status().isOk)
+                    .andReturn()
+                    .response
+                    .contentAsString,
+                DetailedComponentVersion::class.java,
+            )
+
+        // The `component` field is a display name preview cannot know (it takes no
+        // component), so normalise it; every version coordinate must match.
+        assertEquals(reference.copy(component = preview.component), preview)
+    }
+
+    private fun <T> getJson(
+        url: String,
+        type: Class<T>,
+    ): T =
+        objectMapper.readValue(
+            mvc.perform(get(url).accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk).andReturn().response.contentAsString,
+            type,
+        )
+
+    companion object {
+        // application-common.yml resolves work-dir from this property; without it
+        // the @SpringBootTest context fails to start. Pattern per InfoControllerV4Test.
+        @JvmStatic
+        @BeforeAll
+        fun configureTestDataDir() {
+            val resourcesPath: Path =
+                Paths.get(VersionsControllerV4Test::class.java.getResource("/expected-data")!!.toURI()).parent
+            System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", resourcesPath.toString())
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImplTest.kt
@@ -1,0 +1,269 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewFormats
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewOverride
+import org.octopusden.octopus.components.registry.server.dto.v4.VersionPreviewRequest
+import org.octopusden.octopus.components.registry.server.mapper.JiraComponentVersionToDetailedComponentVersionMapper
+import org.octopusden.octopus.releng.JiraComponentVersionFormatter
+import org.octopusden.releng.versions.NumericVersionFactory
+import org.octopusden.releng.versions.VersionNames
+
+/**
+ * SYS-059: unit coverage for the stateless version-format preview renderer.
+ *
+ * Uses the canonical test `VersionNames("serviceCBranch", "serviceC", "minorC")`
+ * and the real `JiraComponentVersionToDetailedComponentVersionMapper`, so these
+ * assertions prove preview output equals the persisted `detailed-version` render
+ * for the same effective config + version.
+ */
+class VersionPreviewServiceImplTest {
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val mapper =
+        JiraComponentVersionToDetailedComponentVersionMapper(
+            JiraComponentVersionFormatter(versionNames),
+            NumericVersionFactory(versionNames),
+        )
+    private val service = VersionPreviewServiceImpl(versionNames, mapper)
+
+    @Test
+    @DisplayName("SYS-059: base formats render the six coordinates for the input version")
+    fun `SYS-059 base render`() {
+        val result =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3",
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                            buildVersionFormat = "\$major.\$minor.\$service-\$build",
+                            lineVersionFormat = "\$major.\$minor",
+                        ),
+                ),
+            )
+
+        assertEquals("1.2", result.minorVersion.version)
+        assertEquals("1.2", result.minorVersion.jiraVersion)
+        assertEquals("1.2", result.lineVersion.version)
+        assertEquals("1.2.3", result.releaseVersion.version)
+        assertEquals("1.2.3", result.releaseVersion.jiraVersion)
+        assertEquals("1.2.3-0", result.buildVersion.version)
+        assertEquals("1.2.3_RC", result.rcVersion.version)
+        assertEquals("1.2.3_RC", result.rcVersion.jiraVersion)
+        assertNull(result.hotfixVersion)
+    }
+
+    @Test
+    @DisplayName("SYS-059: a version inside an override range uses the override format, outside uses base")
+    fun `SYS-059 override range selection`() {
+        val request = { version: String ->
+            VersionPreviewRequest(
+                version = version,
+                base =
+                    VersionPreviewFormats(
+                        minorVersionFormat = "\$major.\$minor",
+                        releaseVersionFormat = "\$major.\$minor.\$service",
+                        lineVersionFormat = "\$major.\$minor",
+                    ),
+                overrides =
+                    listOf(
+                        VersionPreviewOverride(
+                            versionRange = "(,1.0.107)",
+                            // Same shape as base but zero-padded service — a clear,
+                            // round-tripping difference between override and base.
+                            releaseVersionFormat = "\$major.\$minor.\$service02",
+                        ),
+                    ),
+            )
+        }
+
+        // 1.0.5 is inside (,1.0.107) → override release format (padded service).
+        assertEquals("1.0.05", service.preview(request("1.0.5")).releaseVersion.version)
+        // 2.0.5 is outside → base release format (unpadded service).
+        assertEquals("2.0.5", service.preview(request("2.0.5")).releaseVersion.version)
+    }
+
+    @Test
+    @DisplayName("SYS-059: custom versionPrefix renders jiraVersion with the wrapper; version stays unwrapped")
+    fun `SYS-059 custom prefix render`() {
+        val result =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3",
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                            versionPrefix = "acme",
+                            versionFormat = "\$versionPrefix-\$baseVersionFormat",
+                        ),
+                ),
+            )
+
+        // The mapper's `.version` is the raw template render (no wrapper); the
+        // `.jiraVersion` is the customer-formatted coordinate (with prefix).
+        // This dichotomy is exactly what the saved `detailed-version` produces.
+        assertEquals("1.2.3", result.releaseVersion.version)
+        assertEquals("acme-1.2.3", result.releaseVersion.jiraVersion)
+    }
+
+    @Test
+    @DisplayName("SYS-059: zero-padding is driven purely by the format template (no buildSystem input)")
+    fun `SYS-059 padding is template-driven`() {
+        val result =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3",
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service02",
+                        ),
+                ),
+            )
+
+        // $service02 pads the service segment to two digits — purely from the template.
+        assertEquals("1.2.03", result.releaseVersion.version)
+    }
+
+    @Test
+    @DisplayName("SYS-059: a hotfix format renders a hotfix coordinate; its absence renders none")
+    fun `SYS-059 hotfix coordinate`() {
+        val withHotfix =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3.4.5",
+                    // Hotfix eligibility is caller-supplied (VCS-derived), like the persisted path.
+                    hotfixEnabled = true,
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                            hotfixVersionFormat = "\$major.\$minor.\$service-\$fix-\$build",
+                        ),
+                ),
+            )
+        assertNotNull(withHotfix.hotfixVersion)
+        assertEquals("1.2.3-4-5", withHotfix.hotfixVersion!!.version)
+
+        val withoutHotfix =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3.4.5",
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                        ),
+                ),
+            )
+        assertNull(withoutHotfix.hotfixVersion)
+
+        // A hotfix FORMAT alone does not render a hotfix coordinate — eligibility
+        // is VCS-derived (hotfixEnabled), exactly as detailed-version behaves.
+        val formatButDisabled =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3.4.5",
+                    hotfixEnabled = false,
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                            hotfixVersionFormat = "\$major.\$minor.\$service-\$fix-\$build",
+                        ),
+                ),
+            )
+        assertNull(formatButDisabled.hotfixVersion)
+
+        // Hotfix-eligible but no format supplied: the persisted path stores "" and
+        // renders a degenerate empty hotfix coordinate — preview matches that.
+        val enabledNoFormat =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3.4.5",
+                    hotfixEnabled = true,
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                        ),
+                ),
+            )
+        assertNotNull(enabledNoFormat.hotfixVersion)
+        assertEquals("", enabledNoFormat.hotfixVersion!!.version)
+    }
+
+    @Test
+    @DisplayName("SYS-059: a version matching none of the supplied formats is not-found (404), mirroring detailed-version")
+    fun `SYS-059 unmatched version is not found`() {
+        assertThrows<NotFoundException> {
+            service.preview(
+                VersionPreviewRequest(
+                    // A single numeric segment matches neither the 2-var minor
+                    // nor the 3-var release format → normalizeVersion returns null.
+                    version = "5",
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                        ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-059: a blank or non-numeric version is rejected (IllegalArgumentException → 400)")
+    fun `SYS-059 invalid version rejected`() {
+        val base = VersionPreviewFormats(minorVersionFormat = "\$major.\$minor", releaseVersionFormat = "\$major.\$minor.\$service")
+        assertThrows<IllegalArgumentException> {
+            service.preview(VersionPreviewRequest(version = "", base = base))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.preview(VersionPreviewRequest(version = "   ", base = base))
+        }
+        assertThrows<IllegalArgumentException> {
+            service.preview(VersionPreviewRequest(version = "not-a-version", base = base))
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-059: a malformed override range is rejected (IllegalArgumentException → 400)")
+    fun `SYS-059 malformed override range rejected`() {
+        assertThrows<IllegalArgumentException> {
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.0.50",
+                    base = VersionPreviewFormats(minorVersionFormat = "\$major.\$minor", releaseVersionFormat = "\$major.\$minor.\$service"),
+                    overrides = listOf(VersionPreviewOverride(versionRange = "not-a-range", releaseVersionFormat = "\$major.\$minor")),
+                ),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-059: versionPrefix without versionFormat is rejected (IllegalArgumentException → 400)")
+    fun `SYS-059 prefix without wrapper format rejected`() {
+        assertThrows<IllegalArgumentException> {
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.2.3",
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service",
+                            versionPrefix = "acme",
+                        ),
+                ),
+            )
+        }
+    }
+}

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -67,6 +67,7 @@
 | SYS-056 | `GET /components?releaseManager=<u>` / `?securityChampion=<u>` filter the list to components on which the user is a release manager / security champion (JOIN through the ordered child tables, OR across CSV / repeatable values, distinct); the list summary additionally emits `releaseManagers` / `securityChampions` username arrays (batched, emitted-empty-not-null) | High | integration-test | ✅ Tested |
 | SYS-057 | `GET /rest/api/4/health/statistics` returns registry-wide counts (`totalComponents`, `activeComponents`) and people-dimension breakdowns (`componentsByOwner`, `componentsByReleaseManager`, `componentsBySecurityChampion`) computed via SQL GROUP BY (never by loading all components into memory); ACCESS_COMPONENTS-gated; counts + people only (problem/validation aggregation is portal-owned) | High | integration-test | ✅ Tested |
 | SYS-058 | Artifact-ID ownership is modelled explicitly as a per-component LIST of `(group-list, mode ∈ {EXPLICIT, ALL_EXCEPT_CLAIMED, ALL}, version range)` mappings (`component_artifact_mappings` + `_tokens`), replacing the opaque regex `component_artifact_ids`. Cross-component uniqueness is decided deterministically from the stored modes (restores legacy validator #24/#25), enforced on v4 create/update (409); per-range overrides REPLACE the base for their range; v1–v3 wire renders the primary mapping; migration classifies DSL patterns into modes strictly (no escape hatch) | High | unit + integration-test | ✅ Tested |
+| SYS-059 | `POST /rest/api/4/versions/preview` renders a `DetailedComponentVersion` from ad-hoc Jira formats (base + per-range overrides) and an input version, with no persistence and no component lookup — reusing the persisted-path render seam (including `normalizeVersion` canonicalization) so output matches `detailed-version` for the same effective config. Range is resolved server-side; `line`/`build` mirror `minor`/`release` and `minor`/`release` default to `$major`/`$major.$minor` when blank; hotfix coordinate gated on caller-supplied `hotfixEnabled` (VCS-derived), not format presence; custom `versionPrefix`/`versionFormat` render the wrapped `jiraVersion`; padding is template-driven (no `buildSystem`); blank/non-numeric version or malformed range → 400, a version matching no format → 404; authenticated-only | High | unit + integration-test | ✅ Tested |
 
 ---
 
@@ -2099,3 +2100,81 @@ is invented.
 `SYS-057 statistics groups components by owner RM and SC`,
 `SYS-057 statistics people breakdowns count active components only`,
 `SYS-057 statistics is ACCESS_COMPONENTS gated`.
+
+### SYS-059: Live version-format preview endpoint
+
+**Priority:** High
+**Test layer:** unit + integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+The Portal component editor shows a "Version Preview" of the coordinates a version
+would resolve to. Previously it either rendered client-side (a hand-maintained
+ladder that drifts from the server's real formatter) or called the saved-config
+`detailed-version` endpoint (which reflects the *persisted* config, not the
+*unsaved* edits). For customers with custom version prefixes / zero-padding the
+client ladder cannot faithfully reproduce the server's rendering. A stateless
+server endpoint that renders from the **unsaved** editor config makes the preview
+live and byte-accurate without a save.
+
+**Description:**
+`POST /rest/api/4/versions/preview` (new `VersionsControllerV4`, NOT
+`@ConditionalOnDatabaseEnabled` — rendering only needs the always-present
+`VersionNames` / formatter beans, so it works in git and DB modes). The request
+carries an input `version`, a `base` block of effective Jira formats, and a list
+of per-range `overrides`; there is no persistence and no component lookup.
+
+Server logic (`VersionPreviewService`):
+1. Resolve the range: the first override whose `versionRange` contains the input
+   version wins; the `base` applies when none matches.
+2. Materialise the effective `ComponentVersionFormat` = base overlaid with the
+   matched override's present (non-null) fields. `minorVersionFormat` /
+   `releaseVersionFormat` default to `$major` / `$major.$minor` when blank, and
+   `lineVersionFormat` / `buildVersionFormat` mirror `minorVersionFormat` /
+   `releaseVersionFormat` when blank — matching `EntityMappers.buildJiraComponent`
+   (the persisted DB path); the editor contract documents the same fallbacks.
+3. Canonicalise the input via `JiraComponentVersionFormatter.normalizeVersion(...,
+   strict=false, hotfixEnabled)` — exactly as `getJiraComponentVersion` does: pick
+   the format the version matches, re-render it, and drive ALL coordinates off that
+   clean version. A version matching no format → `null` → `NotFoundException` (404),
+   mirroring the resolver's not-found.
+4. Build a `JiraComponentVersion` from those formats + the clean version and hand
+   it to the existing `Mapper<JiraComponentVersion, DetailedComponentVersion>` — the
+   SAME render seam the persisted `detailed-version` uses, so output is
+   byte-for-byte identical for the same effective config + version.
+
+Field naming mirrors the v4 write contract (`minorVersionFormat` is the
+resolver's `majorVersionFormat`). `buildSystem` is deliberately absent: padding /
+custom-variable expansion is driven purely by the format templates + `VersionNames`.
+Hotfix eligibility is caller-supplied via `hotfixEnabled` (VCS-branch-derived in the
+persisted path, NOT inferred from the presence of a hotfix format); a hotfix
+coordinate renders only when `hotfixEnabled` is true and a hotfix format resolves.
+Custom-component behaviour (`versionPrefix` + `versionFormat`) renders the wrapped
+value on `jiraVersion` while `version` stays the raw template render — exactly the
+dichotomy `detailed-version` already produces. Authenticated-only via the
+`rest/api/4` catch-all; no finer permission since no persisted data is touched.
+
+**Acceptance criteria:**
+1. Base formats render the six coordinates for the input version, matching
+   `detailed-version` for the same effective config.
+2. A version inside an override range renders that range's format; outside → base.
+3. Custom `versionPrefix`/`versionFormat` renders the wrapped `jiraVersion`;
+   `version` stays unwrapped. Zero-padding is driven purely by the format template.
+4. A hotfix coordinate renders only when `hotfixEnabled` is true and a hotfix format
+   resolves; a hotfix format alone (with `hotfixEnabled` false) renders none.
+5. Blank / non-numeric `version`, a malformed override range, or a `versionPrefix`
+   without `versionFormat` → `400`; a version matching none of the supplied formats
+   → `404`.
+6. An authenticated caller gets `200`; an unauthenticated request gets `401`.
+7. Preview output equals `detailed-version` for a real seeded component (parity guard).
+
+**Test method:** `VersionPreviewServiceImplTest` —
+`SYS-059 base render`, `SYS-059 override range selection`,
+`SYS-059 custom prefix render`, `SYS-059 padding is template-driven`,
+`SYS-059 hotfix coordinate`, `SYS-059 unmatched version is not found`,
+`SYS-059 invalid version rejected`,
+`SYS-059 malformed override range rejected`,
+`SYS-059 prefix without wrapper format rejected`; `VersionsControllerV4Test` —
+`SYS-059 authenticated preview returns rendered coordinates`,
+`SYS-059 unauthenticated preview is 401`, `SYS-059 invalid version is 400`,
+`SYS-059 preview matches detailed-version for a real component`.


### PR DESCRIPTION
## What

Adds `POST /rest/api/4/versions/preview` — a **stateless** endpoint that renders a `DetailedComponentVersion` from ad-hoc Jira version formats (a `base` block + per-range `overrides`) and an input version, with **no persistence and no component lookup**. It lets the Portal component editor show a **live, version-accurate** preview of the *unsaved* config, instead of the saved-config `detailed-version` call (CRS issue #402).

## Parity by construction

Preview output equals `GET .../detailed-version` for the same effective config + version, because it reuses the persisted render path:
1. Resolve the range server-side (first override whose range contains the version wins; base otherwise).
2. Materialise the effective `ComponentVersionFormat` — `line`/`build` mirror `minor`/`release`, and `minor`/`release` default to `$major`/`$major.$minor` when blank (matching `EntityMappers.buildJiraComponent`).
3. Canonicalise the version with the same `JiraComponentVersionFormatter.normalizeVersion(..., strict=false, hotfixEnabled)` the resolver's `getJiraComponentVersion` uses, then drive the existing `Mapper<JiraComponentVersion, DetailedComponentVersion>`.

## Notes

- **Not DB-gated** — only needs the always-present `VersionNames`/formatter beans, so it works in git and DB modes.
- **Auth**: authenticated-only via the existing `rest/api/4` catch-all; no finer permission since no persisted data is touched.
- **`buildSystem` deliberately absent** — padding / custom-prefix wrapping is driven purely by the format templates + `VersionNames`.
- **Hotfix** eligibility is caller-supplied `hotfixEnabled` (VCS-branch-derived in the persisted path), not inferred from a hotfix format's presence.
- **4xx**: blank/non-numeric version, malformed range, or prefix-without-format → `400`; version matching no configured format → `404`.
- Field naming mirrors the v4 write contract (`minorVersionFormat` ↔ the resolver's `majorVersionFormat`).

## Tests / gates

- Unit (`VersionPreviewServiceImplTest`): base render, override-range selection, custom prefix (`.version` vs wrapped `.jiraVersion`), template-driven padding, hotfix gating, unmatched→404, invalid/malformed→400.
- Integration (`VersionsControllerV4Test`): 200 authenticated, 401 anonymous, 400 invalid, **and a parity guard** asserting preview == `detailed-version` for a real seeded component (custom prefix + hotfix).
- OpenAPI v4 spec regenerated (`OpenApiV4SpecTest` green); `qualityStatic` green.
- New requirement **SYS-059** in `docs/registry/requirements-common.md`.

This must land in **v3** first so the Portal can regenerate its vendored spec against it (the portal switch is a follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)