### PR TITLE
ci(teamcity): store LAST_RELEASE_VERSION on the writable parent Octopus project

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -20,10 +20,13 @@ project {
 
     params {
         param("JDK_VERSION", "11")
-        param("LAST_RELEASE_VERSION", "2.0.88")
+        // Mutable release state: the actual value lives on the parent `Octopus`
+        // project (UI-managed, REST-writable) — this project is read-only under
+        // versioned settings, so post-processing cannot write a param here.
+        param("LAST_RELEASE_VERSION", "%LAST_RELEASE_VERSION_COMPONENTS_REGISTRY_SERVICE%")
         // Compat baseline = the FROZEN last-2.x prod byte-compat oracle, pinned
-        // in code (NOT tracking `LAST_RELEASE_VERSION`, which the cutover moved
-        // to 3.0.1 — comparing a v3 candidate against a v3 baseline is a
+        // in code (NOT tracking `LAST_RELEASE_VERSION`, which follows the latest
+        // 3.x release — comparing a v3 candidate against a v3 baseline is a
         // tautology, and the released 3.0.1 image cannot even boot in the
         // harness's V1 mode because its `registry_config` startup read trips
         // H2's reserved `key`). Bump this ONLY on a deliberate re-baseline.
@@ -1366,6 +1369,11 @@ object id50ReleasePostProcessingAuto : BuildType({
 
     params {
         param("env.JAVA_HOME", "%env.JDK_ZULU_17_x64%")
+        // Redirect the template's "Update latest release version" step to the
+        // parent `Octopus` project: this project is read-only (versioned
+        // settings), so a REST PUT against it gets 500 ReadOnlyEntityException.
+        param("TEAMCITY_UPDATE_PROJECT_IDS", "Octopus")
+        param("TEAMCITY_UPDATE_PARAMETER_NAME", "LAST_RELEASE_VERSION_COMPONENTS_REGISTRY_SERVICE")
     }
 })
 


### PR DESCRIPTION
## Problem

Every **[5.0] Release Post Processing [AUTO]** run fails on its final step, blocking the downstream QA deploy trigger:

```
PUT /app/rest/latest/projects/RnDProcessesAutomation_Octopus_OctopusComponentsRegistryService/parameters/LAST_RELEASE_VERSION
→ 500: jetbrains.buildServer.serverSide.ReadOnlyEntityException:
  The project is read only, reason: editing of the settings is disabled in the versioned settings configuration
```

The TC project is defined by versioned settings (this repo's `.teamcity/settings.kts`, `buildSettingsMode=useFromVCS`, `allowUIEditing=false`), so it is read-only for REST writes. `LAST_RELEASE_VERSION` is mutable release state — it cannot live inside a read-only, VCS-defined project.

## Fix

Move the value to the writable, UI-managed parent TC project `Octopus`:

- `LAST_RELEASE_VERSION_COMPONENTS_REGISTRY_SERVICE` has been created on `Octopus` and seeded with the actual latest release, **3.0.2** (done via REST already — this also fixes the stale 2.0.88 the DSL used to pin).
- Project-level `LAST_RELEASE_VERSION` becomes an indirection to that param, so the template's "Check release version is new" step keeps reading it unchanged.
- `id50ReleasePostProcessingAuto` overrides the template's `TEAMCITY_UPDATE_PROJECT_IDS`/`TEAMCITY_UPDATE_PARAMETER_NAME`, so the final step writes to the writable project. This mirrors the pattern the [7.0] prod deploy already uses (`COMPONENTS_REGISTRY_SERVICE_VERSION` written to a downstream project).

Also refreshed the adjacent `COMPAT_BASELINE_VERSION` comment that referenced the now-moving 3.0.1 value.

## Verification

- `mvn teamcity-configs:generate` passes; generated `project-config.xml` / `RootProjectId_50ReleasePostProcessingAuto.xml` carry the expected values.
- Full 500 reproduced and root-caused via TC REST (`versionedSettings/config` shows `allowUIEditing:false`, `useFromVCS`); parent `Octopus` confirmed writable (sync disabled) by creating the seed param.
- Same fix applied to the Portal (companion PR in octopus-components-management-portal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)