### PR TITLE
fix(dist): fail-loud guard on malformed distribution.GAV coordinates (TD-011)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -2416,6 +2416,7 @@ class ComponentManagementServiceImpl(
         config: ComponentConfigurationEntity,
         artifacts: List<MavenArtifactRequest>,
     ) {
+        artifacts.forEach { validateMavenArtifactCoordinate(it) }
         config.mavenArtifacts.clear()
         artifacts.forEachIndexed { index, req ->
             config.mavenArtifacts.add(
@@ -3341,6 +3342,25 @@ class ComponentManagementServiceImpl(
         require(value.isNotBlank()) { "package.packageType must not be blank" }
         require(value in PACKAGE_TYPE_NAMES) {
             "Invalid package.packageType: '$value'. Allowed: $PACKAGE_TYPE_NAMES"
+        }
+    }
+
+    /**
+     * A distribution Maven coordinate must carry BOTH a groupPattern and an
+     * artifactPattern — the structured-DTO equivalent of the import path's
+     * "group:artifact" requirement (parseMavenGavEntry rejects < 2 segments).
+     * A blank field was previously copied verbatim (201), silently persisting a
+     * broken coordinate — symmetric with the import silent-drop. A groupId-only
+     * coordinate (blank artifactPattern) is not supported; see TD-011 / #349
+     * (if groupId-only support is ever added, relax the artifactPattern check).
+     */
+    private fun validateMavenArtifactCoordinate(req: MavenArtifactRequest) {
+        require(req.groupPattern.isNotBlank()) {
+            "distribution.mavenArtifacts: groupPattern must not be blank"
+        }
+        require(req.artifactPattern.isNotBlank()) {
+            "distribution.mavenArtifacts: artifactPattern must not be blank " +
+                "(groupId-only coordinate '${req.groupPattern}' is not supported — see TD-011/#349)"
         }
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -2424,8 +2424,11 @@ class ComponentManagementServiceImpl(
                     componentConfiguration = config,
                     groupPattern = req.groupPattern,
                     artifactPattern = req.artifactPattern,
-                    extension = req.extension,
-                    classifier = req.classifier,
+                    // Normalize blank → null, matching the import path
+                    // (parseMavenGavEntry's `takeIf { isNotEmpty }`), so a v4-written
+                    // "" and an import-written null compare equal in MavenGavCollision.
+                    extension = req.extension?.takeIf { it.isNotBlank() },
+                    classifier = req.classifier?.takeIf { it.isNotBlank() },
                     sortOrder = index,
                 ),
             )
@@ -3361,6 +3364,23 @@ class ComponentManagementServiceImpl(
         require(req.artifactPattern.isNotBlank()) {
             "distribution.mavenArtifacts: artifactPattern must not be blank " +
                 "(groupId-only coordinate '${req.groupPattern}' is not supported — see TD-011/#349)"
+        }
+        // The V1-compat read path (EntityMappers.composeGavCsv) rebuilds the GAV
+        // string as `group:artifact[:ext[:classifier]]` joined by ','. A ':' or
+        // ',' inside any field would silently corrupt that round-trip — the exact
+        // divergence class this guard closes — so reject the separators in every
+        // field (the import path, which splits a raw string on those chars, can
+        // never produce a segment containing them).
+        listOf(
+            "groupPattern" to req.groupPattern,
+            "artifactPattern" to req.artifactPattern,
+            "extension" to req.extension,
+            "classifier" to req.classifier,
+        ).forEach { (field, value) ->
+            require(value == null || (!value.contains(':') && !value.contains(','))) {
+                "distribution.mavenArtifacts: $field must not contain ':' or ',' " +
+                    "(they are the coordinate separators; value='$value')"
+            }
         }
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -3366,20 +3366,22 @@ class ComponentManagementServiceImpl(
                 "(groupId-only coordinate '${req.groupPattern}' is not supported — see TD-011/#349)"
         }
         // The V1-compat read path (EntityMappers.composeGavCsv) rebuilds the GAV
-        // string as `group:artifact[:ext[:classifier]]` joined by ','. A ':' or
-        // ',' inside any field would silently corrupt that round-trip — the exact
-        // divergence class this guard closes — so reject the separators in every
-        // field (the import path, which splits a raw string on those chars, can
-        // never produce a segment containing them).
+        // string as `group:artifact[:ext[:classifier]]`. A ':' inside any field
+        // would silently corrupt that round-trip (re-parsing to a DIFFERENT
+        // coordinate) — the exact divergence class this guard closes — and ':'
+        // is never valid inside a Maven groupId/artifactId/type/classifier. So
+        // reject ':' in every field. NOTE: ',' is NOT rejected — a groupPattern
+        // is legitimately a comma-separated CSV of groups (MavenGavCollision
+        // splits it), a first-class pattern shape.
         listOf(
             "groupPattern" to req.groupPattern,
             "artifactPattern" to req.artifactPattern,
             "extension" to req.extension,
             "classifier" to req.classifier,
         ).forEach { (field, value) ->
-            require(value == null || (!value.contains(':') && !value.contains(','))) {
-                "distribution.mavenArtifacts: $field must not contain ':' or ',' " +
-                    "(they are the coordinate separators; value='$value')"
+            require(value == null || !value.contains(':')) {
+                "distribution.mavenArtifacts: $field must not contain ':' " +
+                    "(the coordinate segment separator; value='$value')"
             }
         }
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DistributionCoordinateGuard.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DistributionCoordinateGuard.kt
@@ -1,0 +1,55 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
+import org.octopusden.octopus.components.registry.server.util.parseMavenGavEntry
+import org.octopusden.octopus.components.registry.server.util.splitCsv
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+
+/**
+ * Fail-loud guard for malformed Maven coordinates in `distribution.GAV`
+ * (TD-011 / #349).
+ *
+ * The import path ([ImportServiceImpl.attachMavenArtifacts]) parses each
+ * comma-separated `distribution.GAV` entry with `parseMavenGavEntry` and
+ * **silently dropped** (`?: continue`) any entry that isn't a valid
+ * `groupId:artifactId[:ext[:classifier]]` — a groupId-only value (no `:`) or a
+ * blank group/artifact segment. That silent drop causes value-level divergence
+ * on the distribution endpoints (a coordinate present in the DSL just vanishes
+ * from the DB-sourced response), invisible to the compat baseline unless such a
+ * component happens to be in the smoke/replay window.
+ *
+ * This guard converts that silent drop into a loud, actionable import failure
+ * that names the component, the raw entry, and the reason — symmetric with the
+ * v4 write-path check ([ComponentManagementServiceImpl.validateMavenArtifactCoordinate]).
+ * `file://` / `http(s)://` entries are NOT Maven coordinates (they are handled by
+ * [ImportServiceImpl.attachFileUrlArtifacts]) and are skipped here, matching the
+ * import's own URL-first branching.
+ *
+ * NOTE (TD-011): the doc's alternative resolution is to *support* a groupId-only
+ * `distribution.GAV` (nullable artifactId, round-tripped). This guard chooses the
+ * fail-loud resolution instead. If groupId-only support is ever added, the
+ * `parts.size < 2` case must be accepted here (and in `parseMavenGavEntry`)
+ * rather than reported.
+ */
+internal fun validateDistributionCoordinates(
+    componentKey: String,
+    configs: List<EscrowModuleConfig>,
+) {
+    val violations = configs.flatMap { cfg ->
+        val gavCsv = cfg.distribution?.GAV() ?: return@flatMap emptyList<String>()
+        splitCsv(gavCsv)
+            .filterNot { it.startsWith("file://") || it.startsWith("http://") || it.startsWith("https://") }
+            .filter { parseMavenGavEntry(it) == null }
+            .map { entry -> "'$entry' (range '${cfg.versionRangeString ?: ALL_VERSIONS}')" }
+    }
+
+    if (violations.isEmpty()) return
+
+    throw IllegalStateException(
+        "Component '$componentKey' has malformed distribution.GAV Maven coordinate(s): " +
+            "${violations.joinToString("; ")}. Each entry must be " +
+            "'groupId:artifactId[:extension[:classifier]]' (a groupId-only value with no ':' is " +
+            "not supported); fix the DSL or use a file://|http(s):// URL for a fileUrl artifact. " +
+            "See TD-011 / CRS #349.",
+    )
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt
@@ -913,6 +913,12 @@ class ImportServiceImpl(
         // migrateAllComponents fails just this component, not the batch).
         validatePerComponentDistributionInvariants(componentKey, configs)
 
+        // TD-011 / CRS #349: reject malformed distribution.GAV Maven coordinates
+        // (groupId-only / blank segment) that the import previously silently
+        // dropped. Fail-loud with component + raw entry + reason; symmetric with
+        // the v4 write-path check. Same per-component try/catch scope as above.
+        validateDistributionCoordinates(componentKey, configs)
+
         // Decoupled version model (ADR-018): the base row is ALWAYS the effective
         // default at ALL_VERSIONS, and coverage is a separate layer expressed as
         // RANGE_PRESENCE rows. `supported = ALL` exactly when the DSL declares no

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
@@ -185,6 +185,63 @@ class V4WriteValidationTest {
     }
 
     @Test
+    @DisplayName("CREATE rejects distribution.mavenArtifacts pattern containing ':' or ',' (round-trip separators)")
+    fun create_rejects_mavenCoordinateWithSeparators() {
+        // A ':' or ',' smuggled into a pattern corrupts the V1-compat GAV CSV
+        // round-trip (EntityMappers.composeGavCsv). The import path can't produce
+        // such a segment; the v4 write path must reject it for symmetry.
+        val colon =
+            """
+            {
+              "name": "validation-test-comp-mvn-colon",
+              "componentOwner": "owner1",
+              "group": {"groupKey": "org.example.test", "isFake": false},
+              "baseConfiguration": {
+                "build": {"buildSystem": "MAVEN"},
+                "mavenArtifacts": [ {"groupPattern": "org.example:injected", "artifactPattern": "alpha"} ]
+              }
+            }
+            """.trimIndent()
+        postCreate(colon).andExpect(status().isBadRequest)
+
+        val comma =
+            """
+            {
+              "name": "validation-test-comp-mvn-comma",
+              "componentOwner": "owner1",
+              "group": {"groupKey": "org.example.test", "isFake": false},
+              "baseConfiguration": {
+                "build": {"buildSystem": "MAVEN"},
+                "mavenArtifacts": [ {"groupPattern": "org.example", "artifactPattern": "alpha,beta"} ]
+              }
+            }
+            """.trimIndent()
+        postCreate(comma).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("PATCH rejects a blank distribution.mavenArtifacts coordinate (symmetric with CREATE)")
+    fun patch_rejects_blankMavenArtifactPattern() {
+        val seedResponse =
+            postCreate(validSeedBody("validation-test-comp-mvn-patch"))
+                .andExpect(status().is2xxSuccessful)
+                .andReturn().response.contentAsString
+        val seed = objectMapper.readTree(seedResponse)
+        val id = seed["id"].asText()
+        val versionLock = seed["version"].asLong()
+        val patchBody =
+            """{"version": $versionLock, "baseConfiguration": {"mavenArtifacts": """ +
+                """[ {"groupPattern": "org.example", "artifactPattern": ""} ]}}"""
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(patchBody),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
     @DisplayName("CREATE accepts a well-formed distribution.mavenArtifacts coordinate")
     fun create_accepts_validMavenCoordinate() {
         val body =

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
@@ -185,11 +185,12 @@ class V4WriteValidationTest {
     }
 
     @Test
-    @DisplayName("CREATE rejects distribution.mavenArtifacts pattern containing ':' or ',' (round-trip separators)")
-    fun create_rejects_mavenCoordinateWithSeparators() {
-        // A ':' or ',' smuggled into a pattern corrupts the V1-compat GAV CSV
-        // round-trip (EntityMappers.composeGavCsv). The import path can't produce
-        // such a segment; the v4 write path must reject it for symmetry.
+    @DisplayName("CREATE rejects a distribution.mavenArtifacts pattern containing ':' (segment separator)")
+    fun create_rejects_mavenCoordinateWithColon() {
+        // A ':' smuggled into a pattern corrupts the V1-compat GAV round-trip
+        // (EntityMappers.composeGavCsv re-parses to a different coordinate). The
+        // import path can't produce such a segment; the v4 write path rejects it
+        // for symmetry. (',' is intentionally allowed — groupPattern is a CSV.)
         val colon =
             """
             {
@@ -203,20 +204,24 @@ class V4WriteValidationTest {
             }
             """.trimIndent()
         postCreate(colon).andExpect(status().isBadRequest)
+    }
 
-        val comma =
+    @Test
+    @DisplayName("CREATE accepts a CSV groupPattern (comma-separated groups are a valid pattern shape)")
+    fun create_accepts_csvGroupPattern() {
+        val body =
             """
             {
-              "name": "validation-test-comp-mvn-comma",
+              "name": "validation-test-comp-mvn-csvgroup",
               "componentOwner": "owner1",
               "group": {"groupKey": "org.example.test", "isFake": false},
               "baseConfiguration": {
                 "build": {"buildSystem": "MAVEN"},
-                "mavenArtifacts": [ {"groupPattern": "org.example", "artifactPattern": "alpha,beta"} ]
+                "mavenArtifacts": [ {"groupPattern": "org.example.a,org.example.b", "artifactPattern": "alpha"} ]
               }
             }
             """.trimIndent()
-        postCreate(comma).andExpect(status().isBadRequest)
+        postCreate(body).andExpect(status().isCreated)
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
@@ -142,6 +142,66 @@ class V4WriteValidationTest {
         postCreate(body).andExpect(status().isBadRequest)
     }
 
+    // ── distribution.mavenArtifacts coordinate validation (TD-011 / #349) ──
+    // Symmetric with the import fail-loud guard: a Maven coordinate must carry
+    // BOTH a groupPattern and an artifactPattern. A blank field is the v4
+    // structured equivalent of the import's "< 2 colon-segments" drop, and was
+    // previously accepted verbatim (201) — a silent-broken-data trap.
+
+    @Test
+    @DisplayName("CREATE rejects distribution.mavenArtifacts[].groupPattern blank")
+    fun create_rejects_blankMavenGroupPattern() {
+        val body =
+            """
+            {
+              "name": "validation-test-comp-mvn-blankgroup",
+              "componentOwner": "owner1",
+              "group": {"groupKey": "org.example.test", "isFake": false},
+              "baseConfiguration": {
+                "build": {"buildSystem": "MAVEN"},
+                "mavenArtifacts": [ {"groupPattern": "", "artifactPattern": "alpha"} ]
+              }
+            }
+            """.trimIndent()
+        postCreate(body).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("CREATE rejects distribution.mavenArtifacts[].artifactPattern blank (groupId-only coordinate)")
+    fun create_rejects_blankMavenArtifactPattern() {
+        val body =
+            """
+            {
+              "name": "validation-test-comp-mvn-blankart",
+              "componentOwner": "owner1",
+              "group": {"groupKey": "org.example.test", "isFake": false},
+              "baseConfiguration": {
+                "build": {"buildSystem": "MAVEN"},
+                "mavenArtifacts": [ {"groupPattern": "org.example", "artifactPattern": ""} ]
+              }
+            }
+            """.trimIndent()
+        postCreate(body).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("CREATE accepts a well-formed distribution.mavenArtifacts coordinate")
+    fun create_accepts_validMavenCoordinate() {
+        val body =
+            """
+            {
+              "name": "validation-test-comp-mvn-ok",
+              "componentOwner": "owner1",
+              "group": {"groupKey": "org.example.test", "isFake": false},
+              "baseConfiguration": {
+                "build": {"buildSystem": "MAVEN"},
+                "mavenArtifacts": [ {"groupPattern": "org.example", "artifactPattern": "alpha", "extension": "jar"} ]
+              }
+            }
+            """.trimIndent()
+        postCreate(body).andExpect(status().isCreated)
+    }
+
     @Test
     @DisplayName("POST /field-overrides rejects scalar build.buildSystem with unknown enum value")
     fun fieldOverride_rejects_unknownBuildSystemScalar() {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DistributionCoordinateGuardTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/DistributionCoordinateGuardTest.kt
@@ -1,0 +1,73 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import java.nio.file.Files
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.octopusden.octopus.components.registry.api.enums.ProductTypes
+import org.octopusden.octopus.escrow.configuration.loader.ComponentRegistryInfo
+import org.octopusden.octopus.escrow.configuration.loader.ConfigLoader
+import org.octopusden.octopus.escrow.configuration.loader.EscrowConfigurationLoader
+import org.octopusden.octopus.escrow.configuration.model.EscrowModuleConfig
+import org.octopusden.releng.versions.VersionNames
+
+/**
+ * TD-011 / #349 — the import must FAIL LOUD on a malformed `distribution.GAV`
+ * Maven coordinate (groupId-only / blank segment) that it previously silently
+ * dropped, and must NOT fire for a well-formed coordinate or a file/http URL
+ * (fileUrl) entry. Driven through the REAL DSL loader over self-contained
+ * fixtures (loader wiring mirrors PerComponentDistributionGuardTest). Plain unit
+ * test — no Spring/DB — so it runs under `:test`.
+ */
+class DistributionCoordinateGuardTest {
+
+    private val versionNames = VersionNames("serviceCBranch", "serviceC", "minorC")
+    private val component = "distComponent"
+
+    private fun loadConfigs(fixture: String): List<EscrowModuleConfig> {
+        val productTypes = ProductTypes.values().associateWith { it.name }
+        val loader = EscrowConfigurationLoader(
+            ConfigLoader(
+                ComponentRegistryInfo.fromClassPath("distribution-coordinate-guard/$fixture"),
+                versionNames,
+                productTypes,
+            ),
+            listOf("org.octopusden.octopus", "io.bcomponent"),
+            listOf("NONE", "CLASSIC", "ALFA"),
+            versionNames,
+            Files.createTempDirectory("dist-coordinate-guard-copyrights"),
+        )
+        val config = loader.loadFullConfigurationWithoutValidationForUnknownAttributes(emptyMap<String, String>())
+        return config.escrowModules[component]!!.moduleConfigurations
+    }
+
+    @Test
+    @DisplayName("fails loud on a groupId-only distribution.GAV (no ':'), naming component + raw entry")
+    fun failsOnBareGroupId() {
+        val ex = assertThrows<IllegalStateException> {
+            validateDistributionCoordinates(component, loadConfigs("BareGroupIdGav.groovy"))
+        }
+        val msg = ex.message!!
+        assertTrue(msg.contains(component), "message names the component: $msg")
+        assertTrue(msg.contains("org.octopusden.octopus.bare"), "message names the raw entry: $msg")
+        assertTrue(msg.contains("groupId:artifactId"), "message states the reason/expected shape: $msg")
+    }
+
+    @Test
+    @DisplayName("does not fire for a well-formed group:artifact:ext coordinate")
+    fun passesOnValidGav() {
+        assertDoesNotThrow {
+            validateDistributionCoordinates(component, loadConfigs("ValidGav.groovy"))
+        }
+    }
+
+    @Test
+    @DisplayName("skips file://|http(s) URL entries (fileUrl artifacts, not Maven coordinates)")
+    fun skipsUrlEntries() {
+        assertDoesNotThrow {
+            validateDistributionCoordinates(component, loadConfigs("UrlGavSkipped.groovy"))
+        }
+    }
+}

--- a/components-registry-service-server/src/test/resources/distribution-coordinate-guard/BareGroupIdGav.groovy
+++ b/components-registry-service-server/src/test/resources/distribution-coordinate-guard/BareGroupIdGav.groovy
@@ -1,0 +1,28 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// TD-011 / #349 fixture — a bare-groupId distribution.GAV (no ':'), which the
+// import previously silently dropped. The guard must fail loud, naming the
+// component + raw entry.
+Defaults {
+    system = "NONE"
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer { versionFormat = '$versionPrefix-$baseVersionFormat' }
+    }
+}
+
+distComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/dist"
+    groupId = "org.octopusden.octopus.dist"
+    distribution {
+        GAV = "org.octopusden.octopus.bare"
+    }
+    jira { projectKey = "DIST" }
+}

--- a/components-registry-service-server/src/test/resources/distribution-coordinate-guard/UrlGavSkipped.groovy
+++ b/components-registry-service-server/src/test/resources/distribution-coordinate-guard/UrlGavSkipped.groovy
@@ -1,0 +1,27 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// A file://|http(s) URL in GAV is a fileUrl artifact, NOT a Maven coordinate —
+// the guard must skip it (no ':' split applies) and NOT fire.
+Defaults {
+    system = "NONE"
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer { versionFormat = '$versionPrefix-$baseVersionFormat' }
+    }
+}
+
+distComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/dist"
+    groupId = "org.octopusden.octopus.dist"
+    distribution {
+        GAV = "file:///as-1.6"
+    }
+    jira { projectKey = "DIST" }
+}

--- a/components-registry-service-server/src/test/resources/distribution-coordinate-guard/ValidGav.groovy
+++ b/components-registry-service-server/src/test/resources/distribution-coordinate-guard/ValidGav.groovy
@@ -1,0 +1,26 @@
+import static org.octopusden.octopus.escrow.BuildSystem.MAVEN
+import static org.octopusden.octopus.escrow.RepositoryType.GIT
+
+// Well-formed group:artifact[:ext] coordinate — the guard must NOT fire.
+Defaults {
+    system = "NONE"
+    buildSystem = MAVEN
+    repositoryType = GIT
+    artifactId = /[\w-]+/
+    tag = '$module-$version'
+    jira {
+        majorVersionFormat = '$major'
+        releaseVersionFormat = '$major.$minor.$service'
+        customer { versionFormat = '$versionPrefix-$baseVersionFormat' }
+    }
+}
+
+distComponent {
+    componentOwner = "user1"
+    vcsUrl = "ssh://git@example/dist"
+    groupId = "org.octopusden.octopus.dist"
+    distribution {
+        GAV = "org.octopusden.octopus.dist:builder:war"
+    }
+    jira { projectKey = "DIST" }
+}


### PR DESCRIPTION
Refs #349 (TD-011). Closes the silent-drop of unparseable Maven `distribution.GAV` coordinates, symmetrically on the import path and the v4 write path.

## Problem
`ImportServiceImpl.attachMavenArtifacts` did `parseMavenGavEntry(entry) ?: continue` — a `distribution.GAV` value that isn't `groupId:artifactId[:ext[:classifier]]` (a groupId-only value with no `:`, or a blank segment) was **silently dropped** at import → value-level divergence on the distribution endpoints, invisible to the compat baseline. The v4 write path was the symmetric gap: `replaceMavenArtifacts` copied `groupPattern`/`artifactPattern` verbatim, so a blank coordinate was accepted (201).

## Change
- **Import (fail-loud):** new `validateDistributionCoordinates(componentKey, configs)` mirroring the #387 `PerComponentDistributionGuard` — a non-URL `distribution.GAV` entry that fails to parse now fails that component's import loudly (component + raw entry + reason), instead of vanishing. Invoked in `importModule` beside the #387 guard, so it runs in the same per-component try/catch (fails just that component, not the batch — same blast radius as #387).
- **v4 write (symmetric):** `validateMavenArtifactCoordinate` rejects blank `groupPattern`/`artifactPattern` on create/PATCH/marker overrides (400), via `replaceMavenArtifacts` (the single funnel).
- **Scope:** DEB/RPM are plain package filenames (not `:`-coordinates) and can't silent-drop, so they're intentionally out of scope; docker accepts a no-colon name as a valid image.

## Decision (fail-loud vs TD-011 "support")
TD-011's doc proposes *supporting* a groupId-only GAV (nullable artifactId, round-tripped). This PR takes the **fail-loud** resolution instead (per request): convert silent data-loss into a clear, actionable failure. No in-repo DSL uses a bare-groupId GAV, so no fixture/import breaks. Both the guard and the validator document how to relax to "support" if that's ever wanted.

## Tests (RED → GREEN)
- `DistributionCoordinateGuardTest` — real-DSL fixtures: bare-groupId → throws (names component + entry + reason); valid `group:artifact:ext` → no throw; `file://` URL → skipped.
- `V4WriteValidationTest` — create with blank `groupPattern` / blank `artifactPattern` → 400; well-formed coordinate → 201. (RED before the fix: blanks were accepted 201.)
- Full `build` + full server `dbTest` green.

**Post-merge:** close #349 manually (auto-close fires only on merge to the default branch `main`, not `v3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)