### PR TITLE
ci: bump octopus-base 2.4.1 → 2.5.2 (restores Maven Central releases)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/infrastructure/components-registry-service-core/_VER_/components-registry-service-core-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
     with:
       java-version: '21'
       flow-type: hybrid
@@ -14,13 +14,13 @@ jobs:
     secrets: inherit
 
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
     with:
       java-version: '21'
     secrets: inherit
 
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
     with:
       java-version: '21'
       enable-codeql: true
@@ -35,6 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.5.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
     with:
       java-version: '21'
       enable-codeql: true

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
 }
 
 octopusQuality {
-    // NOTE: in octopus-quality 2.4.1 `excludeProjects` maps ONLY to coverage exclusion
+    // NOTE: in octopus-quality 2.5.2 `excludeProjects` maps ONLY to coverage exclusion
     // (coverageExcludedProjects) — it does NOT exclude these modules from qualityStatic, which
     // runs checkstyle/pmd/codenarc/detekt/ktlint over ALL subprojects. These four are excluded
     // from the aggregate coverage gate (CLI/automation/compat-test/test-common are tooling/test
@@ -149,7 +149,7 @@ configure(subprojects) {
 
     if (!project.name.equalsIgnoreCase("components-registry-service-light-client")) {
         apply plugin: 'org.jetbrains.kotlin.jvm'
-        // octopus-quality 2.4.1 self-applies the Java/Groovy analysers (checkstyle/pmd — now gated
+        // octopus-quality 2.5.2 self-applies the Java/Groovy analysers (checkstyle/pmd — now gated
         // to Java-source modules — plus codenarc/spotbugs/jacoco). Per its documented consumer
         // contract it merely *configures* detekt/ktlint reactively via plugins.withId(...) — they
         // must be APPLIED here or the Kotlin static-analysis gate silently does nothing (checkstyle/

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
         id 'org.jetbrains.kotlin.plugin.jpa'            version settings['kotlin.version']
         id 'io.gitlab.arturbosch.detekt'                version settings['detekt.version']
         id 'org.jlleitschuh.gradle.ktlint'              version settings['ktlint-gradle.version']
-        id 'org.octopusden.octopus-quality'             version '2.4.1'
+        id 'org.octopusden.octopus-quality'             version '2.5.2'
         id 'com.bmuschko.docker-java-application'       version settings['gradle-docker-plugin.version']
         id 'com.github.johnrengelman.shadow'            version '8.1.1'
         id 'org.octopusden.octopus.oc-template'         version settings['octopus-oc-template.version']


### PR DESCRIPTION
## What

Bumps the shared **octopus-base** dependency from **v2.4.1 → v2.5.2**, leaving no reference behind:

- all reusable workflow and action refs — `build`, `merge-gate`, `quality-gates`, `security-reports`, `release`, `check-and-register`, and the `merge-gate` composite action — `@v2.4.1` → `@v2.5.2`;
- the **octopus-quality** Gradle convention plugin in `pluginManagement`, `2.4.1` → `2.5.2`.

## Why

Releases to Maven Central have been failing since Sonatype retired OSSRH. Two things changed in v2.5.x:

**Publishing.** The temporary compatibility bridge stopped completing the final promotion, so the job failed while the artifacts sometimes published anyway — a red build and a published version were not mutually exclusive. Publishing now goes through the Central Portal API, and a release counts as done only once every artifact is genuinely resolvable on Maven Central: the git tag is created after Central confirms, not before. A failed publish is classified in the log — deterministic, transient or resumable — and a run that died after uploading can be finished with the printed deployment id instead of re-uploading a version Maven Central will never let you replace.

**Registration.** The released version used to be resolved by asking "what is the highest version tag in this repository?" — a question unrelated to what the triggering run released. Any stray higher tag silently registers the wrong version, and post-release bookkeeping then records it as the component's latest release. Not hypothetical: on the canary a leftover `v9.9.9` tag hijacked a real `2.2.37` release, so the log recorded 9.9.9 and the stored latest version became 9.9.9, while the real release got no bookkeeping at all. The version is now read from the release that the triggering run stamped with its own id and attempt, falling back only to sources tied to that run.

## Why it's safe

- Everything outside the release path is unchanged code. `build`, `quality-gates` and `security-reports`, the `merge-gate` composite action, and the `octopus-quality` plugin sources are **byte for byte identical** between `v2.4.1` and `v2.5.2` — the corresponding `git diff v2.4.1..v2.5.2` in octopus-base is empty. So no analysis behaviour changes and existing baselines stay valid; those refs move only to stop this repository running a mixed set of pins.
- The release path is the intended change, and it has been exercised end to end before this PR (below).
- Nothing in this PR touches sources, build logic or baselines.

## Verification behind v2.5.2

- **octopus-test `2.2.37`** — a full release driven from the internal CI: Portal deployment reached `PUBLISHED`, the artifact was confirmed resolvable on Maven Central, the tag was created, the release was registered, and post-processing ran for that version.
- **octopus-base `2.5.2`** — released through the same path, with consumer verification against octopus-test before publishing, and both published coordinates confirmed on Maven Central afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build, release, quality, security, and merge validation processes to use the latest shared workflow versions.
  * Upgraded the project’s quality tooling to version 2.5.2.
* **Documentation**
  * Clarified coverage exclusion and code analysis behavior in the build configuration comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->