### PR TITLE
fix(admin): forbid re-running a completed migration (git==0 → 409)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminControllerV4.kt
@@ -77,6 +77,16 @@ class AdminControllerV4(
      */
     @PostMapping("/migrate")
     fun migrate(): ResponseEntity<MigrationJobResponse> {
+        // Forbid re-running once the migration is complete: `git` is the count of DSL
+        // (git-sourced) components not yet in the DB, so git==0 means there is nothing left
+        // to migrate. Re-running would only re-do defaults and confuse operators. A partial
+        // state (git>0, e.g. after failures) still allows a retry. Fail-loud (409) so a direct
+        // API caller is blocked too, not only the SPA button.
+        if (importService.getMigrationStatus().git == 0L) {
+            throw MigrationAlreadyCompleteException(
+                "Migration already complete: no git-sourced components remain (git=0). Nothing to migrate.",
+            )
+        }
         val outcome = migrationJobService.startAsync()
         val httpStatus = if (outcome.isNewlyStarted) HttpStatus.ACCEPTED else HttpStatus.CONFLICT
         return ResponseEntity.status(httpStatus).body(MigrationJobResponse.from(outcome.state))
@@ -122,6 +132,16 @@ class AdminControllerV4(
     fun handleConfigValidation(e: ConfigValidationException): ResponseEntity<Map<String, Any?>> =
         ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(
             mapOf("error" to "config-validation", "message" to (e.message ?: "Invalid configuration")),
+        )
+
+    /**
+     * Re-running a completed migration (git==0) is a 409 with a distinct `code` so the SPA
+     * can tell it apart from the same-kind attach 409 (which carries a job body).
+     */
+    @ExceptionHandler(MigrationAlreadyCompleteException::class)
+    fun handleMigrationAlreadyComplete(e: MigrationAlreadyCompleteException): ResponseEntity<Map<String, Any?>> =
+        ResponseEntity.status(HttpStatus.CONFLICT).body(
+            mapOf("code" to "migration-complete", "message" to (e.message ?: "Migration already complete")),
         )
 
     @GetMapping("/export")
@@ -239,3 +259,12 @@ class AdminControllerV4(
         )
     }
 }
+
+/**
+ * Thrown by `POST /admin/migrate` when the migration is already complete (no git-sourced
+ * components remain). Mapped to 409 `{code: "migration-complete"}` by the controller so a
+ * finished migration cannot be re-run from the SPA or a direct API call.
+ */
+class MigrationAlreadyCompleteException(
+    message: String,
+) : RuntimeException(message)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AdminMigrateJobControllerTest.kt
@@ -1,14 +1,19 @@
 package org.octopusden.octopus.components.registry.server.controller
 
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.service.ImportService
 import org.octopusden.octopus.components.registry.server.service.JobState
 import org.octopusden.octopus.components.registry.server.service.MigrationJobService
 import org.octopusden.octopus.components.registry.server.service.MigrationJobState
+import org.octopusden.octopus.components.registry.server.service.MigrationStatus
 import org.octopusden.octopus.components.registry.server.service.StartMigrationResult
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
@@ -53,8 +58,31 @@ class AdminMigrateJobControllerTest {
     @MockBean
     private lateinit var migrationJobService: MigrationJobService
 
+    @MockBean
+    private lateinit var importService: ImportService
+
     @Autowired
     private lateinit var mvc: MockMvc
+
+    @BeforeEach
+    fun stubIncompleteMigration() {
+        // Default: there is still something to migrate (git > 0) so the completeness guard
+        // does not fire for the existing start/attach cases. The git==0 case overrides this.
+        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 5, db = 10, total = 15))
+    }
+
+    @Test
+    fun `POST migrate returns 409 migration-complete when nothing remains in git`() {
+        // Full migration done (git == 0): re-running is forbidden — the job must NOT start.
+        `when`(importService.getMigrationStatus()).thenReturn(MigrationStatus(git = 0, db = 15, total = 15))
+
+        mvc
+            .perform(post("/rest/api/4/admin/migrate").with(adminJwt()))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.code").value("migration-complete"))
+
+        verify(migrationJobService, never()).startAsync()
+    }
 
     @Test
     fun `POST migrate first call returns 202 with the freshly-started job body`() {


### PR DESCRIPTION
## Why
After a full Git→DB migration, the Admin **Run migration** button stayed enabled and would re-trigger the process (reported from the stand). Re-running a completed migration is pointless (nothing left in Git; it only re-does defaults) and confusing.

## What
`POST /rest/api/4/admin/migrate` now returns **409 `{code: "migration-complete"}`** when `getMigrationStatus().git == 0` (no git-sourced components remain). Fail-loud so a direct API caller is blocked too, not just the SPA. A **partial** state (`git > 0`, e.g. after failures) still allows a retry.

Distinct `code` keeps it apart from the existing same-kind attach 409 (which carries a job body).

## Tests (TDD, red→green)
- `test:` commit — new `AdminMigrateJobControllerTest` case asserting 409 + `startAsync` never called for `git==0` (RED against the pre-fix controller).
- `fix:` commit — the guard (GREEN). `AdminControllerV4SecurityTest` (real importService, git>0) unaffected. Full `test` + `dbTest` green locally.

## Pairs with
Portal PR (disables the Run button when `git === 0` + hint): octopusden/octopus-components-management-portal (fix/block-completed-migration-rerun). Independent of the service-events work (#415).

🤖 Generated with [Claude Code](https://claude.com/claude-code)