### PR TITLE
ci(release): pin release workflow to octopus-base@v2.3.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@feature/common-quality-gates
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'


### PR DESCRIPTION
## Problem

The `3.0.1` GitHub release triggered from TeamCity (`[4.0] Release`) failed. The `repository_dispatch` run of `.github/workflows/release.yml` (`28819416702`) **failed at startup in 0s** with "This run likely failed because of a workflow file issue", so no jobs ran and no `3.0.1` tag/release was produced. The TeamCity `CallGitHubRelease.main.kts` poller then timed out after 11 attempts (`TimeoutException`, exit code 3).

**Root cause:** `release.yml` referenced the reusable workflow at a **feature branch**:
```yaml
uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@feature/common-quality-gates
```
That branch has since been merged and deleted in `octopus-base` (`Branch not found`, 404), so GitHub could not resolve the called workflow. The ref was switched from `@v2.1.10` to this branch in `9b86cccd feat: prepare v3`.

## Fix

Pin to the stable tag **`@v2.3.5`**:
- Its `workflow_call` input signature matches what we pass — `flow-type`/`java-version` required; `commit-hash`/`build-version`/`docker-image` optional — i.e. the same shape the feature branch carried once it landed in the v2.2/v2.3 line.
- Reverting to `@v2.1.10` is **not** viable: it declares extra `required: true` inputs this caller does not provide (would fail validation again).
- `v2.3.5` is also the octopus-base tag the TeamCity `CallGitHubRelease` step already clones, keeping both halves of the release on one base version.

## After merge

Re-trigger `[4.0] Release` in TeamCity to cut `3.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use a fixed, stable version for build execution, helping make releases more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->