### PR TITLE
feat(admin): persist operational service events (SYS-060/061)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ApplicationConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ApplicationConfig.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.ConcurrentHashMap
     AdminConfigProperties::class,
     TeamcityProperties::class,
     EmployeeServiceProperties::class,
+    ServiceEventProperties::class,
 )
 class ApplicationConfig(
     val componentsRegistryProperties: ComponentsRegistryProperties,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ServiceEventProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/ServiceEventProperties.kt
@@ -1,0 +1,24 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * SYS-060/061 configuration for the operational service-event journal. Bound from
+ * `components-registry.service-events.*` (defaults below); production wires the
+ * ingest token through `service-config` per env.
+ */
+@ConfigurationProperties(prefix = "components-registry.service-events")
+class ServiceEventProperties(
+    /**
+     * Shared secret required in the `X-Service-Event-Token` header on the portal
+     * ingest endpoint (`POST /rest/api/4/admin/service-events`). BLANK BY DEFAULT →
+     * ingest is disabled and every ingest call is rejected 403 (fail-closed): a
+     * misconfigured/unset token never opens the endpoint to the network. The GET
+     * read side is unaffected (JWT + IMPORT_DATA).
+     */
+    val ingestToken: String = "",
+    /** Retention window in days; the scheduled prune deletes rows older than this. */
+    val retentionDays: Long = 90,
+    /** Cron for the retention prune (default 03:30 UTC daily — off the release/CI path). */
+    val pruneCron: String = "0 30 3 * * *",
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/WebSecurityConfig.kt
@@ -103,6 +103,13 @@ class WebSecurityConfig(
                     // migration era is over (no body detail, just a running flag — no leak).
                     .requestMatchers(HttpMethod.GET, "/rest/api/4/migration-status")
                     .permitAll()
+                    // SYS-061: portal service-event ingest. Tokenless at the filter chain
+                    // (the portal BFF has no JWT — same pattern as /migration-status above),
+                    // guarded instead by a shared-secret header verified in
+                    // ServiceEventIngestControllerV4 (fail-closed). ONLY the POST is opened;
+                    // the sibling GET read stays under the /rest/api/4/** authenticated rule.
+                    .requestMatchers(HttpMethod.POST, "/rest/api/4/admin/service-events")
+                    .permitAll()
                     // v4 writes + admin + audit — authenticated + method-level @PreAuthorize.
                     .requestMatchers("/rest/api/4/**")
                     .authenticated()

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -79,6 +79,16 @@ class AdminControllerV4(
      */
     @PostMapping("/migrate")
     fun migrate(): ResponseEntity<MigrationJobResponse> {
+        // Forbid re-running once the migration is complete: `git` is the count of DSL
+        // (git-sourced) components not yet in the DB, so git==0 means there is nothing left
+        // to migrate. Re-running would only re-do defaults and confuse operators. A partial
+        // state (git>0, e.g. after failures) still allows a retry. Fail-loud (409) so a direct
+        // API caller is blocked too, not only the SPA button.
+        if (importService.getMigrationStatus().git == 0L) {
+            throw MigrationAlreadyCompleteException(
+                "Migration already complete: no git-sourced components remain (git=0). Nothing to migrate.",
+            )
+        }
         val outcome = migrationJobService.startAsync(currentUserResolver.currentUsername())
         val httpStatus = if (outcome.isNewlyStarted) HttpStatus.ACCEPTED else HttpStatus.CONFLICT
         return ResponseEntity.status(httpStatus).body(MigrationJobResponse.from(outcome.state))
@@ -124,6 +134,16 @@ class AdminControllerV4(
     fun handleConfigValidation(e: ConfigValidationException): ResponseEntity<Map<String, Any?>> =
         ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(
             mapOf("error" to "config-validation", "message" to (e.message ?: "Invalid configuration")),
+        )
+
+    /**
+     * Re-running a completed migration (git==0) is a 409 with a distinct `code` so the SPA
+     * can tell it apart from the same-kind attach 409 (which carries a job body).
+     */
+    @ExceptionHandler(MigrationAlreadyCompleteException::class)
+    fun handleMigrationAlreadyComplete(e: MigrationAlreadyCompleteException): ResponseEntity<Map<String, Any?>> =
+        ResponseEntity.status(HttpStatus.CONFLICT).body(
+            mapOf("code" to "migration-complete", "message" to (e.message ?: "Migration already complete")),
         )
 
     @GetMapping("/export")
@@ -241,3 +261,12 @@ class AdminControllerV4(
         )
     }
 }
+
+/**
+ * Thrown by `POST /admin/migrate` when the migration is already complete (no git-sourced
+ * components remain). Mapped to 409 `{code: "migration-complete"}` by the controller so a
+ * finished migration cannot be re-run from the SPA or a direct API call.
+ */
+class MigrationAlreadyCompleteException(
+    message: String,
+) : RuntimeException(message)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -16,6 +16,7 @@ import org.octopusden.octopus.components.registry.server.service.MigrationResult
 import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.ValidationResult
 import org.octopusden.octopus.components.registry.server.service.impl.ConfigValidationException
+import org.octopusden.octopus.components.registry.server.security.CurrentUserResolver
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
 import org.springframework.cloud.context.refresh.ContextRefresher
 import org.springframework.http.HttpStatus
@@ -40,6 +41,7 @@ class AdminControllerV4(
     private val historyMigrationJobService: HistoryMigrationJobService,
     private val teamcitySyncJobService: TeamcitySyncJobService,
     private val contextRefresher: ContextRefresher,
+    private val currentUserResolver: CurrentUserResolver,
 ) {
     @PostMapping("/migrate-component/{name}")
     fun migrateComponent(
@@ -77,7 +79,7 @@ class AdminControllerV4(
      */
     @PostMapping("/migrate")
     fun migrate(): ResponseEntity<MigrationJobResponse> {
-        val outcome = migrationJobService.startAsync()
+        val outcome = migrationJobService.startAsync(currentUserResolver.currentUsername())
         val httpStatus = if (outcome.isNewlyStarted) HttpStatus.ACCEPTED else HttpStatus.CONFLICT
         return ResponseEntity.status(httpStatus).body(MigrationJobResponse.from(outcome.state))
     }
@@ -141,7 +143,7 @@ class AdminControllerV4(
         @RequestParam(required = false) toRef: String?,
         @RequestParam(defaultValue = "false") reset: Boolean,
     ): ResponseEntity<HistoryMigrationJobResponse> {
-        val outcome = historyMigrationJobService.startAsync(toRef, reset)
+        val outcome = historyMigrationJobService.startAsync(toRef, reset, currentUserResolver.currentUsername())
         val httpStatus = if (outcome.isNewlyStarted) HttpStatus.ACCEPTED else HttpStatus.CONFLICT
         return ResponseEntity.status(httpStatus).body(HistoryMigrationJobResponse.from(outcome.state))
     }
@@ -201,7 +203,7 @@ class AdminControllerV4(
      */
     @PostMapping("/teamcity-project-ids/sync")
     fun startTeamcitySync(): ResponseEntity<TeamcitySyncJobResponse> {
-        val outcome = teamcitySyncJobService.startAsync()
+        val outcome = teamcitySyncJobService.startAsync(currentUserResolver.currentUsername())
         val httpStatus = if (outcome.isNewlyStarted) HttpStatus.ACCEPTED else HttpStatus.CONFLICT
         return ResponseEntity.status(httpStatus).body(TeamcitySyncJobResponse.from(outcome.state))
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4.kt
@@ -1,0 +1,51 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventFilter
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventResponse
+import org.octopusden.octopus.components.registry.server.service.ServiceEventQueryService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+/**
+ * SYS-060: read side of the operational service-event journal. IMPORT_DATA-gated,
+ * mirroring [AdminControllerV4] (`@permissionEvaluator.canImport()`) — the portal
+ * Admin "Events" tab lives behind the same operator permission.
+ *
+ * The write/ingest side (POST) is a SEPARATE, method-scoped-permitAll controller
+ * ([ServiceEventIngestControllerV4]) so it can accept tokenless portal calls guarded
+ * by a shared secret instead of a JWT.
+ */
+@ConditionalOnDatabaseEnabled
+@RestController
+@RequestMapping("rest/api/4/admin/service-events")
+@PreAuthorize("@permissionEvaluator.canImport()")
+class ServiceEventControllerV4(
+    private val serviceEventQueryService: ServiceEventQueryService,
+) {
+    /**
+     * Paginated journal, newest first. `eventType` / `source` / `status` are optional
+     * exact filters; `from`/`to` are ISO-8601 instants forming a half-open `[from, to)`
+     * window over `started_at`.
+     */
+    @GetMapping
+    fun list(
+        @RequestParam(required = false) eventType: String?,
+        @RequestParam(required = false) source: String?,
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        pageable: Pageable,
+    ): Page<ServiceEventResponse> =
+        serviceEventQueryService.find(
+            ServiceEventFilter(eventType = eventType, source = source, status = status, from = from, to = to),
+            pageable,
+        )
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
@@ -1,0 +1,115 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
+import org.octopusden.octopus.components.registry.server.config.ServiceEventProperties
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventIngestRequest
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * SYS-061: ingest side of the service-event journal. Lets the portal BFF report its
+ * OWN operational events (portal redeploys, scheduled validation sweeps) into the
+ * shared timeline so the Admin "Events" tab shows both services.
+ *
+ * Auth is a shared-secret header (`X-Service-Event-Token`), NOT a JWT: the portal
+ * BFF calls CRS tokenless today (see the validation sweep's `RegistryClient`), and
+ * this is the same internal-network pattern as the permitAll `/migration-status`
+ * probe. The filter chain permits `POST /rest/api/4/admin/service-events` (see
+ * [org.octopusden.octopus.components.registry.server.config.WebSecurityConfig]) and
+ * the secret is verified HERE — a `@PreAuthorize` cannot read a header.
+ *
+ * FAIL-CLOSED: a blank/unset configured token rejects every call (403), so a
+ * misconfiguration never opens the endpoint to the network. Constant-time compare
+ * avoids leaking the token via timing. A leaked token only lets an attacker forge
+ * journal rows (no component data is mutated); a stronger service-account/OIDC/mTLS
+ * scheme is tracked as a post-cutover follow-up.
+ */
+@ConditionalOnDatabaseEnabled
+@RestController
+@RequestMapping("rest/api/4/admin/service-events")
+class ServiceEventIngestControllerV4(
+    private val serviceEventRecorder: ServiceEventRecorder,
+    private val properties: ServiceEventProperties,
+) {
+    @PostMapping
+    fun ingest(
+        @RequestHeader(name = HEADER_TOKEN, required = false) token: String?,
+        @RequestBody request: ServiceEventIngestRequest,
+    ): ResponseEntity<Any> {
+        if (!tokenAccepted(token)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(mapOf("error" to "forbidden", "message" to "Invalid or missing service-event token"))
+        }
+
+        val type =
+            parseEnum(request.eventType) { ServiceEventType.valueOf(it) }
+                ?: return badRequest("Unknown eventType: ${request.eventType}")
+        val status =
+            parseEnum(request.status) { ServiceEventStatus.valueOf(it) }
+                ?: return badRequest("Unknown status: ${request.status}")
+        val source =
+            ServiceEventSource.fromWire(request.source)
+                ?: return badRequest("Unknown source: ${request.source}")
+
+        // Ingest is for portal-owned, already-terminal events only. Reject a non-terminal
+        // status (a RUNNING row ingested here would never be closed — CRS reconcile only
+        // targets crs rows) and reject a non-portal source (a token holder reports its own
+        // events, and crs rows are owned by this service's in-process emitters).
+        if (status == ServiceEventStatus.RUNNING) {
+            return badRequest("Ingested events must be terminal (COMPLETED/FAILED), not RUNNING")
+        }
+        if (source != ServiceEventSource.PORTAL) {
+            return badRequest("Ingest accepts source=portal only (got: ${request.source})")
+        }
+
+        serviceEventRecorder.recordInstant(
+            type = type,
+            source = source,
+            triggeredBy = request.triggeredBy,
+            status = status,
+            serviceVersion = request.serviceVersion,
+            correlationId = request.correlationId,
+            summary = request.summary,
+            detail = request.detail,
+            startedAt = request.startedAt ?: java.time.Instant.now(),
+            finishedAt = request.finishedAt,
+        )
+        LOG.debug("Ingested service-event: type={}, source={}, status={}", type, source, status)
+        return ResponseEntity.accepted().build()
+    }
+
+    /** Fail-closed constant-time secret check. Blank configured token → always reject. */
+    private fun tokenAccepted(presented: String?): Boolean {
+        val expected = properties.ingestToken
+        if (expected.isBlank() || presented.isNullOrEmpty()) return false
+        return MessageDigest.isEqual(
+            presented.toByteArray(StandardCharsets.UTF_8),
+            expected.toByteArray(StandardCharsets.UTF_8),
+        )
+    }
+
+    private inline fun <T> parseEnum(
+        raw: String,
+        parse: (String) -> T,
+    ): T? = runCatching { parse(raw.trim().uppercase()) }.getOrNull()
+
+    private fun badRequest(message: String): ResponseEntity<Any> =
+        ResponseEntity.badRequest().body(mapOf("error" to "bad-request", "message" to message))
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ServiceEventIngestControllerV4::class.java)
+        const val HEADER_TOKEN = "X-Service-Event-Token"
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import org.octopusden.octopus.components.registry.core.dto.ErrorResponse
 import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.config.ServiceEventProperties
 import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventIngestRequest
@@ -50,7 +51,7 @@ class ServiceEventIngestControllerV4(
     ): ResponseEntity<Any> {
         if (!tokenAccepted(token)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(mapOf("error" to "forbidden", "message" to "Invalid or missing service-event token"))
+                .body(ErrorResponse("Invalid or missing service-event token", "forbidden"))
         }
 
         val type =
@@ -106,7 +107,7 @@ class ServiceEventIngestControllerV4(
     ): T? = runCatching { parse(raw.trim().uppercase()) }.getOrNull()
 
     private fun badRequest(message: String): ResponseEntity<Any> =
-        ResponseEntity.badRequest().body(mapOf("error" to "bad-request", "message" to message))
+        ResponseEntity.badRequest().body(ErrorResponse(message, "bad-request"))
 
     companion object {
         private val LOG = LoggerFactory.getLogger(ServiceEventIngestControllerV4::class.java)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
@@ -113,7 +113,7 @@ class ServiceEventIngestControllerV4(
     private inline fun <T> parseEnum(
         raw: String,
         parse: (String) -> T,
-    ): T? = runCatching { parse(raw.trim().uppercase()) }.getOrNull()
+    ): T? = runCatching { parse(raw.trim().uppercase(java.util.Locale.ROOT)) }.getOrNull()
 
     private fun badRequest(message: String): ResponseEntity<Any> =
         ResponseEntity.badRequest().body(ErrorResponse(message, "bad-request"))

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
@@ -1,5 +1,7 @@
 package org.octopusden.octopus.components.registry.server.controller
 
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.octopusden.octopus.components.registry.core.dto.ErrorResponse
 import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
 import org.octopusden.octopus.components.registry.server.config.ServiceEventProperties
@@ -45,6 +47,11 @@ class ServiceEventIngestControllerV4(
     private val properties: ServiceEventProperties,
 ) {
     @PostMapping
+    @ApiResponses(
+        ApiResponse(responseCode = "202", description = "Event accepted and recorded"),
+        ApiResponse(responseCode = "400", description = "Unknown eventType/status/source, or a non-terminal / non-portal event"),
+        ApiResponse(responseCode = "403", description = "Invalid or missing X-Service-Event-Token"),
+    )
     fun ingest(
         @RequestHeader(name = HEADER_TOKEN, required = false) token: String?,
         @RequestBody request: ServiceEventIngestRequest,
@@ -95,11 +102,13 @@ class ServiceEventIngestControllerV4(
     private fun tokenAccepted(presented: String?): Boolean {
         val expected = properties.ingestToken
         if (expected.isBlank() || presented.isNullOrEmpty()) return false
-        return MessageDigest.isEqual(
-            presented.toByteArray(StandardCharsets.UTF_8),
-            expected.toByteArray(StandardCharsets.UTF_8),
-        )
+        // Compare fixed-length SHA-256 digests so neither the boolean result nor the timing
+        // leaks the token length (MessageDigest.isEqual short-circuits on unequal array lengths).
+        return MessageDigest.isEqual(sha256(presented), sha256(expected))
     }
+
+    private fun sha256(value: String): ByteArray =
+        MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
 
     private inline fun <T> parseEnum(
         raw: String,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4.kt
@@ -36,8 +36,8 @@ import java.security.MessageDigest
  * FAIL-CLOSED: a blank/unset configured token rejects every call (403), so a
  * misconfiguration never opens the endpoint to the network. Constant-time compare
  * avoids leaking the token via timing. A leaked token only lets an attacker forge
- * journal rows (no component data is mutated); a stronger service-account/OIDC/mTLS
- * scheme is tracked as a post-cutover follow-up.
+ * journal rows (no component data is mutated); replacing this with a Keycloak
+ * client-credentials service account is tracked as TD-015 (docs/registry/tech-debt).
  */
 @ConditionalOnDatabaseEnabled
 @RestController

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventFilter.kt
@@ -1,0 +1,15 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import java.time.Instant
+
+/**
+ * SYS-060 filter params for `GET /rest/api/4/admin/service-events`, all independently
+ * optional. `from`/`to` form a half-open `[from, to)` window over `started_at`.
+ */
+data class ServiceEventFilter(
+    val eventType: String? = null,
+    val source: String? = null,
+    val status: String? = null,
+    val from: Instant? = null,
+    val to: Instant? = null,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventIngestRequest.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventIngestRequest.kt
@@ -1,0 +1,25 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import java.time.Instant
+
+/**
+ * SYS-061 — body of `POST /rest/api/4/admin/service-events`, used by the portal BFF
+ * to report its own operational events (portal redeploys, validation sweeps) into the
+ * shared journal. Portal events arrive already-terminal (no RUNNING lifecycle), so
+ * `status` is COMPLETED/FAILED and the timestamps are supplied by the caller.
+ *
+ * `eventType` / `status` / `source` are parsed leniently against the server enums at
+ * the controller boundary; unknown values → 400.
+ */
+data class ServiceEventIngestRequest(
+    val eventType: String,
+    val status: String,
+    val source: String,
+    val triggeredBy: String? = null,
+    val serviceVersion: String? = null,
+    val correlationId: String? = null,
+    val summary: String? = null,
+    val detail: Map<String, Any?>? = null,
+    val startedAt: Instant? = null,
+    val finishedAt: Instant? = null,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventResponse.kt
@@ -1,0 +1,40 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+import org.octopusden.octopus.components.registry.server.entity.ServiceEventEntity
+import java.time.Instant
+
+/**
+ * SYS-060 — wire shape of one operational service-event row, served by
+ * `GET /rest/api/4/admin/service-events`. camelCase (matches [AuditLogResponse]),
+ * consumed by the portal Admin "Events" tab.
+ */
+data class ServiceEventResponse(
+    val id: Long,
+    val eventType: String,
+    val status: String,
+    val source: String,
+    val triggeredBy: String?,
+    val serviceVersion: String?,
+    val correlationId: String?,
+    val summary: String?,
+    val detail: Map<String, Any?>?,
+    val startedAt: Instant,
+    val finishedAt: Instant?,
+) {
+    companion object {
+        fun from(entity: ServiceEventEntity): ServiceEventResponse =
+            ServiceEventResponse(
+                id = entity.id ?: 0L,
+                eventType = entity.eventType,
+                status = entity.status,
+                source = entity.source,
+                triggeredBy = entity.triggeredBy,
+                serviceVersion = entity.serviceVersion,
+                correlationId = entity.correlationId,
+                summary = entity.summary,
+                detail = entity.detail,
+                startedAt = entity.startedAt,
+                finishedAt = entity.finishedAt,
+            )
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventResponse.kt
@@ -24,7 +24,8 @@ data class ServiceEventResponse(
     companion object {
         fun from(entity: ServiceEventEntity): ServiceEventResponse =
             ServiceEventResponse(
-                id = entity.id ?: 0L,
+                // A persisted row always has an id; fail loud rather than emit a misleading 0.
+                id = requireNotNull(entity.id) { "persisted service_event row has a null id" },
                 eventType = entity.eventType,
                 status = entity.status,
                 source = entity.source,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ServiceEventEntity.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/entity/ServiceEventEntity.kt
@@ -1,0 +1,64 @@
+package org.octopusden.octopus.components.registry.server.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+
+/**
+ * SYS-060 — append-only operational service-event row.
+ *
+ * Records JOB RUNS (component/history migration, TeamCity resync, portal
+ * validation sweep) and DEPLOY markers (STARTUP), which today live only in an
+ * in-memory `AtomicReference` + logs and are lost on pod restart. One row per
+ * run: created RUNNING, transitioned in place to COMPLETED/FAILED (matched by
+ * [correlationId]); STARTUP rows are written terminal.
+ *
+ * `detail` mirrors the `audit_log` JSON convention exactly — a plain `TEXT`
+ * column at the DDL level with `@JdbcTypeCode(SqlTypes.JSON)` so Hibernate
+ * serializes/deserializes the `Map<String, Any?>` payload (result counters /
+ * errorMessage). See [AuditLogEntity].
+ */
+@Entity
+@Table(name = "service_event")
+class ServiceEventEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "event_type", nullable = false, length = 40)
+    var eventType: String = "",
+
+    @Column(name = "status", nullable = false, length = 20)
+    var status: String = "",
+
+    @Column(name = "source", nullable = false, length = 20)
+    var source: String = "",
+
+    @Column(name = "triggered_by")
+    var triggeredBy: String? = null,
+
+    @Column(name = "service_version", length = 100)
+    var serviceVersion: String? = null,
+
+    @Column(name = "correlation_id")
+    var correlationId: String? = null,
+
+    @Column(name = "summary", columnDefinition = "TEXT")
+    var summary: String? = null,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "detail", columnDefinition = "TEXT")
+    var detail: Map<String, Any?>? = null,
+
+    @Column(name = "started_at", nullable = false)
+    var startedAt: Instant = Instant.now(),
+
+    @Column(name = "finished_at")
+    var finishedAt: Instant? = null,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/listener/ServiceStartupListener.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/listener/ServiceStartupListener.kt
@@ -1,0 +1,62 @@
+package org.octopusden.octopus.components.registry.server.listener
+
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.boot.info.BuildProperties
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Component
+
+/**
+ * SYS-060: on each pod start, (1) reconcile any service-event rows left RUNNING by a
+ * previous pod that died mid-run — flip them to FAILED("interrupted by restart") so a
+ * job that "failed" by being killed is reported, never left hanging RUNNING — then
+ * (2) write a terminal STARTUP row carrying the build version, giving the Admin
+ * "Events" tab a redeploy history.
+ *
+ * Hooks [ApplicationReadyEvent] (context fully refreshed, DataSource up), NOT the
+ * too-early [org.springframework.boot.context.event.ApplicationStartingEvent] that
+ * [StartupApplicationListener] uses. Ordering with the TeamCity cron is safe: the
+ * scheduled tasks start after context-ready and the resync cron fires Sun 04:00 UTC,
+ * so the reconcile cannot race a freshly-created RUNNING row. (`ApplicationReadyEvent`
+ * fires just after the web server opens, so in theory an admin POST /migrate landing in
+ * the sub-millisecond window before the reconcile runs could have its fresh RUNNING row
+ * flipped to FAILED; negligible in practice on a single pod and self-correcting on the
+ * next run.)
+ *
+ * SINGLE-POD ONLY: the reconcile flips every crs RUNNING row, which would clobber a
+ * peer pod's live run under multi-pod. Prod runs `replicas: 1`; mirror the single-pod
+ * caveats on `AsyncJobLifecycle` / `MigrationStatusControllerV4`. `@ConditionalOnDatabaseEnabled`
+ * keeps it out of the no-db profile.
+ */
+@ConditionalOnDatabaseEnabled
+@Component
+class ServiceStartupListener(
+    private val serviceEventRecorder: ServiceEventRecorder,
+    private val buildProperties: ObjectProvider<BuildProperties>,
+) : ApplicationListener<ApplicationReadyEvent> {
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        val reconciled = serviceEventRecorder.reconcileOrphanedRunning(ServiceEventSource.CRS)
+        if (reconciled > 0) {
+            LOG.warn("Reconciled {} service-event row(s) left RUNNING by a previous pod -> FAILED", reconciled)
+        }
+        // version is nullable on Spring Boot 4 and absent in dev runs without build-info;
+        // fall back to empty so a STARTUP row is still written (matches PortalInfoController).
+        val version = buildProperties.ifAvailable?.version.orEmpty()
+        serviceEventRecorder.recordInstant(
+            type = ServiceEventType.STARTUP,
+            source = ServiceEventSource.CRS,
+            triggeredBy = "system",
+            serviceVersion = version,
+            summary = "components-registry-service started",
+        )
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ServiceStartupListener::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ServiceEventRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ServiceEventRepository.kt
@@ -1,0 +1,58 @@
+package org.octopusden.octopus.components.registry.server.repository
+
+import org.octopusden.octopus.components.registry.server.entity.ServiceEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Repository
+interface ServiceEventRepository :
+    JpaRepository<ServiceEventEntity, Long>,
+    JpaSpecificationExecutor<ServiceEventEntity> {
+    /**
+     * The RUNNING row for a job id, if any. Used by `recordFinish` to transition a
+     * run in place; matching on status (not just correlationId) means a
+     * finish never overwrites an already-terminal row, and the caller falls back
+     * to inserting a terminal row when this returns null (SYS-060).
+     */
+    fun findFirstByCorrelationIdAndStatusOrderByIdDesc(
+        correlationId: String,
+        status: String,
+    ): ServiceEventEntity?
+
+    /**
+     * Reconcile runs interrupted by a pod restart: flip every still-RUNNING row of
+     * a given source to FAILED with a fixed reason + finish time. Single-pod only
+     * (prod replicas=1) — flipping a peer pod's live run would be wrong; see
+     * `ServiceStartupListener`. Returns the number of rows reconciled.
+     */
+    @Modifying
+    @Transactional
+    @Query(
+        """
+        UPDATE ServiceEventEntity e
+        SET e.status = :failed, e.summary = :summary, e.finishedAt = :now
+        WHERE e.source = :source AND e.status = :running
+        """,
+    )
+    fun reconcileRunning(
+        @Param("source") source: String,
+        @Param("running") running: String,
+        @Param("failed") failed: String,
+        @Param("summary") summary: String,
+        @Param("now") now: Instant,
+    ): Int
+
+    /** Retention prune: delete terminal rows older than the cutoff. Returns rows deleted. */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ServiceEventEntity e WHERE e.startedAt < :cutoff")
+    fun deleteByStartedAtBefore(
+        @Param("cutoff") cutoff: Instant,
+    ): Int
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ServiceEventRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ServiceEventRepository.kt
@@ -48,10 +48,15 @@ interface ServiceEventRepository :
         @Param("now") now: Instant,
     ): Int
 
-    /** Retention prune: delete terminal rows older than the cutoff. Returns rows deleted. */
+    /**
+     * Retention prune: delete TERMINAL rows older than the cutoff. RUNNING rows
+     * (finishedAt IS NULL) are never pruned, so a long-running job that outlives the
+     * retention window keeps its row for the in-place recordFinish transition (preserves
+     * one-row-per-run). Returns rows deleted.
+     */
     @Modifying
     @Transactional
-    @Query("DELETE FROM ServiceEventEntity e WHERE e.startedAt < :cutoff")
+    @Query("DELETE FROM ServiceEventEntity e WHERE e.startedAt < :cutoff AND e.finishedAt IS NOT NULL")
     fun deleteByStartedAtBefore(
         @Param("cutoff") cutoff: Instant,
     ): Int

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/HistoryMigrationJobService.kt
@@ -90,10 +90,15 @@ interface HistoryMigrationJobService {
      * [GitHistoryImportService.importHistory]:
      *  - `toRef` defaults to the auto-resolved tag matching the configured prefix;
      *  - `reset=true` is required to re-run on top of a terminal `git_history_import_state` row.
+     *
+     * [triggeredBy] is the actor recorded on the service-event journal row (SYS-060) —
+     * a username for admin-triggered runs. Captured on the caller thread because the
+     * background executor does not carry the security context.
      */
     fun startAsync(
         toRef: String?,
         reset: Boolean,
+        triggeredBy: String = "system",
     ): StartHistoryMigrationResult
 
     /**

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/MigrationJobService.kt
@@ -76,8 +76,12 @@ interface MigrationJobService {
      *
      * COMPLETED / FAILED states do not block: a new call after a finished job replaces
      * the slot.
+     *
+     * [triggeredBy] is the actor recorded on the service-event journal row (SYS-060) —
+     * a username for admin-triggered runs. Captured on the caller thread because the
+     * background executor does not carry the security context.
      */
-    fun startAsync(): StartMigrationResult
+    fun startAsync(triggeredBy: String = "system"): StartMigrationResult
 
     /** Latest known job state, or `null` if no job has been started since the pod booted. */
     fun current(): MigrationJobState?

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventModel.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventModel.kt
@@ -1,0 +1,54 @@
+package org.octopusden.octopus.components.registry.server.service
+
+/**
+ * SYS-060: domain enums for the operational service-event journal (`service_event`).
+ *
+ * Stored as their `name()` string in the entity (like `audit_log.action` / `.source`)
+ * rather than as a JPA `@Enumerated` column, so a new value added here never risks an
+ * ordinal shift and unknown values read back gracefully. Validation happens at the
+ * recorder / ingest boundary.
+ */
+enum class ServiceEventType {
+    /** A service process (re)started. `serviceVersion` carries the build version. */
+    STARTUP,
+
+    /** Git→DB components migration run. */
+    MIGRATION_COMPONENTS,
+
+    /** Git-history backfill run. */
+    MIGRATION_HISTORY,
+
+    /** TeamCity project-id/url resync run. */
+    TEAMCITY_RESYNC,
+
+    /** Portal-owned scheduled component-validation sweep run (source=portal). */
+    VALIDATION_SWEEP,
+}
+
+/** Lifecycle status of a service-event row. STARTUP rows are written terminal (COMPLETED). */
+enum class ServiceEventStatus {
+    RUNNING,
+    COMPLETED,
+    FAILED,
+}
+
+/** Which service emitted the event. */
+enum class ServiceEventSource {
+    /** components-registry-service (this service). */
+    CRS,
+
+    /** components-management-portal BFF. */
+    PORTAL,
+    ;
+
+    /**
+     * Wire form is lowercase (`crs` / `portal`) to match the `service_event.source`
+     * DDL comment and the portal ingest contract; parsing is case-insensitive.
+     */
+    val wire: String get() = name.lowercase()
+
+    companion object {
+        fun fromWire(value: String): ServiceEventSource? =
+            entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventModel.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventModel.kt
@@ -1,5 +1,7 @@
 package org.octopusden.octopus.components.registry.server.service
 
+import java.util.Locale
+
 /**
  * SYS-060: domain enums for the operational service-event journal (`service_event`).
  *
@@ -45,7 +47,7 @@ enum class ServiceEventSource {
      * Wire form is lowercase (`crs` / `portal`) to match the `service_event.source`
      * DDL comment and the portal ingest contract; parsing is case-insensitive.
      */
-    val wire: String get() = name.lowercase()
+    val wire: String get() = name.lowercase(Locale.ROOT)
 
     companion object {
         fun fromWire(value: String): ServiceEventSource? =

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventQueryService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventQueryService.kt
@@ -1,0 +1,15 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventFilter
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+/** SYS-060: read side of the service-event journal. */
+interface ServiceEventQueryService {
+    /** Paginated events matching [filter], newest first by `started_at` when unsorted. */
+    fun find(
+        filter: ServiceEventFilter,
+        pageable: Pageable,
+    ): Page<ServiceEventResponse>
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventRecorder.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventRecorder.kt
@@ -1,0 +1,108 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import java.time.Instant
+
+/**
+ * SYS-060: records operational service events into the append-only `service_event`
+ * journal. Every method is **best-effort** — a journal write must never roll back
+ * or crash the job/boot it observes, so failures are caught and logged, not
+ * propagated. Each write runs in its own `REQUIRES_NEW` transaction (the callers
+ * run on background-executor / startup threads that carry no ambient transaction).
+ *
+ * Lifecycle contract for a job run:
+ *  - [recordStart] once, at the top of the work runnable → a RUNNING row.
+ *  - [recordFinish] once, at the terminal branch → transitions that RUNNING row
+ *    in place to COMPLETED/FAILED. If no RUNNING row exists (e.g. the executor
+ *    rejected the submission before the runnable ran), it inserts a terminal row
+ *    instead, so a failure is never silently lost.
+ *
+ * [recordInstant] writes a single terminal row in one shot — used for STARTUP
+ * markers and for portal-sourced events (validation sweeps, portal redeploys)
+ * that arrive already-terminal over the ingest endpoint.
+ */
+interface ServiceEventRecorder {
+    fun recordStart(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        summary: String?,
+    )
+
+    fun recordFinish(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        status: ServiceEventStatus,
+        summary: String?,
+        detail: Map<String, Any?>?,
+    )
+
+    @Suppress("LongParameterList") // A service-event is a flat record; each field is independent.
+    fun recordInstant(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        status: ServiceEventStatus = ServiceEventStatus.COMPLETED,
+        serviceVersion: String? = null,
+        correlationId: String? = null,
+        summary: String? = null,
+        detail: Map<String, Any?>? = null,
+        startedAt: Instant = Instant.now(),
+        finishedAt: Instant? = null,
+    )
+
+    /**
+     * Flip every still-RUNNING row of [source] to FAILED ("interrupted by restart").
+     * Called once on startup; single-pod only. Returns rows reconciled.
+     */
+    fun reconcileOrphanedRunning(source: ServiceEventSource): Int
+
+    /** Delete rows started before [cutoff]. Returns rows pruned. */
+    fun prune(cutoff: Instant): Int
+}
+
+/**
+ * Inert recorder. Used as the default constructor arg on the async job impls so unit
+ * tests that don't care about journaling can construct them without a recorder; Spring
+ * injects the real [ServiceEventRecorder] bean in production (a Kotlin-optional param is
+ * still autowired when a matching bean exists). Also the safe no-op in the no-db profile,
+ * where no recorder bean is registered.
+ */
+object NoOpServiceEventRecorder : ServiceEventRecorder {
+    override fun recordStart(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        summary: String?,
+    ) = Unit
+
+    override fun recordFinish(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        status: ServiceEventStatus,
+        summary: String?,
+        detail: Map<String, Any?>?,
+    ) = Unit
+
+    override fun recordInstant(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        status: ServiceEventStatus,
+        serviceVersion: String?,
+        correlationId: String?,
+        summary: String?,
+        detail: Map<String, Any?>?,
+        startedAt: Instant,
+        finishedAt: Instant?,
+    ) = Unit
+
+    override fun reconcileOrphanedRunning(source: ServiceEventSource): Int = 0
+
+    override fun prune(cutoff: Instant): Int = 0
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventRetentionScheduler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventRetentionScheduler.kt
@@ -1,0 +1,44 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
+import org.octopusden.octopus.components.registry.server.config.ServiceEventProperties
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * SYS-060 retention: the `service_event` journal is append-only and grows on every
+ * redeploy and every validation sweep, while a pod can run for weeks between releases
+ * — so pruning must be SCHEDULED, not startup-only (a startup-only prune never runs on
+ * a long-lived pod). Deletes rows older than `retention-days` daily (best-effort, via
+ * the recorder). Delete-by-timestamp is idempotent, so it is safe even were it ever to
+ * run on more than one pod; prod is single-pod regardless.
+ *
+ * Carries `@EnableScheduling` so the app-wide scheduler is active whenever the DB layer
+ * is (the only other scheduled bean, `TeamcitySyncScheduler`, is gated on a TC property
+ * and cannot be relied on to enable scheduling here). `@ConditionalOnDatabaseEnabled`
+ * keeps it out of the no-db profile.
+ */
+@ConditionalOnDatabaseEnabled
+@Component
+@EnableScheduling
+class ServiceEventRetentionScheduler(
+    private val serviceEventRecorder: ServiceEventRecorder,
+    private val properties: ServiceEventProperties,
+) {
+    @Scheduled(cron = "\${components-registry.service-events.prune-cron:0 30 3 * * *}", zone = "UTC")
+    fun prune() {
+        val cutoff = Instant.now().minus(Duration.ofDays(properties.retentionDays))
+        val pruned = serviceEventRecorder.prune(cutoff)
+        if (pruned > 0) {
+            LOG.info("Pruned {} service-event row(s) older than {} days", pruned, properties.retentionDays)
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ServiceEventRetentionScheduler::class.java)
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -26,6 +26,7 @@ import org.springframework.core.task.TaskExecutor
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.RejectedExecutionException
 
 /**
  * In-memory async wrapper around [GitHistoryImportService.importHistory].
@@ -79,11 +80,10 @@ class HistoryMigrationJobServiceImpl(
                     buildCandidate = ::buildCandidate,
                     work = { jobId -> runHistoryMigration(jobId, toRef, reset, triggeredBy) },
                 )
-            } catch (
-                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
-            ) {
-                // Executor rejected submission (pod shutdown): runnable never ran, so
-                // recordStart never fired. Record a standalone terminal FAILED (SYS-060).
+            } catch (rejected: RejectedExecutionException) {
+                // ONLY executor-rejection (pod shutdown): runnable never ran, so recordStart
+                // never fired — record a standalone terminal FAILED (SYS-060). A cross-kind
+                // MigrationConflictException is NOT a failure and is deliberately not caught here.
                 serviceEventRecorder.recordInstant(
                     type = ServiceEventType.MIGRATION_HISTORY,
                     source = ServiceEventSource.CRS,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/HistoryMigrationJobServiceImpl.kt
@@ -14,6 +14,11 @@ import org.octopusden.octopus.components.registry.server.service.HistoryRecovery
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
+import org.octopusden.octopus.components.registry.server.service.NoOpServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
 import org.octopusden.octopus.components.registry.server.service.StartHistoryMigrationResult
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -43,6 +48,7 @@ class HistoryMigrationJobServiceImpl(
     @Qualifier("migrationExecutor") executor: TaskExecutor,
     lifecycleGate: MigrationLifecycleGate,
     private val forceResetter: HistoryForceResetter,
+    private val serviceEventRecorder: ServiceEventRecorder = NoOpServiceEventRecorder,
 ) : HistoryMigrationJobService {
     private val lifecycle =
         AsyncJobLifecycle<HistoryMigrationJobState>(
@@ -65,12 +71,29 @@ class HistoryMigrationJobServiceImpl(
     override fun startAsync(
         toRef: String?,
         reset: Boolean,
+        triggeredBy: String,
     ): StartHistoryMigrationResult {
         val outcome =
-            lifecycle.claimAndSubmit(
-                buildCandidate = ::buildCandidate,
-                work = { jobId -> runHistoryMigration(jobId, toRef, reset) },
-            )
+            try {
+                lifecycle.claimAndSubmit(
+                    buildCandidate = ::buildCandidate,
+                    work = { jobId -> runHistoryMigration(jobId, toRef, reset, triggeredBy) },
+                )
+            } catch (
+                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
+            ) {
+                // Executor rejected submission (pod shutdown): runnable never ran, so
+                // recordStart never fired. Record a standalone terminal FAILED (SYS-060).
+                serviceEventRecorder.recordInstant(
+                    type = ServiceEventType.MIGRATION_HISTORY,
+                    source = ServiceEventSource.CRS,
+                    triggeredBy = triggeredBy,
+                    status = ServiceEventStatus.FAILED,
+                    summary = "History migration failed to start",
+                    detail = mapOf("errorMessage" to (rejected.message ?: rejected::class.java.simpleName)),
+                )
+                throw rejected
+            }
         return when (outcome) {
             is AsyncJobLifecycle.ClaimOutcome.Attached ->
                 StartHistoryMigrationResult(outcome.state, isNewlyStarted = false)
@@ -226,7 +249,15 @@ class HistoryMigrationJobServiceImpl(
         jobId: String,
         toRef: String?,
         reset: Boolean,
+        triggeredBy: String,
     ) {
+        serviceEventRecorder.recordStart(
+            type = ServiceEventType.MIGRATION_HISTORY,
+            source = ServiceEventSource.CRS,
+            triggeredBy = triggeredBy,
+            correlationId = jobId,
+            summary = "History migration running",
+        )
         try {
             val result = gitHistoryImportService.importHistory(toRef, reset, progressListener(jobId))
             lifecycle.update(jobId) { current ->
@@ -254,6 +285,23 @@ class HistoryMigrationJobServiceImpl(
                 result.auditRecords,
                 result.durationMs,
             )
+            serviceEventRecorder.recordFinish(
+                type = ServiceEventType.MIGRATION_HISTORY,
+                source = ServiceEventSource.CRS,
+                triggeredBy = triggeredBy,
+                correlationId = jobId,
+                status = ServiceEventStatus.COMPLETED,
+                summary = "History migration completed",
+                detail =
+                    mapOf(
+                        "processedCommits" to result.processedCommits,
+                        "auditRecords" to result.auditRecords,
+                        "skippedNoGroovy" to result.skippedNoGroovy,
+                        "skippedParseError" to result.skippedParseError,
+                        "skippedUnknownNames" to result.skippedUnknownNames,
+                        "durationMs" to result.durationMs,
+                    ),
+            )
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Throwable,
         ) {
@@ -271,6 +319,15 @@ class HistoryMigrationJobServiceImpl(
                     recoveryAction = HistoryRecoveryAction.RETRY,
                 )
             }
+            serviceEventRecorder.recordFinish(
+                type = ServiceEventType.MIGRATION_HISTORY,
+                source = ServiceEventSource.CRS,
+                triggeredBy = triggeredBy,
+                correlationId = jobId,
+                status = ServiceEventStatus.FAILED,
+                summary = "History migration failed",
+                detail = mapOf("errorMessage" to (e.message ?: e::class.java.simpleName)),
+            )
         } finally {
             lifecycle.release(jobId)
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
@@ -11,6 +11,11 @@ import org.octopusden.octopus.components.registry.server.service.MigrationLifecy
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
 import org.octopusden.octopus.components.registry.server.service.MigrationPhase
 import org.octopusden.octopus.components.registry.server.service.MigrationProgressListener
+import org.octopusden.octopus.components.registry.server.service.NoOpServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
 import org.octopusden.octopus.components.registry.server.service.StartMigrationResult
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -47,6 +52,7 @@ class MigrationJobServiceImpl(
     private val importService: ImportService,
     @Qualifier("migrationExecutor") executor: TaskExecutor,
     lifecycleGate: MigrationLifecycleGate,
+    private val serviceEventRecorder: ServiceEventRecorder = NoOpServiceEventRecorder,
 ) : MigrationJobService {
     private val lifecycle =
         AsyncJobLifecycle<MigrationJobState>(
@@ -66,12 +72,28 @@ class MigrationJobServiceImpl(
             },
         )
 
-    override fun startAsync(): StartMigrationResult {
+    override fun startAsync(triggeredBy: String): StartMigrationResult {
         val outcome =
-            lifecycle.claimAndSubmit(
-                buildCandidate = ::buildCandidate,
-                work = ::runMigration,
-            )
+            try {
+                lifecycle.claimAndSubmit(
+                    buildCandidate = ::buildCandidate,
+                    work = { jobId -> runMigration(jobId, triggeredBy) },
+                )
+            } catch (
+                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
+            ) {
+                // Executor rejected submission (pod shutdown): runnable never ran, so
+                // recordStart never fired. Record a standalone terminal FAILED (SYS-060).
+                serviceEventRecorder.recordInstant(
+                    type = ServiceEventType.MIGRATION_COMPONENTS,
+                    source = ServiceEventSource.CRS,
+                    triggeredBy = triggeredBy,
+                    status = ServiceEventStatus.FAILED,
+                    summary = "Components migration failed to start",
+                    detail = mapOf("errorMessage" to (rejected.message ?: rejected::class.java.simpleName)),
+                )
+                throw rejected
+            }
         return when (outcome) {
             is AsyncJobLifecycle.ClaimOutcome.Attached -> StartMigrationResult(outcome.state, isNewlyStarted = false)
             is AsyncJobLifecycle.ClaimOutcome.Started -> StartMigrationResult(outcome.state, isNewlyStarted = true)
@@ -106,7 +128,17 @@ class MigrationJobServiceImpl(
             phase = MigrationPhase.DEFAULTS,
         )
 
-    private fun runMigration(jobId: String) {
+    private fun runMigration(
+        jobId: String,
+        triggeredBy: String,
+    ) {
+        serviceEventRecorder.recordStart(
+            type = ServiceEventType.MIGRATION_COMPONENTS,
+            source = ServiceEventSource.CRS,
+            triggeredBy = triggeredBy,
+            correlationId = jobId,
+            summary = "Components migration running",
+        )
         try {
             // phase=DEFAULTS was already published by buildCandidate(); we don't
             // re-set it here because a) it's already correct, b) re-publishing
@@ -143,6 +175,21 @@ class MigrationJobServiceImpl(
                 components.failed,
                 components.skipped,
             )
+            serviceEventRecorder.recordFinish(
+                type = ServiceEventType.MIGRATION_COMPONENTS,
+                source = ServiceEventSource.CRS,
+                triggeredBy = triggeredBy,
+                correlationId = jobId,
+                status = ServiceEventStatus.COMPLETED,
+                summary = "Components migration completed",
+                detail =
+                    mapOf(
+                        "total" to components.total,
+                        "migrated" to components.migrated,
+                        "failed" to components.failed,
+                        "skipped" to components.skipped,
+                    ),
+            )
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Throwable,
         ) {
@@ -156,6 +203,15 @@ class MigrationJobServiceImpl(
                     errorMessage = e.message ?: e::class.java.simpleName,
                 )
             }
+            serviceEventRecorder.recordFinish(
+                type = ServiceEventType.MIGRATION_COMPONENTS,
+                source = ServiceEventSource.CRS,
+                triggeredBy = triggeredBy,
+                correlationId = jobId,
+                status = ServiceEventStatus.FAILED,
+                summary = "Components migration failed",
+                detail = mapOf("errorMessage" to (e.message ?: e::class.java.simpleName)),
+            )
         } finally {
             // Always release the cross-kind gate, even on failure / unhandled
             // throw, so a follow-up history migration isn't blocked forever by

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/MigrationJobServiceImpl.kt
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.task.TaskExecutor
 import org.springframework.stereotype.Service
 import java.time.Instant
+import java.util.concurrent.RejectedExecutionException
 
 /**
  * In-memory async wrapper around [ImportService.migrate]. Lifecycle boilerplate
@@ -79,11 +80,10 @@ class MigrationJobServiceImpl(
                     buildCandidate = ::buildCandidate,
                     work = { jobId -> runMigration(jobId, triggeredBy) },
                 )
-            } catch (
-                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
-            ) {
-                // Executor rejected submission (pod shutdown): runnable never ran, so
-                // recordStart never fired. Record a standalone terminal FAILED (SYS-060).
+            } catch (rejected: RejectedExecutionException) {
+                // ONLY executor-rejection (pod shutdown): runnable never ran, so recordStart
+                // never fired — record a standalone terminal FAILED (SYS-060). A cross-kind
+                // MigrationConflictException is NOT a failure and is deliberately not caught here.
                 serviceEventRecorder.recordInstant(
                     type = ServiceEventType.MIGRATION_COMPONENTS,
                     source = ServiceEventSource.CRS,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
@@ -1,0 +1,63 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventFilter
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventResponse
+import org.octopusden.octopus.components.registry.server.entity.ServiceEventEntity
+import org.octopusden.octopus.components.registry.server.repository.ServiceEventRepository
+import org.octopusden.octopus.components.registry.server.service.ServiceEventQueryService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@ConditionalOnDatabaseEnabled
+@Service
+@Transactional(readOnly = true)
+class ServiceEventQueryServiceImpl(
+    private val serviceEventRepository: ServiceEventRepository,
+) : ServiceEventQueryService {
+    override fun find(
+        filter: ServiceEventFilter,
+        pageable: Pageable,
+    ): Page<ServiceEventResponse> =
+        serviceEventRepository
+            .findAll(buildSpecification(filter), withDefaultSort(pageable))
+            .map(ServiceEventResponse::from)
+
+    // The journal is a timeline: newest first by started_at unless the caller asked otherwise.
+    private fun withDefaultSort(pageable: Pageable): Pageable =
+        if (pageable.sort.isUnsorted) {
+            PageRequest.of(pageable.pageNumber, pageable.pageSize, Sort.by(Sort.Direction.DESC, "startedAt"))
+        } else {
+            pageable
+        }
+
+    private fun buildSpecification(filter: ServiceEventFilter): Specification<ServiceEventEntity> {
+        var spec = Specification.where<ServiceEventEntity>(null)
+
+        filter.eventType?.takeIf { it.isNotBlank() }?.let { eventType ->
+            // Case-insensitive, mirroring the source/status filters below: stored values are the
+            // uppercase enum name(), so a caller passing `startup` / `teamcity_resync` still matches.
+            spec = spec.and(Specification { root, _, cb -> cb.equal(cb.upper(root.get("eventType")), eventType.uppercase()) })
+        }
+        filter.source?.takeIf { it.isNotBlank() }?.let { source ->
+            // Match the stored lowercase wire form regardless of caller casing.
+            spec = spec.and(Specification { root, _, cb -> cb.equal(cb.lower(root.get("source")), source.lowercase()) })
+        }
+        filter.status?.takeIf { it.isNotBlank() }?.let { status ->
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("status"), status.uppercase()) })
+        }
+        filter.from?.let { from ->
+            spec = spec.and(Specification { root, _, cb -> cb.greaterThanOrEqualTo(root.get<Instant>("startedAt"), from) })
+        }
+        filter.to?.let { to ->
+            spec = spec.and(Specification { root, _, cb -> cb.lessThan(root.get<Instant>("startedAt"), to) })
+        }
+        return spec
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.util.Locale
 
 @ConditionalOnDatabaseEnabled
 @Service
@@ -45,13 +46,13 @@ class ServiceEventQueryServiceImpl(
         // Applying upper()/lower() to the column instead would defeat the btree indexes on
         // event_type / source / status as the journal grows.
         filter.eventType?.takeIf { it.isNotBlank() }?.let { eventType ->
-            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("eventType"), eventType.uppercase()) })
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("eventType"), eventType.uppercase(Locale.ROOT)) })
         }
         filter.source?.takeIf { it.isNotBlank() }?.let { source ->
-            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("source"), source.lowercase()) })
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("source"), source.lowercase(Locale.ROOT)) })
         }
         filter.status?.takeIf { it.isNotBlank() }?.let { status ->
-            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("status"), status.uppercase()) })
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("status"), status.uppercase(Locale.ROOT)) })
         }
         filter.from?.let { from ->
             spec = spec.and(Specification { root, _, cb -> cb.greaterThanOrEqualTo(root.get<Instant>("startedAt"), from) })

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
@@ -40,14 +40,15 @@ class ServiceEventQueryServiceImpl(
     private fun buildSpecification(filter: ServiceEventFilter): Specification<ServiceEventEntity> {
         var spec = Specification.where<ServiceEventEntity>(null)
 
+        // Stored values are already canonical (enum name() for eventType/status, lowercase
+        // `wire` for source), so normalize the INPUT and compare directly against the column.
+        // Applying upper()/lower() to the column instead would defeat the btree indexes on
+        // event_type / source / status as the journal grows.
         filter.eventType?.takeIf { it.isNotBlank() }?.let { eventType ->
-            // Case-insensitive, mirroring the source/status filters below: stored values are the
-            // uppercase enum name(), so a caller passing `startup` / `teamcity_resync` still matches.
-            spec = spec.and(Specification { root, _, cb -> cb.equal(cb.upper(root.get("eventType")), eventType.uppercase()) })
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("eventType"), eventType.uppercase()) })
         }
         filter.source?.takeIf { it.isNotBlank() }?.let { source ->
-            // Match the stored lowercase wire form regardless of caller casing.
-            spec = spec.and(Specification { root, _, cb -> cb.equal(cb.lower(root.get("source")), source.lowercase()) })
+            spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("source"), source.lowercase()) })
         }
         filter.status?.takeIf { it.isNotBlank() }?.let { status ->
             spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("status"), status.uppercase()) })

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderImpl.kt
@@ -1,0 +1,184 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
+import org.octopusden.octopus.components.registry.server.entity.ServiceEventEntity
+import org.octopusden.octopus.components.registry.server.repository.ServiceEventRepository
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Instant
+
+/**
+ * Best-effort recorder. Each write goes through a `REQUIRES_NEW` [TransactionTemplate]
+ * so it commits (or rolls back) independently of any surrounding transaction, wrapped
+ * in a `try/catch` OUTSIDE the transaction so a failed/rolled-back journal write is
+ * swallowed with a WARN rather than propagated into the job/boot that triggered it.
+ *
+ * Mirrors the `REQUIRES_NEW`-per-write precedent of
+ * [org.octopusden.octopus.components.registry.server.service.impl.GitHistoryCommitWriter],
+ * but keeps the fail-safe wrapper in the same class via an explicit template rather
+ * than relying on self-invocation proxying.
+ */
+@ConditionalOnDatabaseEnabled
+@Service
+class ServiceEventRecorderImpl(
+    private val repository: ServiceEventRepository,
+    transactionManager: PlatformTransactionManager,
+) : ServiceEventRecorder {
+    private val requiresNew =
+        TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+
+    override fun recordStart(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        summary: String?,
+    ) = safe("recordStart", type, correlationId) {
+        requiresNew.executeWithoutResult {
+            repository.save(
+                ServiceEventEntity(
+                    eventType = type.name,
+                    status = ServiceEventStatus.RUNNING.name,
+                    source = source.wire,
+                    triggeredBy = triggeredBy,
+                    correlationId = correlationId,
+                    summary = summary,
+                    startedAt = Instant.now(),
+                ),
+            )
+        }
+    }
+
+    override fun recordFinish(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        status: ServiceEventStatus,
+        summary: String?,
+        detail: Map<String, Any?>?,
+    ) = safe("recordFinish", type, correlationId) {
+        requiresNew.executeWithoutResult {
+            val running =
+                repository.findFirstByCorrelationIdAndStatusOrderByIdDesc(
+                    correlationId,
+                    ServiceEventStatus.RUNNING.name,
+                )
+            val now = Instant.now()
+            if (running != null) {
+                running.status = status.name
+                running.finishedAt = now
+                summary?.let { running.summary = it }
+                detail?.let { running.detail = it }
+                repository.save(running)
+            } else {
+                // No RUNNING row to close (e.g. the executor rejected the submission
+                // before the runnable ran, so recordStart never fired). Insert a
+                // terminal row so the failure is still recorded (SYS-060).
+                repository.save(
+                    ServiceEventEntity(
+                        eventType = type.name,
+                        status = status.name,
+                        source = source.wire,
+                        triggeredBy = triggeredBy,
+                        correlationId = correlationId,
+                        summary = summary,
+                        detail = detail,
+                        startedAt = now,
+                        finishedAt = now,
+                    ),
+                )
+            }
+        }
+    }
+
+    override fun recordInstant(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        status: ServiceEventStatus,
+        serviceVersion: String?,
+        correlationId: String?,
+        summary: String?,
+        detail: Map<String, Any?>?,
+        startedAt: Instant,
+        finishedAt: Instant?,
+    ) = safe("recordInstant", type, correlationId) {
+        requiresNew.executeWithoutResult {
+            repository.save(
+                ServiceEventEntity(
+                    eventType = type.name,
+                    status = status.name,
+                    source = source.wire,
+                    triggeredBy = triggeredBy,
+                    serviceVersion = serviceVersion,
+                    correlationId = correlationId,
+                    summary = summary,
+                    detail = detail,
+                    startedAt = startedAt,
+                    finishedAt = finishedAt ?: startedAt,
+                ),
+            )
+        }
+    }
+
+    override fun reconcileOrphanedRunning(source: ServiceEventSource): Int =
+        safeCount("reconcileOrphanedRunning") {
+            requiresNew.execute {
+                repository.reconcileRunning(
+                    source = source.wire,
+                    running = ServiceEventStatus.RUNNING.name,
+                    failed = ServiceEventStatus.FAILED.name,
+                    summary = INTERRUPTED_BY_RESTART,
+                    now = Instant.now(),
+                )
+            } ?: 0
+        }
+
+    override fun prune(cutoff: Instant): Int =
+        safeCount("prune") {
+            requiresNew.execute { repository.deleteByStartedAtBefore(cutoff) } ?: 0
+        }
+
+    private inline fun safe(
+        op: String,
+        type: ServiceEventType,
+        correlationId: String?,
+        block: () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Throwable,
+        ) {
+            LOG.warn("service-event {} failed (type={}, correlationId={}) — journal write skipped", op, type, correlationId, e)
+        }
+    }
+
+    private inline fun safeCount(
+        op: String,
+        block: () -> Int,
+    ): Int =
+        try {
+            block()
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Throwable,
+        ) {
+            LOG.warn("service-event {} failed — skipped", op, e)
+            0
+        }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ServiceEventRecorderImpl::class.java)
+        const val INTERRUPTED_BY_RESTART = "interrupted by restart"
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncJobService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncJobService.kt
@@ -62,8 +62,13 @@ interface TeamcitySyncJobService {
      *
      * COMPLETED / FAILED states do not block: a new call after a finished job
      * replaces the slot.
+     *
+     * [triggeredBy] is the actor recorded on the service-event journal row
+     * (SYS-060): a username for admin-triggered runs, `"scheduler"` for the cron.
+     * Captured on the caller thread because the background executor does not carry
+     * the security context.
      */
-    fun startAsync(): StartTeamcitySyncResult
+    fun startAsync(triggeredBy: String = "system"): StartTeamcitySyncResult
 
     /** Latest known state, or `null` if no job has been started since the pod booted. */
     fun current(): TeamcitySyncJobState?

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncScheduler.kt
@@ -45,12 +45,18 @@ class TeamcitySyncScheduler(
 ) {
     private val log = KotlinLogging.logger {}
 
+    private companion object {
+        // Actor stamped on the SYS-060 service-event journal row for cron-fired runs
+        // (vs a username for admin-triggered ones).
+        const val TRIGGERED_BY_SCHEDULER = "scheduler"
+    }
+
     @Scheduled(cron = "\${teamcity.sync.cron:0 0 4 * * SUN}", zone = "UTC")
     @Suppress("TooGenericExceptionCaught")
     fun weeklyResync() {
         log.info { "TC sync: weekly cron firing" }
         try {
-            val outcome = teamcitySyncJobService.startAsync()
+            val outcome = teamcitySyncJobService.startAsync(TRIGGERED_BY_SCHEDULER)
             if (outcome.isNewlyStarted) {
                 log.info { "TC sync: weekly cron started job ${outcome.state.id}" }
             } else {

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
@@ -5,6 +5,11 @@ import org.octopusden.octopus.components.registry.server.service.AsyncJobLifecyc
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate.JobKind
+import org.octopusden.octopus.components.registry.server.service.NoOpServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
 import org.octopusden.octopus.components.registry.server.teamcity.StartTeamcitySyncResult
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobService
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncJobState
@@ -31,6 +36,7 @@ class TeamcitySyncJobServiceImpl(
     private val teamcitySyncService: TeamcitySyncService,
     @Qualifier("migrationExecutor") executor: TaskExecutor,
     lifecycleGate: MigrationLifecycleGate,
+    private val serviceEventRecorder: ServiceEventRecorder = NoOpServiceEventRecorder,
 ) : TeamcitySyncJobService {
     private val lifecycle =
         AsyncJobLifecycle<TeamcitySyncJobState>(
@@ -49,12 +55,30 @@ class TeamcitySyncJobServiceImpl(
             },
         )
 
-    override fun startAsync(): StartTeamcitySyncResult {
+    override fun startAsync(triggeredBy: String): StartTeamcitySyncResult {
         val outcome =
-            lifecycle.claimAndSubmit(
-                buildCandidate = ::buildCandidate,
-                work = ::runResync,
-            )
+            try {
+                lifecycle.claimAndSubmit(
+                    buildCandidate = ::buildCandidate,
+                    work = { jobId -> runResync(jobId, triggeredBy) },
+                )
+            } catch (
+                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
+            ) {
+                // Executor rejected the submission (typically pod shutdown): the work
+                // runnable never ran, so recordStart never fired. Record a standalone
+                // terminal FAILED row so the failure is not lost (SYS-060), then let the
+                // rejection propagate as before.
+                serviceEventRecorder.recordInstant(
+                    type = ServiceEventType.TEAMCITY_RESYNC,
+                    source = ServiceEventSource.CRS,
+                    triggeredBy = triggeredBy,
+                    status = ServiceEventStatus.FAILED,
+                    summary = "TeamCity resync failed to start",
+                    detail = mapOf("errorMessage" to (rejected.message ?: rejected::class.java.simpleName)),
+                )
+                throw rejected
+            }
         return when (outcome) {
             is AsyncJobLifecycle.ClaimOutcome.Attached ->
                 StartTeamcitySyncResult(outcome.state, isNewlyStarted = false)
@@ -75,7 +99,22 @@ class TeamcitySyncJobServiceImpl(
             errorMessage = null,
         )
 
-    private fun runResync(jobId: String) {
+    private fun runResync(
+        jobId: String,
+        triggeredBy: String,
+    ) {
+        // recordStart runs here (executor thread) rather than at claim time so the
+        // RUNNING journal row is written before the finish transition in BOTH the
+        // async executor and the SyncTaskExecutor (tests) — ordering that a
+        // claim-time write cannot guarantee. triggeredBy is captured on the caller
+        // thread and passed in, so no SecurityContext propagation is needed here.
+        serviceEventRecorder.recordStart(
+            type = ServiceEventType.TEAMCITY_RESYNC,
+            source = ServiceEventSource.CRS,
+            triggeredBy = triggeredBy,
+            correlationId = jobId,
+            summary = "TeamCity resync running",
+        )
         try {
             val result = teamcitySyncService.resync()
             lifecycle.update(jobId) { current ->
@@ -97,6 +136,27 @@ class TeamcitySyncJobServiceImpl(
                 result.ambiguousAutoResolved,
                 result.errors.size,
             )
+            // A run that matched everything but hit per-component errors still COMPLETED
+            // the pass; flag it so the Events feed distinguishes clean from partial runs.
+            val completedWithErrors = result.errors.isNotEmpty()
+            serviceEventRecorder.recordFinish(
+                type = ServiceEventType.TEAMCITY_RESYNC,
+                source = ServiceEventSource.CRS,
+                triggeredBy = triggeredBy,
+                correlationId = jobId,
+                status = ServiceEventStatus.COMPLETED,
+                summary = if (completedWithErrors) "TeamCity resync completed with errors" else "TeamCity resync completed",
+                detail =
+                    mapOf(
+                        "scanned" to result.scanned,
+                        "updated" to result.updated,
+                        "unchanged" to result.unchanged,
+                        "skippedNoMatch" to result.skippedNoMatch,
+                        "skippedAmbiguous" to result.skippedAmbiguous,
+                        "ambiguousAutoResolved" to result.ambiguousAutoResolved,
+                        "errors" to result.errors,
+                    ),
+            )
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Throwable,
         ) {
@@ -108,6 +168,15 @@ class TeamcitySyncJobServiceImpl(
                     errorMessage = e.message ?: e::class.java.simpleName,
                 )
             }
+            serviceEventRecorder.recordFinish(
+                type = ServiceEventType.TEAMCITY_RESYNC,
+                source = ServiceEventSource.CRS,
+                triggeredBy = triggeredBy,
+                correlationId = jobId,
+                status = ServiceEventStatus.FAILED,
+                summary = "TeamCity resync failed",
+                detail = mapOf("errorMessage" to (e.message ?: e::class.java.simpleName)),
+            )
         } finally {
             lifecycle.release(jobId)
         }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImpl.kt
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.task.TaskExecutor
 import org.springframework.stereotype.Service
 import java.time.Instant
+import java.util.concurrent.RejectedExecutionException
 
 /**
  * In-memory async wrapper around [TeamcitySyncService.resync]. Mirrors
@@ -62,13 +63,13 @@ class TeamcitySyncJobServiceImpl(
                     buildCandidate = ::buildCandidate,
                     work = { jobId -> runResync(jobId, triggeredBy) },
                 )
-            } catch (
-                @Suppress("TooGenericExceptionCaught") rejected: Throwable,
-            ) {
-                // Executor rejected the submission (typically pod shutdown): the work
-                // runnable never ran, so recordStart never fired. Record a standalone
-                // terminal FAILED row so the failure is not lost (SYS-060), then let the
-                // rejection propagate as before.
+            } catch (rejected: RejectedExecutionException) {
+                // ONLY executor-rejection (typically pod shutdown; Spring's
+                // TaskRejectedException extends RejectedExecutionException): the work
+                // runnable never ran, so recordStart never fired — record a standalone
+                // terminal FAILED so the failure is not lost (SYS-060), then rethrow.
+                // A cross-kind MigrationConflictException is NOT a failure and must NOT be
+                // journaled — it is deliberately not caught here and propagates to the 409 handler.
                 serviceEventRecorder.recordInstant(
                     type = ServiceEventType.TEAMCITY_RESYNC,
                     source = ServiceEventSource.CRS,

--- a/components-registry-service-server/src/main/resources/db/migration/V4__add_service_event.sql
+++ b/components-registry-service-server/src/main/resources/db/migration/V4__add_service_event.sql
@@ -1,0 +1,30 @@
+-- SYS-060: append-only journal of operational / service events (redeploys, data
+-- migrations, TeamCity resync, portal validation sweeps). Unlike audit_log (which
+-- tracks ENTITY changes), this table records JOB RUNS and DEPLOY markers so the
+-- portal Admin "Events" tab can show a persistent history that survives pod
+-- restarts (today those runs live only in an in-memory AtomicReference + logs).
+--
+-- One row per run, transitioned RUNNING -> COMPLETED/FAILED in place (matched by
+-- correlation_id). STARTUP rows are written terminal (COMPLETED). A run whose pod
+-- dies mid-flight is reconciled to FAILED on the next startup so it never hangs
+-- RUNNING (SYS-060). detail is JSON (result counts / errorMessage), mirroring the
+-- audit_log old_value/new_value convention: TEXT column + @JdbcTypeCode(JSON).
+CREATE TABLE service_event (
+    id              BIGSERIAL PRIMARY KEY,
+    event_type      VARCHAR(40) NOT NULL,   -- STARTUP | MIGRATION_COMPONENTS | MIGRATION_HISTORY | TEAMCITY_RESYNC | VALIDATION_SWEEP
+    status          VARCHAR(20) NOT NULL,   -- RUNNING | COMPLETED | FAILED
+    source          VARCHAR(20) NOT NULL,   -- crs | portal
+    triggered_by    VARCHAR(255),           -- system | scheduler | <username>
+    service_version VARCHAR(100),           -- build version, for STARTUP rows
+    correlation_id  VARCHAR(255),           -- job id; the RUNNING row is updated in place by this key
+    summary         TEXT,
+    detail          TEXT,                   -- JSON (@JdbcTypeCode(SqlTypes.JSON)): result counters / errorMessage
+    started_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    finished_at     TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX idx_service_event_started    ON service_event(started_at DESC);
+CREATE INDEX idx_service_event_type       ON service_event(event_type);
+CREATE INDEX idx_service_event_source     ON service_event(source);
+CREATE INDEX idx_service_event_status     ON service_event(status);
+CREATE INDEX idx_service_event_correlation ON service_event(correlation_id);

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -2033,6 +2033,52 @@
         },
         "type" : "object"
       },
+      "PageServiceEventResponse" : {
+        "properties" : {
+          "content" : {
+            "items" : {
+              "$ref" : "#/components/schemas/ServiceEventResponse"
+            },
+            "type" : "array"
+          },
+          "empty" : {
+            "type" : "boolean"
+          },
+          "first" : {
+            "type" : "boolean"
+          },
+          "last" : {
+            "type" : "boolean"
+          },
+          "number" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "numberOfElements" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "pageable" : {
+            "$ref" : "#/components/schemas/PageableObject"
+          },
+          "size" : {
+            "format" : "int32",
+            "type" : "integer"
+          },
+          "sort" : {
+            "$ref" : "#/components/schemas/SortObject"
+          },
+          "totalElements" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "totalPages" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "type" : "object"
+      },
       "Pageable" : {
         "properties" : {
           "page" : {
@@ -2131,6 +2177,102 @@
           "groupName",
           "groupType",
           "id"
+        ],
+        "type" : "object"
+      },
+      "ServiceEventIngestRequest" : {
+        "properties" : {
+          "correlationId" : {
+            "type" : "string"
+          },
+          "detail" : {
+            "additionalProperties" : {
+              "type" : "object"
+            },
+            "type" : "object"
+          },
+          "eventType" : {
+            "type" : "string"
+          },
+          "finishedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "serviceVersion" : {
+            "type" : "string"
+          },
+          "source" : {
+            "type" : "string"
+          },
+          "startedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "summary" : {
+            "type" : "string"
+          },
+          "triggeredBy" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "eventType",
+          "source",
+          "status"
+        ],
+        "type" : "object"
+      },
+      "ServiceEventResponse" : {
+        "properties" : {
+          "correlationId" : {
+            "type" : "string"
+          },
+          "detail" : {
+            "additionalProperties" : {
+              "type" : "object"
+            },
+            "type" : "object"
+          },
+          "eventType" : {
+            "type" : "string"
+          },
+          "finishedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "id" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "serviceVersion" : {
+            "type" : "string"
+          },
+          "source" : {
+            "type" : "string"
+          },
+          "startedAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "summary" : {
+            "type" : "string"
+          },
+          "triggeredBy" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "eventType",
+          "id",
+          "source",
+          "startedAt",
+          "status"
         ],
         "type" : "object"
       },
@@ -3972,6 +4114,256 @@
         },
         "tags" : [
           "admin-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/admin/service-events" : {
+      "get" : {
+        "operationId" : "list",
+        "parameters" : [
+          {
+            "in" : "query",
+            "name" : "eventType",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "source",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "status",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "from",
+            "required" : false,
+            "schema" : {
+              "format" : "date-time",
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "to",
+            "required" : false,
+            "schema" : {
+              "format" : "date-time",
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "pageable",
+            "required" : true,
+            "schema" : {
+              "$ref" : "#/components/schemas/Pageable"
+            }
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PageServiceEventResponse"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "service-event-controller-v-4"
+        ]
+      },
+      "post" : {
+        "operationId" : "ingest",
+        "parameters" : [
+          {
+            "in" : "header",
+            "name" : "X-Service-Event-Token",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ServiceEventIngestRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "service-event-ingest-controller-v-4"
         ]
       }
     },

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -4281,7 +4281,7 @@
           "required" : true
         },
         "responses" : {
-          "200" : {
+          "202" : {
             "content" : {
               "*/*" : {
                 "schema" : {
@@ -4289,7 +4289,7 @@
                 }
               }
             },
-            "description" : "OK"
+            "description" : "Event accepted and recorded"
           },
           "400" : {
             "content" : {
@@ -4299,7 +4299,17 @@
                 }
               }
             },
-            "description" : "Bad Request"
+            "description" : "Unknown eventType/status/source, or a non-terminal / non-portal event"
+          },
+          "403" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            },
+            "description" : "Invalid or missing X-Service-Event-Token"
           },
           "404" : {
             "content" : {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4SecurityTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -102,7 +103,7 @@ class AdminControllerV4SecurityTest {
             .perform(post("/rest/api/4/admin/migrate"))
             .andExpect(status().isUnauthorized)
 
-        verify(migrationJobService, never()).startAsync()
+        verify(migrationJobService, never()).startAsync(anyString())
     }
 
     @Test
@@ -112,13 +113,13 @@ class AdminControllerV4SecurityTest {
             .perform(post("/rest/api/4/admin/migrate").with(editorJwt()))
             .andExpect(status().isForbidden)
 
-        verify(migrationJobService, never()).startAsync()
+        verify(migrationJobService, never()).startAsync(anyString())
     }
 
     @Test
     @DisplayName("MIG-024: POST /admin/migrate with IMPORT_DATA JWT returns 202 and invokes MigrationJobService.startAsync exactly once")
     fun `MIG-024 admin JWT POST migrate returns 202 and starts the job`() {
-        `when`(migrationJobService.startAsync()).thenReturn(
+        `when`(migrationJobService.startAsync(anyString())).thenReturn(
             StartMigrationResult(state = RUNNING_STATE, isNewlyStarted = true),
         )
 
@@ -126,7 +127,7 @@ class AdminControllerV4SecurityTest {
             .perform(post("/rest/api/4/admin/migrate").with(adminJwt()))
             .andExpect(status().isAccepted)
 
-        verify(migrationJobService, times(1)).startAsync()
+        verify(migrationJobService, times(1)).startAsync(anyString())
     }
 
     // #250: config-write guard. Since #343, field-config / component-defaults are

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.controller
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.`when`
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
@@ -58,7 +59,7 @@ class AdminMigrateJobControllerTest {
 
     @Test
     fun `POST migrate first call returns 202 with the freshly-started job body`() {
-        `when`(migrationJobService.startAsync()).thenReturn(
+        `when`(migrationJobService.startAsync(anyString())).thenReturn(
             StartMigrationResult(state = RUNNING_STATE, isNewlyStarted = true),
         )
 
@@ -74,7 +75,7 @@ class AdminMigrateJobControllerTest {
         // Service signals "already running" via isNewlyStarted=false; the controller
         // maps that to 409 Conflict. The body is the existing job state — same id —
         // so the SPA can "attach" and start polling.
-        `when`(migrationJobService.startAsync()).thenReturn(
+        `when`(migrationJobService.startAsync(anyString())).thenReturn(
             StartMigrationResult(state = RUNNING_STATE, isNewlyStarted = false),
         )
 

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
@@ -1,15 +1,20 @@
 package org.octopusden.octopus.components.registry.server.controller
 
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
 import org.octopusden.octopus.components.registry.server.service.MigrationJobState
+import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.StartMigrationResult
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
@@ -54,8 +59,31 @@ class AdminMigrateJobControllerTest {
     @MockBean
     private lateinit var migrationJobService: MigrationJobService
 
+    @MockBean
+    private lateinit var importService: ImportService
+
     @Autowired
     private lateinit var mvc: MockMvc
+
+    @BeforeEach
+    fun stubIncompleteMigration() {
+        // Default: there is still something to migrate (git > 0) so the completeness guard
+        // does not fire for the existing start/attach cases. The git==0 case overrides this.
+        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 5, db = 10, total = 15))
+    }
+
+    @Test
+    fun `POST migrate returns 409 migration-complete when nothing remains in git`() {
+        // Full migration done (git == 0): re-running is forbidden — the job must NOT start.
+        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 0, db = 15, total = 15))
+
+        mvc
+            .perform(post("/rest/api/4/admin/migrate").with(adminJwt()))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.code").value("migration-complete"))
+
+        verify(migrationJobService, never()).startAsync(anyString())
+    }
 
     @Test
     fun `POST migrate first call returns 202 with the freshly-started job body`() {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
@@ -69,13 +69,13 @@ class AdminMigrateJobControllerTest {
     fun stubIncompleteMigration() {
         // Default: there is still something to migrate (git > 0) so the completeness guard
         // does not fire for the existing start/attach cases. The git==0 case overrides this.
-        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 5, db = 10, total = 15))
+        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 5L, db = 10L, total = 15L))
     }
 
     @Test
     fun `POST migrate returns 409 migration-complete when nothing remains in git`() {
         // Full migration done (git == 0): re-running is forbidden — the job must NOT start.
-        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 0, db = 15, total = 15))
+        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 0L, db = 15L, total = 15L))
 
         mvc
             .perform(post("/rest/api/4/admin/migrate").with(adminJwt()))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4Test.kt
@@ -1,0 +1,113 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ServiceEventEntity
+import org.octopusden.octopus.components.registry.server.repository.ServiceEventRepository
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * SYS-060: `GET /rest/api/4/admin/service-events` is IMPORT_DATA-gated, returns the
+ * journal newest-first, and honours the optional filters.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class ServiceEventControllerV4Test {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var repository: ServiceEventRepository
+
+    init {
+        val testResourcesPath =
+            java.nio.file.Paths.get(ServiceEventControllerV4Test::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @BeforeEach
+    fun seed() {
+        // Clear the STARTUP row the app writes on boot (and any auto-migrate rows) so
+        // assertions see only what this test inserts.
+        repository.deleteAll()
+        val now = Instant.now()
+        repository.save(
+            row(ServiceEventType.TEAMCITY_RESYNC, ServiceEventStatus.COMPLETED, now.minus(2, ChronoUnit.HOURS)),
+        )
+        repository.save(
+            row(ServiceEventType.MIGRATION_COMPONENTS, ServiceEventStatus.FAILED, now.minus(1, ChronoUnit.HOURS)),
+        )
+    }
+
+    @Test
+    fun `SYS-060 lists events newest-first for an IMPORT_DATA caller`() {
+        mvc
+            .perform(get("/rest/api/4/admin/service-events").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            // Newest (migration, 1h ago) first.
+            .andExpect(jsonPath("$.content[0].eventType").value("MIGRATION_COMPONENTS"))
+            .andExpect(jsonPath("$.content[0].status").value("FAILED"))
+            .andExpect(jsonPath("$.content[1].eventType").value("TEAMCITY_RESYNC"))
+    }
+
+    @Test
+    fun `SYS-060 filters by status`() {
+        mvc
+            .perform(get("/rest/api/4/admin/service-events?status=FAILED").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].eventType").value("MIGRATION_COMPONENTS"))
+    }
+
+    @Test
+    fun `SYS-060 read requires IMPORT_DATA (editor is forbidden)`() {
+        mvc
+            .perform(get("/rest/api/4/admin/service-events").with(editorJwt()))
+            .andExpect(status().isForbidden)
+    }
+
+    private fun row(
+        type: ServiceEventType,
+        status: ServiceEventStatus,
+        startedAt: Instant,
+    ) = ServiceEventEntity(
+        eventType = type.name,
+        status = status.name,
+        source = ServiceEventSource.CRS.wire,
+        triggeredBy = "alice",
+        startedAt = startedAt,
+        finishedAt = startedAt.plusSeconds(5),
+    )
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4Test.kt
@@ -1,0 +1,96 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.components.registry.server.config.ServiceEventProperties
+import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventIngestRequest
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.octopusden.octopus.components.registry.server.support.RecordingServiceEventRecorder
+import org.springframework.http.HttpStatus
+
+/**
+ * SYS-061: portal ingest is gated by the shared-secret header, fail-closed, and
+ * validates the enum fields. Unit-level — the controller logic is independent of the
+ * MVC/security stack (the filter-chain permitAll is a WebSecurityConfig concern).
+ */
+class ServiceEventIngestControllerV4Test {
+    private val validRequest =
+        ServiceEventIngestRequest(
+            eventType = ServiceEventType.VALIDATION_SWEEP.name,
+            status = ServiceEventStatus.COMPLETED.name,
+            source = ServiceEventSource.PORTAL.wire,
+            triggeredBy = "scheduler",
+            summary = "sweep done",
+        )
+
+    private fun controller(
+        recorder: RecordingServiceEventRecorder,
+        token: String,
+    ) = ServiceEventIngestControllerV4(recorder, ServiceEventProperties(ingestToken = token))
+
+    @Test
+    fun `SYS-061 valid token and body records the event`() {
+        val recorder = RecordingServiceEventRecorder()
+        val response = controller(recorder, token = "secret").ingest("secret", validRequest)
+
+        assertEquals(HttpStatus.ACCEPTED, response.statusCode)
+        val recorded = recorder.instants.single()
+        assertEquals(ServiceEventType.VALIDATION_SWEEP, recorded.type)
+        assertEquals(ServiceEventSource.PORTAL, recorded.source)
+        assertEquals(ServiceEventStatus.COMPLETED, recorded.status)
+    }
+
+    @Test
+    fun `SYS-061 wrong token is 403 and records nothing`() {
+        val recorder = RecordingServiceEventRecorder()
+        val response = controller(recorder, token = "secret").ingest("nope", validRequest)
+
+        assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+        assertTrue(recorder.instants.isEmpty())
+    }
+
+    @Test
+    fun `SYS-061 blank configured token is fail-closed 403 even with a header`() {
+        val recorder = RecordingServiceEventRecorder()
+        val response = controller(recorder, token = "").ingest("anything", validRequest)
+
+        assertEquals(HttpStatus.FORBIDDEN, response.statusCode)
+        assertTrue(recorder.instants.isEmpty())
+    }
+
+    @Test
+    fun `SYS-061 unknown eventType is 400`() {
+        val recorder = RecordingServiceEventRecorder()
+        val response =
+            controller(recorder, token = "secret")
+                .ingest("secret", validRequest.copy(eventType = "NOT_A_TYPE"))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertTrue(recorder.instants.isEmpty())
+    }
+
+    @Test
+    fun `SYS-061 non-terminal status is 400 (ingest is terminal-only)`() {
+        val recorder = RecordingServiceEventRecorder()
+        val response =
+            controller(recorder, token = "secret")
+                .ingest("secret", validRequest.copy(status = ServiceEventStatus.RUNNING.name))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertTrue(recorder.instants.isEmpty())
+    }
+
+    @Test
+    fun `SYS-061 non-portal source is 400 (ingest is portal-only)`() {
+        val recorder = RecordingServiceEventRecorder()
+        val response =
+            controller(recorder, token = "secret")
+                .ingest("secret", validRequest.copy(source = ServiceEventSource.CRS.wire))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertTrue(recorder.instants.isEmpty())
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/TeamcityResyncControllerTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -89,7 +90,7 @@ class TeamcityResyncControllerTest {
             .perform(post("/rest/api/4/admin/teamcity-project-ids/sync"))
             .andExpect(status().isUnauthorized)
 
-        verify(teamcitySyncJobService, never()).startAsync()
+        verify(teamcitySyncJobService, never()).startAsync(anyString())
     }
 
     @Test
@@ -99,13 +100,13 @@ class TeamcityResyncControllerTest {
             .perform(post("/rest/api/4/admin/teamcity-project-ids/sync").with(editorJwt()))
             .andExpect(status().isForbidden)
 
-        verify(teamcitySyncJobService, never()).startAsync()
+        verify(teamcitySyncJobService, never()).startAsync(anyString())
     }
 
     @Test
     @DisplayName("admin POST /admin/teamcity-project-ids/sync newly-started → 202 with kind=job body")
     fun syncAdminFreshReturns202() {
-        `when`(teamcitySyncJobService.startAsync())
+        `when`(teamcitySyncJobService.startAsync(anyString()))
             .thenReturn(StartTeamcitySyncResult(runningState("job-1"), isNewlyStarted = true))
 
         mvc
@@ -116,13 +117,13 @@ class TeamcityResyncControllerTest {
             .andExpect(jsonPath("$.kind").value("job"))
             .andExpect(jsonPath("$.result").doesNotExist())
 
-        verify(teamcitySyncJobService, times(1)).startAsync()
+        verify(teamcitySyncJobService, times(1)).startAsync(anyString())
     }
 
     @Test
     @DisplayName("admin POST /admin/teamcity-project-ids/sync same-kind RUNNING → 409 with same job body")
     fun syncAdminSameKindAttachReturns409() {
-        `when`(teamcitySyncJobService.startAsync())
+        `when`(teamcitySyncJobService.startAsync(anyString()))
             .thenReturn(StartTeamcitySyncResult(runningState("job-existing"), isNewlyStarted = false))
 
         mvc
@@ -136,7 +137,7 @@ class TeamcityResyncControllerTest {
     @Test
     @DisplayName("admin POST /admin/teamcity-project-ids/sync cross-kind COMPONENTS → 409 with conflict envelope")
     fun syncAdminCrossKindComponentsReturns409Conflict() {
-        `when`(teamcitySyncJobService.startAsync())
+        `when`(teamcitySyncJobService.startAsync(anyString()))
             .thenThrow(
                 MigrationConflictException(
                     MigrationLifecycleGate.ActiveJob(MigrationLifecycleGate.JobKind.COMPONENTS, "components-1"),
@@ -158,7 +159,7 @@ class TeamcityResyncControllerTest {
     @Test
     @DisplayName("admin POST /admin/teamcity-project-ids/sync cross-kind HISTORY → 409 with conflict envelope")
     fun syncAdminCrossKindHistoryReturns409Conflict() {
-        `when`(teamcitySyncJobService.startAsync())
+        `when`(teamcitySyncJobService.startAsync(anyString()))
             .thenThrow(
                 MigrationConflictException(
                     MigrationLifecycleGate.ActiveJob(MigrationLifecycleGate.JobKind.HISTORY, "history-1"),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/listener/ServiceStartupListenerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/listener/ServiceStartupListenerTest.kt
@@ -1,0 +1,56 @@
+package org.octopusden.octopus.components.registry.server.listener
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.octopusden.octopus.components.registry.server.support.RecordingServiceEventRecorder
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.boot.info.BuildProperties
+import java.util.Properties
+
+/**
+ * SYS-060: on startup the listener first reconciles any orphaned RUNNING crs rows to
+ * FAILED, THEN writes the STARTUP marker with the build version — in that order, so a
+ * run interrupted by the previous pod's death is reported as FAILED and never left
+ * hanging RUNNING.
+ */
+class ServiceStartupListenerTest {
+    @Suppress("UNCHECKED_CAST")
+    private fun buildPropsProvider(version: String?): ObjectProvider<BuildProperties> {
+        val provider = mock(ObjectProvider::class.java) as ObjectProvider<BuildProperties>
+        val available = version?.let { BuildProperties(Properties().apply { setProperty("version", it) }) }
+        `when`(provider.ifAvailable).thenReturn(available)
+        return provider
+    }
+
+    @Test
+    fun `SYS-060 startup reconciles orphaned running then records STARTUP with version`() {
+        val recorder = RecordingServiceEventRecorder()
+        val listener = ServiceStartupListener(recorder, buildPropsProvider("2.1.0"))
+
+        listener.onApplicationEvent(mock(ApplicationReadyEvent::class.java))
+
+        // Reconcile must precede the STARTUP write.
+        assertEquals(listOf("reconcile", "instant:COMPLETED"), recorder.order)
+        assertEquals(listOf(ServiceEventSource.CRS), recorder.reconciledSources)
+        val startup = recorder.instants.single()
+        assertEquals(ServiceEventType.STARTUP, startup.type)
+        assertEquals(ServiceEventSource.CRS, startup.source)
+        assertEquals("system", startup.triggeredBy)
+        assertEquals("2.1.0", startup.serviceVersion)
+    }
+
+    @Test
+    fun `SYS-060 startup tolerates missing build-info (blank version)`() {
+        val recorder = RecordingServiceEventRecorder()
+        val listener = ServiceStartupListener(recorder, buildPropsProvider(null))
+
+        listener.onApplicationEvent(mock(ApplicationReadyEvent::class.java))
+
+        assertEquals("", recorder.instants.single().serviceVersion)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderImplTest.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.service.impl
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -51,6 +52,14 @@ class ServiceEventRecorderImplTest {
     @BeforeEach
     fun clean() {
         repository.deleteAll()
+    }
+
+    @Test
+    fun `SYS-060 the wired ServiceEventRecorder bean is the real impl, not the NoOp default`() {
+        // NoOpServiceEventRecorder is only a default constructor arg (not a @Component), so the
+        // sole ServiceEventRecorder candidate in a db-mode context is ServiceEventRecorderImpl —
+        // which Spring therefore injects into the async job impls (guards the DI contract).
+        assertTrue(recorder is ServiceEventRecorderImpl, "expected the real recorder bean, got ${recorder::class}")
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderImplTest.kt
@@ -1,0 +1,129 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.repository.ServiceEventRepository
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * SYS-060: DB-backed behaviour of the service-event recorder — RUNNING→terminal
+ * transition in place, terminal-insert fallback when no RUNNING row exists,
+ * startup reconciliation, and retention prune.
+ */
+@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
+@ActiveProfiles("common", "test-db")
+@Tag("integration")
+class ServiceEventRecorderImplTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var recorder: ServiceEventRecorder
+
+    @Autowired
+    private lateinit var repository: ServiceEventRepository
+
+    init {
+        val testResourcesPath =
+            java.nio.file.Paths.get(ServiceEventRecorderImplTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @BeforeEach
+    fun clean() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `SYS-060 recordStart then recordFinish transitions the running row in place`() {
+        recorder.recordStart(ServiceEventType.TEAMCITY_RESYNC, ServiceEventSource.CRS, "alice", "job-1", "running")
+        val running = repository.findAll().single()
+        assertEquals(ServiceEventStatus.RUNNING.name, running.status)
+        assertNull(running.finishedAt)
+
+        recorder.recordFinish(
+            ServiceEventType.TEAMCITY_RESYNC, ServiceEventSource.CRS, "alice", "job-1",
+            ServiceEventStatus.COMPLETED, "done", mapOf("updated" to 2),
+        )
+
+        val row = repository.findAll().single() // still ONE row — transitioned, not appended
+        assertEquals(ServiceEventStatus.COMPLETED.name, row.status)
+        assertNotNull(row.finishedAt)
+        assertEquals(2, row.detail?.get("updated"))
+    }
+
+    @Test
+    fun `SYS-060 recordFinish without a running row inserts a terminal row`() {
+        recorder.recordFinish(
+            ServiceEventType.MIGRATION_COMPONENTS, ServiceEventSource.CRS, "alice", "orphan-job",
+            ServiceEventStatus.FAILED, "boom", mapOf("errorMessage" to "x"),
+        )
+
+        val row = repository.findAll().single()
+        assertEquals(ServiceEventStatus.FAILED.name, row.status)
+        assertEquals("orphan-job", row.correlationId)
+        assertNotNull(row.finishedAt)
+    }
+
+    @Test
+    fun `SYS-060 reconcileOrphanedRunning flips crs running rows to failed`() {
+        recorder.recordStart(ServiceEventType.MIGRATION_HISTORY, ServiceEventSource.CRS, "system", "stuck", "running")
+
+        val reconciled = recorder.reconcileOrphanedRunning(ServiceEventSource.CRS)
+
+        assertEquals(1, reconciled)
+        val row = repository.findAll().single()
+        assertEquals(ServiceEventStatus.FAILED.name, row.status)
+        assertEquals("interrupted by restart", row.summary)
+        assertNotNull(row.finishedAt)
+    }
+
+    @Test
+    fun `SYS-060 prune deletes rows started before the cutoff`() {
+        recorder.recordInstant(
+            type = ServiceEventType.STARTUP, source = ServiceEventSource.CRS, triggeredBy = "system",
+            startedAt = Instant.now().minus(Duration.ofDays(120)),
+        )
+        recorder.recordInstant(
+            type = ServiceEventType.STARTUP, source = ServiceEventSource.CRS, triggeredBy = "system",
+            startedAt = Instant.now(),
+        )
+
+        val pruned = recorder.prune(Instant.now().minus(Duration.ofDays(90)))
+
+        assertEquals(1, pruned)
+        assertEquals(1, repository.findAll().size)
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderSwallowTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventRecorderSwallowTest.kt
@@ -1,0 +1,42 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.octopusden.octopus.components.registry.server.repository.ServiceEventRepository
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import java.time.Instant
+
+/**
+ * SYS-060: journaling is best-effort — a transaction/DB failure is swallowed (logged),
+ * never propagated to the job/boot being observed. Simulated by a transaction manager
+ * that fails to begin a transaction; every recorder method must return normally.
+ */
+class ServiceEventRecorderSwallowTest {
+    private fun failingRecorder(): ServiceEventRecorderImpl {
+        val txManager = mock(PlatformTransactionManager::class.java)
+        `when`(txManager.getTransaction(any(TransactionDefinition::class.java)))
+            .thenThrow(RuntimeException("cannot begin tx"))
+        return ServiceEventRecorderImpl(mock(ServiceEventRepository::class.java), txManager)
+    }
+
+    @Test
+    fun `SYS-060 a write failure is swallowed`() {
+        val recorder = failingRecorder()
+        assertDoesNotThrow {
+            recorder.recordStart(ServiceEventType.TEAMCITY_RESYNC, ServiceEventSource.CRS, "u", "j", "s")
+            recorder.recordFinish(ServiceEventType.TEAMCITY_RESYNC, ServiceEventSource.CRS, "u", "j", ServiceEventStatus.FAILED, "s", null)
+            recorder.recordInstant(ServiceEventType.STARTUP, ServiceEventSource.CRS, "u")
+        }
+        // count-returning ops degrade to 0 rather than throwing.
+        assertEquals(0, recorder.reconcileOrphanedRunning(ServiceEventSource.CRS))
+        assertEquals(0, recorder.prune(Instant.now()))
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/support/RecordingServiceEventRecorder.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/support/RecordingServiceEventRecorder.kt
@@ -1,0 +1,110 @@
+package org.octopusden.octopus.components.registry.server.support
+
+import org.octopusden.octopus.components.registry.server.service.ServiceEventRecorder
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import java.time.Instant
+
+/**
+ * Hand-written capturing test double for [ServiceEventRecorder]. Preferred over a
+ * Mockito mock here because the recorder's methods take non-null Kotlin enum args,
+ * which Mockito's `any()` (returns null) trips before the proxy intercepts. Captures
+ * each call so tests can assert what was recorded and in what order, without matchers.
+ */
+class RecordingServiceEventRecorder(
+    private val reconcileResult: Int = 0,
+    private val pruneResult: Int = 0,
+) : ServiceEventRecorder {
+    data class StartCall(
+        val type: ServiceEventType,
+        val source: ServiceEventSource,
+        val triggeredBy: String?,
+        val correlationId: String,
+        val summary: String?,
+    )
+
+    data class FinishCall(
+        val type: ServiceEventType,
+        val source: ServiceEventSource,
+        val triggeredBy: String?,
+        val correlationId: String,
+        val status: ServiceEventStatus,
+        val summary: String?,
+        val detail: Map<String, Any?>?,
+    )
+
+    data class InstantCall(
+        val type: ServiceEventType,
+        val source: ServiceEventSource,
+        val triggeredBy: String?,
+        val status: ServiceEventStatus,
+        val serviceVersion: String?,
+        val correlationId: String?,
+        val summary: String?,
+        val detail: Map<String, Any?>?,
+        val startedAt: Instant,
+        val finishedAt: Instant?,
+    )
+
+    val starts = mutableListOf<StartCall>()
+    val finishes = mutableListOf<FinishCall>()
+    val instants = mutableListOf<InstantCall>()
+    val reconciledSources = mutableListOf<ServiceEventSource>()
+    val prunedCutoffs = mutableListOf<Instant>()
+
+    /** Method-name log for ordering assertions (e.g. reconcile before startup). */
+    val order = mutableListOf<String>()
+
+    override fun recordStart(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        summary: String?,
+    ) {
+        starts += StartCall(type, source, triggeredBy, correlationId, summary)
+        order += "start"
+    }
+
+    override fun recordFinish(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        correlationId: String,
+        status: ServiceEventStatus,
+        summary: String?,
+        detail: Map<String, Any?>?,
+    ) {
+        finishes += FinishCall(type, source, triggeredBy, correlationId, status, summary, detail)
+        order += "finish:$status"
+    }
+
+    override fun recordInstant(
+        type: ServiceEventType,
+        source: ServiceEventSource,
+        triggeredBy: String?,
+        status: ServiceEventStatus,
+        serviceVersion: String?,
+        correlationId: String?,
+        summary: String?,
+        detail: Map<String, Any?>?,
+        startedAt: Instant,
+        finishedAt: Instant?,
+    ) {
+        instants += InstantCall(type, source, triggeredBy, status, serviceVersion, correlationId, summary, detail, startedAt, finishedAt)
+        order += "instant:$status"
+    }
+
+    override fun reconcileOrphanedRunning(source: ServiceEventSource): Int {
+        reconciledSources += source
+        order += "reconcile"
+        return reconcileResult
+    }
+
+    override fun prune(cutoff: Instant): Int {
+        prunedCutoffs += cutoff
+        order += "prune"
+        return pruneResult
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncSchedulerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncSchedulerTest.kt
@@ -40,18 +40,18 @@ class TeamcitySyncSchedulerTest {
     @DisplayName("weeklyResync calls startAsync and returns normally on isNewlyStarted=true")
     fun startsFreshJob() {
         val jobService = mock(TeamcitySyncJobService::class.java)
-        `when`(jobService.startAsync()).thenReturn(StartTeamcitySyncResult(startedState("job-1"), isNewlyStarted = true))
+        `when`(jobService.startAsync("scheduler")).thenReturn(StartTeamcitySyncResult(startedState("job-1"), isNewlyStarted = true))
 
         TeamcitySyncScheduler(jobService).weeklyResync()
 
-        verify(jobService, times(1)).startAsync()
+        verify(jobService, times(1)).startAsync("scheduler")
     }
 
     @Test
     @DisplayName("weeklyResync swallows isNewlyStarted=false (same-kind attach) without throwing")
     fun swallowsSameKindAttach() {
         val jobService = mock(TeamcitySyncJobService::class.java)
-        `when`(jobService.startAsync()).thenReturn(StartTeamcitySyncResult(startedState("job-2"), isNewlyStarted = false))
+        `when`(jobService.startAsync("scheduler")).thenReturn(StartTeamcitySyncResult(startedState("job-2"), isNewlyStarted = false))
 
         // Must NOT throw — catching the same-kind attach in @Scheduled is the entire point.
         TeamcitySyncScheduler(jobService).weeklyResync()
@@ -61,7 +61,7 @@ class TeamcitySyncSchedulerTest {
     @DisplayName("weeklyResync swallows MigrationConflictException (cross-kind) without throwing")
     fun swallowsCrossKindConflict() {
         val jobService = mock(TeamcitySyncJobService::class.java)
-        `when`(jobService.startAsync())
+        `when`(jobService.startAsync("scheduler"))
             .thenThrow(
                 MigrationConflictException(
                     MigrationLifecycleGate.ActiveJob(MigrationLifecycleGate.JobKind.HISTORY, "history-1"),
@@ -76,7 +76,7 @@ class TeamcitySyncSchedulerTest {
     @DisplayName("weeklyResync swallows generic RuntimeException without throwing (back-compat)")
     fun swallowsGenericRuntimeException() {
         val jobService = mock(TeamcitySyncJobService::class.java)
-        `when`(jobService.startAsync()).thenThrow(RuntimeException("transient pool issue"))
+        `when`(jobService.startAsync("scheduler")).thenThrow(RuntimeException("transient pool issue"))
 
         // Pre-refactor scheduler had a catch-all — preserve that so a transient
         // RejectedExecutionException doesn't suppress next week's fire.

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
@@ -15,6 +15,10 @@ import org.mockito.Mockito.`when`
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationConflictException
 import org.octopusden.octopus.components.registry.server.service.MigrationLifecycleGate
+import org.octopusden.octopus.components.registry.server.service.ServiceEventSource
+import org.octopusden.octopus.components.registry.server.service.ServiceEventStatus
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
+import org.octopusden.octopus.components.registry.server.support.RecordingServiceEventRecorder
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncResult
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcitySyncService
 import org.springframework.core.task.SyncTaskExecutor
@@ -185,6 +189,65 @@ class TeamcitySyncJobServiceImplTest {
         assertTrue(second.isNewlyStarted)
         assertTrue(first.state.id != second.state.id, "completed job should not block a new run")
         verify(syncService, times(2)).resync()
+    }
+
+    @Test
+    @DisplayName("SYS-060 completed run records COMPLETED with result counters + triggeredBy")
+    fun sys060RecordsCompleted() {
+        val populated =
+            TeamcitySyncResult(
+                scanned = 5, updated = 2, unchanged = 3,
+                skippedNoMatch = 0, skippedAmbiguous = 0, ambiguousAutoResolved = 0, errors = emptyList(),
+            )
+        val syncService = mock(TeamcitySyncService::class.java)
+        `when`(syncService.resync()).thenReturn(populated)
+        val recorder = RecordingServiceEventRecorder()
+        val service = TeamcitySyncJobServiceImpl(syncService, SyncTaskExecutor(), MigrationLifecycleGate(), recorder)
+
+        service.startAsync("alice")
+
+        // recordStart precedes recordFinish; one row per run.
+        assertEquals(listOf("start", "finish:COMPLETED"), recorder.order)
+        val start = recorder.starts.single()
+        assertEquals(ServiceEventType.TEAMCITY_RESYNC, start.type)
+        assertEquals(ServiceEventSource.CRS, start.source)
+        assertEquals("alice", start.triggeredBy)
+        val finish = recorder.finishes.single()
+        assertEquals(ServiceEventStatus.COMPLETED, finish.status)
+        assertEquals(start.correlationId, finish.correlationId)
+        assertEquals(2, finish.detail?.get("updated"))
+    }
+
+    @Test
+    @DisplayName("SYS-060 failed run records FAILED with the error message")
+    fun sys060RecordsFailed() {
+        val syncService = mock(TeamcitySyncService::class.java)
+        `when`(syncService.resync()).thenThrow(IllegalStateException("TC unavailable"))
+        val recorder = RecordingServiceEventRecorder()
+        val service = TeamcitySyncJobServiceImpl(syncService, SyncTaskExecutor(), MigrationLifecycleGate(), recorder)
+
+        service.startAsync("alice")
+
+        assertEquals(listOf("start", "finish:FAILED"), recorder.order)
+        val finish = recorder.finishes.single()
+        assertEquals(ServiceEventStatus.FAILED, finish.status)
+        assertEquals("TC unavailable", finish.detail?.get("errorMessage"))
+    }
+
+    @Test
+    @DisplayName("SYS-060 rejected submission records a standalone FAILED (no running row)")
+    fun sys060RecordsRejected() {
+        val syncService = mock(TeamcitySyncService::class.java)
+        val recorder = RecordingServiceEventRecorder()
+        val service = TeamcitySyncJobServiceImpl(syncService, RejectingExecutor("pool shutting down"), MigrationLifecycleGate(), recorder)
+
+        assertFailsWith<java.util.concurrent.RejectedExecutionException> { service.startAsync("alice") }
+
+        // The runnable never ran, so no recordStart; a terminal FAILED is recorded directly.
+        assertTrue(recorder.starts.isEmpty())
+        val instant = recorder.instants.single()
+        assertEquals(ServiceEventType.TEAMCITY_RESYNC, instant.type)
+        assertEquals(ServiceEventStatus.FAILED, instant.status)
     }
 
     // -- Test doubles -------------------------------------------------------

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/impl/TeamcitySyncJobServiceImplTest.kt
@@ -250,6 +250,22 @@ class TeamcitySyncJobServiceImplTest {
         assertEquals(ServiceEventStatus.FAILED, instant.status)
     }
 
+    @Test
+    @DisplayName("SYS-060 cross-kind conflict records NOTHING (a conflict is not a failure)")
+    fun sys060CrossKindConflictRecordsNothing() {
+        val gate = MigrationLifecycleGate()
+        gate.tryClaim(MigrationLifecycleGate.JobKind.COMPONENTS, "components-1")
+        val recorder = RecordingServiceEventRecorder()
+        val service = TeamcitySyncJobServiceImpl(mock(TeamcitySyncService::class.java), SyncTaskExecutor(), gate, recorder)
+
+        assertFailsWith<MigrationConflictException> { service.startAsync("alice") }
+
+        // A cross-kind conflict means the job never started — it must NOT be journaled as FAILED.
+        assertTrue(recorder.starts.isEmpty())
+        assertTrue(recorder.finishes.isEmpty())
+        assertTrue(recorder.instants.isEmpty())
+    }
+
     // -- Test doubles -------------------------------------------------------
 
     /** Capture-but-don't-run executor — observe RUNNING state without the work finishing. */

--- a/docs/registry/deployment/service-event-ingest-token.md
+++ b/docs/registry/deployment/service-event-ingest-token.md
@@ -37,16 +37,11 @@ value on both services within one environment (it is a shared secret for the CRS
    secret (nothing is committed to `service-config`):
    - CRS profile: `components-registry.service-events.ingest-token = <secret>`
    - Portal profile: `portal.service-events.token = <same secret for that env>`
-3. **Enable** the portal reporter for that environment (NOT a secret — set in `service-config`):
-   ```yaml
-   # components-management-portal-cloud-qa.yml / -cloud-prod.yml
-   portal:
-     service-events:
-       enabled: true
-   ```
-   (Default is `false`; leaving it off means the portal records nothing and CRS-side events
-   still work.)
-4. **Roll** both services (or wait for the next deploy) so they pick up the config.
+3. **Roll** both services (or wait for the next deploy) so they pick up the config.
+
+The token is the single on/off switch on both sides — setting it (non-blank) turns reporting
+on; there is no separate enable flag. Leaving it blank/unset means the portal records nothing
+and CRS-side events still work.
 
 ## Verify
 
@@ -57,5 +52,5 @@ value on both services within one environment (it is a shared secret for the CRS
 
 ## Rollback / disable
 
-Set `portal.service-events.enabled=false` (or blank the token). Portal events stop being
-recorded immediately; CRS-side events are unaffected. No schema or data change.
+Blank/remove the token (either side). Portal events stop being recorded immediately; CRS-side
+events are unaffected. No schema or data change.

--- a/docs/registry/deployment/service-event-ingest-token.md
+++ b/docs/registry/deployment/service-event-ingest-token.md
@@ -1,0 +1,61 @@
+# Service-event ingest token (SYS-061)
+
+How to provision the shared secret that lets the **portal** report its operational events
+(portal redeploys, "Validation of components" sweep runs) into the CRS `service_event`
+journal shown on the Admin → **Events** tab.
+
+> Not needed for CRS-side events. Redeploys of CRS, data migrations, and TeamCity resync
+> are recorded by CRS itself and appear on the Events tab **without any token**. The token
+> only gates the portal → CRS ingest endpoint (`POST /rest/api/4/admin/service-events`).
+
+## What the token is
+
+A **symmetric shared secret** between the portal BFF and CRS — it is not issued by Keycloak
+and has nothing to do with OIDC. The portal sends it as the `X-Service-Event-Token` header;
+CRS compares it constant-time and is **fail-closed** (blank/unset or mismatch → `403`, so
+portal events are simply not recorded). It is an interim scheme; the OIDC service-account
+replacement is tracked in [tech-debt/015](../tech-debt/015-service-event-ingest-auth.md).
+
+## One secret PER ENVIRONMENT
+
+Use a **different** value for QA and prod (a QA leak must not affect prod), but the **same**
+value on both services within one environment (it is a shared secret for the CRS↔portal pair).
+
+| Environment | CRS key | Portal key | must match |
+|-------------|---------|------------|------------|
+| QA   | `components-registry.service-events.ingest-token` | `portal.service-events.token` | same value within QA |
+| prod | `components-registry.service-events.ingest-token` | `portal.service-events.token` | same value within prod |
+
+## Steps
+
+1. **Generate** a secret per environment:
+   ```
+   openssl rand -hex 32
+   ```
+2. **Store in Vault** under each environment's Spring Cloud Config profile
+   (`application-cloud-qa` / `application-cloud-prod`), by property key — same as every other
+   secret (nothing is committed to `service-config`):
+   - CRS profile: `components-registry.service-events.ingest-token = <secret>`
+   - Portal profile: `portal.service-events.token = <same secret for that env>`
+3. **Enable** the portal reporter for that environment (NOT a secret — set in `service-config`):
+   ```yaml
+   # components-management-portal-cloud-qa.yml / -cloud-prod.yml
+   portal:
+     service-events:
+       enabled: true
+   ```
+   (Default is `false`; leaving it off means the portal records nothing and CRS-side events
+   still work.)
+4. **Roll** both services (or wait for the next deploy) so they pick up the config.
+
+## Verify
+
+- Portal log has no `Failed to report ... service-event to CRS` warnings.
+- After a portal redeploy, the Admin → Events tab shows a `STARTUP` row with `source=portal`.
+- After a validation sweep completes, a `VALIDATION_SWEEP` row appears (`source=portal`).
+- A `403` on the portal→CRS POST means the two values differ or one side is blank.
+
+## Rollback / disable
+
+Set `portal.service-events.enabled=false` (or blank the token). Portal events stop being
+recorded immediately; CRS-side events are unaffected. No schema or data change.

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -68,6 +68,8 @@
 | SYS-057 | `GET /rest/api/4/health/statistics` returns registry-wide counts (`totalComponents`, `activeComponents`) and people-dimension breakdowns (`componentsByOwner`, `componentsByReleaseManager`, `componentsBySecurityChampion`) computed via SQL GROUP BY (never by loading all components into memory); ACCESS_COMPONENTS-gated; counts + people only (problem/validation aggregation is portal-owned) | High | integration-test | ✅ Tested |
 | SYS-058 | Artifact-ID ownership is modelled explicitly as a per-component LIST of `(group-list, mode ∈ {EXPLICIT, ALL_EXCEPT_CLAIMED, ALL}, version range)` mappings (`component_artifact_mappings` + `_tokens`), replacing the opaque regex `component_artifact_ids`. Cross-component uniqueness is decided deterministically from the stored modes (restores legacy validator #24/#25), enforced on v4 create/update (409); per-range overrides REPLACE the base for their range; v1–v3 wire renders the primary mapping; migration classifies DSL patterns into modes strictly (no escape hatch) | High | unit + integration-test | ✅ Tested |
 | SYS-059 | `POST /rest/api/4/versions/preview` renders a `DetailedComponentVersion` from ad-hoc Jira formats (base + per-range overrides) and an input version, with no persistence and no component lookup — reusing the persisted-path render seam (including `normalizeVersion` canonicalization) so output matches `detailed-version` for the same effective config. Range is resolved server-side; `line`/`build` mirror `minor`/`release` and `minor`/`release` default to `$major`/`$major.$minor` when blank; hotfix coordinate gated on caller-supplied `hotfixEnabled` (VCS-derived), not format presence; custom `versionPrefix`/`versionFormat` render the wrapped `jiraVersion`; padding is template-driven (no `buildSystem`); blank/non-numeric version or malformed range → 400, a version matching no format → 404; authenticated-only | High | unit + integration-test | ✅ Tested |
+| SYS-060 | An append-only `service_event` journal persists operational events — CRS redeploys (STARTUP + build version), and every components-migration / history-migration / TeamCity-resync run (RUNNING→COMPLETED/FAILED, one row per run) — which previously lived only in an in-memory slot + logs and were lost on restart. **Any job failure (including executor-rejected submission) writes a FAILED row with the error**; a run whose pod dies mid-flight is reconciled to FAILED("interrupted by restart") on next startup (single-pod). Writes are best-effort (`REQUIRES_NEW` + swallow) so journaling never rolls back or crashes the observed job. `GET /rest/api/4/admin/service-events` returns the paginated journal (filter by type/source/status/time), IMPORT_DATA-gated; a scheduled daily prune enforces retention | High | unit + integration-test | ✅ Tested |
+| SYS-061 | `POST /rest/api/4/admin/service-events` ingests portal-sourced events (portal redeploys, validation-sweep runs) into the shared journal, so the Admin "Events" tab shows both services on one timeline. Authenticated by a shared-secret `X-Service-Event-Token` header (the portal BFF calls CRS tokenless), verified constant-time and **fail-closed** (blank/unset configured token rejects every call 403); method-scoped permitAll at the filter chain so the sibling GET read stays JWT+IMPORT_DATA gated; unknown eventType/status/source → 400 | High | integration-test | ✅ Tested |
 
 ---
 
@@ -2178,3 +2180,92 @@ dichotomy `detailed-version` already produces. Authenticated-only via the
 `SYS-059 authenticated preview returns rendered coordinates`,
 `SYS-059 unauthenticated preview is 401`, `SYS-059 invalid version is 400`,
 `SYS-059 preview matches detailed-version for a real component`.
+
+### SYS-060: Operational service-event journal
+
+Migration/resync job runs and pod redeploys previously lived only in an in-memory
+`AtomicReference` (single-pod, lost on restart) + SLF4J logs, so operators had no
+persistent history. SYS-060 adds an append-only `service_event` table
+(`V4__add_service_event.sql`; also auto-created by Hibernate `ddl-auto` in the
+flyway-disabled envs) recording:
+
+- **STARTUP** — one terminal row per pod boot, carrying `service_version`
+  (`ServiceStartupListener` on `ApplicationReadyEvent`), giving a redeploy history.
+- **MIGRATION_COMPONENTS / MIGRATION_HISTORY / TEAMCITY_RESYNC** — one row per run,
+  created RUNNING at the top of the work runnable and transitioned in place to
+  COMPLETED/FAILED (matched by the job id in `correlation_id`).
+
+`ServiceEventRecorder` owns the writes. Each runs in its own `REQUIRES_NEW`
+transaction wrapped in a swallow-and-log so a journal failure never rolls back or
+crashes the job/boot it observes (mirrors `GitHistoryCommitWriter`). `recordFinish`
+falls back to inserting a terminal row if no RUNNING row exists.
+
+**Failure reporting (hard requirement):** every job-failure path writes a FAILED row
+with the error in `detail` — the `catch` branch of each run, AND the executor-reject
+path (`startAsync` catches the rejection, records a standalone terminal FAILED, and
+rethrows). A run interrupted by a pod restart (RUNNING row with no live job) is
+reconciled to `FAILED("interrupted by restart")` on the next startup. Single-pod only
+(prod `replicas: 1`) — the reconcile flips all crs RUNNING rows.
+
+`GET /rest/api/4/admin/service-events` returns the paginated journal (newest first;
+optional `eventType`/`source`/`status`/`from`/`to` filters), IMPORT_DATA-gated like
+`AdminControllerV4`. A `@Scheduled` daily prune deletes rows older than
+`components-registry.service-events.retention-days` (default 90) — scheduled, not
+startup-only, because a long-lived pod would otherwise never prune.
+
+**Acceptance criteria:**
+1. A pod start writes a terminal STARTUP row with the build version.
+2. A TeamCity resync (and components/history migration) writes a RUNNING row that
+   transitions to COMPLETED with the result counters in `detail` on success.
+3. A job that throws writes a single FAILED row (same `correlation_id`) with the
+   error message; a partial TC run (result carries per-component errors) COMPLETEs
+   with a "completed with errors" summary.
+4. An executor-rejected submission (no runnable ran) still writes a terminal FAILED row.
+5. On startup, any leftover RUNNING row of source `crs` is flipped to FAILED
+   ("interrupted by restart").
+6. A recorder write that throws is swallowed (logged) and does not propagate to the job.
+7. `GET /admin/service-events` returns rows newest-first, honours the filters, and is
+   403 for a caller without IMPORT_DATA.
+
+**Test method:** `ServiceEventRecorderImplTest` —
+`SYS-060 recordStart then recordFinish transitions the running row`,
+`SYS-060 recordFinish without a running row inserts a terminal row`,
+`SYS-060 reconcileOrphanedRunning flips running rows to failed`,
+`SYS-060 prune deletes rows before the cutoff`,
+`SYS-060 a write failure is swallowed`;
+`TeamcitySyncJobServiceImplTest` — `SYS-060 completed run records COMPLETED`,
+`SYS-060 failed run records FAILED`, `SYS-060 rejected submission records FAILED`;
+`ServiceStartupListenerTest` — `SYS-060 startup reconciles and records STARTUP`;
+`ServiceEventControllerV4Test` — `SYS-060 lists newest-first with filters`,
+`SYS-060 read requires IMPORT_DATA`.
+
+### SYS-061: Portal service-event ingest (shared-secret)
+
+The "validation of components" sweep and portal redeploys are portal-owned and not
+visible to CRS. SYS-061 lets the portal BFF report them into the shared journal via
+`POST /rest/api/4/admin/service-events` so the Admin "Events" tab shows both services
+on one timeline. Portal events arrive already-terminal (COMPLETED/FAILED) with
+caller-supplied timestamps; the body carries `eventType`/`status`/`source` (parsed
+leniently against the server enums → 400 on unknown values).
+
+Auth is a shared-secret `X-Service-Event-Token` header, not a JWT — the portal BFF
+calls CRS tokenless (same internal-network pattern as the permitAll `/migration-status`
+probe). The POST is method-scoped permitAll at the filter chain (above the
+`/rest/api/4/**` authenticated catch-all) so the sibling GET read stays JWT +
+IMPORT_DATA gated; the secret is verified in the controller (a `@PreAuthorize` cannot
+read a header), constant-time (`MessageDigest.isEqual`), **fail-closed**: a blank/unset
+configured token rejects every call (403), so a misconfiguration never opens ingest to
+the network. A leaked token only lets an attacker forge journal rows (no component data
+is mutated); a stronger service-account/OIDC/mTLS scheme is a post-cutover follow-up.
+
+**Acceptance criteria:**
+1. A POST with the correct token and a valid body records a terminal portal-sourced row.
+2. A POST with a wrong/missing token → 403; with the configured token blank/unset →
+   403 (fail-closed) even if the header is present.
+3. An unknown `eventType`/`status`/`source` → 400.
+4. The GET read side is unaffected (still JWT + IMPORT_DATA).
+
+**Test method:** `ServiceEventIngestControllerV4Test` —
+`SYS-061 valid token and body records the event`,
+`SYS-061 wrong token is 403`, `SYS-061 blank configured token is fail-closed 403`,
+`SYS-061 unknown eventType is 400`.

--- a/docs/registry/tech-debt/015-service-event-ingest-auth.md
+++ b/docs/registry/tech-debt/015-service-event-ingest-auth.md
@@ -1,0 +1,46 @@
+# TD-015: Replace the service-event ingest shared-secret with an OIDC service account
+
+## Status
+
+Open. Shipped with the shared-secret scheme (SYS-061); upgrade tracked here.
+
+## Background
+
+`POST /rest/api/4/admin/service-events` (SYS-061) lets the portal BFF report its own
+operational events (portal redeploys, validation-sweep runs) into the CRS
+`service_event` journal. The portal calls CRS **tokenless** today (the validation sweep
+hits CRS with no bearer token), and the portal events are emitted from **background
+threads** (`ApplicationReadyEvent`, the sweep scheduler) that carry **no user JWT** to
+relay — so the endpoint needs a *machine* identity, not the caller's user token.
+
+The v1 solution is a **shared-secret header** (`X-Service-Event-Token`): the value lives
+in Vault, is verified constant-time in `ServiceEventIngestControllerV4`, and is
+**fail-closed** (blank/unset → 403). The POST is method-scoped `permitAll` at the filter
+chain so the sibling GET read stays JWT + `IMPORT_DATA` gated.
+
+This is acceptable for an internal, journal-only endpoint (no component data is mutated;
+single-pod; internal network) but it is **not the platform-native scheme**: it is a
+symmetric pre-shared key rather than a real identity, separate from the Keycloak/OIDC
+mechanism that secures everything else on `/rest/api/4/**`.
+
+## Target
+
+Client-credentials **service account** via Keycloak:
+
+- Portal BFF acquires its own machine token (client-credentials grant) and calls CRS with
+  a normal `Bearer` JWT (client secret from Vault, like the other `application-cloud-*`
+  secrets).
+- CRS authorizes the ingest via a role/permission (mirror `AdminControllerV4`'s
+  `@permissionEvaluator` gate) and **drops** the `permitAll` matcher + the shared-secret
+  check.
+- Remove `X-Service-Event-Token` and `components-registry.service-events.ingest-token` /
+  `portal.service-events.token`.
+
+## Effort / notes
+
+- Provision (or reuse) a Keycloak client for the portal BFF; wire client-credentials token
+  acquisition into the BFF's outbound CRS calls.
+- Map the client's role to a CRS permission and remove the method-scoped `permitAll` in
+  `WebSecurityConfig`.
+- No data migration; the `service_event` table and read API are unaffected.
+- Until then the shared-secret path is safe as a temporary measure (fail-closed, journal-only).

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -649,7 +649,7 @@ spring:
 **Service-event ingest token (SYS-061):** the portal→CRS ingest shared secret is a
 per-environment Vault entry (`components-registry.service-events.ingest-token` on CRS,
 `portal.service-events.token` on the portal — same value within an env, different across
-envs) plus `portal.service-events.enabled: true`. Step-by-step in
+envs). The token is the single on/off switch (no separate enable flag). Step-by-step in
 [deployment/service-event-ingest-token.md](deployment/service-event-ingest-token.md).
 Not required for CRS-side events (redeploys, migrations, TeamCity resync).
 

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -646,6 +646,13 @@ spring:
           jwk-set-uri: ${auth-server.url}/realms/${auth-server.realm}/protocol/openid-connect/certs
 ```
 
+**Service-event ingest token (SYS-061):** the portal→CRS ingest shared secret is a
+per-environment Vault entry (`components-registry.service-events.ingest-token` on CRS,
+`portal.service-events.token` on the portal — same value within an env, different across
+envs) plus `portal.service-events.enabled: true`. Step-by-step in
+[deployment/service-event-ingest-token.md](deployment/service-event-ingest-token.md).
+Not required for CRS-side events (redeploys, migrations, TeamCity resync).
+
 ### 10.3 Helm Deployment (`<gitserver>/f1/service-deployment`)
 
 Extend existing deployment spec in `okd/deployments/`:

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -357,6 +357,38 @@ The fallback path is exercised by code paths that don't carry a request context.
 - v4 writes/admin/audit: **require JWT** + the permission named in ADR-004.
 - Gradual migration: consumers can be updated to pass JWT tokens over time. Phase 3 (close anonymous reads on v1/v2/v3) requires coordinated update of all consumers — timeline TBD.
 
+### 6.6 Operational service-event journal (SYS-060/061)
+Distinct from `audit_log` (which tracks **entity** changes), the `service_event` table is
+an append-only journal of **operational** events surfaced on the portal Admin "Events"
+tab: CRS/portal redeploys (STARTUP + build version), and every components-migration /
+history-migration / TeamCity-resync / portal validation-sweep **run**. These previously
+lived only in an in-memory `AtomicReference` (single-pod, lost on restart) + logs.
+
+- **Write path:** `ServiceEventRecorder` (`REQUIRES_NEW` per write via `TransactionTemplate`,
+  wrapped in swallow-and-log so journaling never rolls back or crashes the observed
+  job/boot). Job impls call `recordStart` at the top of the work runnable (executor
+  thread; `triggeredBy` captured on the caller thread and passed in, since the executor
+  carries no `SecurityContext`) and `recordFinish` at the terminal branch — one row per
+  run, RUNNING→COMPLETED/FAILED in place (matched by job id in `correlation_id`).
+- **Failure reporting (hard requirement):** every failure path writes FAILED — the run's
+  `catch`, and the executor-reject path (`startAsync` catches the rejection and records a
+  standalone terminal FAILED). `ServiceStartupListener` (`ApplicationReadyEvent`)
+  reconciles any RUNNING row left by a dead pod to `FAILED("interrupted by restart")`
+  before writing the STARTUP marker. **Single-pod** (`replicas: 1`) — the reconcile flips
+  all crs RUNNING rows.
+- **Read:** `GET /rest/api/4/admin/service-events` (paginated, filter by
+  type/source/status/time), IMPORT_DATA-gated like `AdminControllerV4`.
+- **Ingest (SYS-061):** `POST /rest/api/4/admin/service-events` lets the portal BFF report
+  its own events (portal redeploys, validation sweeps). Shared-secret `X-Service-Event-Token`
+  header (portal calls CRS tokenless), method-scoped permitAll at the filter chain,
+  constant-time + fail-closed secret check in the controller. A stronger
+  service-account/OIDC/mTLS scheme is a post-cutover follow-up.
+- **Retention:** a `@Scheduled` daily prune deletes rows older than
+  `components-registry.service-events.retention-days` (default 90) — scheduled, not
+  startup-only, so a long-lived pod still prunes.
+- **Schema:** `V4__add_service_event.sql` (+ Hibernate `ddl-auto` in the flyway-disabled
+  envs; `detail` is `TEXT`+`@JdbcTypeCode(JSON)` mirroring `audit_log`).
+
 ## 7. Data Migration
 
 ### 7.1 Migration Strategy: Component-Source Routing


### PR DESCRIPTION
## Why
The portal Admin needs to show operational/service events — redeploys, data migrations, TeamCity resync, and (via ingest) the portal's scheduled component-validation sweep. Today migration/resync runs live only in an in-memory `AtomicReference` + logs (lost on pod restart) and redeploys aren't recorded at all. This adds a persistent, append-only journal.

## What (SYS-060 / SYS-061)
**Storage & recorder**
- `service_event` table (`V4__add_service_event.sql`; also created by Hibernate `ddl-auto` in the flyway-disabled envs). `detail` is `TEXT`+`@JdbcTypeCode(JSON)`, mirroring `audit_log`.
- `ServiceEventRecorder`: best-effort — each write in its own `REQUIRES_NEW` tx, wrapped in swallow-and-log **outside** the tx, so journaling can never roll back or crash the observed job/boot.

**Emitters (fail-loud on failure — hard requirement)**
- The 3 async jobs (components migration, history migration, TeamCity resync) record `RUNNING` at the top of the work runnable and transition it in place to `COMPLETED`/`FAILED` — **one row per run**. `triggeredBy` is captured on the caller thread (`CurrentUserResolver` / `"scheduler"`) and passed through `startAsync`.
- **Every failure path writes FAILED**: the run's `catch`, and the executor-reject path (`startAsync` catches the rejection → standalone terminal FAILED).
- `ServiceStartupListener` (`ApplicationReadyEvent`) reconciles any `RUNNING` crs row left by a dead pod → `FAILED("interrupted by restart")`, then writes a `STARTUP` marker with the build version. **Single-pod** (`replicas: 1`).

**API**
- `GET /rest/api/4/admin/service-events` — paginated (filter by type/source/status/time), IMPORT_DATA-gated like the rest of `AdminControllerV4`.
- `POST /rest/api/4/admin/service-events` — ingest for portal-sourced events (portal redeploys, validation sweeps). Shared-secret `X-Service-Event-Token` (constant-time, **fail-closed**), method-scoped `permitAll` at the filter chain above the `/rest/api/4/**` authenticated rule; accepts terminal status + `source=portal` only.

**Retention**: a `@Scheduled` daily prune deletes rows older than `components-registry.service-events.retention-days` (default 90) — scheduled, not startup-only.

## Config (service-config, per env)
- `components-registry.service-events.ingest-token` — shared secret (blank ⇒ ingest disabled, fail-closed).
- `components-registry.service-events.retention-days` (default 90), `.prune-cron` (default `0 30 3 * * *`).

## Tests / gates
`test` (incl. OpenApi drift gate), `dbTest` (full integration), and fat-jar `integrationTest` all green locally. New tests: recorder DB behaviour + best-effort swallow, TC emit (completed/failed/reject), startup listener reconcile+marker, ingest (secret/terminal/source/400), read controller (gate + filter). Existing job/controller tests updated for the `triggeredBy` signature.

## Docs
SYS-060/061 in `requirements-common.md`, `technical-design.md` §6.6, regenerated `openapi/v4.json`.

## Follow-ups (separate PRs)
- Portal: BFF emitters (portal redeploy + validation-sweep) + Admin "Events" tab + `vendor-spec` re-pin.
- Post-cutover: replace shared-secret ingest with service-account/OIDC/mTLS (TD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent service-event journal to track startup and migration/sync lifecycle across restarts.
  * Added `GET /rest/api/4/admin/service-events` with paging and filters (newest-first by default).
  * Added `POST /rest/api/4/admin/service-events` for portal ingest with `X-Service-Event-Token` fail-closed validation and strict event constraints; job executions now record who triggered them.
  * Added scheduled retention pruning (cron-configurable).
* **Bug Fixes**
  * Startup now reconciles orphaned “running” events and writes a startup marker; reconciled items are marked failed.
* **Documentation**
  * Updated SYS-060/SYS-061 docs and OpenAPI v4 contract for the new endpoints.
* **Tests**
  * Added integration tests for listing/ingest, security behavior, journaling, reconciliation, and best-effort swallowing of write issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->