### PR TITLE
ci(teamcity): restrict weekly Sunday schedule to main (was all branches)

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -6,7 +6,9 @@ import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
 import jetbrains.buildServer.configs.kotlin.buildSteps.gradle
 import jetbrains.buildServer.configs.kotlin.buildSteps.kotlinFile
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
+import jetbrains.buildServer.configs.kotlin.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 
 version = "2025.03"
@@ -244,6 +246,26 @@ object id10CompileUtAuto : BuildType({
     requirements {
         doesNotContain("env.OS_TYPE", "WIN", "RQ_2875")
     }
+
+    triggers {
+        // Weekly heartbeat, MAIN ONLY. The inherited Schedule trigger (TRIGGER_1006,
+        // Sundays 10:00 UTC) fired on EVERY active branch, rebuilding the whole
+        // [2.x] fan-out on weekends. It is disabled below and replaced by this
+        // schedule scoped to the default branch; downstream AUTO configs reach main
+        // through their finishBuildTrigger off [1.0]. (TRIGGER_1003, the per-commit
+        // VCS trigger, stays — normal per-branch CI on check-in.)
+        schedule {
+            schedulingPolicy = weekly {
+                timezone = "UTC"
+                dayOfWeek = ScheduleTrigger.DAY.Sunday
+                hour = 10
+            }
+            branchFilter = "+:<default>"
+            triggerBuild = always()
+        }
+    }
+
+    disableSettings("TRIGGER_1006")
 })
 
 // [2.1] Integration & DB Tests — runs the heavy @Tag("integration") DB suite (Postgres
@@ -361,14 +383,16 @@ object id12IntegrationDbTestsAuto : BuildType({
         }
     }
 
-    // Disable the inherited VCS trigger from Octopus_OctopusGradleBuild:
+    // Disable the inherited triggers from Octopus_OctopusGradleBuild:
     //   TRIGGER_1003 — VCS Trigger (fires on every commit on every branch)
+    //   TRIGGER_1006 — Schedule Trigger (weekly, Sundays 10:00 UTC, all branches)
     // [2.1] is driven by the finishBuildTrigger off [1.0] above; a VCS-check-in
     // trigger here only double-runs the heavy DB suite (once off the commit,
-    // once off [1.0] finishing). The inherited Schedule trigger (TRIGGER_1006)
-    // is intentionally left in place. (The build-number override is handled by
-    // the PIN_BUILD_NUMBER step above, not by disabling RUNNER_1720.)
-    disableSettings("TRIGGER_1003")
+    // once off [1.0] finishing). The Schedule trigger is dropped too — the weekend
+    // run is now MAIN-ONLY via [1.0]'s schedule → this config's finishBuildTrigger.
+    // (The build-number override is handled by the PIN_BUILD_NUMBER step above,
+    // not by disabling RUNNER_1720.)
+    disableSettings("TRIGGER_1003", "TRIGGER_1006")
 })
 
 // Compat — HTTP (two pre-deployed URLs) — manual, on-demand. Runs the compat-


### PR DESCRIPTION
## Problem

On weekends, **every active branch** (stale/PR branches included) was rebuilt — dozens of `[1.0] Compile & UT` runs marked *"No changes"*, each cascading the whole `[2.x]` fan-out.

Root cause: the base template `Octopus_OctopusGradleBuild` carries an inherited **Schedule trigger `TRIGGER_1006`** (weekly, Sundays 10:00 UTC, `branchFilter = +:*`). It fires the build on *all* active branches; `TRIGGER_1003` (the per-commit VCS trigger) is a separate, correct thing.

## What was verified

Queried the TeamCity server (`/app/rest/buildTypes/id:<template>/triggers`) for every template used in this project:

| Template | Configs | Has `TRIGGER_1006`? |
|---|---|---|
| `Octopus_OctopusGradleBuild` | id10, id12, id15, id16 | **yes** — schedulingTrigger, Sun 10:00, `+:*` |
| `RnDProcessesAutomation_IdpComponentOkdDeploy` | id30, id60, **id70 (PROD)** | no triggers at all |
| `Octopus_OctopusComponents_OctopusRelease` | id40 | none |
| `…HOctopusTest_OctopusReleasePostProcessing` | id50 | vcsTrigger only |

So the weekend all-branch storm comes **only** from `Octopus_OctopusGradleBuild` → affects only **id10** and **id12** (id15/id16 already disable it). The deploy/release configs — including PROD deploy — have no scheduling trigger and need no change.

## Change

- **`[1.0]` (id10)** — disable the inherited `TRIGGER_1006`; add a fresh `schedule` trigger scoped to the default branch (`+:<default>`), same weekly Sunday 10:00 UTC cadence. Downstream AUTO configs reach main via their existing `finishBuildTrigger` off `[1.0]`, so the weekly run still fans out — **on main only**.
- **`[2.1]` (id12)** — also disable `TRIGGER_1006` (it independently inherited the all-branch schedule); it keeps its Sunday main run via the `finishBuildTrigger` off `[1.0]`.
- `[1.5]`/`[1.6]` already disabled it; **`TRIGGER_1003` untouched** → normal per-branch CI on check-in is unaffected.

## Validation

`mvn teamcity-configs:generate` → **BUILD SUCCESS**. Generated `[1.0]` XML shows a `schedulingTrigger` with `branchFilter=+:<default>`, Sunday / 10:00 / UTC, and `TRIGGER_1006` in `disabled-settings`. `TRIGGER_1006` ends up disabled only on id10/id12/id15/id16.

## Review note

An independent review initially flagged a potential weekend PROD-deploy risk (id70) and dead `disableSettings` on template-less configs. Both were resolved by the server verification above: the deploy template has **no** triggers (no PROD risk), and speculative disables on id17/18/20/30/50/60 were removed — the final diff touches only id10 + id12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build scheduling so the compilation build runs weekly on Sundays at 10:00 UTC for the main branch.
  * Disabled automatic VCS and schedule triggers for database integration tests, which now run only after the compilation build completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->