### PR TITLE
ci(coverage): stop running integrationTest on GitHub (flaky FatJar+Postgres)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,11 +424,22 @@ gradle.projectsEvaluated {
     def testTargets = coverageProjects.findAll { it.tasks.findByName('test') != null }
 
     // Heavy @Tag("integration") tests run in `dbTest`/`integrationTest` (excluded from
-    // `check`), but their coverage must still count toward the gate and they must run
-    // as part of `qualityCoverage` (the command the GH quality job invokes).
+    // `check`). `qualityCoverage` (the command the GH quality job invokes) TRIGGERS the
+    // heavy suites listed here and folds their coverage into the aggregate gate.
+    //
+    // `integrationTest` (FatJar boot FT) is deliberately NOT triggered here. It launches the
+    // packaged fat jar in a SEPARATE JVM (in-memory H2 — no Testcontainers) and asserts
+    // startup/health + the auth-disabled fail-fast contract within tight time windows. Those
+    // timing-sensitive smoke checks flake on shared GH-hosted runners (observed: the fail-fast
+    // assertion missing its 15s window), and the extra full-app JVM piles memory pressure onto
+    // the co-scheduled dbTest Postgres Testcontainers in the same coverage job — code-unrelated
+    // red (GH issue #424). It stays TeamCity-only, where it still runs and gates publish/push
+    // via `dockerPushImage`'s hard dependency (see components-registry-service-server/build.gradle).
+    // Its coverage is NOT lost: `coverageExecData` below still includes `integrationTest.exec`
+    // when present, so any run that DID execute it (TeamCity) folds that coverage in.
     def heavyTestTaskPaths = []
     subprojects.each { sp ->
-        ['dbTest', 'integrationTest'].each { tn ->
+        ['dbTest'].each { tn ->
             if (sp.tasks.findByName(tn) != null) heavyTestTaskPaths << "${sp.path}:${tn}"
         }
     }
@@ -444,7 +455,7 @@ gradle.projectsEvaluated {
 
     tasks.register('jacocoOverallCoverageReport', org.gradle.testing.jacoco.tasks.JacocoReport) {
         group = 'verification'
-        description = 'Aggregated JaCoCo report across all coverage modules (test + dbTest + integrationTest)'
+        description = 'Aggregated JaCoCo report across all coverage modules (test + dbTest, plus integrationTest.exec when present)'
         dependsOn(testTargets.collect { "${it.path}:test" })
         dependsOn(heavyTestTaskPaths)
         executionData.from(coverageExecData(testTargets))
@@ -460,7 +471,7 @@ gradle.projectsEvaluated {
 
     tasks.register('jacocoOverallCoverageVerification', org.gradle.testing.jacoco.tasks.JacocoCoverageVerification) {
         group = 'verification'
-        description = 'Verifies aggregated JaCoCo line coverage >= 70% across all coverage modules (test + dbTest + integrationTest)'
+        description = 'Verifies aggregated JaCoCo line coverage >= 70% across all coverage modules (test + dbTest, plus integrationTest.exec when present)'
         dependsOn(testTargets.collect { "${it.path}:test" })
         dependsOn(heavyTestTaskPaths)
         executionData.from(coverageExecData(testTargets))

--- a/components-registry-service-server/build.gradle
+++ b/components-registry-service-server/build.gradle
@@ -183,9 +183,12 @@ tasks.register('jacocoIntegrationTestReport', org.gradle.testing.jacoco.tasks.Ja
 }
 
 // integrationTest (fat-jar boot FT) is intentionally NOT wired into `check`/`build`: in CI it
-// runs in [1.0] only because dockerPushImage HARD-depends on it (so it gates publish/push),
-// and on GH PRs it runs under `qualityCoverage`. See root build.gradle (qualityCoverage +
-// publish gating).
+// runs on TeamCity [1.0] only, because dockerPushImage HARD-depends on it (so it gates
+// publish/push). It is NOT triggered by `qualityCoverage` (i.e. NOT run on GH PRs) — it boots
+// the packaged jar in a separate JVM (in-memory H2) and makes timing-sensitive startup/fail-fast
+// assertions that flake on shared GH-hosted runners (GH issue #424). Its coverage still folds
+// into the aggregate when present (root build.gradle coverageExecData). See root build.gradle
+// (qualityCoverage + publish gating).
 integrationTest.dependsOn bootJar
 integrationTest.finalizedBy jacocoIntegrationTestReport
 


### PR DESCRIPTION
Closes #424.

## Problem

The GH `quality/tests-coverage` job runs `./gradlew qualityCoverage`. Its aggregate jacoco tasks (`jacocoOverallCoverage{Report,Verification}`) `dependsOn(heavyTestTaskPaths)`, and that list included the FatJar-boot **`integrationTest`**.

That suite launches the packaged fat jar in a **separate JVM (in-memory H2, no Testcontainers)** and makes **timing-sensitive** startup/health + auth-disabled **fail-fast** assertions. On shared GH-hosted runners those flake — the observed failure was `FatJarAuthDisabledIntegrationTest` asserting the process exits within 15s and missing that window — and booting the extra full-app JVM piles memory pressure onto the **co-scheduled `dbTest` Postgres Testcontainers** in the same job (hence the `postmaster ... unexpected exit` noise in the log came from `dbTest`, not from `integrationTest`). Net effect: a red `tests-coverage` / `gate/merge` unrelated to the PR's code.

## Fix

Build `heavyTestTaskPaths` from **`dbTest` only**, so `qualityCoverage` triggers `test` + `dbTest` (both stable on GH) but no longer triggers `integrationTest`.

- **Coverage is not lost.** `coverageExecData` still includes `integrationTest.exec` *when present*, so any run that executed it (TeamCity) still folds its coverage into the aggregate. (The FatJar child JVM runs without a JaCoCo agent anyway, so its contribution to `main`-code coverage is negligible.)
- **TeamCity unchanged.** `integrationTest` still runs there and gates publish/push via `dockerPushImage`'s hard dependency. Only GH stops running the FatJar boot FT.

Also corrected the now-stale comments in `build.gradle` and `components-registry-service-server/build.gradle`.

## Verification

- `dbTest` ran locally clean (77 classes, 0 failures/0 errors) with `integrationTest` removed from the trigger.
- The aggregate `>= 70%` line-coverage threshold is validated by **this PR's own `quality/tests-coverage` gate** (now `test` + `dbTest`, no `integrationTest`) — the real environment. `dbTest` already runs on GH today; only the flaky FatJar boot is dropped.

_Rationale corrected after Codex review flagged that the FatJar suite uses H2, not a Postgres Testcontainer._

🤖 Generated with [Claude Code](https://claude.com/claude-code)