### PR TITLE
feat(component-defaults): surface jira.componentVersionFormat.versionFormat

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/AdminConfigProperties.kt
@@ -133,6 +133,13 @@ class AdminConfigProperties {
             var buildVersionFormat: String? = null
             var lineVersionFormat: String? = null
             var hotfixVersionFormat: String? = null
+
+            /**
+             * Full version-format wrapper (e.g. `$versionPrefix-$baseVersionFormat`),
+             * surfaced in component-defaults so the create wizard can seed its
+             * Full Version Format field from configuration.
+             */
+            var versionFormat: String? = null
         }
     }
 

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncService.kt
@@ -202,6 +202,7 @@ class ConfigSyncService(
                             cvf.buildVersionFormat?.let { put("buildVersionFormat", it) }
                             cvf.lineVersionFormat?.let { put("lineVersionFormat", it) }
                             cvf.hotfixVersionFormat?.let { put("hotfixVersionFormat", it) }
+                            cvf.versionFormat?.let { put("versionFormat", it) }
                         }.takeIf { it.isNotEmpty() }?.let { put("componentVersionFormat", it) }
                     }
                 }.takeIf { it.isNotEmpty() }?.let { put("jira", it) }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ConfigSyncServiceTest.kt
@@ -379,6 +379,7 @@ class ConfigSyncServiceTest {
                         buildVersionFormat = "\$major.\$minor.\$service-\$build"
                         lineVersionFormat = "\$major.\$minor"
                         hotfixVersionFormat = "\$major.\$minor.\$service.\$fix"
+                        versionFormat = "\$versionPrefix-\$baseVersionFormat"
                     }
                 }
                 distribution = AdminConfigProperties.Distribution().apply {
@@ -450,6 +451,7 @@ class ConfigSyncServiceTest {
                         "buildVersionFormat" to "\$major.\$minor.\$service-\$build",
                         "lineVersionFormat" to "\$major.\$minor",
                         "hotfixVersionFormat" to "\$major.\$minor.\$service.\$fix",
+                        "versionFormat" to "\$versionPrefix-\$baseVersionFormat",
                     ),
                 ),
                 "distribution" to mapOf(


### PR DESCRIPTION
## What
Surface `jira.componentVersionFormat.versionFormat` in the component-defaults contract.

- `AdminConfigProperties.Jira.ComponentVersionFormat` gains `versionFormat` (the full/custom version-format wrapper, e.g. `$versionPrefix-$baseVersionFormat` — legacy `Defaults.groovy` `jira.customer.versionFormat`).
- `ConfigSyncService` emits it in the `component-defaults` map (`GET /rest/api/4/config/component-defaults`).

## Why
The Portal create/clone wizard now has a **required** "Full Version Format" field (a component's Jira versions can't render without it). Its value must come from configuration (service-config), not a hardcoded portal default — this change lets the wizard seed it from `component-defaults`.

Paired with a service-config change (F1SC-190) that sets the value, and Portal PR #175.

## Tests
Extended `ConfigSyncServiceTest` full-map assertion to cover `versionFormat` round-tripping through the map builder. `:components-registry-service-server:test --tests "*ConfigSyncServiceTest*"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
