### PR TITLE
chore(publish): stop publishing deployables and tooling to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,19 +23,24 @@ plugins {
     id 'com.platformlib.gradle-wrapper' version '0.2.6'
 }
 
-// Modules deliberately NOT published to Maven Central. Central is an exchange for artifacts
-// other projects consume as a Maven dependency; these are deployables and internal tooling:
-//   - components-registry-service-server: the service itself. Its deliverable is the docker
-//     image on ghcr; the published jar is a 1.5 MB deploy artifact nobody depends on. (Consumers
-//     reference its openapi/v4.json by git path, not via the artifact.)
-//   - components-registry-cli (crsctl): standalone CLI. README documents building it locally
-//     (`:components-registry-cli:shadowJar`); packaging/distribution is a separate follow-up.
-//     Shadow + Gradle module metadata were dragging its 15.9 MB `-all` fat jar into Central.
-//   - components-registry-compat-test: internal compatibility harness, never a dependency.
-// NOT in this list: components-registry-automation — its TeamCity metarunner resolves
-// `<group>:components-registry-automation:<version>:jar:all` from a Maven repo at build time,
-// so it must stay published (see components-registry-automation/metarunners/).
-def unpublishedModules = ['components-registry-service-server', 'components-registry-cli', 'components-registry-compat-test']
+// Modules published to Maven Central — an allowlist, so a module that is not listed is not
+// published. Central is for artifacts other projects consume as a Maven dependency; NOT listed
+// here on purpose: components-registry-service-server and components-registry-cli (deployables,
+// shipped as a docker image / built locally per the CLI README) and components-registry-compat-test
+// (internal harness). components-registry-automation IS listed even though it is tooling: its
+// TeamCity metarunner resolves `<group>:components-registry-automation:<version>:jar:all` from a
+// Maven repo at build time (see components-registry-automation/metarunners/).
+def centralPublishedModules = [
+        'component-resolver-api',
+        'component-resolver-core',
+        'components-registry-api',
+        'components-registry-dsl',
+        'components-registry-service-client',
+        'components-registry-service-light-client',
+        'components-registry-service-core',
+        'test-common',
+        'components-registry-automation',
+] as Set
 
 octopusQuality {
     // NOTE: in octopus-quality 2.5.2 `excludeProjects` maps ONLY to coverage exclusion
@@ -302,12 +307,10 @@ configure(subprojects) {
         withSourcesJar()
     }
 
-    // Maven Central is for modules other projects consume as a DEPENDENCY. Deployables and
-    // internal tooling are deliberately not published there (see unpublishedModules above):
-    // creating no publication is what keeps them out — `publishToSonatype` then has nothing
-    // to upload for them, while `build`, the docker image and the shadow/boot jars are
-    // untouched.
-    if (!(project.name in unpublishedModules)) {
+    // Only allowlisted modules get a publication (see centralPublishedModules above); for the
+    // rest `publishToSonatype` has nothing to upload, while `build`, the docker image and the
+    // shadow/boot jars are unaffected.
+    if (project.name in centralPublishedModules) {
         publishing {
             publications {
                 mavenJava(MavenPublication) {
@@ -436,6 +439,21 @@ ${sectionsHtml}
 </body>
 </html>
 """
+}
+
+// Fail the build if any module publishes to Maven Central outside the allowlist. A
+// publication-surface reduction has no test of its own: without this guard, dropping the
+// allowlist check or adding a module-level `publishing {}` block silently starts pushing a
+// deployable to Central again, and it is only noticed at the next quota audit.
+gradle.projectsEvaluated {
+    def actual = subprojects.findAll { !it.publishing.publications.isEmpty() }*.name as Set
+    if (actual != centralPublishedModules) {
+        throw new GradleException(
+                "Maven Central publication set drifted.\n" +
+                        "  allowlisted: ${centralPublishedModules.sort()}\n" +
+                        "  publishing:  ${actual.sort()}\n" +
+                        "Update `centralPublishedModules` in the root build.gradle only if the change is intentional.")
+    }
 }
 
 // Aggregate JaCoCo tasks and coverage gate wired in projectsEvaluated (outside any task

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,20 @@ plugins {
     id 'com.platformlib.gradle-wrapper' version '0.2.6'
 }
 
+// Modules deliberately NOT published to Maven Central. Central is an exchange for artifacts
+// other projects consume as a Maven dependency; these are deployables and internal tooling:
+//   - components-registry-service-server: the service itself. Its deliverable is the docker
+//     image on ghcr; the published jar is a 1.5 MB deploy artifact nobody depends on. (Consumers
+//     reference its openapi/v4.json by git path, not via the artifact.)
+//   - components-registry-cli (crsctl): standalone CLI. README documents building it locally
+//     (`:components-registry-cli:shadowJar`); packaging/distribution is a separate follow-up.
+//     Shadow + Gradle module metadata were dragging its 15.9 MB `-all` fat jar into Central.
+//   - components-registry-compat-test: internal compatibility harness, never a dependency.
+// NOT in this list: components-registry-automation — its TeamCity metarunner resolves
+// `<group>:components-registry-automation:<version>:jar:all` from a Maven repo at build time,
+// so it must stay published (see components-registry-automation/metarunners/).
+def unpublishedModules = ['components-registry-service-server', 'components-registry-cli', 'components-registry-compat-test']
+
 octopusQuality {
     // NOTE: in octopus-quality 2.5.2 `excludeProjects` maps ONLY to coverage exclusion
     // (coverageExcludedProjects) — it does NOT exclude these modules from qualityStatic, which
@@ -288,44 +302,51 @@ configure(subprojects) {
         withSourcesJar()
     }
 
-    publishing {
-        publications {
-            mavenJava(MavenPublication) {
-                from components.java
-                pom {
-                    name.set(project.name)
-                    description.set("Octopus module: ${project.name}")
-                    url.set("https://github.com/octopusden/octopus-components-registry-service.git")
-                    licenses {
-                        license {
-                            name.set("The Apache License, Version 2.0")
-                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                        }
-                    }
-                    scm {
+    // Maven Central is for modules other projects consume as a DEPENDENCY. Deployables and
+    // internal tooling are deliberately not published there (see unpublishedModules above):
+    // creating no publication is what keeps them out — `publishToSonatype` then has nothing
+    // to upload for them, while `build`, the docker image and the shadow/boot jars are
+    // untouched.
+    if (!(project.name in unpublishedModules)) {
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    from components.java
+                    pom {
+                        name.set(project.name)
+                        description.set("Octopus module: ${project.name}")
                         url.set("https://github.com/octopusden/octopus-components-registry-service.git")
-                        connection.set("scm:git://github.com/octopusden/octopus-components-registry-service.git")
-                    }
-                    developers {
-                        developer {
-                            id.set("octopus")
-                            name.set("octopus")
+                        licenses {
+                            license {
+                                name.set("The Apache License, Version 2.0")
+                                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                            }
+                        }
+                        scm {
+                            url.set("https://github.com/octopusden/octopus-components-registry-service.git")
+                            connection.set("scm:git://github.com/octopusden/octopus-components-registry-service.git")
+                        }
+                        developers {
+                            developer {
+                                id.set("octopus")
+                                name.set("octopus")
+                            }
                         }
                     }
                 }
             }
         }
-    }
 
-    signing {
-        required(gradle.taskGraph.hasTask("publishToSonatype"))
-        sign(publishing.publications)
-        def signingKey = findProperty("signingKey")
-        def signingPassword = findProperty("signingPassword")
-        useInMemoryPgpKeys(
-                signingKey,
-                signingPassword
-        )
+        signing {
+            required(gradle.taskGraph.hasTask("publishToSonatype"))
+            sign(publishing.publications)
+            def signingKey = findProperty("signingKey")
+            def signingPassword = findProperty("signingPassword")
+            useInMemoryPgpKeys(
+                    signingKey,
+                    signingPassword
+            )
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,21 @@ plugins {
 }
 
 // Modules published to Maven Central — an allowlist, so a module that is not listed is not
-// published. Central is for artifacts other projects consume as a Maven dependency; NOT listed
-// here on purpose: components-registry-service-server and components-registry-cli (deployables,
-// shipped as a docker image / built locally per the CLI README) and components-registry-compat-test
-// (internal harness). components-registry-automation IS listed even though it is tooling: its
-// TeamCity metarunner resolves `<group>:components-registry-automation:<version>:jar:all` from a
-// Maven repo at build time (see components-registry-automation/metarunners/).
+// published. Central is for artifacts other projects consume as a Maven dependency.
+//
+// Deliberately NOT listed:
+//   components-registry-service-server, components-registry-cli — deployables (docker image on
+//     ghcr / built locally per the CLI README);
+//   components-registry-compat-test — internal harness;
+//   component-validation — pure validation library with no external consumer yet. The server
+//     depends on it as `project(':component-validation')`, which needs no publication, and it has
+//     never been on Central (it was added after the last release). Publishing it would start
+//     costing quota for something nobody can resolve; add it here the moment a consumer outside
+//     this repository needs it as a dependency.
+//
+// components-registry-automation IS listed even though it is tooling: its TeamCity metarunner
+// resolves `<group>:components-registry-automation:<version>:jar:all` from a Maven repo at build
+// time (see components-registry-automation/metarunners/).
 def centralPublishedModules = [
         'component-resolver-api',
         'component-resolver-core',
@@ -441,20 +450,44 @@ ${sectionsHtml}
 """
 }
 
-// Fail the build if any module publishes to Maven Central outside the allowlist. A
-// publication-surface reduction has no test of its own: without this guard, dropping the
-// allowlist check or adding a module-level `publishing {}` block silently starts pushing a
-// deployable to Central again, and it is only noticed at the next quota audit.
-gradle.projectsEvaluated {
+// POLICY check, run in a task action rather than at configuration time: a publication-policy
+// problem must fail the release, not every Gradle invocation (`build`, `test`, `dependencies`,
+// IDE sync) — the same reasoning as the coverage-policy checks below. Wired into the publish
+// path, so a drift cannot reach Central: re-adding a publication for an excluded module, or
+// dropping the allowlist check itself, fails before anything is uploaded.
+def centralPublicationPolicyProblems = {
     def actual = subprojects.findAll { !it.publishing.publications.isEmpty() }*.name as Set
     if (actual != centralPublishedModules) {
-        throw new GradleException(
-                "Maven Central publication set drifted.\n" +
-                        "  allowlisted: ${centralPublishedModules.sort()}\n" +
-                        "  publishing:  ${actual.sort()}\n" +
-                        "Update `centralPublishedModules` in the root build.gradle only if the change is intentional.")
+        return ["Maven Central publication set drifted.\n" +
+                    "  allowlisted: ${centralPublishedModules.sort()}\n" +
+                    "  publishing:  ${actual.sort()}\n" +
+                    "Update `centralPublishedModules` in the root build.gradle only if the change is intentional."]
+    }
+    return []
+}
+
+def verifyCentralPublicationPolicy = tasks.register('verifyCentralPublicationPolicy') {
+    group = 'verification'
+    description = 'Fails if the set of modules publishing to Maven Central differs from the allowlist.'
+    doLast {
+        def problems = centralPublicationPolicyProblems()
+        if (problems) {
+            throw new GradleException(problems.join('\n\n'))
+        }
+        logger.lifecycle("Maven Central publication set matches the allowlist (${centralPublishedModules.size()} modules).")
     }
 }
+
+// `publishToSonatype` only exists with -Pnexus, and `publish` is per-project — match by name so
+// the gate attaches wherever it is present without forcing either to be created.
+gradle.projectsEvaluated {
+    allprojects { proj ->
+        proj.tasks.matching { it.name in ['publishToSonatype', 'publish', 'publishToMavenLocal'] }.configureEach {
+            dependsOn verifyCentralPublicationPolicy
+        }
+    }
+}
+
 
 // Aggregate JaCoCo tasks and coverage gate wired in projectsEvaluated (outside any task
 // configuration action) so the task container is still mutable.

--- a/components-registry-cli/README.md
+++ b/components-registry-cli/README.md
@@ -16,7 +16,7 @@ stderr, and a small, pinned set of process exit codes.
 | Anonymous reads — `components`, `component`, `meta` (except `meta employees`), `whoami` | **Works out of the box.** No login or token required. |
 | `login` / `logout` / `audit` / `meta employees` | **Gated.** These need an authenticated identity. The device-flow `login` depends on a pending Keycloak **public device-flow client** (Part C spike) that does not exist yet, so the auth path is **not usable end-to-end** today. |
 | Release / Homebrew tap / macOS notarization | **Separate follow-up.** Not part of this module yet. |
-| Prebuilt download | **Not available yet — build locally (below).** This module is not published to Maven Central: a Maven coordinate is the wrong channel for a CLI, and the fat jar cost ~16 MB of the org's monthly Central quota per release. The intended channel is a GitHub Release asset attached to the release the pipeline already creates; until that exists, build the jar locally. |
+| Prebuilt download | **Not available yet — build locally (below).** This module is not published to Maven Central: a Maven coordinate is the wrong channel for a CLI. The intended channel is a GitHub Release asset attached to the release the pipeline already creates; until that exists, build the jar locally. |
 
 Anonymous read commands are fully functional now. Everything under the "Auth (gated)" heading below
 is implemented in the CLI but blocked on the OIDC client provisioning.

--- a/components-registry-cli/README.md
+++ b/components-registry-cli/README.md
@@ -16,6 +16,7 @@ stderr, and a small, pinned set of process exit codes.
 | Anonymous reads — `components`, `component`, `meta` (except `meta employees`), `whoami` | **Works out of the box.** No login or token required. |
 | `login` / `logout` / `audit` / `meta employees` | **Gated.** These need an authenticated identity. The device-flow `login` depends on a pending Keycloak **public device-flow client** (Part C spike) that does not exist yet, so the auth path is **not usable end-to-end** today. |
 | Release / Homebrew tap / macOS notarization | **Separate follow-up.** Not part of this module yet. |
+| Prebuilt download | **Not available yet — build locally (below).** This module is not published to Maven Central: a Maven coordinate is the wrong channel for a CLI, and the fat jar cost ~16 MB of the org's monthly Central quota per release. The intended channel is a GitHub Release asset attached to the release the pipeline already creates; until that exists, build the jar locally. |
 
 Anonymous read commands are fully functional now. Everything under the "Auth (gated)" heading below
 is implemented in the CLI but blocked on the OIDC client provisioning.
@@ -31,7 +32,7 @@ Produce the fat jar:
 ```
 
 The runnable fat jar uses the `all` classifier (the thin `…-<version>.jar` is the plain library
-jar, kept for the repo's release tooling and Maven publication):
+jar, kept for the repo's release tooling):
 
 ```
 components-registry-cli/build/libs/components-registry-cli-1.0-SNAPSHOT-all.jar

--- a/components-registry-cli/build.gradle
+++ b/components-registry-cli/build.gradle
@@ -27,7 +27,7 @@ shadowJar {
 
 // Keep the thin `jar` ENABLED: the repo's TeamCity release tooling (extractModuleInfo) requires
 // every module to produce the standard components-registry-cli-<version>.jar. (This module is no
-// longer published to Maven Central — see unpublishedModules in the root build.gradle — so the
+// longer published to Maven Central — see centralPublishedModules in the root build.gradle — so the
 // publication is not a reason any more; the release tooling still is.) Mirrors
 // :components-registry-automation, which also ships a shadowJar while leaving the thin jar in
 // place. (Do NOT set jar.enabled = false here —

--- a/components-registry-cli/build.gradle
+++ b/components-registry-cli/build.gradle
@@ -26,9 +26,11 @@ shadowJar {
 }
 
 // Keep the thin `jar` ENABLED: the repo's TeamCity release tooling (extractModuleInfo) requires
-// every module to produce the standard components-registry-cli-<version>.jar, and the maven
-// publication (from components.java) needs it too. Mirrors :components-registry-automation, which
-// also ships a shadowJar while leaving the thin jar in place. (Do NOT set jar.enabled = false here —
+// every module to produce the standard components-registry-cli-<version>.jar. (This module is no
+// longer published to Maven Central — see unpublishedModules in the root build.gradle — so the
+// publication is not a reason any more; the release tooling still is.) Mirrors
+// :components-registry-automation, which also ships a shadowJar while leaving the thin jar in
+// place. (Do NOT set jar.enabled = false here —
 // that broke the [1.0] Compile&UT build: "Artifact components-registry-cli-<version>.jar wasn't
 // produced by this build".)
 jar {

--- a/components-registry-compat-test/build.gradle
+++ b/components-registry-compat-test/build.gradle
@@ -39,9 +39,6 @@ dependencies {
     testRuntimeOnly "ch.qos.logback:logback-classic:1.3.14"
 }
 
-tasks.named('publish') { enabled = false }
-tasks.named('publishToMavenLocal') { enabled = false }
-
 test {
     onlyIf("at least one of compat.baseline.url / compat.candidate.url is set (partial config triggers explainInvalid)") { compatActivated() }
     // Compat runs hit live stands whose state (cache snapshots, deployments) changes


### PR DESCRIPTION
## Why

The org is over Maven Central's **monthly** publishing limits — Release Size 1.21 GB vs 80 MB, File Count 10 094 vs 1 000, Release Count 32 vs 7. Measured directly against Central, **CRS is the single biggest contributor**: 670 files and 39.8 MB per release ⇒ ~6 000 files and ~358 MB/month at 9 releases (July).

Most of that is artifacts **nobody consumes as a Maven dependency**. Central is an exchange for dependencies; deployables and internal tooling don't belong there.

## Measured footprint (3.0.8, from repo1)

| module | files | size | |
|---|--:|--:|---|
| components-registry-automation | 70 | 19.75 MB | **keep** (see below) |
| **components-registry-cli** | 60 | **16.43 MB** | **drop** |
| **components-registry-service-server** | 60 | **2.00 MB** | **drop** |
| component-resolver-core | 50 | 0.62 MB | keep |
| components-registry-api | 50 | 0.30 MB | keep |
| component-resolver-api | 50 | 0.27 MB | keep |
| components-registry-service-light-client | 60 | 0.17 MB | keep |
| components-registry-service-core | 50 | 0.11 MB | keep |
| components-registry-dsl | 50 | 0.08 MB | keep |
| test-common | 60 | 0.05 MB | keep |
| components-registry-service-client | 60 | 0.04 MB | keep |
| **components-registry-compat-test** | 50 | 0.01 MB | **drop** |
| **total** | **670** | **39.83 MB/release** | |

## What is dropped, and why it's safe

- **components-registry-service-server** — the deliverable is the docker image on ghcr. Consumers needing `openapi/v4.json` read it **from git at a pinned ref** (portal `frontend/scripts/vendor-spec.sh`), not from the artifact. `.teamcity/settings.kts` already notes the server's Maven publication is unusable for the compat baseline (non-boot jar) and uses `docker pull` + `docker cp` instead.
- **components-registry-cli (crsctl)** — no consumers anywhere in the org. Its README documents building locally (`:components-registry-cli:shadowJar`) and defers release/packaging to a separate follow-up. Shadow + Gradle module metadata were dragging a **15.9 MB `-all` fat jar** into Central through the `shadowRuntimeElements` variant of `components.java`.
- **components-registry-compat-test** — internal compatibility harness, never a dependency.

**`component-validation`** (added to `main` by #443 after this branch was opened) is also **not** published: it has never been on Central, the server consumes it as `project(':component-validation')` which needs no publication, and nothing in the organisation resolves it as a dependency. Excluding it declines to *start* publishing rather than dropping an artifact; the allowlist comment names the trigger to revisit — the first consumer outside this repository.

The 8 consumed library modules still publish and sign **exactly as before** (verified: the diff is re-indentation only for them).

## Kept on purpose: components-registry-automation

Even though it's the heaviest artifact (19.75 MB), it **must stay**: its TeamCity metarunner resolves the fat jar from a Maven repo at build time —

```xml
-Dartifact=${group}:${name}:${version}:jar:all
java -jar ./.$name/$name-$version-all.jar %ARGS%
```

(`components-registry-automation/metarunners/OctopusComponentsRegistryAutomation.xml`). A plain dependency search doesn't reveal this — consumption goes through the metarunner.

## Implementation note

Declaring **no publication** is what actually keeps a module out of Central. The module-level `tasks.named('publish') { enabled = false }` that compat-test already had was **ineffective** — `publishToSonatype` depends on the `PublishToMavenRepository` tasks, not on the per-project `publish` lifecycle task — which is exactly why compat-test was on Central despite the intent. Those two dead lines are removed.

## Effect

| | before | after |
|---|--:|--:|
| files / release | 670 | **500** |
| MB / release | 39.83 | **21.39** |
| at 9 releases/month | 6 030 files, 358 MB | **4 500 files, 193 MB** |
| **saved** | | **−1 530 files, −166 MB / month** |

## Verification

- Full build green: `AUTH_SERVER_URL=… ./gradlew build -x dockerBuildImage -x dockerPushImage -x ocCreate -x ocProcess -x :components-registry-automation:test` → `BUILD SUCCESSFUL`
- `publishToMavenLocal --dry-run` → exactly **9** `publishMavenJavaPublication*` + **9** `signMavenJavaPublication` tasks; the 3 dropped modules have neither
- Independent review (Sonnet): no blockers; Groovy scoping, `publish`-task wiring at build.gradle:553-560, `.teamcity/settings.kts`, and mavenLocal resolution all checked

## Deliberately out of scope

`withJavadocJar()/withSourcesJar()` still run for the 3 unpublished modules — wasted work, but TeamCity artifact rules may expect those jars and the saving is seconds. Left as-is.

## Follow-up

After this, **92% of CRS's remaining Central size is automation's 19.7 MB fat jar**, which lives there only because TeamCity fetches it from a Maven repo. If TC agents resolve through the internal Artifactory (the metarunner uses `userSettingsSelection:default`), publishing that fat jar internally instead would save a further ~178 MB/month. Needs agent-settings verification — separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to publish/sign only an allowlisted set of modules to Maven Central.
  * Added a build-time safeguard that fails the build if the actual publishing set drifts from the allowlist.
  * Preserved required thin/thick JAR outputs for CI and release tooling.
  * Adjusted the compatibility-test module to no longer explicitly disable publishing tasks.
  * Refreshed CLI documentation to reflect current build/download status and clarify fat-jar naming/classifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
