### PR TITLE
Add post Github commit status step

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1431,10 +1431,6 @@ object id29Step2AggregateAuto : BuildType({
             reuseBuilds = ReuseBuilds.SUCCESSFUL
             onDependencyFailure = FailureAction.ADD_PROBLEM
         }
-        snapshot(id30DeployToOkdQaDevAuto) {
-            reuseBuilds = ReuseBuilds.SUCCESSFUL
-            onDependencyFailure = FailureAction.ADD_PROBLEM
-        }
     }
 })
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -65,6 +65,7 @@ project {
     buildType(id18CompatLocalStandGitModeAuto)
     buildType(id20ValidateComponentsRegistryProductionDataAuto)
     buildType(id30DeployToOkdQaDevAuto)
+    buildType(id29Step2AggregateAuto)
     buildType(id40ReleaseManual)
     buildType(id50ReleasePostProcessingAuto)
     buildType(id60DeployToOkdQaGhAuto)
@@ -83,6 +84,7 @@ project {
         id17CompatLocalStandManual,
         id18CompatLocalStandGitModeAuto,
         id30DeployToOkdQaDevAuto,
+        id29Step2AggregateAuto,
         id40ReleaseManual,
         id50ReleasePostProcessingAuto,
         id60DeployToOkdQaGhAuto,
@@ -1377,6 +1379,55 @@ object id30DeployToOkdQaDevAuto : BuildType({
             onDependencyFailure = FailureAction.FAIL_TO_START
             // Reuse a suitable successful [1.0] rather than forcing a fresh one.
             reuseBuilds = ReuseBuilds.SUCCESSFUL
+        }
+    }
+})
+
+object id29Step2AggregateAuto : BuildType({
+    templates(AbsoluteId("RDDepartment_PostGithubStatus"))
+    id("29Step2AggregateAuto")
+    name = "[2.9] Step 2 Aggregate [AUTO]"
+
+    // Surface [1.0]'s build number so the whole chain (id10 = id12 = … = id29)
+    // shows the same version tag in the TC chain view.
+    buildNumberPattern = "%BUILD_NUMBER%"
+
+    params {
+        param("BUILD_NUMBER", "${id10CompileUtAuto.depParamRefs.buildNumber}")
+    }
+
+    vcs {
+        root(AbsoluteId("Octopus_OctopusComponents_OctopusGithubVcsRoot"))
+    }
+
+    triggers {
+        finishBuildTrigger {
+            buildType = "${id10CompileUtAuto.id}"
+            successfulOnly = true
+            branchFilter = "+:*"
+        }
+    }
+
+    dependencies {
+        snapshot(id20ValidateComponentsRegistryProductionDataAuto) {
+            reuseBuilds = ReuseBuilds.SUCCESSFUL
+            onDependencyFailure = FailureAction.ADD_PROBLEM
+        }
+        snapshot(id12IntegrationDbTestsAuto) {
+            reuseBuilds = ReuseBuilds.SUCCESSFUL
+            onDependencyFailure = FailureAction.ADD_PROBLEM
+        }
+        snapshot(id17CompatLocalStandManual) {
+            reuseBuilds = ReuseBuilds.SUCCESSFUL
+            onDependencyFailure = FailureAction.ADD_PROBLEM
+        }
+        snapshot(id18CompatLocalStandGitModeAuto) {
+            reuseBuilds = ReuseBuilds.SUCCESSFUL
+            onDependencyFailure = FailureAction.ADD_PROBLEM
+        }
+        snapshot(id30DeployToOkdQaDevAuto) {
+            reuseBuilds = ReuseBuilds.SUCCESSFUL
+            onDependencyFailure = FailureAction.ADD_PROBLEM
         }
     }
 })

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1409,6 +1409,12 @@ object id29Step2AggregateAuto : BuildType({
     }
 
     dependencies {
+        // [1.0] Compile & UT included so the single "Build Validation" status also
+        // covers compile + unit tests, not just the [2.x] fan-out.
+        snapshot(id10CompileUtAuto) {
+            reuseBuilds = ReuseBuilds.SUCCESSFUL
+            onDependencyFailure = FailureAction.ADD_PROBLEM
+        }
         snapshot(id20ValidateComponentsRegistryProductionDataAuto) {
             reuseBuilds = ReuseBuilds.SUCCESSFUL
             onDependencyFailure = FailureAction.ADD_PROBLEM


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated “[2.9] Step 2 Aggregate [AUTO]” build configuration.
  * It now triggers on successful completion of the compile step across all branches, aggregates results from validation, integration DB tests, and compatibility suites, and snapshots required builds.
  * Build numbering is propagated from the upstream compile build, and dependency failures are reported as problems for clearer tracking.
  * Configured to use the standard GitHub status template for consistent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->