### PR TITLE
feat(field-override): one-off admin split of legacy composite ranges (SYS-066)

### DIFF
--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CompositeOverrideSplitAdminController.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/CompositeOverrideSplitAdminController.kt
@@ -1,0 +1,64 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.octopusden.octopus.components.registry.server.config.ConditionalOnDatabaseEnabled
+import org.octopusden.octopus.components.registry.server.dto.v4.CompositeOverrideSplitResult
+import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
+import org.octopusden.octopus.components.registry.server.service.CompositeOverrideSplitAbortedException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * SYS-066 — one-off admin endpoint that splits legacy composite field-override rows into
+ * single-segment rows. Deliberately a SEPARATE controller (not a method on [AdminControllerV4]) so it
+ * can be gated by a single `@ConditionalOnProperty`: with the flag unset the bean is not registered
+ * (404), enforcing "our DB only" structurally and leaving every other admin endpoint untouched.
+ * Same base path + auth (`canImport`, i.e. IMPORT_DATA) + DB-only condition as [AdminControllerV4].
+ *
+ * Default OFF; enable per-deployment with
+ * `components-registry.composite-override-split.enabled=true` for the one-off run, then disable again.
+ *
+ * CONCURRENCY: this scans and rewrites configuration rows, which have no `@Version` optimistic lock,
+ * under the default READ COMMITTED isolation. A field-override PATCH committing on a target component
+ * DURING the write could be lost. This is not guarded with pessimistic locks (disproportionate for a
+ * one-off, flag-gated tool); instead the operational contract is: run it in a MAINTENANCE WINDOW with
+ * the registry quiesced (no concurrent component/override edits), flag on → dry-run → review → write →
+ * flag off. The `manifestToken` guards against changes BETWEEN dry-run and write; quiescence guards the
+ * write itself.
+ */
+@ConditionalOnDatabaseEnabled
+@ConditionalOnProperty(
+    name = ["components-registry.composite-override-split.enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+@RestController
+@RequestMapping("rest/api/4/admin")
+@PreAuthorize("@permissionEvaluator.canImport()")
+class CompositeOverrideSplitAdminController(
+    private val componentManagementService: ComponentManagementService,
+) {
+    /**
+     * Preview ([dryRun]=true, the default) returns the manifest + a `manifestToken`. To write, call
+     * again with `dryRun=false` and the token from the preview; the token is recomputed in-transaction
+     * and compared, so the write aborts (409) if the data changed since review or the token is missing.
+     */
+    @PostMapping("/field-overrides/split-composites")
+    fun splitComposites(
+        @RequestParam(defaultValue = "true") dryRun: Boolean,
+        @RequestParam(required = false) manifestToken: String?,
+    ): ResponseEntity<CompositeOverrideSplitResult> =
+        ResponseEntity.ok(componentManagementService.splitCompositeFieldOverrides(dryRun, manifestToken))
+
+    @ExceptionHandler(CompositeOverrideSplitAbortedException::class)
+    fun handleAborted(e: CompositeOverrideSplitAbortedException): ResponseEntity<Map<String, Any?>> =
+        ResponseEntity.status(HttpStatus.CONFLICT).body(
+            mapOf("code" to "composite-split-aborted", "message" to (e.message ?: "Composite split aborted")),
+        )
+}

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/CompositeOverrideSplitDtos.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/CompositeOverrideSplitDtos.kt
@@ -1,0 +1,27 @@
+package org.octopusden.octopus.components.registry.server.dto.v4
+
+/**
+ * SYS-066 — result of the one-off composite field-override split. A `dryRun` invocation returns the
+ * [manifest] + [manifestToken] without writing; a write must echo the token back (see the service),
+ * which is recomputed in-transaction and compared to guarantee the reviewed state is the one changed.
+ */
+data class CompositeOverrideSplitResult(
+    val dryRun: Boolean,
+    /** Deterministic hash over the canonically-ordered manifest — pins the reviewed state. */
+    val manifestToken: String,
+    val rowsSplit: Int,
+    val segmentsCreated: Int,
+    /** Segments not created because an identical sibling row already covered that exact interval. */
+    val segmentsSkippedAsDuplicate: Int,
+    val componentsAffected: Int,
+    val manifest: List<CompositeOverrideSplitEntry>,
+)
+
+/** One composite row that will be (or was) split into [segments]. */
+data class CompositeOverrideSplitEntry(
+    val componentKey: String,
+    val overriddenAttribute: String,
+    val originalRange: String,
+    val segments: List<String>,
+    val vcsEntryCount: Int,
+)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentManagementService.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/ComponentManagementService.kt
@@ -6,6 +6,7 @@ import org.octopusden.octopus.components.registry.server.dto.v4.ComponentEditors
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentSummaryResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.CompositeOverrideSplitResult
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideUpdateRequest
@@ -89,6 +90,23 @@ interface ComponentManagementService {
      * Informational only — see [ComponentEditorsResponse].
      */
     fun getEditors(idOrName: String): ComponentEditorsResponse
+
+    /**
+     * SYS-066 — one-off split of legacy composite field-override rows (multi-segment Maven ranges
+     * from the old DSL import) into single-segment rows, so their ranges become API-editable while
+     * the resolved per-version output is preserved. Fail-closed: a malformed range, a composite on
+     * any attribute other than `vcs.settings`, self-overlapping segments, or a sibling collision
+     * whose payload is not provably identical aborts the WHOLE transaction (no writes).
+     *
+     * [dryRun] = true previews the change and returns a deterministic [CompositeOverrideSplitResult.manifestToken];
+     * a write ([dryRun] = false) must pass that token back (from a preceding dry-run), which is
+     * recomputed in-transaction and compared — a mismatch (the data moved since review) or a
+     * missing token aborts. Idempotent: with no composites left the manifest is empty.
+     */
+    fun splitCompositeFieldOverrides(
+        dryRun: Boolean,
+        manifestToken: String?,
+    ): CompositeOverrideSplitResult
 }
 
 /** A rendered as-code document plus the canonical component key (for the filename). */

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/CompositeOverrideSplitAbortedException.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/CompositeOverrideSplitAbortedException.kt
@@ -1,0 +1,12 @@
+package org.octopusden.octopus.components.registry.server.service
+
+/**
+ * SYS-066 — thrown to ABORT the composite field-override split (rolling back the whole transaction)
+ * when it cannot proceed safely: a composite on an unexpected attribute, self-overlapping segments,
+ * a sibling collision whose payload is not provably identical, a malformed range, or a
+ * stale/missing manifest token on a write. Mapped to HTTP 409 by the admin controller.
+ */
+class CompositeOverrideSplitAbortedException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -15,6 +15,8 @@ import org.octopusden.octopus.components.registry.server.dto.v4.ComponentEditors
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentFilter
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentSummaryResponse
 import org.octopusden.octopus.components.registry.server.dto.v4.ComponentUpdateRequest
+import org.octopusden.octopus.components.registry.server.dto.v4.CompositeOverrideSplitEntry
+import org.octopusden.octopus.components.registry.server.dto.v4.CompositeOverrideSplitResult
 import org.octopusden.octopus.components.registry.server.dto.v4.DockerImageRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideCreateRequest
 import org.octopusden.octopus.components.registry.server.dto.v4.FieldOverrideResponse
@@ -87,6 +89,7 @@ import org.octopusden.octopus.components.registry.server.security.CurrentUserRes
 import org.octopusden.octopus.components.registry.server.security.PermissionEvaluator
 import org.octopusden.octopus.components.registry.server.service.ComponentManagementService
 import org.octopusden.octopus.components.registry.server.service.ComponentSourceRegistry
+import org.octopusden.octopus.components.registry.server.service.CompositeOverrideSplitAbortedException
 import org.octopusden.octopus.components.registry.server.service.RenderedComponentCode
 import org.octopusden.octopus.components.registry.server.teamcity.TeamcityProperties
 import org.octopusden.octopus.components.registry.server.util.ArtifactOwnershipModeClassifier
@@ -113,6 +116,7 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.web.server.ResponseStatusException
 import java.nio.file.Files
+import java.security.MessageDigest
 import java.time.Instant
 import java.util.UUID
 
@@ -4168,6 +4172,320 @@ class ComponentManagementServiceImpl(
                 },
         )
 
+    // ── SYS-066: one-off composite field-override split ──────────────────────
+
+    @Suppress("LongMethod", "NestedBlockDepth", "CyclomaticComplexMethod")
+    override fun splitCompositeFieldOverrides(
+        dryRun: Boolean,
+        manifestToken: String?,
+    ): CompositeOverrideSplitResult {
+        // 1. Discover composite field-override rows (one-off scope → full scan). A malformed range
+        //    aborts (splitCompositeStrict throws); a single-segment row is not composite.
+        data class SplitPlan(
+            val row: ComponentConfigurationEntity,
+            val segments: List<String>,
+        )
+        val plans = mutableListOf<SplitPlan>()
+        configurationRepository
+            .findAll()
+            .filter { it.rowType in FIELD_OVERRIDE_ROW_TYPES }
+            .forEach { row ->
+                if (VersionRangePartition.isAllVersions(row.versionRange)) return@forEach
+                val segments =
+                    try {
+                        VersionRangePartition.splitCompositeStrict(row.versionRange)
+                    } catch (e: IllegalArgumentException) {
+                        throw CompositeOverrideSplitAbortedException(
+                            "Malformed field-override range '${row.versionRange}' on component " +
+                                "'${row.component.componentKey}': ${e.message}. Aborting; no rows changed.",
+                            e,
+                        )
+                    }
+                if (segments.size > 1) {
+                    // The regex splitter is permissive (e.g. it accepts `[3,]`). Validate every produced
+                    // segment through the production VersionRangeFactory so a malformed segment aborts
+                    // here rather than being written as a bad row or mishandled by the collision check.
+                    segments.forEach { seg ->
+                        runCatching { versionRangeFactory.create(normalizeRange(seg)) }.onFailure {
+                            throw CompositeOverrideSplitAbortedException(
+                                "Composite '${row.versionRange}' on component " +
+                                    "'${row.component.componentKey}' yields an invalid segment '$seg' " +
+                                    "(${it.message}). Aborting; no rows changed.",
+                            )
+                        }
+                    }
+                    plans += SplitPlan(row, segments)
+                }
+            }
+
+        // 2. Fail-closed scope guard: the approved manifest is exclusively vcs.settings MARKER rows.
+        val outOfScope =
+            plans.filterNot {
+                it.row.rowType == "MARKER" && it.row.overriddenAttribute == MarkerAttributes.VCS_SETTINGS
+            }
+        if (outOfScope.isNotEmpty()) {
+            val offenders =
+                outOfScope.joinToString("; ") {
+                    "${it.row.component.componentKey}:${it.row.overriddenAttribute}='${it.row.versionRange}'"
+                }
+            throw CompositeOverrideSplitAbortedException(
+                "Refusing to split composite overrides on attributes other than 'vcs.settings' " +
+                    "(needs human review): $offenders. Aborting; no rows changed.",
+            )
+        }
+
+        // 3. Preflight ALL plans before any write: intra-composite disjointness + sibling collisions.
+        //    A segment already covered by an identical sibling is skipped (not recreated).
+        data class ResolvedPlan(
+            val row: ComponentConfigurationEntity,
+            val segments: List<String>,
+            val segmentsToCreate: List<String>,
+            val skipped: Int,
+        )
+        val resolved =
+            plans.map { plan ->
+                val row = plan.row
+                val component = row.component
+                val attribute = row.overriddenAttribute!!
+
+                // 3.0 Copy-completeness guard: the split deep-copies ONLY vcsEntries. A well-formed
+                //     vcs.settings MARKER carries nothing else; if a corrupt legacy row also holds any
+                //     other child collection, abort rather than silently drop it on the delete.
+                val nonVcsChildren = listOf<List<*>>(
+                    row.mavenArtifacts,
+                    row.fileUrlArtifacts,
+                    row.dockerImages,
+                    row.packages,
+                    row.requiredToolJunctions,
+                    row.buildToolBeans,
+                )
+                if (nonVcsChildren.any { it.isNotEmpty() }) {
+                    throw CompositeOverrideSplitAbortedException(
+                        "Composite '${row.versionRange}' on '${component.componentKey}' carries non-VCS " +
+                            "child data the split does not copy. Aborting; no rows changed.",
+                    )
+                }
+
+                // 3a. A composite's own segments must be mutually disjoint (a malformed legacy value
+                //     like [1,3),[2,4) parses cleanly yet overlaps → cannot split unambiguously).
+                for (i in plan.segments.indices) {
+                    for (j in i + 1 until plan.segments.size) {
+                        if (rangesIntersectFailClosed(plan.segments[i], plan.segments[j])) {
+                            throw CompositeOverrideSplitAbortedException(
+                                "Composite '${row.versionRange}' on '${component.componentKey}' has " +
+                                    "overlapping segments ('${plan.segments[i]}' ∩ '${plan.segments[j]}'). " +
+                                    "Aborting; no rows changed.",
+                            )
+                        }
+                    }
+                }
+
+                // 3b. Each segment vs every OTHER override row on the same (component, attribute).
+                val siblings =
+                    component.configurations.filter {
+                        it.id != row.id && it.overriddenAttribute == attribute && it.rowType in FIELD_OVERRIDE_ROW_TYPES
+                    }
+                val toCreate = mutableListOf<String>()
+                var skipped = 0
+                for (segment in plan.segments) {
+                    var duplicate = false
+                    for (sibling in siblings) {
+                        if (!rangesIntersectFailClosed(segment, sibling.versionRange)) continue
+                        // Intersects → allowed to SKIP only when the sibling is the SAME interval with an
+                        // identical payload (already covered identically). Equality is decided by exact
+                        // canonical-string match, NOT the DefaultArtifactVersion-based simpleContains: a
+                        // false "equal" here would DELETE the composite while skipping creation → silent
+                        // coverage loss, so we fail closed on anything but a byte-identical range. Do NOT
+                        // break on the first identical sibling — keep inspecting the rest, because a
+                        // SEPARATE sibling could still partially overlap this segment (deleting the
+                        // composite would then change that region's resolver precedence). Any intersection
+                        // that is not a byte-identical duplicate aborts.
+                        if (normalizeRange(segment) == normalizeRange(sibling.versionRange) && vcsPayloadEqual(row, sibling)) {
+                            duplicate = true
+                            continue
+                        }
+                        throw CompositeOverrideSplitAbortedException(
+                            "Segment '$segment' of composite '${row.versionRange}' on " +
+                                "'${component.componentKey}' intersects existing override " +
+                                "'${sibling.versionRange}'. Aborting; no rows changed.",
+                        )
+                    }
+                    if (duplicate) skipped++ else toCreate += segment
+                }
+                ResolvedPlan(row, plan.segments, toCreate, skipped)
+            }
+
+        // 4. Manifest + deterministic token (canonical order; independent of DB row order + payload).
+        val manifest =
+            resolved
+                .map { rp ->
+                    CompositeOverrideSplitEntry(
+                        componentKey = rp.row.component.componentKey,
+                        overriddenAttribute = rp.row.overriddenAttribute!!,
+                        originalRange = rp.row.versionRange,
+                        segments = rp.segments,
+                        vcsEntryCount = rp.row.vcsEntries.size,
+                    )
+                }.sortedWith(
+                    compareBy({ it.componentKey }, { it.overriddenAttribute }, { normalizeRange(it.originalRange) }),
+                )
+        val token =
+            sha256Hex(
+                resolved
+                    .map { rp ->
+                        val payload =
+                            rp.row.vcsEntries
+                                .sortedBy { it.sortOrder }
+                                .joinToString(ENTRY_SEP) {
+                                    listOf(
+                                        it.name,
+                                        it.vcsPath,
+                                        it.branch ?: NULL_MARK,
+                                        it.tag ?: NULL_MARK,
+                                        it.hotfixBranch ?: NULL_MARK,
+                                        it.repositoryType ?: NULL_MARK,
+                                        it.sortOrder.toString(),
+                                    ).joinToString(FIELD_SEP)
+                                }
+                        listOf(
+                            rp.row.component.componentKey,
+                            rp.row.overriddenAttribute,
+                            normalizeRange(rp.row.versionRange),
+                            rp.segmentsToCreate.sorted().joinToString(SEG_SEP),
+                            rp.skipped.toString(),
+                            payload,
+                        ).joinToString(COL_SEP)
+                    }.sorted()
+                    .joinToString(ROW_SEP),
+            )
+
+        // 5. Dry-run: preview only, write nothing.
+        if (dryRun) {
+            return compositeSplitResult(
+                dryRun = true,
+                token = token,
+                resolved = resolved.size,
+                created = resolved.sumOf { it.segmentsToCreate.size },
+                skipped = resolved.sumOf { it.skipped },
+                components = plans.map { it.row.component.id }.distinct().size,
+                manifest = manifest,
+            )
+        }
+
+        // 6. Write: bind to the reviewed manifest.
+        if (manifestToken.isNullOrBlank()) {
+            throw CompositeOverrideSplitAbortedException(
+                "A write (dryRun=false) requires the manifestToken from a preceding dry-run. Aborting.",
+            )
+        }
+        if (manifestToken != token) {
+            throw CompositeOverrideSplitAbortedException(
+                "manifestToken does not match the current data (it changed since the dry-run was " +
+                    "reviewed). Re-run dryRun=true and review again. Aborting; no rows changed.",
+            )
+        }
+
+        // 7. Apply: create single-segment rows (deep-copying vcs entries), delete the composite,
+        //    bump each affected component's @Version once, audit per component.
+        val affected = LinkedHashSet<ComponentEntity>()
+        resolved.forEach { rp ->
+            val row = rp.row
+            val component = row.component
+            val before = fieldOverrideAuditSnapshot(row)
+            rp.segmentsToCreate.forEach { segment ->
+                val newRow =
+                    ComponentConfigurationEntity(
+                        component = component,
+                        versionRange = segment,
+                        overriddenAttribute = row.overriddenAttribute,
+                        rowType = "MARKER",
+                    )
+                row.vcsEntries.sortedBy { it.sortOrder }.forEach { e ->
+                    newRow.vcsEntries.add(
+                        VcsSettingsEntryEntity(
+                            componentConfiguration = newRow,
+                            name = e.name,
+                            vcsPath = e.vcsPath,
+                            branch = e.branch,
+                            tag = e.tag,
+                            hotfixBranch = e.hotfixBranch,
+                            repositoryType = e.repositoryType,
+                            sortOrder = e.sortOrder,
+                        ),
+                    )
+                }
+                component.configurations.add(newRow)
+                configurationRepository.save(newRow)
+            }
+            component.configurations.remove(row)
+            configurationRepository.delete(row)
+            affected += component
+            publishAuditEvent(
+                action = "UPDATE",
+                entityId = component.id.toString(),
+                oldValue = before,
+                newValue =
+                    mapOf(
+                        "fieldOverride[${row.overriddenAttribute}]" to
+                            mapOf("splitInto" to rp.segmentsToCreate, "skippedDuplicates" to rp.skipped),
+                    ),
+            )
+        }
+        affected.forEach { bumpParentVersion(it) }
+
+        return compositeSplitResult(
+            dryRun = false,
+            token = token,
+            resolved = resolved.size,
+            created = resolved.sumOf { it.segmentsToCreate.size },
+            skipped = resolved.sumOf { it.skipped },
+            components = affected.size,
+            manifest = manifest,
+        )
+    }
+
+    private fun compositeSplitResult(
+        dryRun: Boolean,
+        token: String,
+        resolved: Int,
+        created: Int,
+        skipped: Int,
+        components: Int,
+        manifest: List<CompositeOverrideSplitEntry>,
+    ) = CompositeOverrideSplitResult(
+        dryRun = dryRun,
+        manifestToken = token,
+        rowsSplit = resolved,
+        segmentsCreated = created,
+        segmentsSkippedAsDuplicate = skipped,
+        componentsAffected = components,
+        manifest = manifest,
+    )
+
+    /** Intersection via the releng factory; UNPARSEABLE → treated as intersecting (fail-closed). */
+    private fun rangesIntersectFailClosed(
+        a: String,
+        b: String,
+    ): Boolean =
+        runCatching {
+            versionRangeFactory.create(normalizeRange(a)).isIntersect(versionRangeFactory.create(normalizeRange(b)))
+        }.getOrDefault(true)
+
+    /** Ordered (by sortOrder) vcs-entry payload equality — sortOrder is output-affecting (V4Mappers). */
+    private fun vcsPayloadEqual(
+        a: ComponentConfigurationEntity,
+        b: ComponentConfigurationEntity,
+    ): Boolean {
+        fun sig(e: VcsSettingsEntryEntity) = listOf(e.name, e.vcsPath, e.branch, e.tag, e.hotfixBranch, e.repositoryType, e.sortOrder)
+        return a.vcsEntries.sortedBy { it.sortOrder }.map(::sig) == b.vcsEntries.sortedBy { it.sortOrder }.map(::sig)
+    }
+
+    private fun sha256Hex(input: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(input.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+
     /**
      * Snapshot of a field-override row for the audit trail, keyed by the
      * overridden attribute so the change reads as `fieldOverride[<attr>]` in the
@@ -4221,6 +4539,16 @@ class ComponentManagementServiceImpl(
 
     private companion object {
         private val log = org.slf4j.LoggerFactory.getLogger(ComponentManagementServiceImpl::class.java)
+
+        // SYS-066 manifest-token separators: distinct control chars, one per nesting level, so the
+        // delimiter-joined preimage is injective (no VCS field/range/key contains a control char).
+        // NULL_MARK also distinguishes a SQL NULL from the literal string "null".
+        private const val FIELD_SEP = "\u0000"
+        private const val ENTRY_SEP = "\u0001"
+        private const val SEG_SEP = "\u0002"
+        private const val COL_SEP = "\u0003"
+        private const val ROW_SEP = "\u0004"
+        private const val NULL_MARK = "\u001fNULL\u001f"
 
         /** Split a multi-valued `groupPattern` on comma or pipe (legacy DSL semantics). */
         private val GROUP_ID_SPLIT = Regex("[,|]")

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/VersionRangePartition.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/util/VersionRangePartition.kt
@@ -54,6 +54,11 @@ object VersionRangePartition {
     private val SINGLE_VERSION_PATTERN = Regex("^\\[([^,\\[\\]()]+)\\]$")
     internal const val ALL_VERSIONS_SENTINEL = "(,0),[0,)"
 
+    // Top-level boundary between two segments of a composite: a comma sitting between a bracket-close
+    // and a bracket-open (`),(`, `],[`, `),[`, `],(`). Zero-width look-around so `split` removes only
+    // the comma, letting the fragments rejoin to the exact input.
+    private val COMPOSITE_BOUNDARY = Regex("(?<=[\\])]),(?=[\\[(])")
+
     internal fun normalize(range: String): String = range.trim().replace(Regex("\\s+"), "")
 
     /** True for the all-versions shapes (null / `(,0),[0,)` / `(,)`). */
@@ -95,6 +100,35 @@ object VersionRangePartition {
 
     // Matches a comma-form segment `[a,b)` OR a single-version segment `[x]` inside a composite.
     private val SEGMENT_GLOBAL = Regex("[\\[(][^()\\[\\],]*,[^()\\[\\],]*[\\])]|\\[[^()\\[\\],]+\\]")
+
+    /**
+     * Strictly decompose a (possibly composite) range into its canonical single-segment strings for a
+     * DESTRUCTIVE rewrite. Unlike [toSegments] — which `mapNotNull`s a lenient regex scan and can
+     * SILENTLY DROP an unparseable fragment — this partitions the ENTIRE normalized input on the
+     * top-level segment boundary and requires every fragment to parse as one single segment; anything
+     * malformed throws [IllegalArgumentException] so a caller mutating rows aborts WITHOUT writing.
+     * A non-composite input returns a single element. Renders `[x,x]` as `[x]`. Does NOT check that
+     * the segments are mutually disjoint — that is the caller's concern.
+     */
+    internal fun splitCompositeStrict(range: String): List<String> {
+        val n = normalize(range)
+        require(n.isNotEmpty()) { "Cannot split a blank version range" }
+        val fragments = n.split(COMPOSITE_BOUNDARY)
+        val segments =
+            fragments.map { fragment ->
+                parseSegment(fragment)
+                    ?: throw IllegalArgumentException(
+                        "Range '$range' is not a clean composite of single segments — fragment " +
+                            "'$fragment' is not a valid single Maven segment",
+                    )
+            }
+        // Defence in depth: the fragments must rejoin to the exact normalized input (guards against a
+        // future boundary-regex change that consumes more than the delimiter comma).
+        check(fragments.joinToString(",") == n) {
+            "Range '$range' did not fully decompose into single segments"
+        }
+        return segments.map { render(it) }
+    }
 
     internal fun render(seg: Segment): String {
         // The unbounded-both interval IS all-versions — render the canonical sentinel so an

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/CompositeOverrideSplitAdminControllerTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/CompositeOverrideSplitAdminControllerTest.kt
@@ -1,0 +1,391 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.entity.ComponentConfigurationEntity
+import org.octopusden.octopus.components.registry.server.entity.VcsSettingsEntryEntity
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRepository
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * SYS-066 — the one-off composite field-override split admin endpoint. Flag ENABLED here so the
+ * conditionally-registered controller is wired. Composite rows are seeded directly via the repository
+ * (the public POST rejects composites). ft-db = H2 + auto-migrate.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+    properties = ["components-registry.composite-override-split.enabled=true"],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class CompositeOverrideSplitAdminControllerTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired private lateinit var mvc: MockMvc
+
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @Autowired private lateinit var configurationRepository: ComponentConfigurationRepository
+
+    @Autowired private lateinit var componentRepository: ComponentRepository
+
+    init {
+        // The ft-db profile's `components-registry.groovy-path` interpolates this system property.
+        val testResourcesPath =
+            Paths.get(CompositeOverrideSplitAdminControllerTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @BeforeEach
+    fun isolate() {
+        // The split endpoint scans the WHOLE DB; @DirtiesContext is per-class, so clear field-override
+        // rows (BASE rows are harmless) between methods so each test's global counts are meaningful and
+        // a fail-closed test's bad composite can't poison the next.
+        val overrides = configurationRepository.findAll().filter { it.rowType == "MARKER" || it.rowType == "SCALAR_OVERRIDE" }
+        configurationRepository.deleteAll(overrides)
+    }
+
+    @Test
+    @DisplayName("SYS-066: dry-run previews the split and writes nothing")
+    fun `SYS-066 dry-run previews without writing`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)")
+        val res = split(dryRun = true).andExpect(status().isOk).body()
+        assertTrue(res["dryRun"].asBoolean())
+        assertFalse(res["manifestToken"].asText().isBlank(), "a token is returned for a later write")
+        assertEquals(1, res["rowsSplit"].asInt())
+        assertEquals(2, res["segmentsCreated"].asInt())
+        // Nothing written: the row is still the single composite.
+        val rows = overridesOf(id)
+        assertEquals(1, rows.size)
+        assertEquals("[1.0,2.0-1),(2.0-1,3.0)", rows[0]["versionRange"].asText())
+    }
+
+    @Test
+    @DisplayName("SYS-066: write splits the composite into single-segment rows with copied vcs payload")
+    fun `SYS-066 write splits with copied payload`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)", vcsPath = "ssh://vcs/ufx")
+        val token = split(dryRun = true).body()["manifestToken"].asText()
+        split(dryRun = false, token = token).andExpect(status().isOk)
+        val rows = overridesOf(id).sortedBy { it["versionRange"].asText() }
+        assertEquals(2, rows.size, "composite replaced by its two segments")
+        assertEquals(listOf("(2.0-1,3.0)", "[1.0,2.0-1)"), rows.map { it["versionRange"].asText() }.sorted())
+        rows.forEach {
+            assertEquals("vcs.settings", it["overriddenAttribute"].asText())
+            assertEquals("ssh://vcs/ufx", it["markerChildren"]["vcsEntries"][0]["vcsPath"].asText(), "payload copied")
+        }
+    }
+
+    @Test
+    @DisplayName("SYS-066: exact-version composite splits into [x] rows")
+    fun `SYS-066 exact-version composite splits`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.1.40],[1.1.49],[1.1.51]")
+        writeSplit()
+        assertEquals(
+            listOf("[1.1.40]", "[1.1.49]", "[1.1.51]"),
+            overridesOf(id).map { it["versionRange"].asText() }.sorted(),
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-066: a second run is a no-op (idempotent)")
+    fun `SYS-066 idempotent`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)")
+        writeSplit()
+        val res = split(dryRun = true).andExpect(status().isOk).body()
+        assertEquals(0, res["rowsSplit"].asInt(), "no composites remain")
+        assertTrue(res["manifest"].isEmpty)
+    }
+
+    @Test
+    @DisplayName("SYS-066: the BASE all-versions sentinel is never touched")
+    fun `SYS-066 base sentinel untouched`() {
+        val id = newComponent()
+        val res = split(dryRun = true).andExpect(status().isOk).body()
+        assertEquals(0, res["rowsSplit"].asInt(), "BASE (,0),[0,) is not a composite override")
+    }
+
+    @Test
+    @DisplayName("SYS-066: a composite on a non-vcs.settings attribute aborts fail-closed (409), no writes")
+    fun `SYS-066 non-vcs attribute aborts`() {
+        val id = newComponent()
+        seedCompositeScalar(id)
+        split(dryRun = true).andExpect(status().isConflict)
+        // Untouched.
+        assertTrue(overridesOf(id).any { it["versionRange"].asText().contains("),") })
+    }
+
+    @Test
+    @DisplayName("SYS-066: a self-overlapping composite aborts (409)")
+    fun `SYS-066 self-overlapping aborts`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1,3),[2,4)")
+        split(dryRun = true).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("SYS-066: a sibling collision with a different payload aborts and rolls back")
+    fun `SYS-066 sibling collision different payload aborts`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)", vcsPath = "ssh://vcs/a")
+        seedSimpleMarker(id, "[1.0,2.0-1)", vcsPath = "ssh://vcs/DIFFERENT")
+        split(dryRun = true).andExpect(status().isConflict)
+        // Rollback: composite + sibling both intact (3 rows: BASE excluded → 2 overrides).
+        assertEquals(2, overridesOf(id).size)
+    }
+
+    @Test
+    @DisplayName("SYS-066: a sibling collision with an identical payload skips that duplicate segment")
+    fun `SYS-066 sibling collision identical payload skips`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)", vcsPath = "ssh://vcs/same")
+        seedSimpleMarker(id, "[1.0,2.0-1)", vcsPath = "ssh://vcs/same")
+        val res = split(dryRun = true).andExpect(status().isOk).body()
+        assertEquals(1, res["segmentsSkippedAsDuplicate"].asInt())
+        assertEquals(1, res["segmentsCreated"].asInt(), "only the non-duplicate segment is created")
+        writeSplit()
+        // The pre-existing sibling + the one newly-created segment; composite gone.
+        assertEquals(
+            listOf("(2.0-1,3.0)", "[1.0,2.0-1)"),
+            overridesOf(id).map { it["versionRange"].asText() }.sorted(),
+        )
+    }
+
+    @Test
+    @DisplayName("SYS-066: a write without a manifestToken aborts (409)")
+    fun `SYS-066 write without token aborts`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)")
+        split(dryRun = false).andExpect(status().isConflict)
+        assertEquals(1, overridesOf(id).size, "no writes")
+    }
+
+    @Test
+    @DisplayName("SYS-066: a stale manifestToken (data changed since the dry-run) aborts (409)")
+    fun `SYS-066 stale token aborts`() {
+        val id = newComponent()
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)")
+        val token = split(dryRun = true).body()["manifestToken"].asText()
+        // Data moves: another composite appears on a second component.
+        val id2 = newComponent()
+        seedCompositeMarker(id2, "[5.0,6.0-1),(6.0-1,7.0)")
+        split(dryRun = false, token = token).andExpect(status().isConflict)
+        assertEquals(1, overridesOf(id).size, "no writes after a stale token")
+        assertEquals(1, overridesOf(id2).size)
+    }
+
+    @Test
+    @DisplayName("SYS-066: a malformed composite range aborts (409)")
+    fun `SYS-066 malformed range aborts`() {
+        val id = newComponent()
+        seedRawMarker(id, "[1,2")
+        split(dryRun = true).andExpect(status().isConflict)
+    }
+
+    @Test
+    @DisplayName("SYS-066: an identical AND a conflicting sibling on one segment both get checked (no early-break bypass)")
+    fun `SYS-066 all intersecting siblings are inspected`() {
+        val id = newComponent()
+        // Segment [1.0,2.0-1) is intersected by TWO siblings: an exact identical duplicate AND a
+        // partial-overlap row with a different payload. With order-independent checking, the conflicting
+        // one must abort regardless of which sibling the DB enumerates first (guards the break→continue fix).
+        seedCompositeMarker(id, "[1.0,2.0-1),(2.0-1,3.0)", vcsPath = "ssh://vcs/p")
+        seedSimpleMarker(id, "[1.0,2.0-1)", vcsPath = "ssh://vcs/p") // exact duplicate of segment 1
+        seedSimpleMarker(id, "[1.5,1.6)", vcsPath = "ssh://vcs/DIFFERENT") // partial overlap of segment 1
+        split(dryRun = true).andExpect(status().isConflict)
+        assertEquals(3, overridesOf(id).size, "rollback: composite + both siblings intact")
+    }
+
+    @Test
+    @DisplayName("SYS-066: a composite yielding a factory-invalid segment aborts (409)")
+    fun `SYS-066 composite with invalid segment aborts`() {
+        val id = newComponent()
+        // Regex-splittable but the second segment is a reversed range the VersionRangeFactory rejects;
+        // discovery must factory-validate each segment and abort rather than write a bad row.
+        seedCompositeMarker(id, "[1.0,2.0),[5.0,1.0)")
+        split(dryRun = true).andExpect(status().isConflict)
+        assertEquals(1, overridesOf(id).size, "no writes")
+    }
+
+    @Test
+    @DisplayName("SYS-066: a multi-entry vcs payload is deep-copied field-for-field onto every segment")
+    fun `SYS-066 multi-entry payload preserved on split`() {
+        val id = newComponent()
+        val component = componentRepository.findById(UUID.fromString(id)).orElseThrow()
+        val composite = ComponentConfigurationEntity(
+            component = component,
+            versionRange = "[1.0,2.0-1),(2.0-1,3.0)",
+            overriddenAttribute = "vcs.settings",
+            rowType = "MARKER",
+        )
+        composite.vcsEntries.add(
+            VcsSettingsEntryEntity(
+                componentConfiguration = composite,
+                name = "main",
+                vcsPath = "ssh://a",
+                branch = "b1",
+                tag = "t1",
+                hotfixBranch = "hf1",
+                repositoryType = "GIT",
+                sortOrder = 0,
+            ),
+        )
+        composite.vcsEntries.add(
+            VcsSettingsEntryEntity(
+                componentConfiguration = composite,
+                name = "docs",
+                vcsPath = "ssh://b",
+                branch = "b2",
+                tag = null,
+                hotfixBranch = "hf2",
+                repositoryType = "GIT",
+                sortOrder = 1,
+            ),
+        )
+        configurationRepository.save(composite)
+
+        writeSplit()
+
+        val rows = overridesOf(id)
+        assertEquals(2, rows.size, "composite replaced by its two segments")
+        rows.forEach { r ->
+            val entries = r["markerChildren"]["vcsEntries"]
+            assertEquals(2, entries.size(), "both vcs entries copied (ordered by sortOrder)")
+            assertEquals("main", entries[0]["name"].asText())
+            assertEquals("ssh://a", entries[0]["vcsPath"].asText())
+            assertEquals("b1", entries[0]["branch"].asText())
+            assertEquals("t1", entries[0]["tag"].asText())
+            assertEquals("hf1", entries[0]["hotfixBranch"].asText())
+            assertEquals("docs", entries[1]["name"].asText())
+            assertEquals("ssh://b", entries[1]["vcsPath"].asText())
+            assertEquals("b2", entries[1]["branch"].asText())
+            assertEquals("hf2", entries[1]["hotfixBranch"].asText())
+            assertTrue(
+                entries[1]["tag"] == null || entries[1]["tag"].isNull,
+                "the null tag on the second entry is preserved as null",
+            )
+        }
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private fun ResultActions.body(): JsonNode = objectMapper.readTree(andReturn().response.contentAsString)
+
+    private fun split(
+        dryRun: Boolean,
+        token: String? = null,
+    ): ResultActions {
+        var url = "/rest/api/4/admin/field-overrides/split-composites?dryRun=$dryRun"
+        if (token != null) url += "&manifestToken=$token"
+        return mvc.perform(post(url).with(adminJwt()))
+    }
+
+    /** Dry-run to get the token, then write with it (asserts 200). */
+    private fun writeSplit() {
+        val token = split(dryRun = true).andExpect(status().isOk).body()["manifestToken"].asText()
+        split(dryRun = false, token = token).andExpect(status().isOk)
+    }
+
+    private fun newComponent(): String {
+        val name = "cos-${UUID.randomUUID().toString().take(8)}"
+        val body = mvc
+            .perform(
+                post("/rest/api/4/components").with(adminJwt()).contentType(MediaType.APPLICATION_JSON).content(
+                    """{"name":"$name","componentOwner":"owner1",""" +
+                        """"group":{"groupKey":"org.example.test","isFake":false},""" +
+                        """"baseConfiguration":{"build":{"buildSystem":"MAVEN"}}}""",
+                ),
+            ).andExpect(status().is2xxSuccessful)
+            .andReturn()
+            .response.contentAsString
+        return objectMapper.readTree(body)["id"].asText()
+    }
+
+    private fun seedCompositeMarker(
+        componentId: String,
+        range: String,
+        vcsPath: String = "ssh://vcs/legacy",
+    ) = seedRawMarker(componentId, range, vcsPath)
+
+    private fun seedSimpleMarker(
+        componentId: String,
+        range: String,
+        vcsPath: String,
+    ) = seedRawMarker(componentId, range, vcsPath)
+
+    /** Seed a `vcs.settings` MARKER row (any versionRange, incl. composite/malformed) via the repo. */
+    private fun seedRawMarker(
+        componentId: String,
+        range: String,
+        vcsPath: String = "ssh://vcs/legacy",
+    ): String {
+        val component = componentRepository.findById(UUID.fromString(componentId)).orElseThrow()
+        val row = ComponentConfigurationEntity(
+            component = component,
+            versionRange = range,
+            overriddenAttribute = "vcs.settings",
+            rowType = "MARKER",
+        )
+        row.vcsEntries.add(
+            VcsSettingsEntryEntity(componentConfiguration = row, name = "main", vcsPath = vcsPath, repositoryType = "GIT"),
+        )
+        return configurationRepository.save(row).id!!.toString()
+    }
+
+    /** Seed a SCALAR_OVERRIDE row with a composite range (out-of-scope for the split → abort). */
+    private fun seedCompositeScalar(componentId: String): String {
+        val component = componentRepository.findById(UUID.fromString(componentId)).orElseThrow()
+        val row = ComponentConfigurationEntity(
+            component = component,
+            versionRange = "[1.0,2.0),[3.0,4.0)",
+            overriddenAttribute = "build.buildFilePath",
+            rowType = "SCALAR_OVERRIDE",
+            buildFilePath = "pom.xml",
+        )
+        return configurationRepository.save(row).id!!.toString()
+    }
+
+    private fun overridesOf(componentId: String): List<JsonNode> =
+        objectMapper
+            .readTree(
+                mvc
+                    .perform(get("/rest/api/4/components/$componentId/field-overrides").with(adminJwt()))
+                    .andExpect(status().isOk)
+                    .andReturn()
+                    .response.contentAsString,
+            ).toList()
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/CompositeOverrideSplitDisabledTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/CompositeOverrideSplitDisabledTest.kt
@@ -1,0 +1,55 @@
+package org.octopusden.octopus.components.registry.server.controller
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+
+/**
+ * SYS-066 — with the feature flag UNSET (the default), the split controller bean is not registered,
+ * so its path is unmapped (404). This is the structural "our DB only" guarantee: colleagues'
+ * deployments never expose the one-off endpoint.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class CompositeOverrideSplitDisabledTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired private lateinit var mvc: MockMvc
+
+    init {
+        val testResourcesPath =
+            Paths.get(CompositeOverrideSplitDisabledTest::class.java.getResource("/expected-data")!!.toURI()).parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @Test
+    @DisplayName("SYS-066: with the flag unset the split endpoint is not wired (404)")
+    fun `SYS-066 endpoint absent when flag off`() {
+        mvc
+            .perform(post("/rest/api/4/admin/field-overrides/split-composites?dryRun=true").with(adminJwt()))
+            .andExpect(status().isNotFound)
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/VersionRangePartitionTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/util/VersionRangePartitionTest.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.components.registry.server.util
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -242,5 +243,52 @@ class VersionRangePartitionTest {
         // No open-upper block (all bounded/historical): the highest range wins — floor, then ceiling.
         assertEquals("[2.0,3.0)", listOf("(,1.0)", "[1.0,2.0)", "[2.0,3.0)").maxWith(rank))
         assertEquals("(,2.0)", listOf("(,1.0)", "(,2.0)").maxWith(rank)) // same (-inf) floor → higher ceiling
+    }
+
+    // ── SYS-066: strict composite decomposition for the one-off split cleanup ───────
+
+    @Test
+    @DisplayName("SYS-066: splitCompositeStrict decomposes composites into canonical single segments")
+    fun `SYS-066 strict split decomposes composites`() {
+        // Two-segment composite around an excluded point.
+        assertEquals(
+            listOf("[2.2.18,2.2.20-132)", "(2.2.20-132,2.2.21)"),
+            VersionRangePartition.splitCompositeStrict("[2.2.18,2.2.20-132),(2.2.20-132,2.2.21)"),
+        )
+        // Exact-version members render in hard-version [x] form, not [x,x].
+        assertEquals(
+            listOf("[1.1.40]", "[1.1.49]", "[1.1.51]"),
+            VersionRangePartition.splitCompositeStrict("[1.1.40],[1.1.49],[1.1.51]"),
+        )
+        // Whitespace is normalized away before splitting.
+        assertEquals(
+            listOf("[1.7,2)", "[2.4.0,2.4.11]"),
+            VersionRangePartition.splitCompositeStrict("[1.7, 2), [2.4.0,2.4.11]"),
+        )
+        // A non-composite input returns a single element (caller decides via size > 1).
+        assertEquals(listOf("[1.0,2.0)"), VersionRangePartition.splitCompositeStrict("[1.0,2.0)"))
+        assertEquals(listOf("[1.0.49]"), VersionRangePartition.splitCompositeStrict("[1.0.49]"))
+    }
+
+    @Test
+    @DisplayName("SYS-066: splitCompositeStrict splits overlapping segments verbatim (disjointness is the caller's job)")
+    fun `SYS-066 strict split does not check disjointness`() {
+        // A self-overlapping composite still decomposes cleanly — overlap detection lives in the caller.
+        assertEquals(listOf("[1,3)", "[2,4)"), VersionRangePartition.splitCompositeStrict("[1,3),[2,4)"))
+    }
+
+    @Test
+    @DisplayName("SYS-066: splitCompositeStrict throws on a malformed range (no silent drop)")
+    fun `SYS-066 strict split throws on malformed input`() {
+        // Unlike the lenient toSegments scan, a malformed fragment must abort, never be dropped.
+        assertThrows(IllegalArgumentException::class.java) {
+            VersionRangePartition.splitCompositeStrict("[1,2),garbage,[5,6)")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            VersionRangePartition.splitCompositeStrict("[1,2")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            VersionRangePartition.splitCompositeStrict("")
+        }
     }
 }

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -66,6 +66,7 @@
 | SYS-061 | `POST /rest/api/4/admin/service-events` ingests portal-sourced events (portal redeploys, validation-sweep runs) into the shared journal, so the Admin "Events" tab shows both services on one timeline. Authenticated by a shared-secret `X-Service-Event-Token` header (the portal BFF calls CRS tokenless), verified constant-time and **fail-closed** (blank/unset configured token rejects every call 403); method-scoped permitAll at the filter chain so the sibling GET read stays JWT+IMPORT_DATA gated; unknown eventType/status/source → 400 | High | integration-test | ✅ Tested |
 | SYS-064 | The component owner's manager (resolved via employee-service `getManager`) may edit the component and its field-overrides — a fourth, derived condition on `canEditComponent` alongside owner/RM/SC/admin. A directory failure or no-manager answer denies (fail-closed), never grants. `GET /{idOrName}/editors` enumerates the resolved manager (unlike the admin bypass, it is one concrete person per component); `getManager` is 2-minute cached per owner (resolved answers only) and its DB read runs in its own short-lived transaction, closed before the network call | High | unit + integration-test | ✅ Tested |
 | SYS-065 | Desired-set field-override PATCH is echo-safe: re-submitting an UNCHANGED override row (same id, same normalized range) does not re-validate its range, so a component carrying a legacy composite range can still be saved; a CREATE or an actual range change is still validated (composite still rejected) | High | integration-test | ✅ Tested |
+| SYS-066 | One-off admin operation `POST /rest/api/4/admin/field-overrides/split-composites` splits legacy composite field-override rows into single-segment rows so their ranges become API-editable while resolved output is preserved. A SEPARATE `@ConditionalOnProperty(components-registry.composite-override-split.enabled, default OFF)` controller (bean absent → 404 → "our DB only"); IMPORT_DATA-gated. Fail-closed: a malformed range, a composite on any attribute other than `vcs.settings`, self-overlapping segments, or a sibling collision whose ordered vcs payload is not identical aborts the whole transaction. `dryRun` (default true) previews + returns a deterministic `manifestToken`; a write must echo the token, recomputed + compared in-transaction (stale/missing → 409). Bumps each affected component's version once; audits per composite row | High | unit + integration-test | ✅ Tested |
 | SYS-067 | When a component's `labels`, `systems`, or `build.requiredTools` is edited, the client sends the complete new list and the stored list is made to match it exactly: entries kept in the list stay, new entries are added, entries left out are removed, and re-sending the same list changes nothing. Applies to all three lists (`component_labels`, `component_systems`, `component_required_tools`) | High | integration-test | ✅ Tested |
 
 ---
@@ -2508,3 +2509,71 @@ three behave identically.
 `SYS-067 an empty list clears the membership`;
 `Sys067LabelSyncPostgresTest` (Testcontainers PostgreSQL) —
 `SYS-067 adding a label preserves the existing labels on PostgreSQL`.
+
+---
+
+### SYS-066: One-off composite field-override split
+
+**Priority:** High
+**Test layer:** unit + integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+Legacy DSL import created field-override rows with composite Maven ranges (multiple top-level
+segments, e.g. `[2.2.18,2.2.20-132),(2.2.20-132,2.2.21)`). SYS-064/SYS-065 made the portal Save
+tolerate them, but such a row's *range* still cannot be edited via the API (composites are rejected
+on POST/PATCH). This one-off operation splits each composite into its single-segment rows — which
+ARE API-editable — while preserving the resolved per-version output. It is scoped to our production
+DB (our DSL is no longer re-imported); colleagues' deployments never expose it.
+
+**Description:**
+A SEPARATE controller `CompositeOverrideSplitAdminController` (base `rest/api/4/admin`, `canImport`
+auth, `@ConditionalOnDatabaseEnabled`) gated by
+`@ConditionalOnProperty("components-registry.composite-override-split.enabled", default false)` — the
+bean is not registered unless enabled (path → 404), enforcing "our DB only" structurally without
+touching other admin endpoints. `POST /field-overrides/split-composites?dryRun={true}&manifestToken=`:
+1. Scans all field-override rows; a row is composite iff `splitCompositeStrict` (which aborts on any
+   malformed/unaccounted input) yields > 1 segment.
+2. Fail-closed scope guard: any composite that is not a `vcs.settings` MARKER aborts (409).
+3. Intra-composite disjointness: a composite whose own segments overlap aborts.
+4. Sibling collision preflight (semantic `isIntersect`, decided by mutual containment): a segment
+   intersecting an existing sibling aborts unless it is the SAME interval with an identical ordered
+   vcs payload (then that duplicate segment is skipped, not recreated).
+5. Deterministic `manifestToken` (SHA-256 over the canonically-ordered plan incl. payload). `dryRun`
+   (default true) previews and writes nothing; a write requires the token, recomputed + compared
+   in-transaction — a stale or missing token aborts (409), so a write can only apply the exact
+   reviewed state.
+6. Writes create single-segment rows (deep-copying vcs entries), delete the composite, bump each
+   affected component's `@Version` once, and emit a per-composite audit UPDATE. Idempotent.
+
+Robustness (review-hardened): the collision preflight inspects EVERY intersecting sibling (a segment is
+skipped only when byte-identical + identical ordered payload, and any other intersecting sibling still
+aborts); every produced segment is validated through the production `VersionRangeFactory` (a
+regex-accepted but factory-invalid segment aborts); the manifest token is a control-delimited,
+null-marked, sorted encoding (injective). Configuration rows have no optimistic-lock version, so the
+operation MUST run in a maintenance window with the registry quiesced (no concurrent edits) — the token
+covers the dry-run→write gap, quiescence covers the write itself.
+
+**Acceptance criteria:**
+1. Dry-run returns the manifest + token and writes nothing.
+2. A write splits a composite into its single-segment rows with the vcs payload copied; the original
+   is gone.
+3. Exact-version composites split into `[x]` rows; whitespace is normalized.
+4. A second run is a no-op (idempotent); the BASE `(,0),[0,)` sentinel is never touched.
+5. Fail-closed: non-`vcs.settings` composite, self-overlap, sibling collision with a different
+   payload, malformed range → 409 with no writes (rollback).
+6. A sibling collision with an identical payload skips only that duplicate segment.
+7. A write without a token, or with a token stale after the data changed, → 409 with no writes.
+8. With the flag unset the endpoint is not wired (404).
+
+**Test method:** `CompositeOverrideSplitAdminControllerTest` —
+`SYS-066 dry-run previews without writing`, `SYS-066 write splits with copied payload`,
+`SYS-066 exact-version composite splits`, `SYS-066 idempotent`, `SYS-066 base sentinel untouched`,
+`SYS-066 non-vcs attribute aborts`, `SYS-066 self-overlapping aborts`,
+`SYS-066 sibling collision different payload aborts`, `SYS-066 sibling collision identical payload skips`,
+`SYS-066 write without token aborts`, `SYS-066 stale token aborts`, `SYS-066 malformed range aborts`,
+`SYS-066 all intersecting siblings are inspected`, `SYS-066 composite with invalid segment aborts`,
+`SYS-066 multi-entry payload preserved on split`;
+`CompositeOverrideSplitDisabledTest` — `SYS-066 endpoint absent when flag off`;
+`VersionRangePartitionTest` — `SYS-066 strict split decomposes composites`,
+`SYS-066 strict split does not check disjointness`, `SYS-066 strict split throws on malformed input`.


### PR DESCRIPTION
## What & why

Legacy DSL import created field-override rows with **composite** Maven ranges (e.g. `[2.2.18,2.2.20-132),(2.2.20-132,2.2.21)`). #450 (SYS-065) made the portal Save *tolerate* them, but such a row's **range** still can't be edited via the API (composites are rejected on POST/PATCH). This one-off operation splits each composite into its single-segment rows — which **are** editable — while preserving the resolved per-version output. Scoped to our production DB (our DSL is no longer re-imported); colleagues' deployments never expose it.

## Design

A **separate, conditionally-registered** controller `CompositeOverrideSplitAdminController` gated by `@ConditionalOnProperty("components-registry.composite-override-split.enabled", default false)` — with the flag unset the bean isn't wired (404), enforcing "our DB only" without touching other admin endpoints. `POST /rest/api/4/admin/field-overrides/split-composites?dryRun={true}&manifestToken=`, IMPORT_DATA-gated, `@ConditionalOnDatabaseEnabled`.

**Fail-closed, dry-run-first, transactional:**
- Aborts (409, no writes, rollback) on: a malformed range; a composite on any attribute other than `vcs.settings`; self-overlapping segments; or a sibling collision whose ordered vcs payload isn't identical.
- `splitCompositeStrict` decomposes the **entire** input (no silent drops); every produced segment is additionally validated through the production `VersionRangeFactory`.
- The collision preflight inspects **every** intersecting sibling (byte-identical + identical ordered payload → skip that duplicate; anything else aborts) — no early-break bypass.
- `dryRun` (default true) previews and returns a control-delimited, null-marked, sorted (injective) SHA-256 `manifestToken`; a write must echo it, recomputed + compared in-transaction (stale/missing → 409), so only the exact reviewed state is applied.
- Writes deep-copy vcs entries, delete the composite, bump each affected component's `@Version` once, audit per composite. Idempotent.

**Concurrency:** configuration rows have no optimistic-lock version, so the op **must run in a maintenance window** with the registry quiesced (documented on the endpoint). The token covers the dry-run→write gap; quiescence covers the write itself. (Pessimistic locking was judged disproportionate for a flag-gated, one-off, operator-run tool.)

## Tests

14 integration (`CompositeOverrideSplitAdminControllerTest`, dbTest) covering dry-run/write/payload-copy/exact-version/idempotent/base-sentinel + all fail-closed paths (out-of-scope attr, self-overlap, both collision cases, multi-sibling order-independence, invalid-segment, missing/stale token, malformed) + 1 flag-off 404 (`CompositeOverrideSplitDisabledTest`) + 3 unit (`VersionRangePartitionTest` strict-split). All green; ktlint + detekt green.

Requirement: **SYS-066** (`docs/registry/requirements-common.md`). Independent of #450 (branched off `main`).

## Review

Hardened per a Sonnet review (comparator/token) **and** a Codex review (early-break collision bypass, factory-validate segments, injective token, concurrency) — all High/Medium findings addressed or documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional admin tool to split legacy composite field overrides into individual, editable ranges.
  * Supports dry-run previews with deterministic confirmation tokens before applying changes.
  * Preserves override settings and safely handles duplicate ranges.
  * Provides detailed results, affected component counts, and audit tracking.

* **Bug Fixes**
  * Unsafe, malformed, conflicting, or stale operations now fail safely without partial changes.

* **Documentation**
  * Added requirements and behavior details for the composite override split workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->