### PR TITLE
fix(labels): preserve pre-existing labels/systems/tools on edit (set-diff sync) [SYS-067]

### DIFF
--- a/components-registry-service-server/ktlint-baseline.xml
+++ b/components-registry-service-server/ktlint-baseline.xml
@@ -36,10 +36,10 @@
         <error line="14" column="1" source="standard:no-consecutive-comments" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt">
-        <error line="2783" column="17" source="standard:property-naming" />
-        <error line="2788" column="17" source="standard:property-naming" />
-        <error line="2797" column="17" source="standard:property-naming" />
-        <error line="2834" column="17" source="standard:property-naming" />
+        <error line="2811" column="17" source="standard:property-naming" />
+        <error line="2816" column="17" source="standard:property-naming" />
+        <error line="2825" column="17" source="standard:property-naming" />
+        <error line="2862" column="17" source="standard:property-naming" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ImportServiceImpl.kt">
         <error line="2701" column="1" source="standard:no-consecutive-comments" />

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/service/impl/ComponentManagementServiceImpl.kt
@@ -1739,9 +1739,27 @@ class ComponentManagementServiceImpl(
         // row. Canonicalise here too so the persistence layer is the
         // single source of truth for the canonical form.
         val canonical = canonicalizeLabels(desired)
+        // Set-diff, NOT delete-all-then-reinsert. `deleteAllInBatch` bulk-deletes
+        // rows but leaves the entities MANAGED in the persistence context; a
+        // subsequent `save` of a still-present code resolves to a `merge` onto
+        // that managed entity, so Hibernate emits neither an INSERT (it believes
+        // the row exists) nor an UPDATE (immutable @Id/@ManyToOne -> HHH000502) —
+        // the bulk-deleted row is silently never recreated, and an edit keeps
+        // only the newly-added labels. Touching only the true delta (remove
+        // codes no longer desired, insert genuinely new ones) avoids the merge
+        // entirely and is idempotent for an unchanged set.
+        //
+        // Invariant that keeps this safe: `toDelete` (existing − desired) and the
+        // insert set (desired − existing) are disjoint by construction, and each
+        // component is synced at most once per transaction — so a just-deleted
+        // (still-managed) row is never re-saved in the same persistence context.
+        // If a future caller ever re-syncs the same component twice in one tx,
+        // detach `toDelete` (or use a PC-aware delete) before re-inserting.
         val existing = componentLabelRepository.findByComponentId(componentId)
-        if (existing.isNotEmpty()) componentLabelRepository.deleteAllInBatch(existing)
-        canonical.forEach { code ->
+        val existingCodes = existing.map { it.labelCode }.toSet()
+        val toDelete = existing.filter { it.labelCode !in canonical }
+        if (toDelete.isNotEmpty()) componentLabelRepository.deleteAllInBatch(toDelete)
+        (canonical - existingCodes).forEach { code ->
             ensureLabelExists(code)
             componentLabelRepository.save(
                 ComponentLabelEntity(componentId = componentId, labelCode = code),
@@ -1761,9 +1779,13 @@ class ComponentManagementServiceImpl(
         componentId: UUID,
         desired: Set<String>,
     ) {
+        // Set-diff, not delete-all-then-reinsert — see [syncLabels] for the
+        // managed-entity/merge hazard the delete-all pattern hides.
         val existing = componentSystemRepository.findByComponentId(componentId)
-        if (existing.isNotEmpty()) componentSystemRepository.deleteAllInBatch(existing)
-        desired.forEach { code ->
+        val existingCodes = existing.map { it.systemCode }.toSet()
+        val toDelete = existing.filter { it.systemCode !in desired }
+        if (toDelete.isNotEmpty()) componentSystemRepository.deleteAllInBatch(toDelete)
+        (desired - existingCodes).forEach { code ->
             ensureSystemExists(code)
             componentSystemRepository.save(
                 ComponentSystemEntity(componentId = componentId, systemCode = code),
@@ -1780,9 +1802,15 @@ class ComponentManagementServiceImpl(
         configId: UUID,
         desired: List<String>,
     ) {
+        // Set-diff, not delete-all-then-reinsert — see [syncLabels] for the
+        // managed-entity/merge hazard the delete-all pattern hides.
+        val canonicalTools = desired.distinct()
+        val canonicalToolSet = canonicalTools.toSet()
         val existing = componentRequiredToolRepository.findByComponentConfigurationId(configId)
-        if (existing.isNotEmpty()) componentRequiredToolRepository.deleteAllInBatch(existing)
-        desired.distinct().forEach { tool ->
+        val existingNames = existing.map { it.toolName }.toSet()
+        val toDelete = existing.filter { it.toolName !in canonicalToolSet }
+        if (toDelete.isNotEmpty()) componentRequiredToolRepository.deleteAllInBatch(toDelete)
+        canonicalTools.filter { it !in existingNames }.forEach { tool ->
             ensureToolExists(tool)
             componentRequiredToolRepository.save(
                 ComponentRequiredToolEntity(componentConfigurationId = configId, toolName = tool),

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/Sys067JunctionSyncPreservesExistingTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/Sys067JunctionSyncPreservesExistingTest.kt
@@ -1,0 +1,204 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.repository.ComponentConfigurationRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentRequiredToolRepository
+import org.octopusden.octopus.components.registry.server.repository.ComponentSystemRepository
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * SYS-067 — editing a component's `labels` / `systems` / `build.requiredTools` makes the stored rows
+ * match the submitted list exactly: entries kept in the list stay, new entries are added, entries
+ * left out are removed, re-sending the same list is a no-op, and an empty list clears the membership.
+ *
+ * The three junction sync methods share one delete-all-then-reinsert-vs-set-diff code path (labels was
+ * the path observed in the production incident; systems and required-tools were latent). keep+add is
+ * exercised on all three; the remove / no-op / clear halves of the replace contract are exercised on
+ * labels (the shared code path makes them representative). Every assertion reads persisted junction
+ * rows via the repository, never the in-memory response projection, so a masked loss cannot pass.
+ *
+ * Baselines use unique per-run codes so a pre-fix failure lands on the behaviour under test, not on
+ * baseline setup, regardless of the seed component's state.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "ft-db")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Timeout(120)
+@Tag("integration")
+class Sys067JunctionSyncPreservesExistingTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var componentLabelRepository: ComponentLabelRepository
+
+    @Autowired
+    private lateinit var componentSystemRepository: ComponentSystemRepository
+
+    @Autowired
+    private lateinit var componentConfigurationRepository: ComponentConfigurationRepository
+
+    @Autowired
+    private lateinit var componentRequiredToolRepository: ComponentRequiredToolRepository
+
+    init {
+        val testResourcesPath =
+            Paths
+                .get(Sys067JunctionSyncPreservesExistingTest::class.java.getResource("/expected-data")!!.toURI())
+                .parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    private fun firstComponentId(): String {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components").with(editorJwt()).param("page", "0").param("size", "1"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body).path("content")[0]["id"].asText()
+    }
+
+    private fun currentVersion(id: String): Long {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(editorJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body)["version"].asLong()
+    }
+
+    // admin: the ft-db seed component has no owner/RM/SC, so a plain editor is 403'd by the
+    // per-component edit gate. These tests pin junction persistence, not authorization.
+    private fun patch(
+        id: String,
+        payload: Map<String, Any?>,
+    ) {
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsBytes(payload + ("version" to currentVersion(id)))),
+            ).andExpect(status().is2xxSuccessful)
+    }
+
+    private fun labelsOf(id: String): Set<String> =
+        componentLabelRepository.findByComponentId(UUID.fromString(id)).map { it.labelCode }.toSet()
+
+    private fun systemsOf(id: String): Set<String> =
+        componentSystemRepository.findByComponentId(UUID.fromString(id)).map { it.systemCode }.toSet()
+
+    private fun baseConfigId(id: String): UUID =
+        componentConfigurationRepository
+            .findByComponentId(UUID.fromString(id))
+            .first { it.rowType == "BASE" }
+            .id!!
+
+    private fun requiredToolsOf(id: String): Set<String> =
+        componentRequiredToolRepository.findByComponentConfigurationId(baseConfigId(id)).map { it.toolName }.toSet()
+
+    // -- keep + add across all three junction types (the incident shape) --
+
+    @Test
+    @DisplayName("SYS-067: adding a label preserves the existing labels")
+    fun `SYS-067 adding a label preserves the existing labels`() {
+        val id = firstComponentId()
+        val keep = "keep-${UUID.randomUUID()}"
+        val add = "add-${UUID.randomUUID()}"
+        patch(id, mapOf("labels" to listOf(keep)))
+        patch(id, mapOf("labels" to listOf(keep, add)))
+        assertEquals(setOf(keep, add), labelsOf(id), "component_labels must hold both labels after add")
+    }
+
+    @Test
+    @DisplayName("SYS-067: adding a system preserves the existing systems")
+    fun `SYS-067 adding a system preserves the existing systems`() {
+        val id = firstComponentId()
+        // Codes must be in the ft-db supportedSystems allowlist (NONE,CLASSIC,ALFA).
+        patch(id, mapOf("systems" to listOf("CLASSIC")))
+        patch(id, mapOf("systems" to listOf("CLASSIC", "ALFA")))
+        assertEquals(setOf("CLASSIC", "ALFA"), systemsOf(id), "component_systems must hold both systems after add")
+    }
+
+    @Test
+    @DisplayName("SYS-067: adding a required tool preserves the existing required tools")
+    fun `SYS-067 adding a required tool preserves the existing required tools`() {
+        val id = firstComponentId()
+        val keep = "keep-${UUID.randomUUID()}"
+        val add = "add-${UUID.randomUUID()}"
+        patch(id, mapOf("baseConfiguration" to mapOf("requiredTools" to listOf(keep))))
+        patch(id, mapOf("baseConfiguration" to mapOf("requiredTools" to listOf(keep, add))))
+        assertEquals(setOf(keep, add), requiredToolsOf(id), "component_required_tools must hold both tools after add")
+    }
+
+    // -- the rest of the replace contract, on labels (shared code path) --
+
+    @Test
+    @DisplayName("SYS-067: a mixed edit keeps the intersection, adds the new and drops the removed")
+    fun `SYS-067 a mixed edit keeps the intersection, adds the new and drops the removed`() {
+        val id = firstComponentId()
+        val a = "a-${UUID.randomUUID()}"
+        val b = "b-${UUID.randomUUID()}"
+        val c = "c-${UUID.randomUUID()}"
+        patch(id, mapOf("labels" to listOf(a, b)))
+        patch(id, mapOf("labels" to listOf(b, c)))
+        assertEquals(setOf(b, c), labelsOf(id), "[a,b] -> [b,c]: b kept, a removed, c added")
+    }
+
+    @Test
+    @DisplayName("SYS-067: re-submitting the same list is a no-op")
+    fun `SYS-067 re-submitting the same list is a no-op`() {
+        val id = firstComponentId()
+        val a = "a-${UUID.randomUUID()}"
+        val b = "b-${UUID.randomUUID()}"
+        patch(id, mapOf("labels" to listOf(a, b)))
+        patch(id, mapOf("labels" to listOf(a, b)))
+        assertEquals(setOf(a, b), labelsOf(id), "re-sending the identical list leaves the membership unchanged")
+    }
+
+    @Test
+    @DisplayName("SYS-067: an empty list clears the membership")
+    fun `SYS-067 an empty list clears the membership`() {
+        val id = firstComponentId()
+        val a = "a-${UUID.randomUUID()}"
+        val b = "b-${UUID.randomUUID()}"
+        patch(id, mapOf("labels" to listOf(a, b)))
+        patch(id, mapOf("labels" to emptyList<String>()))
+        assertEquals(emptySet<String>(), labelsOf(id), "an empty labels list removes all rows")
+    }
+}

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/Sys067LabelSyncPostgresTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/service/impl/Sys067LabelSyncPostgresTest.kt
@@ -1,0 +1,159 @@
+package org.octopusden.octopus.components.registry.server.service.impl
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
+import org.octopusden.cloud.commons.security.client.AuthServerClient
+import org.octopusden.octopus.components.registry.server.ComponentRegistryServiceApplication
+import org.octopusden.octopus.components.registry.server.repository.ComponentLabelRepository
+import org.octopusden.octopus.components.registry.server.support.adminJwt
+import org.octopusden.octopus.components.registry.server.support.editorJwt
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * SYS-067 on real PostgreSQL (Testcontainers).
+ *
+ * The production incident that motivated SYS-067 happened on PostgreSQL. The defect is at the
+ * Hibernate persistence-context level (engine-agnostic) and is fully covered on H2 by
+ * [Sys067JunctionSyncPreservesExistingTest]; this test pins the same label path against the real
+ * engine so the guard is faithful to where the incident occurred. Kept to the label path (the one
+ * observed in production) — systems and required-tools share the identical code path and are covered
+ * on H2. Asserts persisted junction rows, not the response projection.
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = [ComponentRegistryServiceApplication::class],
+)
+@ActiveProfiles("common", "test-db")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Timeout(180)
+@Tag("integration")
+class Sys067LabelSyncPostgresTest {
+    @MockBean
+    @Suppress("UnusedPrivateProperty")
+    private lateinit var authServerClient: AuthServerClient
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var componentLabelRepository: ComponentLabelRepository
+
+    init {
+        val testResourcesPath =
+            Paths
+                .get(Sys067LabelSyncPostgresTest::class.java.getResource("/expected-data")!!.toURI())
+                .parent
+        System.setProperty("COMPONENTS_REGISTRY_SERVICE_TEST_DATA_DIR", testResourcesPath.toString())
+    }
+
+    @BeforeAll
+    fun migrateAllToDb() {
+        mvc
+            .perform(post("/rest/api/4/admin/migrate-defaults").with(adminJwt()).accept(APPLICATION_JSON))
+            .andExpect(status().isOk)
+        val result =
+            mvc
+                .perform(post("/rest/api/4/admin/migrate-components").with(adminJwt()).accept(APPLICATION_JSON))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        assertTrue(
+            objectMapper.readTree(result).path("migrated").asInt() > 0,
+            "expected components to be migrated into Postgres, got: $result",
+        )
+    }
+
+    private fun firstComponentId(): String {
+        val body =
+            mvc
+                .perform(get("/rest/api/4/components").with(editorJwt()).param("page", "0").param("size", "1"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+        return objectMapper.readTree(body).path("content")[0]["id"].asText()
+    }
+
+    private fun getComponent(id: String): JsonNode =
+        objectMapper.readTree(
+            mvc
+                .perform(get("/rest/api/4/components/$id").with(editorJwt()))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString,
+        )
+
+    private fun patchLabels(
+        id: String,
+        labels: List<String>,
+    ) {
+        mvc
+            .perform(
+                patch("/rest/api/4/components/$id")
+                    .with(adminJwt())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsBytes(
+                            mapOf("version" to getComponent(id)["version"].asLong(), "labels" to labels),
+                        ),
+                    ),
+            ).andExpect(status().is2xxSuccessful)
+    }
+
+    @Test
+    @DisplayName("SYS-067: adding a label preserves the existing labels on PostgreSQL")
+    fun `SYS-067 adding a label preserves the existing labels on PostgreSQL`() {
+        val id = firstComponentId()
+        val keep = "keep-${UUID.randomUUID()}"
+        val add = "add-${UUID.randomUUID()}"
+
+        patchLabels(id, listOf(keep))
+        patchLabels(id, listOf(keep, add))
+
+        assertEquals(
+            setOf(keep, add),
+            componentLabelRepository.findByComponentId(UUID.fromString(id)).map { it.labelCode }.toSet(),
+            "component_labels must hold both labels on PostgreSQL after add",
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply { start() }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/docs/registry/requirements-common.md
+++ b/docs/registry/requirements-common.md
@@ -66,6 +66,7 @@
 | SYS-061 | `POST /rest/api/4/admin/service-events` ingests portal-sourced events (portal redeploys, validation-sweep runs) into the shared journal, so the Admin "Events" tab shows both services on one timeline. Authenticated by a shared-secret `X-Service-Event-Token` header (the portal BFF calls CRS tokenless), verified constant-time and **fail-closed** (blank/unset configured token rejects every call 403); method-scoped permitAll at the filter chain so the sibling GET read stays JWT+IMPORT_DATA gated; unknown eventType/status/source → 400 | High | integration-test | ✅ Tested |
 | SYS-064 | The component owner's manager (resolved via employee-service `getManager`) may edit the component and its field-overrides — a fourth, derived condition on `canEditComponent` alongside owner/RM/SC/admin. A directory failure or no-manager answer denies (fail-closed), never grants. `GET /{idOrName}/editors` enumerates the resolved manager (unlike the admin bypass, it is one concrete person per component); `getManager` is 2-minute cached per owner (resolved answers only) and its DB read runs in its own short-lived transaction, closed before the network call | High | unit + integration-test | ✅ Tested |
 | SYS-065 | Desired-set field-override PATCH is echo-safe: re-submitting an UNCHANGED override row (same id, same normalized range) does not re-validate its range, so a component carrying a legacy composite range can still be saved; a CREATE or an actual range change is still validated (composite still rejected) | High | integration-test | ✅ Tested |
+| SYS-067 | When a component's `labels`, `systems`, or `build.requiredTools` is edited, the client sends the complete new list and the stored list is made to match it exactly: entries kept in the list stay, new entries are added, entries left out are removed, and re-sending the same list changes nothing. Applies to all three lists (`component_labels`, `component_systems`, `component_required_tools`) | High | integration-test | ✅ Tested |
 
 ---
 
@@ -2464,3 +2465,46 @@ whole live collection, including legacy composite siblings (via `isIntersect`).
 `SYS-065 value-only edit of composite is accepted`,
 `SYS-065 disjointness still enforced against untouched composite`,
 `SYS-065 valid range change is persisted`.
+
+---
+
+### SYS-067: Editing labels / systems / required tools keeps the entries left in the list
+
+**Priority:** High
+**Test layer:** integration-test
+**Status:** ✅ Tested
+
+**Motivation:**
+`labels`, `systems`, and `build.requiredTools` are lists a user edits as a whole: the save carries the
+complete new list, not a single add or remove. The common edit keeps most entries and adds or drops one,
+so the entries that stay in the list must survive the save intact — losing any of them silently corrupts
+the component's data.
+
+**Description:**
+Saving one of these lists makes the stored rows match the submitted list exactly: an entry present both
+before and after the edit stays, an entry that is new is added, an entry no longer in the list is
+removed. The server compares the submitted list against the current rows and writes only the difference,
+so re-sending the same list performs no writes (idempotent) and sending an empty list clears the list.
+Labels and systems are stored per component; required tools per the component's BASE configuration. All
+three behave identically.
+
+**Acceptance criteria:**
+1. Editing labels / systems / `baseConfiguration.requiredTools` to keep an existing code and add a new
+   one persists BOTH in the respective junction (`component_labels` / `component_systems` /
+   `component_required_tools`).
+2. A mixed edit `[A,B] → [B,C]` keeps the intersection `B`, removes `A`, and adds `C`.
+3. Re-submitting the identical list is a no-op (membership unchanged).
+4. An empty list clears the membership.
+5. The label path holds on real PostgreSQL (Testcontainers), not only H2.
+6. Assertions read persisted junction rows (not the in-memory response projection), so a masked loss
+   cannot pass.
+
+**Test methods:** `Sys067JunctionSyncPreservesExistingTest` (H2) —
+`SYS-067 adding a label preserves the existing labels`,
+`SYS-067 adding a system preserves the existing systems`,
+`SYS-067 adding a required tool preserves the existing required tools`,
+`SYS-067 a mixed edit keeps the intersection, adds the new and drops the removed`,
+`SYS-067 re-submitting the same list is a no-op`,
+`SYS-067 an empty list clears the membership`;
+`Sys067LabelSyncPostgresTest` (Testcontainers PostgreSQL) —
+`SYS-067 adding a label preserves the existing labels on PostgreSQL`.


### PR DESCRIPTION
## Problem (prod incident)

A component lost labels with no audit trail: the last audited edit recorded `labels: [x] → [x, y]`, yet the DB (and UI) showed only `y`; an earlier edit that intended 5 labels left only 1. Investigation (prod DB + service pod logs) traced this to a persistence bug, **not** a manual DB edit.

## Root cause

`ComponentManagementServiceImpl.syncLabels` (and its `syncSystems` / `syncRequiredTools` siblings) replaced the whole junction with:

```
deleteAllInBatch(existing)   // bulk DELETE
desired.forEach { save(ComponentXEntity(id, code)) }
```

`deleteAllInBatch` issues a bulk DELETE but **does not evict** the loaded entities from the persistence context — they stay *managed*. The junction entities carry a composite `@IdClass`, so Spring Data `save` routes to `merge` (not `persist`). Re-saving a code that was already present merges onto the still-managed entity: Hibernate schedules **neither an INSERT** (it believes the row exists) **nor an UPDATE** (the `@Id` / `@ManyToOne` columns are immutable → `HHH000502`), so the bulk-deleted row is **never recreated**.

Net effect: every edit kept only the **newly-added** codes and silently dropped all pre-existing ones. The audit `new` value and the PATCH response are both built from the in-memory intent (`canonicalizedLabels` + `refreshComponentLabelsInMemory`), so they showed the full intended set and **masked** the loss until a fresh DB read.

Prod evidence: two `HHH000502 ... ComponentLabelEntity` WARNs fired during the exact PATCH transaction; response byte-sizes went `[x]` → PATCH `[x,y]` (in-memory) → later GETs `[y]` (DB).

## Fix

Reconcile each junction by **set-diff**: delete only `existing − desired`, insert only `desired − existing`. Kept codes are left untouched (no merge, no `HHH000502`), removals still happen, and an unchanged set is a no-op. Applies to all three: `syncLabels`, `syncSystems`, `syncRequiredTools` (labels was the path observed in prod; the other two were latent).

Documented as requirement **SYS-067** in `docs/registry/requirements-common.md`.

## Testing

- **`Sys067JunctionSyncPreservesExistingTest`** (H2/ft-db): labels, systems, and required-tools — baseline one code, add a second, assert BOTH survive via the **junction repository** (persisted state, not the response projection).
- **`Sys067LabelSyncPostgresTest`** (Testcontainers PostgreSQL): the label path on the real engine where the incident occurred.
- Proven RED on the pre-fix code (`expected [alpha, beta] but was [beta]`, with the two `HHH000502` WARNs) → GREEN after the fix.
- Full multi-module `gradlew build` + `dbTest` green (detekt + ktlint included).

> **Local run:** these guards are `@Tag("integration")`, so they run under **`dbTest`**, not `test`:
> `./gradlew :components-registry-service-server:dbTest --tests "*Sys067*"`
> (`test --tests "*Sys067*"` reports success having executed **zero** of them.)

## Note on the ktlint baseline

The added comments shift four pre-existing SCREAMING_SNAKE `private val` constants lower in the file; they carry a ktlint `standard:property-naming` entry in the module baseline **by line number**. They cannot simply be renamed to camelCase — detekt's `ClassOrdering` treats the SCREAMING_SNAKE vals as constants and would then require moving them above every method. The baseline's four line numbers are refreshed to match; **no new suppressions**.

## Follow-up (separate, not in this PR)

Data remediation to restore labels/systems/tools of components already truncated by the bug (compare current junction rows against import descriptors). Tracked separately; requires prod write access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated component edits to precisely reconcile label, system, and required-tools lists: preserve existing entries, add new ones, and remove omitted ones.
  * Re-submitting the same lists is now idempotent, and submitting an empty list clears the stored membership.
  * Ensured required-tools entries are not duplicated.
* **Documentation**
  * Added SYS-067 requirements defining exact synchronization semantics and acceptance criteria based on persisted junction rows.
* **Tests**
  * Added integration coverage (including PostgreSQL) validating preservation, mixed edits, no-ops, and clearing for labels, systems, and required tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->