### PR TITLE
fix(field-override): echo-safe desired-set save for legacy composite ranges (SYS-065)

### DIFF
--- a/components-registry-service-server/ktlint-baseline.xml
+++ b/components-registry-service-server/ktlint-baseline.xml
@@ -36,10 +36,10 @@
         <error line="14" column="1" source="standard:no-consecutive-comments" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt">
-        <error line="2770" column="17" source="standard:property-naming" />
-        <error line="2775" column="17" source="standard:property-naming" />
-        <error line="2784" column="17" source="standard:property-naming" />
-        <error line="2821" column="17" source="standard:property-naming" />
+        <error line="2783" column="17" source="standard:property-naming" />
+        <error line="2788" column="17" source="standard:property-naming" />
+        <error line="2797" column="17" source="standard:property-naming" />
+        <error line="2834" column="17" source="standard:property-naming" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt">
         <error line="2701" column="1" source="standard:no-consecutive-comments" />

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1325,13 +1325,26 @@ class ComponentManagementServiceImpl(
         excludeOverrideId: UUID?,
     ): List<String>? {
         val canonicalRange = normalizeRange(d.versionRange)
-        validateFieldOverrideRange(
-            range = canonicalRange,
-            component = component,
-            attribute = d.overriddenAttribute,
-            excludeOverrideId = excludeOverrideId,
-        )
-        row.versionRange = canonicalRange
+        // SYS-065 — change-scoped range validation on the desired-set path. On the UPDATE branch
+        // (excludeOverrideId == row.id, a persisted row) an echo of an UNCHANGED range must be a true
+        // no-op: legacy composite rows predate the single-segment input contract, so the portal's
+        // combined Save (which re-sends the whole desired set, untouched rows included) would otherwise
+        // 400 on every save of a component that owns one. Compare NORMALIZED forms — stored ranges are
+        // returned verbatim by the read mapper and may carry whitespace — and when unchanged neither
+        // validate NOR reassign (reassigning would mutate the row and trip audit/editability diffs).
+        // A CREATE (excludeOverrideId == null) always validates + assigns, so composite CREATE stays
+        // rejected and an empty/invalid range cannot slip in. An actual range change is still validated.
+        val rangeUnchangedOnUpdate =
+            excludeOverrideId != null && canonicalRange == normalizeRange(row.versionRange)
+        if (!rangeUnchangedOnUpdate) {
+            validateFieldOverrideRange(
+                range = canonicalRange,
+                component = component,
+                attribute = d.overriddenAttribute,
+                excludeOverrideId = excludeOverrideId,
+            )
+            row.versionRange = canonicalRange
+        }
         return when {
             d.overriddenAttribute in MarkerAttributes.ALL -> {
                 row.rowType = "MARKER"
@@ -2861,6 +2874,19 @@ class ComponentManagementServiceImpl(
      *    Existing composite rows (legacy DSL import) are untouched — the
      *    sibling walk below uses `isIntersect` on them but treats them as
      *    opaque when measuring containment.
+     *
+     *    ECHO-SAFETY CONTRACT (SYS-065): this composite rejection is an
+     *    INPUT-CONTRACT limit (a shape the API declines to accept), NOT a data
+     *    invariant — legacy data may legitimately hold a composite. On the
+     *    desired-set path (a full-collection echo), per-row input-contract
+     *    validators like this one MUST be change-scoped: an UNCHANGED echo of a
+     *    stored row must be a no-op, or a component owning a legacy composite
+     *    can never be saved. See `applyOverrideUpsertPayload`, which skips this
+     *    call when the normalized range is unchanged on update. Set-level data
+     *    invariants (disjointness, point 3) still run against the whole set but
+     *    are satisfied by unchanged rows. Checklist for any future desired-set /
+     *    full-collection-echo endpoint: does any per-item validator reject data
+     *    that already legitimately exists in the store?
      * 3. Any intersection with a sibling override on the same attribute is
      *    rejected — field-override ranges must be DISJOINT. Partial overlap
      *    AND strict containment are both conflicts: a version inside the

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentFieldOverridesPatchTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentFieldOverridesPatchTest.kt
@@ -10,6 +10,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.octopusden.cloud.commons.security.client.AuthServerClient
 import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
 import org.octopusden.octopus.components.registry.server.support.adminJwt
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -58,6 +62,12 @@ class ComponentFieldOverridesPatchTest {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var configurationRepository: ComponentConfigurationRepository
+
+    @Autowired
+    private lateinit var componentRepository: ComponentRepository
 
     init {
         val testResourcesPath =
@@ -131,7 +141,146 @@ class ComponentFieldOverridesPatchTest {
         assertEquals(before + 1, detail["version"].asLong(), "one combined PATCH must bump the version exactly once")
     }
 
+    // ── SYS-065: echo-safe desired-set save (legacy composite ranges) ────────
+
+    @Test
+    @DisplayName(
+        "SYS-065: desired-set PATCH echoing an unchanged legacy composite row + a new override → 200",
+    )
+    fun `SYS-065 unchanged composite echo plus new override is accepted`() {
+        val id = newComponent()
+        val compositeId = seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)")
+        // Echo the composite verbatim (same id, same range, same marker children) AND add a new,
+        // disjoint single-segment override. Before the fix the untouched composite echo re-ran range
+        // validation and 400'd; now it is a no-op.
+        patchComponent(
+            id,
+            """"fieldOverrides":[""" +
+                echoVcsMarker(compositeId, "[1.0,2.0-1),(2.0-1,3.0)") + "," +
+                """{"overriddenAttribute":"build.buildFilePath","versionRange":"[5.0,6.0)","value":"FileA"}""" +
+                """]""",
+        )
+        val overrides = listFieldOverrides(id)
+        val composite = overrides.first { it["id"].asText() == compositeId }
+        assertEquals("[1.0,2.0-1),(2.0-1,3.0)", composite["versionRange"].asText(), "composite preserved byte-identical")
+        assertTrue(overrides.any { it["overriddenAttribute"].asText() == "build.buildFilePath" }, "new override added")
+    }
+
+    @Test
+    @DisplayName("SYS-065: a whitespace composite echoed verbatim → 200 and stays byte-identical")
+    fun `SYS-065 whitespace composite echo is a no-op`() {
+        val id = newComponent()
+        val range = "[1.7, 2), [2.4.0,2.4.11]"
+        val compositeId = seedCompositeMarker(id, range)
+        patchComponent(id, """"fieldOverrides":[${echoVcsMarker(compositeId, range)}]""")
+        val composite = listFieldOverrides(id).first { it["id"].asText() == compositeId }
+        // Proves BOTH the normalized comparison (whitespace echo recognised as unchanged) AND that an
+        // unchanged echo is not reassigned (the stored string keeps its original whitespace).
+        assertEquals(range, composite["versionRange"].asText(), "stored range must keep its original whitespace")
+    }
+
+    @Test
+    @DisplayName("SYS-065: composite CREATE via desired-set is still rejected (400)")
+    fun `SYS-065 composite create still rejected`() {
+        val id = newComponent()
+        patchComponentExpectingBadRequest(
+            id,
+            """"fieldOverrides":[{"overriddenAttribute":"build.buildFilePath","versionRange":"[1.0,2.0),[3.0,4.0)","value":"X"}]""",
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-065: changing a composite row's range (echo a different composite) is still validated (400)")
+    fun `SYS-065 changing composite range still validated`() {
+        val id = newComponent()
+        val compositeId = seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)")
+        patchComponentExpectingBadRequest(
+            id,
+            """"fieldOverrides":[${echoVcsMarker(compositeId, "[1.0,2.0),[9.0,10.0)")}]""",
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-065: value-only edit of a legacy composite (unchanged range, changed children) → 200")
+    fun `SYS-065 value-only edit of composite is accepted`() {
+        val id = newComponent()
+        val range = "[1.0,2.0-1),(2.0-1,3.0)"
+        val compositeId = seedCompositeMarker(id, range)
+        patchComponent(
+            id,
+            """"fieldOverrides":[${echoVcsMarker(compositeId, range, vcsPath = "ssh://vcs/changed")}]""",
+        )
+        val composite = listFieldOverrides(id).first { it["id"].asText() == compositeId }
+        assertEquals(range, composite["versionRange"].asText(), "range unchanged")
+        assertEquals(
+            "ssh://vcs/changed",
+            composite["markerChildren"]["vcsEntries"][0]["vcsPath"].asText(),
+            "the child edit must be applied",
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-065: a NEW override intersecting an untouched composite sibling is still rejected (400)")
+    fun `SYS-065 disjointness still enforced against untouched composite`() {
+        val id = newComponent()
+        // Composite covers [1.0,3.0) except 2.0-1. Echo it unchanged (no-op) AND add a new vcs.settings
+        // override at [1.5,1.6) — inside the composite's first segment. The fix must NOT weaken the
+        // disjoint-range rule: the new row is still validated against the untouched composite sibling.
+        val compositeId = seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)")
+        patchComponentExpectingBadRequest(
+            id,
+            """"fieldOverrides":[""" +
+                echoVcsMarker(compositeId, "[1.0,2.0-1),(2.0-1,3.0)") + "," +
+                """{"overriddenAttribute":"vcs.settings","versionRange":"[1.5,1.6)",""" +
+                """"markerChildren":{"vcsEntries":[{"name":"main","vcsPath":"ssh://vcs/new","repositoryType":"GIT"}]}}""" +
+                """]""",
+        )
+    }
+
     // ── helpers ────────────────────────────────────────────────────────────
+
+    /** Seed a composite (multi-segment) `vcs.settings` MARKER row directly via the repository — the
+     *  public POST rejects composites, so a legacy DSL-imported composite can only be created here. */
+    private fun seedCompositeMarker(
+        componentId: String,
+        range: String,
+        vcsPath: String = "ssh://vcs/legacy",
+    ): String {
+        val component = componentRepository.findById(UUID.fromString(componentId)).orElseThrow()
+        val row = ComponentConfigurationEntity(
+            component = component,
+            versionRange = range,
+            overriddenAttribute = "vcs.settings",
+            rowType = "MARKER",
+        )
+        row.vcsEntries.add(
+            VcsSettingsEntryEntity(componentConfiguration = row, name = "main", vcsPath = vcsPath, repositoryType = "GIT"),
+        )
+        return configurationRepository.save(row).id!!.toString()
+    }
+
+    /** A desired-set entry that echoes a `vcs.settings` MARKER override by id. */
+    private fun echoVcsMarker(
+        id: String,
+        range: String,
+        vcsPath: String = "ssh://vcs/legacy",
+    ): String =
+        """{"id":"$id","overriddenAttribute":"vcs.settings","versionRange":"$range",""" +
+            """"markerChildren":{"vcsEntries":[{"name":"main","vcsPath":"$vcsPath","repositoryType":"GIT"}]}}"""
+
+    private fun patchComponentExpectingBadRequest(
+        componentId: String,
+        fieldsWithoutVersion: String,
+    ) {
+        val payload = """{"version":${currentVersion(componentId)},$fieldsWithoutVersion}"""
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$componentId")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload),
+            ).andExpect(status().isBadRequest)
+    }
 
     private fun newComponent(): String {
         val name = "fo-patch-${UUID.randomUUID().toString().take(8)}"

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentFieldOverridesPatchTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentFieldOverridesPatchTest.kt
@@ -87,6 +87,7 @@ class ComponentFieldOverridesPatchTest {
         assertEquals(1, overrides.size, "PATCH fieldOverrides must create the override")
         assertEquals("build.buildFilePath", overrides[0]["overriddenAttribute"].asText())
         assertEquals("FileA", overrides[0]["value"].asText())
+        assertEquals("[1.0,2.0)", overrides[0]["versionRange"].asText(), "the created range must be persisted")
     }
 
     @Test
@@ -217,6 +218,25 @@ class ComponentFieldOverridesPatchTest {
             composite["markerChildren"]["vcsEntries"][0]["vcsPath"].asText(),
             "the child edit must be applied",
         )
+    }
+
+    @Test
+    @DisplayName("SYS-065: a valid range change on an existing override is validated AND persisted (200)")
+    fun `SYS-065 valid range change is persisted`() {
+        val id = newComponent()
+        val overrideId = seedOverride(id, "build.buildFilePath", "[1.0,2.0)", "FileA")
+        // Exercises the positive `!rangeUnchangedOnUpdate` branch: a genuinely changed range must be
+        // BOTH validated AND assigned. A regression that validates but drops the assignment would leave
+        // the stored range at [1.0,2.0) and fail the final assertion.
+        patchComponent(
+            id,
+            """"fieldOverrides":[{"id":"$overrideId","overriddenAttribute":"build.buildFilePath",""" +
+                """"versionRange":"[3.0,4.0)","value":"FileA"}]""",
+        )
+        val overrides = listFieldOverrides(id)
+        assertEquals(1, overrides.size)
+        assertEquals(overrideId, overrides[0]["id"].asText(), "same row updated in place, not recreated")
+        assertEquals("[3.0,4.0)", overrides[0]["versionRange"].asText(), "the changed range must be persisted")
     }
 
     @Test

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -2459,6 +2459,8 @@ whole live collection, including legacy composite siblings (via `isIntersect`).
 3. Composite CREATE (desired-set or POST) → 400 (message unchanged).
 4. Changing a composite row's range (echoing a different composite) → 400.
 5. A value-only edit of a legacy composite (unchanged range, changed markerChildren) → 200.
+6. A valid range change on an existing override (`[1.0,2.0)` → `[3.0,4.0)`) is validated AND the new
+   normalized range is persisted → 200 (guards the positive validate-and-assign branch).
 
 **Test method:** `ComponentFieldOverridesPatchTest` —
 `SYS-065 unchanged composite echo plus new override is accepted`,
@@ -2466,4 +2468,5 @@ whole live collection, including legacy composite siblings (via `isIntersect`).
 `SYS-065 composite create still rejected`,
 `SYS-065 changing composite range still validated`,
 `SYS-065 value-only edit of composite is accepted`,
-`SYS-065 disjointness still enforced against untouched composite`.
+`SYS-065 disjointness still enforced against untouched composite`,
+`SYS-065 valid range change is persisted`.

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -71,6 +71,7 @@
 | SYS-060 | An append-only `service_event` journal persists operational events — CRS redeploys (STARTUP + build version), and every components-migration / history-migration / TeamCity-resync run (RUNNING→COMPLETED/FAILED, one row per run) — which previously lived only in an in-memory slot + logs and were lost on restart. **Any job failure (including executor-rejected submission) writes a FAILED row with the error**; a run whose pod dies mid-flight is reconciled to FAILED("interrupted by restart") on next startup (single-pod). Writes are best-effort (`REQUIRES_NEW` + swallow) so journaling never rolls back or crashes the observed job. `GET /rest/api/4/admin/service-events` returns the paginated journal (filter by type/source/status/time), IMPORT_DATA-gated; a scheduled daily prune enforces retention | High | unit + integration-test | ✅ Tested |
 | SYS-061 | `POST /rest/api/4/admin/service-events` ingests portal-sourced events (portal redeploys, validation-sweep runs) into the shared journal, so the Admin "Events" tab shows both services on one timeline. Authenticated by a shared-secret `X-Service-Event-Token` header (the portal BFF calls CRS tokenless), verified constant-time and **fail-closed** (blank/unset configured token rejects every call 403); method-scoped permitAll at the filter chain so the sibling GET read stays JWT+IMPORT_DATA gated; unknown eventType/status/source → 400 | High | integration-test | ✅ Tested |
 | SYS-064 | The component owner's manager (resolved via employee-service `getManager`) may edit the component and its field-overrides — a fourth, derived condition on `canEditComponent` alongside owner/RM/SC/admin. A directory failure or no-manager answer denies (fail-closed), never grants. `GET /{idOrName}/editors` enumerates the resolved manager (unlike the admin bypass, it is one concrete person per component); `getManager` is 2-minute cached per owner (resolved answers only) and its DB read runs in its own short-lived transaction, closed before the network call | High | unit + integration-test | ✅ Tested |
+| SYS-065 | Desired-set field-override PATCH is echo-safe: re-submitting an UNCHANGED override row (same id, same normalized range) does not re-validate its range, so a component carrying a legacy composite range can still be saved; a CREATE or an actual range change is still validated (composite still rejected) | High | integration-test | ✅ Tested |
 
 ---
 
@@ -2422,3 +2423,47 @@ DB connection for its duration.
 `SYS-064 non-manager of componentOwner gets 403 on PATCH`,
 `SYS-064 editors includes owner manager`,
 `SYS-064 editors omits manager when owner has none`.
+
+### SYS-065: Echo-safe desired-set field-override save
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+The component PATCH accepts field overrides as a desired-FULL-SET (#385): the client re-sends every
+override row, and the server upserts by id and deletes anything omitted. The portal's combined Save
+therefore echoes untouched rows verbatim, including their `id` and original `versionRange`.
+Separately, composite Maven ranges (multiple top-level segments, e.g.
+`[2.2.18,2.2.20-132),(2.2.20-132,2.2.21)`) are rejected on POST/PATCH as an input-contract limit.
+Legacy DSL import legitimately created composite rows, so a component that owns one could not be
+saved through the portal at all — the desired-set UPDATE loop re-validated the untouched composite
+echo and returned 400, even though the user changed a *different* override. This requirement makes
+the desired-set path change-scoped: an unchanged echo is a true no-op.
+
+**Description:**
+On the desired-set UPDATE path (`applyFieldOverrideDesiredSet` → `applyOverrideUpsertPayload` with a
+persisted row), range validation runs ONLY when the submitted range actually differs from the stored
+range. The comparison normalizes both sides (stored ranges are returned verbatim by the read mapper
+and may contain whitespace). When unchanged, the row is neither re-validated nor reassigned, so its
+stored string stays byte-identical and no audit/editability diff is triggered. A CREATE (no
+`excludeOverrideId`) always validates and assigns — composite CREATE stays rejected and an
+empty/invalid range cannot bypass validation. An actual range change on an existing row is validated
+as before. Set-level disjointness is unaffected: any new/changed row still validates against the
+whole live collection, including legacy composite siblings (via `isIntersect`).
+
+**Acceptance criteria:**
+1. A desired-set PATCH that echoes an unchanged legacy composite `vcs.settings` row and adds a new
+   disjoint single-segment override → 200; the composite row is preserved byte-identical.
+2. A whitespace composite (`[1.7, 2), [2.4.0,2.4.11]`) echoed verbatim → 200; row unchanged.
+3. Composite CREATE (desired-set or POST) → 400 (message unchanged).
+4. Changing a composite row's range (echoing a different composite) → 400.
+5. A value-only edit of a legacy composite (unchanged range, changed markerChildren) → 200.
+
+**Test method:** `ComponentFieldOverridesPatchTest` —
+`SYS-065 unchanged composite echo plus new override is accepted`,
+`SYS-065 whitespace composite echo is a no-op`,
+`SYS-065 composite create still rejected`,
+`SYS-065 changing composite range still validated`,
+`SYS-065 value-only edit of composite is accepted`,
+`SYS-065 disjointness still enforced against untouched composite`.


### PR DESCRIPTION
## Problem

A user editing a component (adding a Java-version override in Build) hit `Save failed — Field-override range '[2.2.18,2.2.20-132),(2.2.20-132,2.2.21)' must be a single Maven segment … Composite ranges are not accepted on POST / PATCH`. The offending range is **not** the one they edited — it is a pre-existing legacy row. 22 legacy composite `vcs.settings` MARKER override rows across 15 components are affected; on each, **no** field-override change can be saved through the portal.

## Root cause

Two contracts collide:
1. Composite Maven ranges are rejected on POST/PATCH (an input-contract limit). Legacy DSL import legitimately created composite rows, so stored data violates this by design.
2. The component PATCH applies `fieldOverrides` as a **desired-FULL-SET**, so the portal's combined Save re-sends every override row — untouched ones echoed verbatim with their `id` + original `versionRange`.

`applyFieldOverrideDesiredSet`'s UPDATE loop called `applyOverrideUpsertPayload` → `validateFieldOverrideRange` on **every** echoed row before change-detection. So an untouched legacy composite, merely echoed, re-ran range validation and 400'd — even when the user changed a *different* override. (The earlier `[X]` fix, #429, addressed a different shape; the shared error message masked this.)

## Fix

Make range validation on the desired-set path **change-scoped** (mirroring the standalone single-row update, which validates the range only when it is present):

- On the UPDATE branch (`excludeOverrideId != null`, a persisted row), skip **both** `validateFieldOverrideRange` and the `row.versionRange` reassignment when `canonicalRange == normalizeRange(row.versionRange)`.
- Compare **normalized** forms — the read mapper returns `versionRange` verbatim and legacy rows carry whitespace — and do **not** reassign on an unchanged echo (avoids mutating the row / tripping audit + editability diffs).
- CREATE (`excludeOverrideId == null`) always validates + assigns, so composite CREATE and empty/invalid ranges stay rejected. An actual range change is still validated. Set-level disjointness is unaffected: new/changed rows still validate against the whole live collection (composite siblings via `isIntersect`).

Adds an echo-safety contract to the `validateFieldOverrideRange` KDoc.

## Tests

6 integration tests in `ComponentFieldOverridesPatchTest` (`SYS-065`), all green; red→green confirmed. Composites are seeded directly via the repository (the API rejects them). `V4WriteValidationTest` regression green (composite POST still 400).

Requirement: **SYS-065** (`docs/registry/requirements-common.md`). (SYS-064 was taken by owner's-manager edit rights, landed on main in the meantime; rebased onto latest main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Desired-set updates now accept unchanged legacy composite overrides, including equivalent whitespace variations.
  - Existing composite override values and formatting are preserved exactly when echoed.
  - Value-only edits and valid range changes continue to work correctly.
  - Invalid composite creations, changed invalid ranges, and disjointness violations remain rejected.

- **Documentation**
  - Added requirements describing echo-safe field-override updates and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->