### PR TITLE
fix(dto): drop redundant @JsonCreator from all-defaults data classes

### DIFF
--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ArtifactComponentDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ArtifactComponentDTO.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ArtifactComponentDTO @JsonCreator constructor(
+data class ArtifactComponentDTO(
     @JsonProperty("artifact") val artifact: ArtifactDependency,
     @JsonProperty("component") val component: VersionedComponent?
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ArtifactComponentsDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ArtifactComponentsDTO.kt
@@ -1,10 +1,9 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ArtifactComponentsDTO @JsonCreator constructor(
+data class ArtifactComponentsDTO(
     @JsonProperty("artifactComponents") val artifactComponents: Collection<ArtifactComponentDTO>
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ArtifactDependency.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ArtifactDependency.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ArtifactDependency @JsonCreator constructor(
+data class ArtifactDependency(
     @JsonProperty("group") val group: String,
     @JsonProperty("name") val name: String,
     @JsonProperty("version") val version: String

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/BuildParametersDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/BuildParametersDTO.kt
@@ -1,12 +1,11 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.octopusden.octopus.components.registry.api.build.tools.BuildTool
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class BuildParametersDTO @JsonCreator constructor(
+data class BuildParametersDTO(
     @JsonProperty("javaVersion") val javaVersion: String? = null,
     @JsonProperty("mavenVersion") val mavenVersion: String? = null,
     @JsonProperty("gradleVersion") val gradleVersion: String? = null,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentArtifactConfigurationDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentArtifactConfigurationDTO.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ComponentArtifactConfigurationDTO @JsonCreator constructor(
+data class ComponentArtifactConfigurationDTO(
     @JsonProperty("groupPattern") val groupPattern: String?,
     @JsonProperty("artifactPattern") val artifactPattern: String?
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentImage.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ComponentImage @JsonCreator constructor(
+data class ComponentImage(
     @JsonProperty("component") val component: String,
     @JsonProperty("version") val version: String,
     @JsonProperty("image") val image: Image

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentInfoDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentInfoDTO.kt
@@ -1,8 +1,7 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class ComponentInfoDTO @JsonCreator constructor(
+data class ComponentInfoDTO(
         @JsonProperty("versionPrefix") val versionPrefix: String,
         @JsonProperty("versionFormat") val versionFormat: String)

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentVersionFormat.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ComponentVersionFormat.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class ComponentVersionFormatDTO @JsonCreator constructor(
+data class ComponentVersionFormatDTO(
         @JsonProperty("majorVersionFormat") val majorVersionFormat: String,
         @JsonProperty("releaseVersionFormat") val releaseVersionFormat: String,
         @JsonProperty("buildVersionFormat") val buildVersionFormat: String,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ErrorResponse.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ErrorResponse.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -15,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * `DATA_INTEGRITY` — clients must tolerate unknown values.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ErrorResponse @JsonCreator constructor(
+data class ErrorResponse(
         @JsonProperty("errorMessage") val errorMessage: String,
         // NON_NULL is wire-compat-bearing: the [1.7]/[1.8] compat oracles byte-diff
         // v1-v3 ERROR bodies against the 2.0.87 baseline, and an emitted

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/EscrowDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/EscrowDTO.kt
@@ -1,12 +1,11 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class EscrowDTO @JsonCreator constructor(
+data class EscrowDTO(
     @JsonProperty("buildTask") val buildTask: String? = null,
     @JsonProperty("providedDependencies") val providedDependencies: List<String>? = emptyList(),
     @JsonProperty("diskSpaceRequirement") val diskSpaceRequirement: Long? = null,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/Image.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/Image.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class Image @JsonCreator constructor(
+data class Image(
     @JsonProperty("name") val name: String,
     @JsonProperty("tag") val tag: String
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/JiraComponentDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/JiraComponentDTO.kt
@@ -1,9 +1,8 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class JiraComponentDTO @JsonCreator constructor(
+data class JiraComponentDTO(
     @JsonProperty("projectKey") val projectKey: String,
     @JsonProperty("displayName") val displayName: String?,
     @JsonProperty("componentVersionFormat") val componentVersionFormat: ComponentVersionFormatDTO,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/JiraComponentVersionDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/JiraComponentVersionDTO.kt
@@ -1,10 +1,9 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
 
-data class JiraComponentVersionDTO @JsonCreator constructor(
+data class JiraComponentVersionDTO(
         @JsonProperty("name") val name: String,
         @JsonProperty("version") val version: String,
         @JsonProperty("component") val component: JiraComponentDTO

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/JiraComponentVersionRangeDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/JiraComponentVersionRangeDTO.kt
@@ -1,9 +1,8 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class JiraComponentVersionRangeDTO @JsonCreator constructor(
+data class JiraComponentVersionRangeDTO(
     @JsonProperty("componentName") val componentName: String,
     @JsonProperty("versionRange") val versionRange: String,
     @JsonProperty("component") val component: JiraComponentDTO,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ServiceStatusDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ServiceStatusDTO.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
@@ -33,7 +32,7 @@ import java.util.*
  *                                        reason as `defaultSource`.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ServiceStatusDTO @JsonCreator constructor(
+data class ServiceStatusDTO(
     @JsonProperty("cacheUpdatedAt") val cacheUpdatedAt: Date,
     @JsonProperty("serviceMode") val serviceMode: ServiceMode,
     @JsonProperty("versionControlRevision") val versionControlRevision: String?,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ToolDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/ToolDTO.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ToolDTO @JsonCreator constructor(
+data class ToolDTO(
     @JsonProperty("name") val name: String,
     @JsonProperty("escrowEnvironmentVariable") val escrowEnvironmentVariable: String,
     @JsonProperty("sourceLocation") val sourceLocation: String,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VCSSettingsDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VCSSettingsDTO.kt
@@ -1,11 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class VCSSettingsDTO @JsonCreator constructor(
+data class VCSSettingsDTO(
     @JsonProperty("versionControlSystemRoots") val versionControlSystemRoots: List<VersionControlSystemRootDTO> = emptyList(),
     @JsonProperty("externalRegistry") val externalRegistry: String? = null,
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VcsRootDateDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VcsRootDateDTO.kt
@@ -1,10 +1,9 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.*
 
-data class VcsRootDateDTO @JsonCreator constructor(
+data class VcsRootDateDTO(
     @JsonProperty("root") val root: VersionControlSystemRootDTO,
     @JsonProperty("date") val date: Date? = null
 )

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionControlSystemRootDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionControlSystemRootDTO.kt
@@ -1,13 +1,12 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class VersionControlSystemRootDTO @JsonCreator constructor(
+data class VersionControlSystemRootDTO(
     @JsonProperty("name") val name: String,
     @JsonProperty("vcsPath") val vcsPath: String,
     @JsonProperty("type") val type: RepositoryType,

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionNamesDTO.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionNamesDTO.kt
@@ -1,13 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class VersionNamesDTO
-@JsonCreator
-constructor(
+data class VersionNamesDTO(
     @JsonProperty("serviceBranch") val serviceBranch: String,
     @JsonProperty("service") val service: String,
     @JsonProperty("minor") val minor: String

--- a/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionedComponent.kt
+++ b/components-registry-service-core/src/main/kotlin/org/octopusden/octopus/components/registry/core/dto/VersionedComponent.kt
@@ -1,13 +1,10 @@
 package org.octopusden.octopus.components.registry.core.dto
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class VersionedComponent
-@JsonCreator
-constructor(
+class VersionedComponent(
     @JsonProperty("id") id: String,
     @JsonProperty("name") name: String?,
     @JsonProperty("version") val version: String,


### PR DESCRIPTION
## Problem

`VCSSettingsDTO` and `BuildParametersDTO` have all constructor parameters with default values. `jackson-module-kotlin` 2.12+ automatically synthesises an implicit no-arg `@JsonCreator(mode=DEFAULT)` for such classes. The explicit `@JsonCreator` on the primary constructor then registers a second `DEFAULT`-mode creator, which Jackson rejects at startup:

```
InvalidDefinitionException: Conflicting property-based creators:
  already had [constructor for VCSSettingsDTO (0 args)],
  encountered [constructor for VCSSettingsDTO (2 args)]
```

## Fix

Drop the explicit `@JsonCreator` (and its import) from both classes. Since Jackson 2.12+, a constructor whose parameters are all annotated with `@JsonProperty` is automatically treated as a properties-based creator — the annotation is redundant and is what causes the conflict.

## Scope

A full audit of all `@JsonCreator` usages in the codebase confirmed these are the only two affected classes (all others have at least one required parameter, which prevents the implicit no-arg creator from being synthesised).

## Replaces

Closes #153 (previous fix covered `VCSSettingsDTO` only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON deserialization reliability for multiple registry API payload DTOs by switching them to standard constructor-based mapping.
  * Unexpected/extra fields are still safely ignored, and existing JSON field mappings and null-handling behavior remain unchanged.

* **Refactor**
  * Removed explicit Jackson constructor annotations across the component registry DTOs to simplify public API object declarations without changing their external structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->