### PR TITLE
feat(service-events): ONBOARDING_VIDEO_VIEW + SYSTEM/USER category axis

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4.kt
@@ -38,6 +38,7 @@ class ServiceEventControllerV4(
     @GetMapping
     fun list(
         @RequestParam(required = false) eventType: String?,
+        @RequestParam(required = false) category: String?,
         @RequestParam(required = false) source: String?,
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
@@ -45,7 +46,14 @@ class ServiceEventControllerV4(
         pageable: Pageable,
     ): Page<ServiceEventResponse> =
         serviceEventQueryService.find(
-            ServiceEventFilter(eventType = eventType, source = source, status = status, from = from, to = to),
+            ServiceEventFilter(
+                eventType = eventType,
+                category = category,
+                source = source,
+                status = status,
+                from = from,
+                to = to,
+            ),
             pageable,
         )
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventFilter.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventFilter.kt
@@ -8,6 +8,8 @@ import java.time.Instant
  */
 data class ServiceEventFilter(
     val eventType: String? = null,
+    /** SYSTEM / USER — matches every event_type in that category (case-insensitive). */
+    val category: String? = null,
     val source: String? = null,
     val status: String? = null,
     val from: Instant? = null,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventResponse.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ServiceEventResponse.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.components.registry.server.dto.v4
 
 import org.octopusden.octopus.components.registry.server.entity.ServiceEventEntity
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
 import java.time.Instant
 
 /**
@@ -11,6 +12,8 @@ import java.time.Instant
 data class ServiceEventResponse(
     val id: Long,
     val eventType: String,
+    /** Derived SYSTEM/USER split (from eventType) so the SPA can separate the two views. */
+    val category: String,
     val status: String,
     val source: String,
     val triggeredBy: String?,
@@ -27,6 +30,7 @@ data class ServiceEventResponse(
                 // A persisted row always has an id; fail loud rather than emit a misleading 0.
                 id = requireNotNull(entity.id) { "persisted service_event row has a null id" },
                 eventType = entity.eventType,
+                category = ServiceEventType.categoryOf(entity.eventType).name,
                 status = entity.status,
                 source = entity.source,
                 triggeredBy = entity.triggeredBy,

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventModel.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventModel.kt
@@ -10,21 +10,52 @@ import java.util.Locale
  * ordinal shift and unknown values read back gracefully. Validation happens at the
  * recorder / ingest boundary.
  */
-enum class ServiceEventType {
+/**
+ * Coarse split so the Admin "Events" tab can separate operational/system events from
+ * product-usage events triggered by an end user (e.g. watching the onboarding video).
+ */
+enum class ServiceEventCategory {
+    /** Operational / lifecycle events emitted by a service (startup, migration, sweep, …). */
+    SYSTEM,
+
+    /** Product-usage events triggered by a specific end user (`triggeredBy` = username). */
+    USER,
+}
+
+enum class ServiceEventType(val category: ServiceEventCategory) {
     /** A service process (re)started. `serviceVersion` carries the build version. */
-    STARTUP,
+    STARTUP(ServiceEventCategory.SYSTEM),
 
     /** Git→DB components migration run. */
-    MIGRATION_COMPONENTS,
+    MIGRATION_COMPONENTS(ServiceEventCategory.SYSTEM),
 
     /** Git-history backfill run. */
-    MIGRATION_HISTORY,
+    MIGRATION_HISTORY(ServiceEventCategory.SYSTEM),
 
     /** TeamCity project-id/url resync run. */
-    TEAMCITY_RESYNC,
+    TEAMCITY_RESYNC(ServiceEventCategory.SYSTEM),
 
     /** Portal-owned scheduled component-validation sweep run (source=portal). */
-    VALIDATION_SWEEP,
+    VALIDATION_SWEEP(ServiceEventCategory.SYSTEM),
+
+    /** A user opened the onboarding intro video (source=portal, triggeredBy=username). */
+    ONBOARDING_VIDEO_VIEW(ServiceEventCategory.USER),
+    ;
+
+    companion object {
+        /**
+         * Category of a stored `event_type` string. Unknown values (a forward-compat row
+         * written by a newer service) read back as SYSTEM so they never leak into the
+         * user-facing product-usage view.
+         */
+        fun categoryOf(eventType: String): ServiceEventCategory =
+            runCatching { valueOf(eventType.trim().uppercase(Locale.ROOT)) }.getOrNull()?.category
+                ?: ServiceEventCategory.SYSTEM
+
+        /** Enum names whose category is [category] — for translating a category filter to an `event_type IN (…)`. */
+        fun namesOf(category: ServiceEventCategory): List<String> =
+            entries.filter { it.category == category }.map { it.name }
+    }
 }
 
 /** Lifecycle status of a service-event row. STARTUP rows are written terminal (COMPLETED). */

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ServiceEventQueryServiceImpl.kt
@@ -5,7 +5,9 @@ import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventFilt
 import org.octopusden.octopus.components.registry.server.dto.v4.ServiceEventResponse
 import org.octopusden.octopus.components.registry.server.entity.ServiceEventEntity
 import org.octopusden.octopus.components.registry.server.repository.ServiceEventRepository
+import org.octopusden.octopus.components.registry.server.service.ServiceEventCategory
 import org.octopusden.octopus.components.registry.server.service.ServiceEventQueryService
+import org.octopusden.octopus.components.registry.server.service.ServiceEventType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -47,6 +49,15 @@ class ServiceEventQueryServiceImpl(
         // event_type / source / status as the journal grows.
         filter.eventType?.takeIf { it.isNotBlank() }?.let { eventType ->
             spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("eventType"), eventType.uppercase(Locale.ROOT)) })
+        }
+        // Category → the set of event_type names in it (SYSTEM/USER). An unknown category
+        // yields no types → match nothing (empty IN), rather than silently ignoring the filter.
+        filter.category?.takeIf { it.isNotBlank() }?.let { category ->
+            val names = runCatching { ServiceEventCategory.valueOf(category.uppercase(Locale.ROOT)) }
+                .getOrNull()
+                ?.let { ServiceEventType.namesOf(it) }
+                ?: emptyList()
+            spec = spec.and(Specification { root, _, cb -> root.get<String>("eventType").`in`(names) })
         }
         filter.source?.takeIf { it.isNotBlank() }?.let { source ->
             spec = spec.and(Specification { root, _, cb -> cb.equal(root.get<String>("source"), source.lowercase(Locale.ROOT)) })

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -2227,6 +2227,9 @@
       },
       "ServiceEventResponse" : {
         "properties" : {
+          "category" : {
+            "type" : "string"
+          },
           "correlationId" : {
             "type" : "string"
           },
@@ -2268,6 +2271,7 @@
           }
         },
         "required" : [
+          "category",
           "eventType",
           "id",
           "source",
@@ -4124,6 +4128,14 @@
           {
             "in" : "query",
             "name" : "eventType",
+            "required" : false,
+            "schema" : {
+              "type" : "string"
+            }
+          },
+          {
+            "in" : "query",
+            "name" : "category",
             "required" : false,
             "schema" : {
               "type" : "string"

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventControllerV4Test.kt
@@ -92,6 +92,35 @@ class ServiceEventControllerV4Test {
     }
 
     @Test
+    fun `response carries the derived SYSTEM category for operational events`() {
+        mvc
+            .perform(get("/rest/api/4/admin/service-events").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].category").value("SYSTEM"))
+            .andExpect(jsonPath("$.content[1].category").value("SYSTEM"))
+    }
+
+    @Test
+    fun `filters by category — USER returns only user events, SYSTEM only operational`() {
+        // Add a user-event (onboarding view) alongside the two seeded system events.
+        repository.save(
+            row(ServiceEventType.ONBOARDING_VIDEO_VIEW, ServiceEventStatus.COMPLETED, Instant.now()),
+        )
+
+        mvc
+            .perform(get("/rest/api/4/admin/service-events?category=USER").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].eventType").value("ONBOARDING_VIDEO_VIEW"))
+            .andExpect(jsonPath("$.content[0].category").value("USER"))
+
+        mvc
+            .perform(get("/rest/api/4/admin/service-events?category=SYSTEM").with(adminJwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+    }
+
+    @Test
     fun `SYS-060 read requires IMPORT_DATA (editor is forbidden)`() {
         mvc
             .perform(get("/rest/api/4/admin/service-events").with(editorJwt()))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4Test.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ServiceEventIngestControllerV4Test.kt
@@ -44,6 +44,21 @@ class ServiceEventIngestControllerV4Test {
     }
 
     @Test
+    fun `accepts ONBOARDING_VIDEO_VIEW as a portal user-event`() {
+        val recorder = RecordingServiceEventRecorder()
+        val request =
+            validRequest.copy(
+                eventType = ServiceEventType.ONBOARDING_VIDEO_VIEW.name,
+                triggeredBy = "alice",
+                summary = "watched onboarding video",
+            )
+        val response = controller(recorder, token = "secret").ingest("secret", request)
+
+        assertEquals(HttpStatus.ACCEPTED, response.statusCode)
+        assertEquals(ServiceEventType.ONBOARDING_VIDEO_VIEW, recorder.instants.single().type)
+    }
+
+    @Test
     fun `SYS-061 wrong token is 403 and records nothing`() {
         val recorder = RecordingServiceEventRecorder()
         val response = controller(recorder, token = "secret").ingest("nope", validRequest)

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventTypeCategoryTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/ServiceEventTypeCategoryTest.kt
@@ -1,0 +1,32 @@
+package org.octopusden.octopus.components.registry.server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/** Pure mapping between [ServiceEventType] and its [ServiceEventCategory]. */
+class ServiceEventTypeCategoryTest {
+    @Test
+    fun `operational types are SYSTEM, onboarding view is USER`() {
+        assertEquals(ServiceEventCategory.SYSTEM, ServiceEventType.STARTUP.category)
+        assertEquals(ServiceEventCategory.SYSTEM, ServiceEventType.VALIDATION_SWEEP.category)
+        assertEquals(ServiceEventCategory.USER, ServiceEventType.ONBOARDING_VIDEO_VIEW.category)
+    }
+
+    @Test
+    fun `categoryOf parses case-insensitively and falls back to SYSTEM for unknown`() {
+        assertEquals(ServiceEventCategory.USER, ServiceEventType.categoryOf("onboarding_video_view"))
+        assertEquals(ServiceEventCategory.SYSTEM, ServiceEventType.categoryOf("STARTUP"))
+        // Forward-compat: a row written by a newer service reads back as SYSTEM, never leaking
+        // into the user-facing view.
+        assertEquals(ServiceEventCategory.SYSTEM, ServiceEventType.categoryOf("SOME_FUTURE_TYPE"))
+    }
+
+    @Test
+    fun `namesOf returns exactly the members of a category`() {
+        assertEquals(listOf("ONBOARDING_VIDEO_VIEW"), ServiceEventType.namesOf(ServiceEventCategory.USER))
+        assertEquals(
+            setOf("STARTUP", "MIGRATION_COMPONENTS", "MIGRATION_HISTORY", "TEAMCITY_RESYNC", "VALIDATION_SWEEP"),
+            ServiceEventType.namesOf(ServiceEventCategory.SYSTEM).toSet(),
+        )
+    }
+}


### PR DESCRIPTION
## What
Foundation (slice 1 of the onboarding-video usage analytics) so the portal can report a video view into the shared `service_event` journal and the Admin "Events" tab can separate product-usage (USER) events from operational (SYSTEM) ones.

## Changes
- `ServiceEventType` gains a `category` (`SYSTEM`/`USER`) and a new USER-category `ONBOARDING_VIDEO_VIEW`; `categoryOf()` / `namesOf()` helpers (unknown → SYSTEM, so a forward-compat row can't leak into the user view).
- `ServiceEventResponse` exposes the derived `category`; `ServiceEventFilter` + query + `GET /rest/api/4/admin/service-events` gain a `category` filter (translated to `event_type IN (…)`, reusing the existing `idx_service_event_type`).
- Regenerated the committed OpenAPI `v4.json` (new field + query param).

## No DB migration
The new type is a new string value in the existing `event_type VARCHAR(40)` column; `category` is derived at read time — no schema change.

## Tests
Unit: category mapping, ingest accepts `ONBOARDING_VIDEO_VIEW`. Integration (`dbTest`): response category derivation + `?category=USER/SYSTEM` filtering. OpenAPI drift gate + `qualityStatic` green.

Follow-ups (separate PRs): portal ingest (`reportVideoView` + fire on video play) and the Admin "Events" System/User split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)