### PR TITLE
feat(audit): stamp a per-save correlation_id on all audit rows

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProvider.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProvider.kt
@@ -9,35 +9,60 @@ import java.util.UUID
  * Supplies the `correlation_id` shared by every audit row written during a single
  * save, so the audit history can group same-transaction changes into one record.
  *
- * The id is bound to the CURRENT TRANSACTION: generated lazily on first use,
- * reused for the rest of that transaction, and cleared when the transaction
- * completes — so a pooled request thread never leaks an id into the next save.
- * A component save is a single `@Transactional` method that publishes one
- * `AuditEvent` per changed entity (base attribute, field override, …); binding
- * to the transaction rather than the request means all of those rows — and only
- * those — share one id, even if a request were ever to span several transactions.
+ * The id is bound to the CURRENT TRANSACTION as a [TransactionSynchronizationManager]
+ * resource: generated lazily on first use, reused for the rest of that transaction,
+ * and unbound when the transaction completes. Binding it as a managed resource (not
+ * a raw `ThreadLocal`) means Spring suspends/resumes it correctly, so a nested
+ * `REQUIRES_NEW` transaction gets its OWN id and the outer id is restored afterwards
+ * — a plain `ThreadLocal` would leak the outer id into the inner transaction.
  *
- * Called outside an active transaction (should not happen for saves, but e.g.
- * background paths that publish audit events directly), it returns a fresh id
- * each call: no grouping, but also no `ThreadLocal` leak.
+ * A component save is a single `@Transactional` method that publishes one
+ * `AuditEvent` per changed entity (base attribute, field override, …); they all
+ * therefore share one id, and rows from a different save get a different one.
+ *
+ * Called with no active transaction, it returns a fresh id each time and binds
+ * nothing — no grouping, no leak. (The audit listener is a `@TransactionalEventListener`,
+ * so audit events are only ever published inside a transaction in practice.)
  */
 @Component
 class AuditCorrelationIdProvider {
-    private val holder = ThreadLocal<String>()
+    // Stable per-bean key for the transaction-scoped resource map (the provider is
+    // a singleton, so the same key object is used for bind/get/unbind across calls).
+    private val resourceKey = Any()
 
     fun current(): String {
-        holder.get()?.let { return it }
-        val id = UUID.randomUUID().toString()
-        if (TransactionSynchronizationManager.isSynchronizationActive()) {
-            holder.set(id)
-            TransactionSynchronizationManager.registerSynchronization(
-                object : TransactionSynchronization {
-                    override fun afterCompletion(status: Int) {
-                        holder.remove()
-                    }
-                },
-            )
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            return UUID.randomUUID().toString()
         }
+        (TransactionSynchronizationManager.getResource(resourceKey) as String?)?.let { return it }
+        val id = UUID.randomUUID().toString()
+        TransactionSynchronizationManager.bindResource(resourceKey, id)
+        TransactionSynchronizationManager.registerSynchronization(CorrelationIdSynchronization(resourceKey, id))
         return id
+    }
+
+    /**
+     * Keeps the correlation-id resource in step with the transaction lifecycle:
+     * unbind while the transaction is suspended (so an inner `REQUIRES_NEW` sees
+     * none and mints its own), rebind on resume, and unbind for good on completion
+     * (both commit and rollback).
+     */
+    private class CorrelationIdSynchronization(
+        private val key: Any,
+        private val id: String,
+    ) : TransactionSynchronization {
+        override fun suspend() {
+            TransactionSynchronizationManager.unbindResourceIfPossible(key)
+        }
+
+        override fun resume() {
+            if (!TransactionSynchronizationManager.hasResource(key)) {
+                TransactionSynchronizationManager.bindResource(key, id)
+            }
+        }
+
+        override fun afterCompletion(status: Int) {
+            TransactionSynchronizationManager.unbindResourceIfPossible(key)
+        }
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProvider.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProvider.kt
@@ -1,0 +1,43 @@
+package org.octopusden.octopus.components.registry.server.event
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.util.UUID
+
+/**
+ * Supplies the `correlation_id` shared by every audit row written during a single
+ * save, so the audit history can group same-transaction changes into one record.
+ *
+ * The id is bound to the CURRENT TRANSACTION: generated lazily on first use,
+ * reused for the rest of that transaction, and cleared when the transaction
+ * completes — so a pooled request thread never leaks an id into the next save.
+ * A component save is a single `@Transactional` method that publishes one
+ * `AuditEvent` per changed entity (base attribute, field override, …); binding
+ * to the transaction rather than the request means all of those rows — and only
+ * those — share one id, even if a request were ever to span several transactions.
+ *
+ * Called outside an active transaction (should not happen for saves, but e.g.
+ * background paths that publish audit events directly), it returns a fresh id
+ * each call: no grouping, but also no `ThreadLocal` leak.
+ */
+@Component
+class AuditCorrelationIdProvider {
+    private val holder = ThreadLocal<String>()
+
+    fun current(): String {
+        holder.get()?.let { return it }
+        val id = UUID.randomUUID().toString()
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            holder.set(id)
+            TransactionSynchronizationManager.registerSynchronization(
+                object : TransactionSynchronization {
+                    override fun afterCompletion(status: Int) {
+                        holder.remove()
+                    }
+                },
+            )
+        }
+        return id
+    }
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProvider.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProvider.kt
@@ -23,46 +23,56 @@ import java.util.UUID
  * Called with no active transaction, it returns a fresh id each time and binds
  * nothing — no grouping, no leak. (The audit listener is a `@TransactionalEventListener`,
  * so audit events are only ever published inside a transaction in practice.)
+ *
+ * NOTE — `audit_log.correlation_id` is intentionally overloaded: rows from this API
+ * save-path carry a per-save UUID (here), while git-history import rows
+ * (`GitHistoryImportServiceImpl`, `source = "git-history"`) carry the git commit
+ * SHA, written directly to the entity and never through this provider. The two
+ * shapes never collide (UUID vs SHA) and never overwrite each other; a grouping
+ * consumer should expect both, keyed by `source`.
  */
 @Component
 class AuditCorrelationIdProvider {
-    // Stable per-bean key for the transaction-scoped resource map (the provider is
-    // a singleton, so the same key object is used for bind/get/unbind across calls).
-    private val resourceKey = Any()
-
     fun current(): String {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
             return UUID.randomUUID().toString()
         }
-        (TransactionSynchronizationManager.getResource(resourceKey) as String?)?.let { return it }
+        (TransactionSynchronizationManager.getResource(RESOURCE_KEY) as String?)?.let { return it }
         val id = UUID.randomUUID().toString()
-        TransactionSynchronizationManager.bindResource(resourceKey, id)
-        TransactionSynchronizationManager.registerSynchronization(CorrelationIdSynchronization(resourceKey, id))
+        TransactionSynchronizationManager.bindResource(RESOURCE_KEY, id)
+        TransactionSynchronizationManager.registerSynchronization(CorrelationIdSynchronization(id))
         return id
     }
 
     /**
      * Keeps the correlation-id resource in step with the transaction lifecycle:
      * unbind while the transaction is suspended (so an inner `REQUIRES_NEW` sees
-     * none and mints its own), rebind on resume, and unbind for good on completion
-     * (both commit and rollback).
+     * none and mints its own), rebind THIS transaction's own id on resume, and
+     * unbind for good on completion (both commit and rollback). Resume rebinds
+     * unconditionally (unbind-any-then-bind-own), so it can never silently adopt a
+     * foreign id — mis-grouping is structurally impossible, not ordering-dependent.
      */
     private class CorrelationIdSynchronization(
-        private val key: Any,
         private val id: String,
     ) : TransactionSynchronization {
         override fun suspend() {
-            TransactionSynchronizationManager.unbindResourceIfPossible(key)
+            TransactionSynchronizationManager.unbindResourceIfPossible(RESOURCE_KEY)
         }
 
         override fun resume() {
-            if (!TransactionSynchronizationManager.hasResource(key)) {
-                TransactionSynchronizationManager.bindResource(key, id)
-            }
+            TransactionSynchronizationManager.unbindResourceIfPossible(RESOURCE_KEY)
+            TransactionSynchronizationManager.bindResource(RESOURCE_KEY, id)
         }
 
         override fun afterCompletion(status: Int) {
-            TransactionSynchronizationManager.unbindResourceIfPossible(key)
+            TransactionSynchronizationManager.unbindResourceIfPossible(RESOURCE_KEY)
         }
+    }
+
+    private companion object {
+        // Instance-independent resource key: even if a manually-constructed provider
+        // (a unit test) and the Spring singleton ran in one transaction, they'd share
+        // the same resource and mint a single id — never two.
+        private val RESOURCE_KEY = Any()
     }
 }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEvent.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEvent.kt
@@ -11,4 +11,7 @@ data class AuditEvent(
     // null for internal/cascade events that carry no user-supplied context.
     val jiraTaskKey: String? = null,
     val changeComment: String? = null,
+    // Shared across every audit row written in the same save/transaction, so the
+    // audit history can group them into one record (see AuditCorrelationIdProvider).
+    val correlationId: String? = null,
 )

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/event/AuditEventListener.kt
@@ -42,6 +42,7 @@ class AuditEventListener(
                 changeDiff = changeDiff,
                 jiraTaskKey = event.jiraTaskKey,
                 changeComment = event.changeComment,
+                correlationId = event.correlationId,
             )
         auditLogRepository.save(auditLog)
     }

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -51,6 +51,7 @@ import org.octopusden.octopus.components.registry.server.entity.LabelEntity
 import org.octopusden.octopus.components.registry.server.entity.SystemEntity
 import org.octopusden.octopus.components.registry.server.entity.ToolEntity
 import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.event.AuditCorrelationIdProvider
 import org.octopusden.octopus.components.registry.server.event.AuditEvent
 import org.octopusden.octopus.components.registry.server.mapper.ALL_VERSIONS
 import org.octopusden.octopus.components.registry.server.util.VersionRangePartition
@@ -147,6 +148,9 @@ class ComponentManagementServiceImpl(
     private val environment: Environment,
     private val componentCodeRenderer: ComponentCodeRenderer,
     private val employeeDirectory: EmployeeDirectoryService,
+    // Defaulted so the few unit tests that construct this service directly need
+    // no new wiring; Spring injects the singleton bean in production.
+    private val auditCorrelationIdProvider: AuditCorrelationIdProvider = AuditCorrelationIdProvider(),
 ) : ComponentManagementService {
     // ConfigHelper is constructed lazily because it touches the Spring
     // Environment on first access; mirrors the pattern used by
@@ -4048,6 +4052,8 @@ class ComponentManagementServiceImpl(
                 // is never persisted (the @Pattern accepts blank as "no key").
                 jiraTaskKey = jiraTaskKey?.trim()?.ifBlank { null },
                 changeComment = changeComment?.trim()?.ifBlank { null },
+                // Same id for every audit row written in this save's transaction.
+                correlationId = auditCorrelationIdProvider.current(),
             ),
         )
     }

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditCorrelationIdTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/AuditCorrelationIdTest.kt
@@ -1,0 +1,184 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * A single save is one transaction that can change several entities — e.g. moving
+ * the base Java version AND adding a per-range override in one PATCH writes two
+ * `audit_log` rows (`build.javaVersion` + `fieldOverride[build.javaVersion]`).
+ * Those rows must share one `correlation_id` so the audit history can group them
+ * into a single transaction record; rows from a DIFFERENT save must get a
+ * different id (no ThreadLocal leak across saves on a pooled request thread).
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class AuditCorrelationIdTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    init {
+        val testResourcesPath =
+            Paths.get(AuditCorrelationIdTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun uniqueName(prefix: String) = "${prefix}_${UUID.randomUUID().toString().take(8)}"
+
+    private fun createComponent(name: String): String {
+        // Unique group per component: the combined base/override PATCH re-runs the
+        // cross-component ownership check (409), which a group shared across test
+        // components would trip — unrelated to what we're asserting here.
+        val groupKey = "org.example.${UUID.randomUUID().toString().take(8)}"
+        val body =
+            mvc
+                .perform(
+                    post("/rest/api/4/components")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"name":"$name","displayName":"$name","componentOwner":"owner1",""" +
+                                """"group":{"groupKey":"$groupKey","isFake":false},""" +
+                                """"baseConfiguration":{"build":{"buildSystem":"MAVEN","javaVersion":"1.8"}}}""",
+                        ),
+                ).andExpect(status().isCreated)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun versionOf(id: String): Long {
+        val detail =
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(adminJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(detail)["version"].asLong()
+    }
+
+    /** Correlation ids of the UPDATE rows for a component, newest first. */
+    private fun updateCorrelationIds(id: String): List<String?> {
+        val body =
+            mvc
+                .perform(
+                    get("/rest/api/4/audit/recent")
+                        .with(adminJwt())
+                        .param("entityId", id)
+                        .param("action", "UPDATE")
+                        .param("size", "50"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["content"].map {
+            it["correlationId"].let { c -> if (c == null || c.isNull) null else c.asText() }
+        }
+    }
+
+    /** One PATCH that changes the base Java version AND adds a `(,2)` override — two
+     *  audit rows in one transaction. */
+    private fun combinedSave(
+        id: String,
+        base: String,
+        overrideValue: String,
+    ) {
+        val res =
+            mvc
+                .perform(
+                    patch("/rest/api/4/components/$id")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"version":${versionOf(id)},""" +
+                                """"baseConfiguration":{"build":{"buildSystem":"MAVEN","javaVersion":"$base"}},""" +
+                                """"fieldOverrides":[{"overriddenAttribute":"build.javaVersion",""" +
+                                """"versionRange":"(,2)","value":"$overrideValue"}]}""",
+                        ),
+                ).andReturn().response
+        assert(res.status == 200) { "combined save failed: HTTP ${res.status} — ${res.contentAsString}" }
+    }
+
+    /** A base-only PATCH (one UPDATE audit row) — a second, independent save. */
+    private fun baseSave(
+        id: String,
+        java: String,
+    ) {
+        val res =
+            mvc
+                .perform(
+                    patch("/rest/api/4/components/$id")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            """{"version":${versionOf(id)},""" +
+                                """"baseConfiguration":{"build":{"buildSystem":"MAVEN","javaVersion":"$java"}}}""",
+                        ),
+                ).andReturn().response
+        assert(res.status == 200) { "base save failed: HTTP ${res.status} — ${res.contentAsString}" }
+    }
+
+    @Test
+    @DisplayName("all audit rows written in one save share a single non-null correlationId")
+    fun oneSave_sharesCorrelationId() {
+        val id = createComponent(uniqueName("corr_same"))
+        // Base 1.8 → 17 AND a new (,2) → 1.8 override, in one PATCH → two UPDATE rows.
+        combinedSave(id, base = "17", overrideValue = "1.8")
+
+        val ids = updateCorrelationIds(id)
+        assert(ids.size >= 2) { "expected at least two UPDATE rows for the combined save, got ${ids.size}" }
+        assert(ids.none { it == null }) { "every audit row must carry a correlationId, got $ids" }
+        assert(ids.toSet().size == 1) { "all rows from one save must share one correlationId, got ${ids.toSet()}" }
+    }
+
+    @Test
+    @DisplayName("audit rows from different saves get different correlationIds (no ThreadLocal leak)")
+    fun differentSaves_differentCorrelationId() {
+        val id = createComponent(uniqueName("corr_diff"))
+        combinedSave(id, base = "17", overrideValue = "1.8")
+        val first = updateCorrelationIds(id).toSet()
+        assert(first.size == 1) { "first save should share one id, got $first" }
+        assert(first.none { it == null }) { "first save's id must be non-null, got $first" }
+
+        // A second, independent save (new request → new transaction → new id).
+        baseSave(id, java = "21")
+        val all = updateCorrelationIds(id).toSet()
+
+        val fromSecond = all - first
+        assert(fromSecond.size == 1) { "second save must add exactly one new correlationId, got all=$all first=$first" }
+        assert(fromSecond.single() != null) { "second save's id must be non-null, got $fromSecond" }
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProviderTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProviderTest.kt
@@ -1,15 +1,10 @@
 package org.octopusden.octopus.components.registry.server.event
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.octopusden.cloud.commons.security.client.AuthServerClient
-import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.annotation.DirtiesContext
-import org.springframework.test.context.ActiveProfiles
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.jdbc.datasource.DriverManagerDataSource
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.support.TransactionTemplate
@@ -17,23 +12,24 @@ import org.springframework.transaction.support.TransactionTemplate
 /**
  * Transaction-scoping guarantees for [AuditCorrelationIdProvider]: one id per
  * transaction, a fresh id per new transaction, a nested `REQUIRES_NEW` gets its
- * own id (and the outer id is restored afterwards), and no id leaks onto the
- * thread once a transaction has completed.
+ * own id (with the outer id restored afterwards), the id is unbound on rollback,
+ * and none leaks onto the thread once a transaction has completed.
+ *
+ * Focused unit test: it drives a real transaction lifecycle (suspend/resume/
+ * completion) via a [DataSourceTransactionManager] over an in-memory H2 datasource,
+ * with no Spring context — the provider touches no DB, only the synchronization
+ * manager, so this exercises exactly the behaviour under test without a full boot.
  */
-@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
-@ActiveProfiles("common", "ft-db")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@Tag("integration")
 class AuditCorrelationIdProviderTest {
-    @MockBean
-    @Suppress("UnusedPrivateProperty")
-    private lateinit var authServerClient: AuthServerClient
-
-    @Autowired
-    private lateinit var provider: AuditCorrelationIdProvider
-
-    @Autowired
+    private val provider = AuditCorrelationIdProvider()
     private lateinit var txManager: PlatformTransactionManager
+
+    @BeforeEach
+    fun setUp() {
+        val ds = DriverManagerDataSource("jdbc:h2:mem:audit-corr;DB_CLOSE_DELAY=-1", "sa", "")
+        ds.setDriverClassName("org.h2.Driver")
+        txManager = DataSourceTransactionManager(ds)
+    }
 
     private fun requiresNewTemplate() =
         TransactionTemplate(txManager).apply {
@@ -71,6 +67,22 @@ class AuditCorrelationIdProviderTest {
         }
         assert(inner != outerBefore) { "inner REQUIRES_NEW must not reuse the outer id ($outerBefore)" }
         assert(outerAfter == outerBefore) { "outer id must be restored after the inner txn ($outerBefore vs $outerAfter)" }
+    }
+
+    @Test
+    @DisplayName("the id is unbound on rollback (afterCompletion fires for both outcomes)")
+    fun unbindsOnRollback() {
+        lateinit var rolledBack: String
+        runCatching {
+            TransactionTemplate(txManager).execute {
+                rolledBack = provider.current()
+                throw RuntimeException("boom") // forces rollback
+            }
+        }
+        // After the rolled-back transaction, no id lingers: an out-of-transaction
+        // call mints a fresh one rather than returning the rolled-back id.
+        val after = provider.current()
+        assert(after != rolledBack) { "rolled-back transaction's id must not linger on the thread" }
     }
 
     @Test

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProviderTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/event/AuditCorrelationIdProviderTest.kt
@@ -1,0 +1,86 @@
+package org.octopusden.octopus.components.registry.server.event
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
+
+/**
+ * Transaction-scoping guarantees for [AuditCorrelationIdProvider]: one id per
+ * transaction, a fresh id per new transaction, a nested `REQUIRES_NEW` gets its
+ * own id (and the outer id is restored afterwards), and no id leaks onto the
+ * thread once a transaction has completed.
+ */
+@SpringBootTest(classes = [ComponentRegistryServiceApplication::class])
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Tag("integration")
+class AuditCorrelationIdProviderTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var provider: AuditCorrelationIdProvider
+
+    @Autowired
+    private lateinit var txManager: PlatformTransactionManager
+
+    private fun requiresNewTemplate() =
+        TransactionTemplate(txManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+
+    @Test
+    @DisplayName("the same id is returned for every call within one transaction")
+    fun sameIdWithinTransaction() {
+        val (a, b) = TransactionTemplate(txManager).execute { provider.current() to provider.current() }!!
+        assert(a == b) { "expected one id per transaction, got $a and $b" }
+    }
+
+    @Test
+    @DisplayName("each transaction gets a distinct id")
+    fun distinctIdPerTransaction() {
+        val tt = TransactionTemplate(txManager)
+        val first = tt.execute { provider.current() }
+        val second = tt.execute { provider.current() }
+        assert(first != null && second != null && first != second) {
+            "expected different ids across transactions, got $first and $second"
+        }
+    }
+
+    @Test
+    @DisplayName("a nested REQUIRES_NEW transaction gets its own id; the outer id is restored")
+    fun nestedRequiresNewIsIsolated() {
+        lateinit var outerBefore: String
+        lateinit var inner: String
+        lateinit var outerAfter: String
+        TransactionTemplate(txManager).execute {
+            outerBefore = provider.current()
+            inner = requiresNewTemplate().execute { provider.current() }!!
+            outerAfter = provider.current()
+        }
+        assert(inner != outerBefore) { "inner REQUIRES_NEW must not reuse the outer id ($outerBefore)" }
+        assert(outerAfter == outerBefore) { "outer id must be restored after the inner txn ($outerBefore vs $outerAfter)" }
+    }
+
+    @Test
+    @DisplayName("no id leaks onto the thread after a transaction completes")
+    fun noLeakAfterCompletion() {
+        val inTx = TransactionTemplate(txManager).execute { provider.current() }
+        // Outside any transaction: fresh id each call, never the completed txn's id.
+        val out1 = provider.current()
+        val out2 = provider.current()
+        assert(out1 != inTx) { "completed transaction's id must not linger on the thread" }
+        assert(out1 != out2) { "each out-of-transaction call must mint a fresh id" }
+    }
+}


### PR DESCRIPTION
Enabler for grouping the audit history by save (the CRS half; Portal grouping follows).

## Problem

A single save is one transaction that can change several entities — e.g. moving the base Java version **and** adding a per-range override in one PATCH writes two `audit_log` rows (`build.javaVersion` + `fieldOverride[build.javaVersion]`). Today those rows share nothing but a ~5 ms timestamp, so the history shows one action as two unrelated entries. The `correlation_id` column (and its index, and `AuditLogResponse.correlationId`) already exist — they were just never populated for component saves.

## Change

Populate `correlation_id` per save, transaction-bound:

- **`AuditCorrelationIdProvider`** — generates the id lazily on first use within a transaction, reuses it for the rest of that transaction, and clears the `ThreadLocal` via a `TransactionSynchronization` on completion (so a pooled request thread never leaks an id into the next save). Transaction-scoping (not request-scoping) means all rows from one `@Transactional` save — and only those — share one id.
- Stamped in the single `publishAuditEvent` choke point; persisted by `AuditEventListener`.
- **No schema change** — column/index/DTO field already present; the read path (`V4Mappers`) already returns it.

## Tests

`AuditCorrelationIdTest` (integration): two changes in one PATCH share one non-null id; a second independent save gets a different id (no cross-save leak). Both would fail before this change (every id was null).

Regression-checked the audit write path (`AuditChangeMetadataTest`, `FieldOverrideAuditTest`, `AuditLogFilterTest`) and the suites that construct the service directly (`MIG047…`, `CheapFieldFormat…`, `ArtifactGroupSplit…`) — the new dependency is defaulted so those need no wiring changes.

## Follow-up

Portal PR: group history rows by `correlationId` into one expandable transaction record (human-readable labels, inline old→new for single-field changes, `+N` overflow) — per the reviewed mockup. Legacy rows (null id) render individually, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
