### PR TITLE
ci(teamcity): drop VCS trigger on [1.2], run QA deploy parallel to integration tests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -337,6 +337,14 @@ object id12IntegrationDbTestsAuto : BuildType({
             onDependencyFailure = FailureAction.FAIL_TO_START
         }
     }
+
+    // Disable the inherited VCS trigger from Octopus_OctopusGradleBuild:
+    //   TRIGGER_1003 — VCS Trigger (fires on every commit on every branch)
+    // [1.2] is driven by the finishBuildTrigger off [1.0] above; a VCS-check-in
+    // trigger here only double-runs the heavy DB suite (once off the commit,
+    // once off [1.0] finishing). The inherited Schedule trigger (TRIGGER_1006)
+    // is intentionally left in place.
+    disableSettings("TRIGGER_1003")
 })
 
 // Compat — HTTP (two pre-deployed URLs) — manual, on-demand. Runs the compat-
@@ -1308,11 +1316,11 @@ object id30DeployToOkdQaDevAuto : BuildType({
     dependencies {
         snapshot(id20ValidateComponentsRegistryProductionDataAuto) {
         }
-        // The heavy DB/integration suite [1.2] must pass before we deploy (it runs in
-        // parallel off [1.0], so by deploy time it's done). The image comes from [1.0].
-        snapshot(id12IntegrationDbTestsAuto) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
+        // [1.2] Integration & DB Tests is intentionally NOT a deploy dependency:
+        // QA deploy runs right after [1.0] Compile&UT — via [2.0] Validate, which
+        // finishes shortly after [1.0] — IN PARALLEL with the heavy [1.2] suite,
+        // so a slow integration run no longer delays QA availability. The image
+        // still comes from [1.0].
     }
 })
 


### PR DESCRIPTION
Two TeamCity build-chain tweaks in the versioned `.teamcity/settings.kts`.

## 1. `[1.2] Integration & DB Tests` — disable the inherited VCS trigger

`[1.2]` inherited a VCS trigger (`TRIGGER_1003`) from the `Octopus_OctopusGradleBuild` template, so the heavy DB suite ran **twice**: once on every commit (VCS trigger) and again when `[1.0] Compile&UT` finished (its own `finishBuildTrigger`). Disable `TRIGGER_1003`; `[1.0]` finishing is the intended driver. The inherited weekly Schedule trigger (`TRIGGER_1006`) is left in place.

## 2. `[3.0] Deploy to OKD QA DEV` — run in parallel with `[1.2]`

Deploy waited for the slow `[1.2]` suite via a `snapshot(id12…)` dependency. Drop it: deploy now fires right after `[1.0] Compile&UT` (via the fast `[2.0] Validate` gate, which is triggered off `[1.0]`) **in parallel with** `[1.2]`, so a slow integration run no longer delays QA availability. The QA image still comes from `[1.0]`; the `[2.0] Validate` gate and trigger are unchanged.

## Validation

`mvn teamcity-configs:generate` → BUILD SUCCESS. Generated XML confirms `TRIGGER_1003` in `[1.2]`'s `<disabled-settings>` and `[3.0]`'s dependencies referencing only `20Validate` (no `12IntegrationDbTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
