### PR TITLE
fix(openapi): expose v1/v2/v3 API groups in swagger-ui

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiLegacyConfig.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/config/OpenApiLegacyConfig.kt
@@ -1,0 +1,50 @@
+package org.octopusden.octopus.components.registry.server.config
+
+import io.swagger.v3.oas.models.info.Info
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * OpenAPI groups for the legacy **v1 / v2 / v3** read contracts.
+ *
+ * These are the stable Feign-client contracts consumed by other services; their
+ * controllers are live on this server (`/rest/api/{1,2,3}/…`) but were missing
+ * from the swagger-ui group dropdown because [OpenApiV4Config] defined only the
+ * `v4` group, and a `GroupedOpenApi` present suppresses the default aggregated
+ * doc from the UI. Exposing one group per legacy major restores them in swagger-ui
+ * (`GET /v3/api-docs/{v1,v2,v3}`), which [WebSecurityConfig] already permits
+ * anonymously via the `/v3/api-docs/` group-doc prefix.
+ *
+ * Unlike `v4`, these groups are NOT drift-gated (no committed spec / OpenApiV4SpecTest
+ * equivalent) — they mirror whatever the legacy controllers expose. `info.version`
+ * is the constant API-major string, not the build version.
+ */
+@Configuration
+class OpenApiLegacyConfig {
+    private fun legacyGroup(major: Int): GroupedOpenApi =
+        GroupedOpenApi.builder()
+            .group("v$major")
+            .pathsToMatch("/rest/api/$major/**")
+            .addOpenApiCustomizer { openApi ->
+                openApi.info(
+                    Info()
+                        .title("Components Registry v$major API")
+                        .version(major.toString())
+                        .description(
+                            "Legacy v$major read contract (Feign client). Served for reference; " +
+                                "the Portal binds to v4.",
+                        ),
+                )
+            }
+            .build()
+
+    @Bean
+    fun v1OpenApiGroup(): GroupedOpenApi = legacyGroup(1)
+
+    @Bean
+    fun v2OpenApiGroup(): GroupedOpenApi = legacyGroup(2)
+
+    @Bean
+    fun v3OpenApiGroup(): GroupedOpenApi = legacyGroup(3)
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiLegacyGroupsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/openapi/OpenApiLegacyGroupsTest.kt
@@ -1,0 +1,83 @@
+package org.octopusden.octopus.components.registry.server.openapi
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.test.BaseComponentsRegistryServiceTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * The v1/v2/v3 read contracts (Feign clients) have live controllers on this
+ * server but were absent from the swagger-ui group dropdown because the only
+ * [org.springdoc.core.models.GroupedOpenApi] defined was `v4`. This gates the
+ * legacy groups: each `GET /v3/api-docs/{v1,v2,v3}` must exist and expose its
+ * own `/rest/api/{n}/…` surface.
+ *
+ * Boot signature is kept byte-identical to [OpenApiV4SpecTest] so the Spring
+ * test-context cache is SHARED (no extra context boot in the [1.0] gate).
+ */
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    classes = [ComponentRegistryServiceApplication::class],
+    properties = ["auth-server.disabled=true"],
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("common", "smoke")
+class OpenApiLegacyGroupsTest {
+    companion object {
+        init {
+            BaseComponentsRegistryServiceTest.configureSpringAppTestDataDir()
+        }
+
+        private val MAPPER = ObjectMapper()
+    }
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    private fun pathKeysOf(group: String): List<String> {
+        val raw = mvc.perform(get("/v3/api-docs/$group"))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsByteArray
+            .toString(Charsets.UTF_8)
+        val paths = MAPPER.readTree(raw).get("paths")
+        Assertions.assertNotNull(paths, "group `$group` spec has no `paths` object")
+        return paths.fieldNames().asSequence().toList()
+    }
+
+    @Test
+    @DisplayName("v1/v2/v3 OpenAPI groups are served and each exposes only its own /rest/api/{n} surface")
+    fun `legacy groups are exposed`() {
+        mapOf(
+            "v1" to Pair("/rest/api/1/", listOf("/rest/api/2/", "/rest/api/3/", "/rest/api/4/")),
+            "v2" to Pair("/rest/api/2/", listOf("/rest/api/1/", "/rest/api/3/", "/rest/api/4/")),
+            "v3" to Pair("/rest/api/3/", listOf("/rest/api/1/", "/rest/api/2/", "/rest/api/4/")),
+        ).forEach { (group, expectation) ->
+            val (ownPrefix, foreignPrefixes) = expectation
+            val keys = pathKeysOf(group)
+            Assertions.assertTrue(
+                keys.any { it.startsWith(ownPrefix) },
+                "group `$group` is missing any path under `$ownPrefix` (got: $keys)",
+            )
+            foreignPrefixes.forEach { foreign ->
+                Assertions.assertTrue(
+                    keys.none { it.startsWith(foreign) },
+                    "group `$group` must not include `$foreign` paths (got: $keys)",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Swagger-ui only listed the **v4** API. The v1/v2/v3 read contracts (Feign clients) have **live controllers** on this server (`/rest/api/{1,2,3}/**`) but were absent from the group dropdown — because the only `GroupedOpenApi` defined was `v4` (`OpenApiV4Config`), and once any group is defined springdoc drops the default aggregated doc from the UI.

## Fix

Add one `GroupedOpenApi` per legacy major (`v1`/`v2`/`v3`), each scoped to its own `/rest/api/{n}/**` paths (`OpenApiLegacyConfig`). They are served at `GET /v3/api-docs/{v1,v2,v3}` — already permitted anonymously by `WebSecurityConfig`'s `/v3/api-docs/**` rule — and now appear in the swagger-ui selector next to v4.

Unlike v4 these groups are **not** drift-gated; they mirror whatever the legacy controllers expose.

## Tests / checks

- New `OpenApiLegacyGroupsTest`: asserts each of v1/v2/v3 is served and contains **only** its own `/rest/api/{n}` surface (no cross-version bleed). Shares `OpenApiV4SpecTest`'s boot signature so the Spring context cache is reused (no extra boot in the gate).
- `OpenApiV4SpecTest` drift gate unaffected (v4 group unchanged).
- Full `:components-registry-service-server:test` suite green.

Note: Kotlin block comments nest, so a literal `/**` in a doc comment opens a nested comment — avoided in `OpenApiLegacyConfig`'s KDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI documentation groups for legacy API versions v1, v2, and v3.
  * Each version now has its own API docs entry with version-specific titles and paths.

* **Tests**
  * Added coverage to verify each legacy API docs group shows only the expected versioned endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->