### PR TITLE
fix(versions): resolve preview overrides per-field (not one winning override)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImpl.kt
@@ -36,19 +36,23 @@ class VersionPreviewServiceImpl(
             "version '$version' is not a parseable numeric version"
         }
 
-        // Range selection: the first override whose range contains the input
-        // version wins; the base applies when none matches. Range strings are
-        // validated here — a malformed range throws IllegalArgumentException
-        // (→ 400 via ControllerExceptionHandler).
-        val matched =
-            request.overrides.firstOrNull { override ->
-                versionRangeFactory.create(override.versionRange).containsVersion(numericVersion)
-            }
         val base = request.base
 
-        // Effective format = base overlaid with the matched override's present
-        // (non-null) fields.
-        fun effective(select: JiraPreviewFormatFields.() -> String?): String? = matched?.select() ?: base.select()
+        // Per-FIELD override resolution. Overrides are per-(range, attribute): the
+        // editor may override different jira attributes on DIFFERENT ranges (e.g.
+        // releaseVersionFormat on (,1.0.107) and hotfixVersionFormat on (,1.2.471)),
+        // and one version can fall inside several of them. So each field is resolved
+        // independently — the first override that BOTH contains the version AND sets
+        // that field wins; otherwise the base. Reading every field off a single
+        // "winning override" would drop the other attributes' overrides. Range
+        // strings are validated here (a malformed range → IllegalArgumentException
+        // → 400 via ControllerExceptionHandler).
+        fun effective(select: JiraPreviewFormatFields.() -> String?): String? =
+            request.overrides
+                .firstOrNull { override ->
+                    override.select() != null && versionRangeFactory.create(override.versionRange).containsVersion(numericVersion)
+                }?.select()
+                ?: base.select()
 
         val prefix = effective { versionPrefix }
         val wrapperFormat = effective { versionFormat }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/VersionPreviewServiceImplTest.kt
@@ -91,6 +91,48 @@ class VersionPreviewServiceImplTest {
     }
 
     @Test
+    @DisplayName("SYS-059: overrides on DIFFERENT ranges/attributes each resolve per-field (not one winning override)")
+    fun `SYS-059 per-field override resolution across ranges`() {
+        // Reproduces the editor scenario: a release override on (,1.0.107) and a
+        // hotfix override on (,1.2.471). Version 1.0.3-87 falls inside BOTH ranges.
+        // The release coordinate MUST use the release override — regardless of the
+        // hotfix override being listed first — because overrides are per-(range,
+        // attribute), not one winning object.
+        val result =
+            service.preview(
+                VersionPreviewRequest(
+                    version = "1.0.3-87",
+                    hotfixEnabled = true,
+                    base =
+                        VersionPreviewFormats(
+                            minorVersionFormat = "\$major.\$minor",
+                            releaseVersionFormat = "\$major.\$minor.\$service-\$fix",
+                            lineVersionFormat = "\$major.\$minor",
+                            hotfixVersionFormat = "\$major.\$minor.\$service-\$fix-\$build",
+                        ),
+                    overrides =
+                        listOf(
+                            // Listed FIRST so a "first matching override wins" bug would
+                            // pick this one and drop the release override below.
+                            VersionPreviewOverride(
+                                versionRange = "(,1.2.471)",
+                                hotfixVersionFormat = "\$major.\$minor.\$service-\$fix",
+                            ),
+                            VersionPreviewOverride(
+                                versionRange = "(,1.0.107)",
+                                releaseVersionFormat = "\$major.\$minor.\$service",
+                            ),
+                        ),
+                ),
+            )
+
+        // Release uses the (,1.0.107) override "$major.$minor.$service" → "1.0.3"
+        // (NOT the base "$major.$minor.$service-$fix" → "1.0.3-87").
+        assertEquals("1.0.3", result.releaseVersion.version)
+        assertEquals("1.0.3_RC", result.rcVersion.version)
+    }
+
+    @Test
     @DisplayName("SYS-059: custom versionPrefix renders jiraVersion with the wrapper; version stays unwrapped")
     fun `SYS-059 custom prefix render`() {
         val result =


### PR DESCRIPTION
## Bug

The live version-preview (`POST /rest/api/4/versions/preview`, #404) resolved per-range overrides by picking **one** override object — the first whose range contains the input version — and reading *every* effective format field off it. But editor overrides are **per-(range, attribute)**: different jira attributes can be overridden on **different ranges**, and one version can fall inside several.

Repro (from the editor): a **release** override on `(,1.0.107)` and a **hotfix** override on `(,1.2.471)`; input `1.0.3-87` is inside both. The hotfix override sorted first, so it became the single "winner" and the release override was dropped — the Release coordinate rendered from the base format (`$major.$minor.$service-$fix` → `1.0.3-87`) instead of the override (`$major.$minor.$service` → `1.0.3`). This diverged from `detailed-version`, which applies each attribute's override independently.

## Fix

Resolve each field on its own: the first override that **both** contains the version **and** sets that field wins; otherwise the base. This matches the persisted resolver's per-attribute-per-range semantics.

## TDD

- `test:` commit — failing guard reproducing the scenario (release + hotfix overrides on different ranges, version in both, hotfix listed first). RED against the old impl.
- `fix:` commit — per-field resolution. GREEN.

Unit (`SYS-059 per-field override resolution across ranges`) + integration parity + `qualityStatic` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)