### PR TITLE
fix(field-override): accept exact-version range [X] as a single Maven segment

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -2703,6 +2703,15 @@ class ComponentManagementServiceImpl(
     // path inside parseSimpleSegment without a separate composite-detector.
     private val SIMPLE_SEGMENT_PATTERN = Regex("^([\\[(])([^,]*),([^,]*)([\\])])$")
 
+    // The exact-version ("hard version") form `[X]` is also a single Maven
+    // segment — the simplest one — but carries no comma, so it never matched
+    // SIMPLE_SEGMENT_PATTERN and was misclassified as composite (rejected on
+    // POST/PATCH). Maven only allows the closed `[X]` shape for a hard version:
+    // `(X)`, `[X)`, `(X]` are all invalid, so this pattern is intentionally
+    // square-bracket only. The releng VersionRangeFactory parses `[X]` as
+    // lo == hi, both inclusive — we mirror that below.
+    private val EXACT_VERSION_PATTERN = Regex("^\\[([^,\\[\\]()]+)]$")
+
     private data class ParsedSimpleRange(
         val lo: String?,
         val loIncl: Boolean,
@@ -2715,6 +2724,10 @@ class ComponentManagementServiceImpl(
 
     private fun parseSimpleSegment(range: String): ParsedSimpleRange? {
         val compact = normalizeRange(range)
+        EXACT_VERSION_PATTERN.matchEntire(compact)?.let { exact ->
+            val v = exact.groupValues[1]
+            return ParsedSimpleRange(lo = v, loIncl = true, hi = v, hiIncl = true)
+        }
         val m = SIMPLE_SEGMENT_PATTERN.matchEntire(compact) ?: return null
         val (open, loStr, hiStr, close) = m.destructured
         if (loStr.any { it in "()[]" } || hiStr.any { it in "()[]" }) return null

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -2822,8 +2822,9 @@ class ComponentManagementServiceImpl(
         val parsedNew = parseSimpleSegment(range)
         require(parsedNew != null) {
             "Field-override range '$range' must be a single Maven segment " +
-                "(e.g. [1.0,2.0)). Composite ranges are not accepted on POST / " +
-                "PATCH — split the override into multiple rows, one per segment."
+                "(e.g. [1.0,2.0) or an exact version [1.0.49]). Composite ranges " +
+                "are not accepted on POST / PATCH — split the override into " +
+                "multiple rows, one per segment."
         }
         val newRangeObj = versionRangeFactory.create(range)
         for (row in component.configurations) {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
@@ -717,6 +717,68 @@ class V4WriteValidationTest {
     }
 
     @Test
+    @DisplayName("EXACT: POST /field-overrides accepts an exact-version range [X] (single Maven hard version)")
+    fun fieldOverride_accepts_exactVersionRange() {
+        // Reported QA case: an exact-version override
+        // range `[1.0.49]` — a valid single Maven segment (hard version, lo == hi,
+        // both inclusive) — was rejected as "composite". parseSimpleSegment only
+        // recognised the two-bound `[X,Y)` form, but a hard version is the SIMPLEST
+        // single segment and must be accepted on POST/PATCH.
+        val id = seedComponentForOverlap("exact-${uniqueSuffix()}")
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0.49]","value":"1.8"}""",
+        ).andExpect(status().isCreated)
+    }
+
+    @Test
+    @DisplayName("EXACT: POST /field-overrides accepts two disjoint exact-version ranges on one attribute")
+    fun fieldOverride_accepts_disjointExactVersions() {
+        val id = seedComponentForOverlap("exact-disjoint-${uniqueSuffix()}")
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0.49]","value":"1.8"}""",
+        ).andExpect(status().isCreated)
+        // [1.0.50] pins a different single version → disjoint from [1.0.49] → accepted.
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0.50]","value":"11"}""",
+        ).andExpect(status().isCreated)
+    }
+
+    @Test
+    @DisplayName("EXACT: POST /field-overrides rejects a duplicate exact-version range (semantic equal)")
+    fun fieldOverride_rejects_duplicateExactVersion() {
+        val id = seedComponentForOverlap("exact-dup-${uniqueSuffix()}")
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0.49]","value":"1.8"}""",
+        ).andExpect(status().isCreated)
+        // Same exact version again → the two point-overrides intersect (both match
+        // 1.0.49) → ambiguous duplicate → 400. Guards that intersection detection
+        // still works once hard versions are parsed as simple segments.
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0.49]","value":"11"}""",
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("EXACT: POST /field-overrides rejects an exact-version range inside an existing sibling range")
+    fun fieldOverride_rejects_exactVersionInsideSibling() {
+        val id = seedComponentForOverlap("exact-inside-${uniqueSuffix()}")
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0,2.0)","value":"11"}""",
+        ).andExpect(status().isCreated)
+        // 1.0.49 falls inside [1.0,2.0) → the point override would match both → reject.
+        postFieldOverride(
+            id,
+            """{"overriddenAttribute":"build.javaVersion","versionRange":"[1.0.49]","value":"1.8"}""",
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
     @DisplayName("R3: PATCH /field-overrides/{id} rejects a range update that overlaps a sibling")
     fun fieldOverride_patch_rejects_partialOverlap() {
         val id = seedComponentForOverlap("patch-ov-${uniqueSuffix()}")

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/V4WriteValidationTest.kt
@@ -883,6 +883,29 @@ class V4WriteValidationTest {
     }
 
     @Test
+    @DisplayName("EXACT: PATCH /field-overrides/{id} accepts an exact-version range update")
+    fun fieldOverride_patch_accepts_exactVersionRange() {
+        val id = seedComponentForOverlap("exact-patch-${uniqueSuffix()}")
+        val created =
+            postFieldOverride(
+                id,
+                """{"overriddenAttribute":"build.javaVersion","versionRange":"[5.0,6.0)","value":"17"}""",
+            ).andExpect(status().isCreated)
+                .andReturn().response.contentAsString
+        val oid = objectMapper.readTree(created)["id"].asText()
+        // Repoint the range to an exact-version pin — a valid single segment, so
+        // the PATCH path (validateFieldOverrideRange with excludeOverrideId) must
+        // accept it just like POST does.
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id/field-overrides/$oid")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"versionRange":"[1.0.49]"}"""),
+            ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
     @DisplayName("R3: POST /field-overrides rejects composite Maven ranges (single-segment only)")
     fun fieldOverride_rejects_compositeRange() {
         val id = seedComponentForOverlap("composite-${uniqueSuffix()}")


### PR DESCRIPTION
## Problem

Saving any component that carries a field-override with an **exact-version range** (a Maven "hard version" like `[1.0.49]`) failed with:

> Field-override range '[1.0.49]' must be a single Maven segment (e.g. [1.0,2.0)). Composite ranges are not accepted on POST / PATCH — split the override into multiple rows, one per segment.

`[1.0.49]` (lo==hi, both inclusive) is a valid **single** Maven segment — the simplest one — not a composite. Because the whole component re-validates on save, the pre-existing override froze **all** edits to the component.

## Root cause

`ComponentManagementServiceImpl.parseSimpleSegment` decided "single vs composite" with a regex that **requires a comma** (`^([\[(])([^,]*),([^,]*)([\])])$`), i.e. only the two-bound `[X,Y)` form. An exact-version pin has no comma, so it returned `null` and was rejected as composite. The releng `VersionRangeFactory` itself parses `[X]` fine, so syntax validation passed — the defect was purely in the composite-detector.

## Fix

- Add `EXACT_VERSION_PATTERN` (`^\[([^,\[\]()]+)]$`, square-bracket only, matching releng's hard-version rule) and parse `[X]` as `lo==hi`, both inclusive.
- Intersection / disjoint / duplicate logic is unchanged — `isIntersect` already treats `[X]` as a hard version.

## Tests (TDD, red→green)

Four cases in `V4WriteValidationTest`: accept a lone exact version, accept two disjoint exacts, reject a duplicate exact, reject an exact version inside a wider sibling range. The first three were red before the fix. Full class passes.

Independent review: clean (no bugs, no stale docs).

## Follow-up

Portal `versionRange.ts` shares the same comma-requiring regex, so the UI cannot yet *author* exact-version overrides — separate PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Field overrides now correctly accept Maven exact-version ranges, such as `[1.2.3]`.
  * Duplicate exact-version overrides and overlaps with broader ranges continue to be rejected.
  * Multiple non-overlapping exact-version overrides are supported.

* **Tests**
  * Added validation coverage for accepted, duplicate, disjoint, and overlapping exact-version ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->