### PR TITLE
ci(compat): pin baseline to frozen 2.0.88 + run compat gate on main

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -21,6 +21,13 @@ project {
     params {
         param("JDK_VERSION", "11")
         param("LAST_RELEASE_VERSION", "2.0.88")
+        // Compat baseline = the FROZEN last-2.x prod byte-compat oracle, pinned
+        // in code (NOT tracking `LAST_RELEASE_VERSION`, which the cutover moved
+        // to 3.0.1 — comparing a v3 candidate against a v3 baseline is a
+        // tautology, and the released 3.0.1 image cannot even boot in the
+        // harness's V1 mode because its `registry_config` startup read trips
+        // H2's reserved `key`). Bump this ONLY on a deliberate re-baseline.
+        param("COMPAT_BASELINE_VERSION", "2.0.88")
         param("PROJECT_VERSION", "")
         param("COMPONENTS_REGISTRY_BRANCH", "master")
         param("OCTOPUS_MODULE_NAME", "octopus-components-registry-service")
@@ -595,11 +602,11 @@ object id16CompatTraceReplayManual : BuildType({
 })
 
 // Compat — Local Stand (baseline + candidate JARs) — auto-fires after id10
-// succeeds on non-main branches (see `triggers { finishBuildTrigger }` below)
-// AND has a snapshot dep on id10. Operator can still Run manually from any
-// branch — manual run from `main` is a tautological V1-vs-V1 measurement and
-// is skipped server-side. Spins TWO CRS instances side-by-side
-// on the agent: baseline (released `%LAST_RELEASE_VERSION%`, docker
+// succeeds on EVERY branch, `main` included (see `triggers { finishBuildTrigger }`
+// below) AND has a snapshot dep on id10. A run from `main` is now a real
+// regression gate — the frozen 2.0.88 baseline vs the v3 trunk — not the old
+// tautological V1-vs-V1 self-comparison. Spins TWO CRS instances side-by-side
+// on the agent: baseline (frozen `%COMPAT_BASELINE_VERSION%`, docker
 // image from corp registry) and candidate (current chain's image
 // pushed by id10), both pointed at the production Components-Registry
 // DSL + service-config. Then runs the compat-test module's full
@@ -681,10 +688,9 @@ object id17CompatLocalStandManual : BuildType({
         // / VCS-refresh-cycle signal that disappears under sequential
         // execution). Lower values trade run time for determinism.
         text("COMPAT_PARALLELISM", "8", allowEmpty = false, display = ParameterDisplay.PROMPT)
-        // Baseline version is the project-level `LAST_RELEASE_VERSION` (e.g.
-        // `2.0.88`); pinned, not prompted — operator updates the project
-        // param when a new release lands.
-        param("COMPAT_BASELINE_VERSION", "%LAST_RELEASE_VERSION%")
+        // Baseline version = the project-level `COMPAT_BASELINE_VERSION`
+        // (frozen 2.x byte-compat oracle, pinned in code — see its definition
+        // in the project `params` block). Inherited, not overridden here.
         // Candidate image tag = the build number of the upstream id10 chain
         // step that just pushed it via `dockerPushImage`. Also reused as
         // %BUILD_NUMBER% so id17's own build number (set above via
@@ -750,14 +756,16 @@ object id17CompatLocalStandManual : BuildType({
             scriptContent = """
                 set -euo pipefail
                 # Green-skip when the compat-test infra isn't in this checkout. [1.7]/[1.8]
-                # auto-fire on [1.0] success for ANY branch; if a build resolves to `main`
-                # (the legacy V1 trunk) — or a deleted feature branch falls back to the
-                # default branch — `scripts/local-stands/` is absent and the wrapper below
-                # would exit 127. Mirror id15/id16: succeed with a clear status, not a red 127.
+                # auto-fire on [1.0] success for ANY branch, `main` included — which now
+                # carries the compat infra (post v3→main cutover), so this normally proceeds.
+                # The skip only trips on a legacy pre-v3 branch, or a deleted feature branch
+                # that falls back to a default without `scripts/local-stands/`, where the
+                # wrapper below would exit 127. Mirror id15/id16: succeed with a clear
+                # status, not a red 127.
                 if [ ! -f scripts/local-stands/teamcity-run.sh ]; then
                     echo "::: scripts/local-stands/teamcity-run.sh not present in this checkout."
-                    echo "::: [1.7] is only meaningful on v3-family branches that carry the compat-test infra."
-                    echo "##teamcity[buildStatus status='SUCCESS' text='Skipped: compat-test infra absent on this branch (likely main); run from v3 family instead.']"
+                    echo "::: [1.7] is only meaningful on branches carrying the compat-test infra (v3 family + post-cutover main)."
+                    echo "##teamcity[buildStatus status='SUCCESS' text='Skipped: compat-test infra absent on this branch (legacy/pre-v3 checkout).']"
                     exit 0
                 fi
                 WORK_DIR="/tmp/crs-id17-%teamcity.build.id%"
@@ -945,18 +953,17 @@ object id17CompatLocalStandManual : BuildType({
     }
 
     triggers {
-        // Auto-fire id17 after id10 (Compile&UT) succeeds on non-main branches.
-        // The former [1.9] cluster-50 pre-gate (id19) was removed — the full
-        // matrix here is the authoritative compat gate. Manual Run from any
-        // branch still works; a run from `main` is a tautological V1-vs-V1
-        // measurement and is skipped server-side.
+        // Auto-fire id17 after id10 (Compile&UT) succeeds on EVERY branch,
+        // `main` included. The former [1.9] cluster-50 pre-gate (id19) was
+        // removed — the full matrix here is the authoritative compat gate.
+        // `main` is no longer excluded: the baseline is now the FROZEN 2.0.88
+        // oracle (see `COMPAT_BASELINE_VERSION`), so a run from `main` compares
+        // the v3 trunk against last-2.x prod — a real regression gate, not the
+        // old tautological V1-vs-V1 self-comparison.
         finishBuildTrigger {
             buildType = "${id10CompileUtAuto.id}"
             successfulOnly = true
-            branchFilter = """
-                +:*
-                -:main
-            """.trimIndent()
+            branchFilter = "+:*"
         }
     }
 
@@ -1010,7 +1017,8 @@ object id18CompatLocalStandGitModeAuto : BuildType({
         text("COMPAT_COMPONENTS_FILE", "components/all.txt", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_FULL", "true", allowEmpty = false, display = ParameterDisplay.PROMPT)
         text("COMPAT_PARALLELISM", "8", allowEmpty = false, display = ParameterDisplay.PROMPT)
-        param("COMPAT_BASELINE_VERSION", "%LAST_RELEASE_VERSION%")
+        // Baseline version inherited from the project-level
+        // `COMPAT_BASELINE_VERSION` (frozen 2.x byte-compat oracle).
         param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
         param("COMPAT_CANDIDATE_VERSION", "%BUILD_NUMBER%")
         param("DOCKER_REGISTRY_INTERNAL", "%DOCKER_REGISTRY%")
@@ -1055,14 +1063,16 @@ object id18CompatLocalStandGitModeAuto : BuildType({
             scriptContent = """
                 set -euo pipefail
                 # Green-skip when the compat-test infra isn't in this checkout. [1.7]/[1.8]
-                # auto-fire on [1.0] success for ANY branch; if a build resolves to `main`
-                # (the legacy V1 trunk) — or a deleted feature branch falls back to the
-                # default branch — `scripts/local-stands/` is absent and the wrapper below
-                # would exit 127. Mirror id15/id16: succeed with a clear status, not a red 127.
+                # auto-fire on [1.0] success for ANY branch, `main` included — which now
+                # carries the compat infra (post v3→main cutover), so this normally proceeds.
+                # The skip only trips on a legacy pre-v3 branch, or a deleted feature branch
+                # that falls back to a default without `scripts/local-stands/`, where the
+                # wrapper below would exit 127. Mirror id15/id16: succeed with a clear
+                # status, not a red 127.
                 if [ ! -f scripts/local-stands/teamcity-run.sh ]; then
                     echo "::: scripts/local-stands/teamcity-run.sh not present in this checkout."
-                    echo "::: [1.8] is only meaningful on v3-family branches that carry the compat-test infra."
-                    echo "##teamcity[buildStatus status='SUCCESS' text='Skipped: compat-test infra absent on this branch (likely main); run from v3 family instead.']"
+                    echo "::: [1.8] is only meaningful on branches carrying the compat-test infra (v3 family + post-cutover main)."
+                    echo "##teamcity[buildStatus status='SUCCESS' text='Skipped: compat-test infra absent on this branch (legacy/pre-v3 checkout).']"
                     exit 0
                 fi
                 WORK_DIR="/tmp/crs-id18-%teamcity.build.id%"
@@ -1195,17 +1205,15 @@ object id18CompatLocalStandGitModeAuto : BuildType({
     }
 
     triggers {
-        // Auto-fire alongside id17 whenever id10 finishes on a non-main branch.
-        // git-mode has signal on every branch (it guards the no-op invariant),
-        // but mirror id17's main exclusion to avoid burning agent minutes on the
-        // release trunk; Manual Run from any branch still works.
+        // Auto-fire alongside id17 whenever id10 finishes on EVERY branch,
+        // `main` included (mirrors id17). git-mode has signal on every branch
+        // (it guards the no-op invariant), and against the frozen 2.0.88
+        // baseline a `main` run is a real regression gate, so no reason to
+        // exclude the release trunk any more.
         finishBuildTrigger {
             buildType = "${id10CompileUtAuto.id}"
             successfulOnly = true
-            branchFilter = """
-                +:*
-                -:main
-            """.trimIndent()
+            branchFilter = "+:*"
         }
     }
 


### PR DESCRIPTION
## Why

The compat Local-Stand gates ([1.7] baseline+candidate JARs, [1.8] git-mode) resolved the baseline image tag from `%LAST_RELEASE_VERSION%`. The **v3→main cutover** bumped that TC-server project param to `3.0.1`, which broke both gates (build `3.0.1-4208`):

1. **v3-vs-v3 tautology** — candidate and baseline both v3, so the gate measures nothing.
2. **baseline can't boot in V1 mode** — the released 3.0.1 image's `registry_config` startup read emits `select … key … where key=?`; H2 2.2.224 treats `key` as a reserved word → `JdbcSQLSyntaxErrorException` → baseline never comes up → both gates red (candidate never even starts).

## What

**Freeze the baseline (decouple from the moving release pointer):**
- Add project-level `COMPAT_BASELINE_VERSION = "2.0.88"` — the frozen last-2.x prod byte-compat oracle (the tag the full 130k sweep was validated against).
- Drop the two build-type-local `%LAST_RELEASE_VERSION%` overrides so id17/id18 inherit it. `LAST_RELEASE_VERSION` is no longer referenced for the baseline (unused elsewhere in the repo).

**Run the compat gate on `main`:**
- Drop `-:main` from the id17/id18 `finishBuildTrigger` branchFilter (now `+:*`). Chained off id10 (Compile&UT), which builds on every branch incl. main — so compat now auto-fires on each main commit.
- Against the frozen 2.0.88 baseline a `main` run is a **real regression gate** (v3 trunk vs last-2.x prod), not the old tautology.

**Housekeeping:** refresh the now-stale "infra absent" guard comments/messages that framed `main` as "the legacy V1 trunk".

## Safety / review notes

- **Non-blocking:** id17/id18 are leaf gates — nothing snapshot-depends on them, so a compat failure on main cannot block deploy/release.
- **Candidate image on main:** id10 runs `dockerPushImage` on all branches; candidate tag = `%BUILD_NUMBER%` (id10 build number) — same mechanism already proven on feature branches.
- **No false-green on main:** post-cutover `main` carries `scripts/local-stands/` + the compat module, so the green-skip guard doesn't misfire.
- **Cost:** each main commit now triggers two heavy (~130k-tuple) compat runs — the intended trade-off for a commit-triggered gate on main.
- **Versioned settings:** takes effect once merged to the branch TeamCity reads DSL from.
- Validated locally with `mvn teamcity-configs:generate` (EXIT=0); generated XML confirms `COMPAT_BASELINE_VERSION=2.0.88` inheritance and `branchFilter="+:*"` on both gates.

Reviewed by an independent correctness pass (findings addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compatibility checks to use a consistent frozen baseline across local stand workflows.
  * Changed automated triggers so regression checks now run on all branches, including the main branch.
  * Improved status messaging for skipped preflight checks to better reflect legacy checkout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->