### PR TITLE
ci(release): pin check-and-register workflow to octopus-base@v2.3.5

### DIFF
--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@feature/common-quality-gates
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/infrastructure/components-registry-service-core/_VER_/components-registry-service-core-_VER_.jar"

--- a/docs/registry/ft-db-testing-plan.md
+++ b/docs/registry/ft-db-testing-plan.md
@@ -96,17 +96,3 @@ when entity column definitions are loosened (e.g. removing PG-specific `columnDe
 **Description:** Under the `ft-db` profile (H2 in-memory, PostgreSQL compatibility mode),
 POST creates a component and PATCH updates nested fields whose entity columns use
 `columnDefinition = "jsonb"`.
-
-## CI status reference
-
-PR #148: CodeRabbit ✅ / GitGuardian ✅. The three "failed" entries (`build.yml`,
-`quality-gates.yml`, `security.yml`) are **pre-existing** on base branch `v3` — the same
-three workflows are red on every v3 commit since `dc9ac3d`. Root cause: all three reference
-`octopusden/octopus-base/.github/workflows/*.yml@feature/common-quality-gates`, but that
-branch does not exist in `octopus-base`. The workflows fail at resolution (0 jobs, 0s
-duration) before any code runs. Not a regression introduced by PR #148.
-
-**Fix track (out of scope for #148):** either create/restore
-`octopusden/octopus-base@feature/common-quality-gates`, or update the three workflow files
-on `v3` to pin to an existing ref (e.g. `@main` or `@v2.1.10`). Needs owner confirmation
-of which common-workflow is the intended successor.


### PR DESCRIPTION
## Problem

`[5.0] Release Post Processing` (and the downstream `[6.0]`/`[7.0]` deploy chain) never started after the **v3.0.1** release, even though the release itself succeeded.

Root cause = the **same dead-ref bug as #418, in the other release workflow**. `.github/workflows/check-and-register.yml` references the reusable workflow at a deleted branch:
```yaml
uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@feature/common-quality-gates
```
That branch was merged and deleted in octopus-base, so the run failed at startup in 0s ("workflow file issue"). Confirmed: the v3.0.1 `check-and-register` run (`28822594858`) has `run_started_at == updated_at` and conclusion `failure`.

## Why this stalls post-processing

`check-and-register` runs on `workflow_run` after a successful *Gradle Release*: it verifies the published artifact, then **registers the release in `octopus-release-log`** (a `github-actions[bot]` commit `<module>-<version>` touching `octopus-components-registry-service.txt`). The `[5.0]` TeamCity trigger is a **VCS trigger on that release-log file** (`+:root=Octopus_OctopusReleaseLog:**/%OCTOPUS_MODULE_NAME%.txt`). Because this workflow died at 0s, the release-log never got a `3.0.1` entry → `[5.0]` never fired.

The release-log's last CRS entry is `2.0.88` (2026-07-01); there is no `3.0.1`.

## Fix

Pin to the stable tag **`@v2.3.5`** (its `common-check-and-register-release.yml` keeps the required `artifact-pattern` input) — matching #418. The portal's `check-and-register.yml` is already on `@v2.3.5`, so it is unaffected.

## After merge

This fixes *future* releases. The already-released **v3.0.1 must still be registered** to unstick `[5.0]` (a GitHub re-run of the failed check-and-register would reuse the old dead-ref file). See follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)