### PR TITLE
feat(supported-versions): carry Jira task key + change comment onto the audit row

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -500,7 +500,7 @@ class ComponentControllerV4(
     )
     fun setSupportedVersions(
         @PathVariable id: UUID,
-        @RequestBody request: SupportedVersionsRequest,
+        @Valid @RequestBody request: SupportedVersionsRequest,
     ): SupportedVersionsResponse = componentManagementService.setSupportedVersions(id, request)
 
     companion object {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/SupportedVersionsDto.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/SupportedVersionsDto.kt
@@ -1,5 +1,8 @@
 package org.octopusden.octopus.components.registry.server.dto.v4
 
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Pattern
+
 /**
  * The component's **supported versions** (coverage) — the first layer of the decoupled version
  * model (ADR-018), independent of per-attribute overrides. `resolve(v)` returns 404 outside it.
@@ -29,4 +32,22 @@ data class SupportedVersionsResponse(
 data class SupportedVersionsRequest(
     val all: Boolean? = null,
     val ranges: List<String>? = null,
+    // Optional change metadata recorded on the audit row (not on the component) — mirrors
+    // ComponentCreateRequest / ComponentUpdateRequest so a coverage change carries its "why".
+    // A blank/whitespace key is accepted as "no key" (normalized to null); a non-blank key must
+    // match the Jira key format. See JIRA_TASK_KEY_PATTERN.
+    @field:Pattern(
+        regexp = JIRA_TASK_KEY_PATTERN,
+        message = "must be a Jira task key like ABC-123",
+    )
+    @field:Schema(
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+        description = "Optional Jira task key motivating the change (e.g. ABC-123); recorded on the audit row.",
+    )
+    val jiraTaskKey: String? = null,
+    @field:Schema(
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+        description = "Optional free-text comment describing the change; recorded on the audit row.",
+    )
+    val changeComment: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1394,6 +1394,8 @@ class ComponentManagementServiceImpl(
             entityId = component.id.toString(),
             oldValue = mapOf("supportedVersions" to existingPresence.map { it.versionRange }.sortedWith(SUPPORTED_RANGE_ORDER)),
             newValue = mapOf("supportedVersions" to resulting.ifEmpty { listOf("ALL") }),
+            jiraTaskKey = request.jiraTaskKey,
+            changeComment = request.changeComment,
         )
         return SupportedVersionsResponse(all = resulting.isEmpty(), ranges = resulting, warnings = warnings)
     }

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -2153,6 +2153,15 @@
           "all" : {
             "type" : "boolean"
           },
+          "changeComment" : {
+            "description" : "Optional free-text comment describing the change; recorded on the audit row.",
+            "type" : "string"
+          },
+          "jiraTaskKey" : {
+            "description" : "Optional Jira task key motivating the change (e.g. ABC-123); recorded on the audit row.",
+            "pattern" : "^\\s*$|^[A-Z][A-Z0-9]+-\\d+$",
+            "type" : "string"
+          },
           "ranges" : {
             "items" : {
               "type" : "string"

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditChangeMetadataTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditChangeMetadataTest.kt
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.nio.file.Paths
 import java.util.UUID
@@ -165,6 +166,42 @@ class AuditChangeMetadataTest {
         assert(row["changeComment"].asText() == comment) {
             "expected changeComment=$comment, got ${row["changeComment"]}"
         }
+    }
+
+    @Test
+    @DisplayName("setSupportedVersions persists jiraTaskKey + changeComment on the UPDATE audit row")
+    fun setSupportedVersions_persistsMetadata() {
+        val id = createComponent(uniqueName("meta_sv"))
+        val key = "GHI-789"
+        val comment = "limit coverage per ticket"
+        mvc
+            .perform(
+                put("/rest/api/4/components/$id/supported-versions")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"ranges":["[1.0,2.0)"],"jiraTaskKey":"$key","changeComment":"$comment"}""",
+                    ),
+            ).andExpect(status().isOk)
+
+        val row = auditRow(id, "UPDATE")
+        assert(row["jiraTaskKey"].asText() == key) { "expected jiraTaskKey=$key, got ${row["jiraTaskKey"]}" }
+        assert(row["changeComment"].asText() == comment) {
+            "expected changeComment=$comment, got ${row["changeComment"]}"
+        }
+    }
+
+    @Test
+    @DisplayName("setSupportedVersions rejects a malformed jiraTaskKey with 400")
+    fun setSupportedVersions_malformedKey_rejected() {
+        val id = createComponent(uniqueName("meta_sv_bad"))
+        mvc
+            .perform(
+                put("/rest/api/4/components/$id/supported-versions")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"ranges":["[1.0,2.0)"],"jiraTaskKey":"not a key"}"""),
+            ).andExpect(status().isBadRequest)
     }
 
     @Test


### PR DESCRIPTION
The `PUT /components/{id}/supported-versions` endpoint accepted only `{all, ranges}`, so a coverage change made on its own (no scalar component PATCH) could not record the optional Jira task key / change comment the Portal collects at save time — they were silently dropped for supported-versions-only saves.

## Change
- `SupportedVersionsRequest` gains two optional, audit-scoped fields: `jiraTaskKey` (with the shared `JIRA_TASK_KEY_PATTERN` validation) and `changeComment`, mirroring `ComponentCreateRequest`/`ComponentUpdateRequest`.
- The `setSupportedVersions` endpoint now validates the body (`@Valid`); a blank/whitespace key stays a valid "no key" (normalized to null), a non-blank key must match `ABC-123`.
- The two fields are passed into the existing `publishAuditEvent(...)` call in `setSupportedVersions`, so a coverage change carries its "why" onto the audit row.
- Regenerates the committed v4 OpenAPI spec (`generateOpenApiDocs`).

## Tests
- `AuditChangeMetadataTest` (integration / dbTest): new cases — metadata persists on the UPDATE audit row for a coverage PUT, and a malformed Jira key is rejected with 400. Full class green (9 tests).

## Portal side
Paired with the Portal PR that threads `meta` into the supported-versions PUT (variant B for the readiness blocker-3 fix). The Portal vendored schema must be regenerated (`npm run vendor-spec`) from v3 after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)