### PR TITLE
ci(coverage): gate BRANCH coverage, add per-module ratchets, record the quality baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ BOOT-INF/
 # CI helpers invoked from TeamCity build steps live in the repo so they can be
 # reviewed and tested outside TC.
 !scripts/teamcity/*.sh
+# Quality-baseline measurement helpers (docs/registry/quality-baseline.md §7). Tracked because the
+# documented recipe calls them by path — an ignored helper leaves the doc pointing at a file nobody
+# else has.
+!scripts/quality-baseline/*.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,17 @@ All existing v1/v2/v3 endpoints (34 endpoints, 28 Feign client methods) must rem
 - Kotlin checks (detekt, ktlint) are **blocking** with module-level baselines.
 - Groovy CodeNarc is **report-only** — do not make blocking without explicit decision.
 - **SpotBugs intentionally disabled** in `build.gradle` via `tasks.matching { it.name.startsWith('spotbugs') }.configureEach { enabled = false }` (the plugin itself stays applied because it's owned by the `octopus-quality` convention plugin). Bytecode-flow analysis gave high false-positive rate on Kotlin lateinit / DSL getter / test code; the per-language tools above already cover the same ground. Do not re-enable without an explicit policy decision.
-- JaCoCo coverage: per-module minimum 10%, overall weighted minimum 70%.
+- JaCoCo coverage, all enforced in `qualityCoverage` (the GitHub `quality` job) and **not** in `check`,
+  so TeamCity `[1.0]` does not gate coverage:
+  - aggregate **LINE ≥ 86%** and **BRANCH ≥ 65%** (`jacocoOverallCoverageVerification`);
+  - per-module strict **LINE/BRANCH ratchet** (`<module>:jacocoCoverageRatchet`), thresholds set to the
+    measured value minus ~2 p.p. — see [`docs/registry/quality-baseline.md`](docs/registry/quality-baseline.md)
+    for the measured numbers and the re-measure recipe;
+  - the plugin-owned per-module 10% floor stays underneath (it is wired off `test` and must keep working
+    without the heavy suites).
+  These are **ratchets**: raise them when coverage rises, and never lower one without saying so in the PR
+  description. A module renamed or dropped without updating `moduleCoverageRatchet` in `build.gradle`
+  fails configuration loudly rather than silently losing its gate.
 - **ArchUnit** architecture fitness functions in `components-registry-service-server` (`server/architecture/ArchitectureFitnessTest.kt`, runs in the fast `test` gate). Scope is **structural**: four package-placement rules (`@RestController`/`@Repository`/`@Entity`/`@Service`) plus one **frozen** layering rule (controllers must not use Spring Data repositories directly). The layering rule's pre-existing accesses are baselined in `archunit_violation_store/` — treat it like `detekt-baseline.xml`, as a **ratchet**: **new** violations fail the build (`freeze.refreeze=false`); the store is **immutable in normal runs** (`allowStoreUpdate=false`), so updating the baseline is a deliberate, flags-flipped regenerate + diff-review (this also stops a rule-text change from silently re-recording a fresh baseline). Runtime/framework policy is intentionally NOT checked here — v4 authorization is deferred to a Spring-context test (TD-017), package cycles to TD-016, and the DB-source/Groovy boundary to TD-019. See `docs/registry/non-functional-spec.md` §5.3.
 
 ## CI Workflows
@@ -140,7 +150,12 @@ All existing v1/v2/v3 endpoints (34 endpoints, 28 Feign client methods) must rem
 - Treat unit-test coverage and FT/integration coverage as separate concerns.
 - Generic GitHub quality checks should enforce only coverage that GitHub actually measures reliably.
 - FT or OKD coverage should be enforced only in the environment that really runs those scenarios.
-- The repository uses both a low per-module coverage floor and an overall weighted coverage threshold.
+- The repository layers three coverage gates: a low plugin-owned per-module floor, a strict per-module
+  LINE/BRANCH ratchet, and an aggregate LINE/BRANCH threshold (see Quality Gates above).
+- Gate BRANCH as well as LINE. LINE alone cannot see a condition that is executed but never asserted
+  both ways, which is exactly the gap a generated test tends to leave.
+- Record measured coverage in `docs/registry/quality-baseline.md` when it moves materially, so a later
+  "before / after" comparison has a dated reference rather than a recollection.
 
 ## Reports
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,17 +127,7 @@ All existing v1/v2/v3 endpoints (34 endpoints, 28 Feign client methods) must rem
 - Kotlin checks (detekt, ktlint) are **blocking** with module-level baselines.
 - Groovy CodeNarc is **report-only** — do not make blocking without explicit decision.
 - **SpotBugs intentionally disabled** in `build.gradle` via `tasks.matching { it.name.startsWith('spotbugs') }.configureEach { enabled = false }` (the plugin itself stays applied because it's owned by the `octopus-quality` convention plugin). Bytecode-flow analysis gave high false-positive rate on Kotlin lateinit / DSL getter / test code; the per-language tools above already cover the same ground. Do not re-enable without an explicit policy decision.
-- JaCoCo coverage, all enforced in `qualityCoverage` (the GitHub `quality` job) and **not** in `check`,
-  so TeamCity `[1.0]` does not gate coverage:
-  - aggregate **LINE ≥ 86%** and **BRANCH ≥ 65%** (`jacocoOverallCoverageVerification`);
-  - per-module strict **LINE/BRANCH ratchet** (`<module>:jacocoCoverageRatchet`), thresholds set to the
-    measured value minus ~2 p.p. — see [`docs/registry/quality-baseline.md`](docs/registry/quality-baseline.md)
-    for the measured numbers and the re-measure recipe;
-  - the plugin-owned per-module 10% floor stays underneath (it is wired off `test` and must keep working
-    without the heavy suites).
-  These are **ratchets**: raise them when coverage rises, and never lower one without saying so in the PR
-  description. A module renamed or dropped without updating `moduleCoverageRatchet` in `build.gradle`
-  fails configuration loudly rather than silently losing its gate.
+- JaCoCo coverage — aggregate LINE ≥ 86% / BRANCH ≥ 65%, plus a strict per-module LINE/BRANCH ratchet on top of the plugin-owned 10% floor. In `qualityCoverage` only, so TeamCity `[1.0]` does not gate coverage. Thresholds are **ratchets** (measured − ~2 p.p.): raise them freely, never lower one without saying so in the PR. Rules and rationale: `build.gradle` (`moduleCoverageRatchet`) and `docs/registry/non-functional-spec.md` §5.10; measured values and re-measure recipe: `docs/registry/quality-baseline.md`.
 - **ArchUnit** architecture fitness functions in `components-registry-service-server` (`server/architecture/ArchitectureFitnessTest.kt`, runs in the fast `test` gate). Scope is **structural**: four package-placement rules (`@RestController`/`@Repository`/`@Entity`/`@Service`) plus one **frozen** layering rule (controllers must not use Spring Data repositories directly). The layering rule's pre-existing accesses are baselined in `archunit_violation_store/` — treat it like `detekt-baseline.xml`, as a **ratchet**: **new** violations fail the build (`freeze.refreeze=false`); the store is **immutable in normal runs** (`allowStoreUpdate=false`), so updating the baseline is a deliberate, flags-flipped regenerate + diff-review (this also stops a rule-text change from silently re-recording a fresh baseline). Runtime/framework policy is intentionally NOT checked here — v4 authorization is deferred to a Spring-context test (TD-017), package cycles to TD-016, and the DB-source/Groovy boundary to TD-019. See `docs/registry/non-functional-spec.md` §5.3.
 
 ## CI Workflows
@@ -150,10 +140,8 @@ All existing v1/v2/v3 endpoints (34 endpoints, 28 Feign client methods) must rem
 - Treat unit-test coverage and FT/integration coverage as separate concerns.
 - Generic GitHub quality checks should enforce only coverage that GitHub actually measures reliably.
 - FT or OKD coverage should be enforced only in the environment that really runs those scenarios.
-- The repository layers three coverage gates: a low plugin-owned per-module floor, a strict per-module
-  LINE/BRANCH ratchet, and an aggregate LINE/BRANCH threshold (see Quality Gates above).
-- Gate BRANCH as well as LINE. LINE alone cannot see a condition that is executed but never asserted
-  both ways, which is exactly the gap a generated test tends to leave.
+- Gate BRANCH as well as LINE: LINE alone cannot see a condition that is executed but never asserted both
+  ways, which is exactly the gap a generated test tends to leave.
 - Record measured coverage in `docs/registry/quality-baseline.md` when it moves materially, so a later
   "before / after" comparison has a dated reference rather than a recollection.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,8 @@ All existing v1/v2/v3 endpoints (34 endpoints, 28 Feign client methods) must rem
 - Treat unit-test coverage and FT/integration coverage as separate concerns.
 - Generic GitHub quality checks should enforce only coverage that GitHub actually measures reliably.
 - FT or OKD coverage should be enforced only in the environment that really runs those scenarios.
-- Gate BRANCH as well as LINE: LINE alone cannot see a condition that is executed but never asserted both
-  ways, which is exactly the gap a generated test tends to leave.
+- Gate BRANCH as well as LINE: LINE alone cannot see a conditional taken on only one path. Note what
+  neither counter can see — whether any outcome was asserted; an assertion-free test can reach 100% on both.
 - Record measured coverage in `docs/registry/quality-baseline.md` when it moves materially, so a later
   "before / after" comparison has a dated reference rather than a recollection.
 

--- a/build.gradle
+++ b/build.gradle
@@ -474,11 +474,15 @@ gradle.projectsEvaluated {
     // sources), but that says nothing about whether the data was actually produced. This task closes the
     // remaining case for both the aggregate and the per-module gates by asserting, at execution time,
     // that each coverage module left exec data behind.
-    // Keyed on test SOURCES, like the ratchet map below and for the same reason: a module can own a
-    // `test` task without owning any test code (`components-registry-service-core` does), and such a
-    // module legitimately produces no exec data. Asserting over every `testTargets` entry would fail the
-    // build for the one module that is correctly untested.
+    // THE definition of "a module the coverage gates apply to", computed once and used by every guard
+    // below (this task and the two ratchet-map checks). Keyed on test SOURCES, not on the presence of a
+    // `test` task: the Kotlin/Java plugins register `test` even for a module with no test code
+    // (`components-registry-service-core`), and such a module legitimately produces no exec data — keying
+    // on the task would fail the build for the one module that is correctly untested. Single definition on
+    // purpose: two copies of this predicate could drift apart under editing, and each guard would then be
+    // protecting a different set of modules than the others.
     def modulesWithTests = testTargets.findAll { !it.sourceSets.test.allSource.isEmpty() }
+    def moduleNamesWithTests = modulesWithTests*.name
     if (modulesWithTests.isEmpty()) {
         throw new GradleException(
             "no coverage modules with tests resolved — the aggregate coverage gate would silently pass on " +
@@ -574,23 +578,23 @@ gradle.projectsEvaluated {
     // ratchet map: absent from both is a configuration error, not a default.
     def coverageRatchetExempt = [:]
 
-    // The map is checked against reality in BOTH directions, keyed on TEST SOURCES rather than on the
-    // presence of a `test` task. The Kotlin/Java plugins register `test` even for a module with no test
-    // code, and a JacocoCoverageVerification with empty execution data is SKIPPED, not failed — so keying
-    // on the task would let a module delete every test and keep a green ratchet, while the ~2 p.p. of
-    // aggregate headroom absorbs a small module's loss. Keying on sources makes that state fail loudly.
+    // The map is checked against reality in BOTH directions, against `moduleNamesWithTests` (defined with
+    // the exec-data guard above — one definition of "module the gates apply to", deliberately not a second
+    // copy of the predicate). Why test SOURCES and not the presence of a `test` task: a
+    // JacocoCoverageVerification with empty execution data is SKIPPED, not failed, so keying on the task
+    // would let a module delete every test and keep a green ratchet, while the ~2 p.p. of aggregate
+    // headroom absorbs a small module's loss. Keying on sources makes that state fail loudly.
     // NOTE: both checks assume `projectsEvaluated` sees the whole project tree, which holds because
     // configuration-on-demand is off (it is not set in gradle.properties). If it is ever enabled, these
     // guards must move into a task action — under configure-on-demand a narrow invocation evaluates only
     // some projects and the checks would fire spuriously.
-    def ratchetableNames = testTargets.findAll { !it.sourceSets.test.allSource.isEmpty() }*.name
-    def unratcheted = ratchetableNames - moduleCoverageRatchet.keySet() - coverageRatchetExempt.keySet()
+    def unratcheted = moduleNamesWithTests - moduleCoverageRatchet.keySet() - coverageRatchetExempt.keySet()
     if (unratcheted) {
         throw new GradleException(
             "coverage modules with tests but no ratchet: ${unratcheted.join(', ')} — measure them (see " +
                 "docs/registry/quality-baseline.md §7) and add entries to moduleCoverageRatchet in build.gradle")
     }
-    def ratchetedWithoutTests = moduleCoverageRatchet.keySet() - ratchetableNames
+    def ratchetedWithoutTests = moduleCoverageRatchet.keySet() - moduleNamesWithTests
     if (ratchetedWithoutTests) {
         throw new GradleException(
             "coverage ratchet is configured for ${ratchetedWithoutTests.join(', ')}, which has no test " +

--- a/build.gradle
+++ b/build.gradle
@@ -464,6 +464,43 @@ gradle.projectsEvaluated {
         })
     }
 
+    // A JaCoCo verification task with EMPTY execution data is SKIPPED, not failed — Gradle's own
+    // `onlyIf` on the task, which a consumer cannot override (specs are AND-ed). So every coverage gate
+    // here has a silent-pass mode: if the exec files are absent, `qualityCoverage` goes green having
+    // measured nothing. Observed, not theorised: pointing the exec glob at a non-existent name makes
+    // `jacocoOverallCoverageVerification` SKIP after a full unit-test run, with BUILD SUCCESSFUL.
+    //
+    // The per-module ratchet is protected structurally (its map is checked against modules that own test
+    // sources), but that says nothing about whether the data was actually produced. This task closes the
+    // remaining case for both the aggregate and the per-module gates by asserting, at execution time,
+    // that each coverage module left exec data behind.
+    // Keyed on test SOURCES, like the ratchet map below and for the same reason: a module can own a
+    // `test` task without owning any test code (`components-registry-service-core` does), and such a
+    // module legitimately produces no exec data. Asserting over every `testTargets` entry would fail the
+    // build for the one module that is correctly untested.
+    def modulesWithTests = testTargets.findAll { !it.sourceSets.test.allSource.isEmpty() }
+    if (modulesWithTests.isEmpty()) {
+        throw new GradleException(
+            "no coverage modules with tests resolved — the aggregate coverage gate would silently pass on " +
+                "empty execution data; check octopusQuality.excludeProjects and coverageProjects in build.gradle")
+    }
+    def execDataByModule = modulesWithTests.collectEntries { p -> [(p.name): coverageExecData([p])] }
+    tasks.register('verifyCoverageDataPresent') {
+        group = 'verification'
+        description = 'Fails when a coverage module produced no JaCoCo execution data (JaCoCo verification SKIPS silently on empty data)'
+        dependsOn(testTargets.collect { "${it.path}:test" })
+        dependsOn(heavyTestTaskPaths)
+        doLast {
+            def missing = execDataByModule.findAll { name, execFiles -> execFiles.isEmpty() }*.key
+            if (missing) {
+                throw new GradleException(
+                    "no JaCoCo execution data for: ${missing.join(', ')}. The coverage gates would have " +
+                        "been SKIPPED rather than failed, passing without measuring anything. Check that the " +
+                        "module's tests ran and that the JaCoCo agent is attached.")
+            }
+        }
+    }
+
     tasks.register('jacocoOverallCoverageReport', org.gradle.testing.jacoco.tasks.JacocoReport) {
         group = 'verification'
         description = 'Aggregated JaCoCo report across all coverage modules (test + dbTest, plus integrationTest.exec when present)'
@@ -561,6 +598,16 @@ gradle.projectsEvaluated {
                 "Restore the tests, or (if the module is intentionally untested) move it to " +
                 "coverageRatchetExempt in build.gradle with the reason")
     }
+    // A threshold of zero is not a ratchet, it is the absence of one — and it reads as a configured gate,
+    // which is worse than no gate at all. (Sibling repos have both shapes of this: a coverage minimum of
+    // 0.00 with the gate "enabled", and a CVE gate whose fail-on score is above the top of the CVSS scale.)
+    def nonRatchets = moduleCoverageRatchet.findAll { name, t -> t.line <= 0 || t.branch <= 0 }*.key
+    if (nonRatchets) {
+        throw new GradleException(
+            "coverage ratchet thresholds must be > 0 — ${nonRatchets.join(', ')} would be a gate that " +
+                "cannot fail. Measure the module (docs/registry/quality-baseline.md §7) and set a real " +
+                "floor, or move it to coverageRatchetExempt with the reason")
+    }
     def ratchetTaskPaths = []
     moduleCoverageRatchet.each { moduleName, thresholds ->
         def p = testTargets.find { it.name == moduleName }
@@ -628,6 +675,8 @@ gradle.projectsEvaluated {
         dependsOn('jacocoOverallCoverageReport')
         dependsOn('jacocoOverallCoverageVerification')
         dependsOn(ratchetTaskPaths)
+        // Without this, an empty-exec-data run reports every coverage gate as SKIPPED and passes.
+        dependsOn('verifyCoverageDataPresent')
     }
 
     // Part A.7: gate publish + image push on the server fat-jar FT. dockerPushImage HARD-depends

--- a/build.gradle
+++ b/build.gradle
@@ -499,9 +499,10 @@ gradle.projectsEvaluated {
                     value = 'COVEREDRATIO'
                     minimum = 0.86
                 }
-                // BRANCH is the counter LINE cannot substitute for: a fully line-covered `if` with only
-                // the true branch exercised still reports 100% LINE. This is the gate that notices a
-                // test which executes a condition without asserting either outcome.
+                // BRANCH is the counter LINE cannot substitute for: a fully line-covered `if` exercised
+                // only on its true path still reports 100% LINE. BRANCH distinguishes "one branch ran"
+                // from "both branches ran" — it says nothing about whether either outcome was asserted,
+                // which is a different question and a different gate (mutation testing).
                 limit {
                     counter = 'BRANCH'
                     value = 'COVEREDRATIO'
@@ -520,8 +521,6 @@ gradle.projectsEvaluated {
     //     coverage stays a `qualityCoverage` (GitHub) concern, as before.
     // Minimums are measured-minus-~2 p.p. ratchets; docs/registry/quality-baseline.md records the
     // measured values, the snapshot they came from, and how to re-measure.
-    // `components-registry-service-core` is absent on purpose: it has no tests of its own, so it has no
-    // per-module report to gate — its classes are covered only through the aggregate above.
     def moduleCoverageRatchet = [
         'components-registry-service-server'      : [line: 0.87, branch: 0.68],
         'components-registry-service-client'      : [line: 0.94, branch: 0.63],
@@ -531,27 +530,40 @@ gradle.projectsEvaluated {
         'component-resolver-api'                  : [line: 0.68, branch: 0.28],
         'components-registry-api'                 : [line: 0.14, branch: 0.07],
     ]
-    // Both directions of the map must stay honest, so neither a rename nor a new module can quietly
-    // remove a gate. NOTE: both checks assume `projectsEvaluated` sees the whole project tree, which holds
-    // because configuration-on-demand is off (it is not set in gradle.properties). If it is ever enabled,
-    // these guards must move to a task action — under configure-on-demand a narrow invocation would
-    // evaluate only some projects and the checks would fire spuriously.
-    def ratchetableProjects = testTargets.findAll { !it.sourceSets.test.allSource.isEmpty() }
-    def unratcheted = ratchetableProjects*.name - moduleCoverageRatchet.keySet()
+    // Escape hatch: a coverage module that OWNS tests but is deliberately left ungated goes here, with the
+    // reason. Empty today, and `components-registry-service-core` deliberately does not need an entry — it
+    // has no test sources at all, so the source-keyed check below already accounts for it (and will demand
+    // a decision the moment someone gives it tests). Every other module that owns tests must be in the
+    // ratchet map: absent from both is a configuration error, not a default.
+    def coverageRatchetExempt = [:]
+
+    // The map is checked against reality in BOTH directions, keyed on TEST SOURCES rather than on the
+    // presence of a `test` task. The Kotlin/Java plugins register `test` even for a module with no test
+    // code, and a JacocoCoverageVerification with empty execution data is SKIPPED, not failed — so keying
+    // on the task would let a module delete every test and keep a green ratchet, while the ~2 p.p. of
+    // aggregate headroom absorbs a small module's loss. Keying on sources makes that state fail loudly.
+    // NOTE: both checks assume `projectsEvaluated` sees the whole project tree, which holds because
+    // configuration-on-demand is off (it is not set in gradle.properties). If it is ever enabled, these
+    // guards must move into a task action — under configure-on-demand a narrow invocation evaluates only
+    // some projects and the checks would fire spuriously.
+    def ratchetableNames = testTargets.findAll { !it.sourceSets.test.allSource.isEmpty() }*.name
+    def unratcheted = ratchetableNames - moduleCoverageRatchet.keySet() - coverageRatchetExempt.keySet()
     if (unratcheted) {
         throw new GradleException(
             "coverage modules with tests but no ratchet: ${unratcheted.join(', ')} — measure them (see " +
                 "docs/registry/quality-baseline.md §7) and add entries to moduleCoverageRatchet in build.gradle")
     }
+    def ratchetedWithoutTests = moduleCoverageRatchet.keySet() - ratchetableNames
+    if (ratchetedWithoutTests) {
+        throw new GradleException(
+            "coverage ratchet is configured for ${ratchetedWithoutTests.join(', ')}, which has no test " +
+                "sources — the ratchet task would SKIP on empty JaCoCo execution data and gate nothing. " +
+                "Restore the tests, or (if the module is intentionally untested) move it to " +
+                "coverageRatchetExempt in build.gradle with the reason")
+    }
     def ratchetTaskPaths = []
     moduleCoverageRatchet.each { moduleName, thresholds ->
         def p = testTargets.find { it.name == moduleName }
-        if (p == null) {
-            // Fail loudly: a renamed/removed module must not silently drop its coverage ratchet.
-            throw new GradleException(
-                "coverage ratchet is configured for '$moduleName', which is not a coverage module with a " +
-                    "`test` task — update moduleCoverageRatchet in build.gradle")
-        }
         // Only `dbTest` — deliberately NOT `integrationTest`, for the reason spelled out at
         // `heavyTestTaskPaths` above: the FatJar boot FT must not be pulled into the GitHub coverage job
         // (timing-sensitive on shared runners, and it piles a second full-app JVM onto the co-scheduled

--- a/build.gradle
+++ b/build.gradle
@@ -429,7 +429,7 @@ gradle.projectsEvaluated {
     def coverageProjects = subprojects.findAll {
         // components-registry-cli is a standalone CLI tool (like -automation): much of its code is
         // Clikt wiring / main() / gated interactive auth paths that unit coverage can't meaningfully
-        // reach. Excluded from the aggregate 70% gate, consistent with octopusQuality.excludeProjects.
+        // reach. Excluded from the aggregate coverage gate, consistent with octopusQuality.excludeProjects.
         !(it.name in ['components-registry-automation', 'components-registry-compat-test', 'test-common', 'components-registry-cli'])
     }
     def testTargets = coverageProjects.findAll { it.tasks.findByName('test') != null }
@@ -482,7 +482,7 @@ gradle.projectsEvaluated {
 
     tasks.register('jacocoOverallCoverageVerification', org.gradle.testing.jacoco.tasks.JacocoCoverageVerification) {
         group = 'verification'
-        description = 'Verifies aggregated JaCoCo line coverage >= 70% across all coverage modules (test + dbTest, plus integrationTest.exec when present)'
+        description = 'Verifies aggregated JaCoCo LINE >= 86% and BRANCH >= 65% across all coverage modules (test + dbTest, plus integrationTest.exec when present)'
         dependsOn(testTargets.collect { "${it.path}:test" })
         dependsOn(heavyTestTaskPaths)
         executionData.from(coverageExecData(testTargets))
@@ -491,13 +491,87 @@ gradle.projectsEvaluated {
         violationRules {
             rule {
                 element = 'BUNDLE'
+                // Ratchets, not targets: each minimum is the measured aggregate coverage minus ~2 p.p.
+                // of headroom (see docs/registry/quality-baseline.md for the measured values and the
+                // recipe to re-measure). Raise them when coverage rises; never lower one silently.
                 limit {
                     counter = 'LINE'
                     value = 'COVEREDRATIO'
-                    minimum = 0.70
+                    minimum = 0.86
+                }
+                // BRANCH is the counter LINE cannot substitute for: a fully line-covered `if` with only
+                // the true branch exercised still reports 100% LINE. This is the gate that notices a
+                // test which executes a condition without asserting either outcome.
+                limit {
+                    counter = 'BRANCH'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.65
                 }
             }
         }
+    }
+
+    // Per-module coverage ratchet. The plugin-owned `jacocoTestCoverageVerification` keeps its lenient
+    // 10% floor (it is wired off `test` and must stay runnable without the heavy suites); this task adds
+    // the strict per-module LINE/BRANCH minimums on top, in a task of our own so that:
+    //   - it declares the heavy suites it needs (`dependsOn`), so a standalone invocation measures the
+    //     same exec set as CI instead of failing on missing dbTest coverage, and
+    //   - it never runs as part of `check`/`test`, so TeamCity [1.0] (`clean build …`) is unaffected —
+    //     coverage stays a `qualityCoverage` (GitHub) concern, as before.
+    // Minimums are measured-minus-~2 p.p. ratchets; docs/registry/quality-baseline.md records the
+    // measured values, the snapshot they came from, and how to re-measure.
+    // `components-registry-service-core` is absent on purpose: it has no tests of its own, so it has no
+    // per-module report to gate — its classes are covered only through the aggregate above.
+    def moduleCoverageRatchet = [
+        'components-registry-service-server'      : [line: 0.87, branch: 0.68],
+        'components-registry-service-client'      : [line: 0.94, branch: 0.63],
+        'component-resolver-core'                 : [line: 0.78, branch: 0.60],
+        'components-registry-dsl'                 : [line: 0.79, branch: 0.45],
+        'components-registry-service-light-client': [line: 0.77, branch: 0.43],
+        'component-resolver-api'                  : [line: 0.68, branch: 0.28],
+        'components-registry-api'                 : [line: 0.14, branch: 0.07],
+    ]
+    def ratchetTaskPaths = []
+    moduleCoverageRatchet.each { moduleName, thresholds ->
+        def p = testTargets.find { it.name == moduleName }
+        if (p == null) {
+            // Fail loudly: a renamed/removed module must not silently drop its coverage ratchet.
+            throw new GradleException(
+                "coverage ratchet is configured for '$moduleName', which is not a coverage module with a " +
+                    "`test` task — update moduleCoverageRatchet in build.gradle")
+        }
+        // Only `dbTest` — deliberately NOT `integrationTest`, for the reason spelled out at
+        // `heavyTestTaskPaths` above: the FatJar boot FT must not be pulled into the GitHub coverage job
+        // (timing-sensitive on shared runners, and it piles a second full-app JVM onto the co-scheduled
+        // Postgres containers — GH issue #424). Its exec file is still folded in by `coverageExecData`
+        // when a run that DID execute it (TeamCity) leaves one behind.
+        def heavyForModule = ['dbTest'].findAll { p.tasks.findByName(it) != null }
+        p.tasks.register('jacocoCoverageRatchet', org.gradle.testing.jacoco.tasks.JacocoCoverageVerification) {
+            group = 'verification'
+            description = "Verifies ${moduleName} JaCoCo LINE >= ${(thresholds.line * 100) as int}% " +
+                "and BRANCH >= ${(thresholds.branch * 100) as int}% (ratchet)"
+            dependsOn("${p.path}:test")
+            heavyForModule.each { dependsOn("${p.path}:$it") }
+            executionData.from(coverageExecData([p]))
+            sourceDirectories.from(files(p.sourceSets.main.allSource.srcDirs))
+            classDirectories.from(files(p.sourceSets.main.output))
+            violationRules {
+                rule {
+                    element = 'BUNDLE'
+                    limit {
+                        counter = 'LINE'
+                        value = 'COVEREDRATIO'
+                        minimum = thresholds.line
+                    }
+                    limit {
+                        counter = 'BRANCH'
+                        value = 'COVEREDRATIO'
+                        minimum = thresholds.branch
+                    }
+                }
+            }
+        }
+        ratchetTaskPaths << "${p.path}:jacocoCoverageRatchet"
     }
 
     // Per-module jacoco (registered by octopus-quality off the `test` task) must also
@@ -528,6 +602,7 @@ gradle.projectsEvaluated {
         dependsOn(heavyTestTaskPaths)
         dependsOn('jacocoOverallCoverageReport')
         dependsOn('jacocoOverallCoverageVerification')
+        dependsOn(ratchetTaskPaths)
     }
 
     // Part A.7: gate publish + image push on the server fat-jar FT. dockerPushImage HARD-depends

--- a/build.gradle
+++ b/build.gradle
@@ -531,6 +531,18 @@ gradle.projectsEvaluated {
         'component-resolver-api'                  : [line: 0.68, branch: 0.28],
         'components-registry-api'                 : [line: 0.14, branch: 0.07],
     ]
+    // Both directions of the map must stay honest, so neither a rename nor a new module can quietly
+    // remove a gate. NOTE: both checks assume `projectsEvaluated` sees the whole project tree, which holds
+    // because configuration-on-demand is off (it is not set in gradle.properties). If it is ever enabled,
+    // these guards must move to a task action — under configure-on-demand a narrow invocation would
+    // evaluate only some projects and the checks would fire spuriously.
+    def ratchetableProjects = testTargets.findAll { !it.sourceSets.test.allSource.isEmpty() }
+    def unratcheted = ratchetableProjects*.name - moduleCoverageRatchet.keySet()
+    if (unratcheted) {
+        throw new GradleException(
+            "coverage modules with tests but no ratchet: ${unratcheted.join(', ')} — measure them (see " +
+                "docs/registry/quality-baseline.md §7) and add entries to moduleCoverageRatchet in build.gradle")
+    }
     def ratchetTaskPaths = []
     moduleCoverageRatchet.each { moduleName, thresholds ->
         def p = testTargets.find { it.name == moduleName }
@@ -544,7 +556,8 @@ gradle.projectsEvaluated {
         // `heavyTestTaskPaths` above: the FatJar boot FT must not be pulled into the GitHub coverage job
         // (timing-sensitive on shared runners, and it piles a second full-app JVM onto the co-scheduled
         // Postgres containers — GH issue #424). Its exec file is still folded in by `coverageExecData`
-        // when a run that DID execute it (TeamCity) leaves one behind.
+        // when a run that DID execute it (TeamCity) leaves one behind — which can only widen the local
+        // pass margin, never cause a false failure, since the thresholds were calibrated without it.
         def heavyForModule = ['dbTest'].findAll { p.tasks.findByName(it) != null }
         p.tasks.register('jacocoCoverageRatchet', org.gradle.testing.jacoco.tasks.JacocoCoverageVerification) {
             group = 'verification'

--- a/docs/registry/non-functional-spec.md
+++ b/docs/registry/non-functional-spec.md
@@ -296,13 +296,30 @@ Every PR must pass:
 4. Integration tests                (DB queries, transactions)
 5. Contract tests                   (Feign client compatibility)
 6. API snapshot tests               (v1/v2/v3 response structure)
+7. Coverage ratchets                (aggregate LINE/BRANCH + per-module LINE/BRANCH)
 ```
+
+**Coverage as a fitness function.** Coverage is gated in `qualityCoverage` (the GitHub `quality` job)
+over the `test` + `dbTest` exec set — deliberately not in `check`, so TeamCity `[1.0]` stays a
+compile/correctness gate:
+
+| Gate | Task | Rule |
+|---|---|---|
+| Aggregate | `jacocoOverallCoverageVerification` | LINE ≥ 86%, BRANCH ≥ 65% |
+| Per module (strict) | `<module>:jacocoCoverageRatchet` | per-module LINE/BRANCH minimums, set to measured − ~2 p.p. |
+| Per module (floor) | `<module>:jacocoTestCoverageVerification` | plugin-owned 10% floor, kept underneath |
+
+Both new gates are **ratchets**: they encode the coverage already achieved so a change cannot quietly
+erode it. BRANCH is gated alongside LINE because a fully line-covered conditional whose second branch is
+never taken reports 100% LINE — LINE alone cannot distinguish "tested" from "executed". The measured
+values, the snapshot they were taken from, and the re-measure recipe live in
+[`quality-baseline.md`](quality-baseline.md).
 
 Production deployment additionally runs:
 ```
-7. Smoke test: health check + basic read
-8. Canary: 10% traffic → monitor error rate for 10 min
-9. Full rollout if error rate < 0.1%
+8. Smoke test: health check + basic read
+9. Canary: 10% traffic → monitor error rate for 10 min
+10. Full rollout if error rate < 0.1%
 ```
 
 ## 6. Observability

--- a/docs/registry/non-functional-spec.md
+++ b/docs/registry/non-functional-spec.md
@@ -310,10 +310,11 @@ compile/correctness gate:
 | Per module (floor) | `<module>:jacocoTestCoverageVerification` | plugin-owned 10% floor, kept underneath |
 
 Both new gates are **ratchets**: they encode the coverage already achieved so a change cannot quietly
-erode it. BRANCH is gated alongside LINE because a fully line-covered conditional whose second branch is
-never taken reports 100% LINE — LINE alone cannot distinguish "tested" from "executed". The measured
-values, the snapshot they were taken from, and the re-measure recipe live in
-[`quality-baseline.md`](quality-baseline.md).
+erode it. BRANCH is gated alongside LINE because a fully line-covered conditional taken only on one path
+still reports 100% LINE — BRANCH distinguishes "one branch ran" from "both branches ran". Neither counter
+says anything about whether an outcome was **asserted**: a test with no assertions at all can reach 100% on
+both. That is a different question, and no coverage counter can gate it. The measured values, the snapshot
+they were taken from, and the re-measure recipe live in [`quality-baseline.md`](quality-baseline.md).
 
 Production deployment additionally runs:
 ```

--- a/docs/registry/quality-baseline.md
+++ b/docs/registry/quality-baseline.md
@@ -209,11 +209,10 @@ pasting it into a `curl` command then puts it in the command text as well. The h
 lookup and the request in one process and passes the header to curl on stdin, so the credential never
 reaches argv, a log, or a transcript.
 
-Export the base URL once — it is internal, so it is deliberately not committed anywhere in this repository:
-
-```bash
-export TC_URL=<teamcity-base-url>
-```
+`TC_URL` is passed **inline on every call**, not exported once: each command here is a separate invocation,
+and in an agent session each one is a fresh shell, so an `export` from a previous step is already gone and
+the helper would exit 2. The base URL is internal and deliberately not committed anywhere in this
+repository — substitute it from the team's CI bookmark.
 
 Build-configuration IDs are `<TC_PROJECT_ID>_<CONFIG>`, where `<CONFIG>` is `10CompileUtAuto`,
 `12IntegrationDbTestsAuto`, `17CompatLocalStandManual`, … as declared in `.teamcity/settings.kts`, and
@@ -222,19 +221,19 @@ Build-configuration IDs are `<TC_PROJECT_ID>_<CONFIG>`, where `<CONFIG>` is `10C
 Last `main` builds of a configuration:
 
 ```bash
-scripts/quality-baseline/tc-get.sh "app/rest/builds?locator=buildType:<TC_PROJECT_ID>_10CompileUtAuto,branch:main,count:3&fields=build(id,number,status,revisions(revision(version)))"
+TC_URL=<teamcity-base-url> scripts/quality-baseline/tc-get.sh "app/rest/builds?locator=buildType:<TC_PROJECT_ID>_10CompileUtAuto,branch:main,count:3&fields=build(id,number,status,revisions(revision(version)))"
 ```
 
 Statistics of one build — `TotalTestCount`, `PassedTestCount`, `IgnoredTestCount`, `BuildDuration`:
 
 ```bash
-scripts/quality-baseline/tc-get.sh "app/rest/builds/id:<BUILD_ID>/statistics"
+TC_URL=<teamcity-base-url> scripts/quality-baseline/tc-get.sh "app/rest/builds/id:<BUILD_ID>/statistics"
 ```
 
 Ignored tests of one build:
 
 ```bash
-scripts/quality-baseline/tc-get.sh "app/rest/testOccurrences?locator=build:(id:<BUILD_ID>),status:UNKNOWN,count:20&fields=testOccurrence(name,status)"
+TC_URL=<teamcity-base-url> scripts/quality-baseline/tc-get.sh "app/rest/testOccurrences?locator=build:(id:<BUILD_ID>),status:UNKNOWN,count:20&fields=testOccurrence(name,status)"
 ```
 
 ### GitHub Actions

--- a/docs/registry/quality-baseline.md
+++ b/docs/registry/quality-baseline.md
@@ -194,57 +194,96 @@ Test counts from the same artifact, by module (source sets `test` = 1069, `dbTes
 
 ### 7. How to re-measure
 
-TeamCity (server host from the team's CI bookmark; personal token from the macOS Keychain — anonymous
-access is disabled):
+Every command below is a **single standalone invocation** — no pipes, no `&&`/`;`, no command
+substitution, no redirects, no loops. That is the repository's mandatory shell form (see `AGENTS.md`
+§Shell Command Safety), and an agent following this recipe must be able to copy each line as-is. Where a
+value from one step feeds the next, substitute it by hand into the `<PLACEHOLDER>`.
+
+### TeamCity
+
+The server host is in the team's CI bookmark; anonymous access is disabled, so requests need the personal
+token. Read it out of the macOS Keychain as its own step and paste the value into `<TOKEN>` below:
 
 ```bash
-TC="<teamcity-base-url>"
-T=$(security find-generic-password -s tc-rest-token -w)
-B=RnDProcessesAutomation_Octopus_OctopusComponentsRegistryService
-# last main builds of a config
-curl -s -H "Authorization: Bearer $T" -H "Accept: application/json" \
-  "$TC/app/rest/builds?locator=buildType:${B}_10CompileUtAuto,branch:main,count:3&fields=build(id,number,status,revisions(revision(version)))"
-# statistics (TotalTestCount / PassedTestCount / IgnoredTestCount / BuildDuration)
-curl -s -H "Authorization: Bearer $T" -H "Accept: application/json" "$TC/app/rest/builds/id:<ID>/statistics"
-# ignored tests
-curl -s -H "Authorization: Bearer $T" -H "Accept: application/json" \
-  "$TC/app/rest/testOccurrences?locator=build:(id:<ID>),status:UNKNOWN,count:20&fields=testOccurrence(name,status)"
+security find-generic-password -s tc-rest-token -w
 ```
 
-GitHub Actions — coverage and static-analysis numbers come from the Quality Gates artifacts, not
-from the job logs:
+Build-configuration IDs are `<TC_PROJECT_ID>_<CONFIG>`, where `<CONFIG>` is `10CompileUtAuto`,
+`12IntegrationDbTestsAuto`, `17CompatLocalStandManual`, … as declared in `.teamcity/settings.kts`, and
+`<TC_PROJECT_ID>` is the project id from that same file.
+
+Last `main` builds of a configuration:
 
 ```bash
-gh run list --branch main --limit 12 \
-  --json workflowName,conclusion,createdAt,databaseId,headSha
+curl -s -H "Authorization: Bearer <TOKEN>" -H "Accept: application/json" "<TC_URL>/app/rest/builds?locator=buildType:<TC_PROJECT_ID>_10CompileUtAuto,branch:main,count:3&fields=build(id,number,status,revisions(revision(version)))"
+```
+
+Statistics of one build — `TotalTestCount`, `PassedTestCount`, `IgnoredTestCount`, `BuildDuration`:
+
+```bash
+curl -s -H "Authorization: Bearer <TOKEN>" -H "Accept: application/json" "<TC_URL>/app/rest/builds/id:<BUILD_ID>/statistics"
+```
+
+Ignored tests of one build:
+
+```bash
+curl -s -H "Authorization: Bearer <TOKEN>" -H "Accept: application/json" "<TC_URL>/app/rest/testOccurrences?locator=build:(id:<BUILD_ID>),status:UNKNOWN,count:20&fields=testOccurrence(name,status)"
+```
+
+### GitHub Actions
+
+Coverage and static-analysis numbers come from the Quality Gates **artifacts**, not from the job logs.
+Find the run:
+
+```bash
+gh run list --branch main --limit 12 --json workflowName,conclusion,createdAt,databaseId,headSha
+```
+
+Download its artifacts. Use a `<TMPDIR>` **outside** the repository — `gh run download` unpacks
+module-shaped directories that otherwise land in the working tree:
+
+```bash
 gh run download <QUALITY_RUN_ID> -R octopusden/octopus-components-registry-service --dir <TMPDIR>
-# aggregate counters:
-#   <TMPDIR>/coverage-reports/build/reports/jacoco/overallCoverage/jacocoOverallCoverageReport.xml
-# per-module counters:
-#   <TMPDIR>/coverage-reports/<module>/build/reports/jacoco/test/jacocoTestReport.xml
-# static analysis:
-#   <TMPDIR>/static-analysis-reports/<module>/build/reports/{checkstyle,pmd,detekt,ktlint}/*.xml
 ```
 
-Read only the **top-level** `<counter>` elements of a JaCoCo report (direct children of `<report>`);
-the nested per-package/class counters must not be summed.
+Then read these files:
 
-The perf median comes from the `perf-test-report` artifact of the `Performance SLA` run, in
-`system-err` (not `system-out`, not the job log):
+| Metric | Path under `<TMPDIR>` |
+|---|---|
+| Aggregate JaCoCo counters | `coverage-reports/build/reports/jacoco/overallCoverage/jacocoOverallCoverageReport.xml` |
+| Per-module JaCoCo counters | `coverage-reports/<module>/build/reports/jacoco/test/jacocoTestReport.xml` |
+| Per-module test counts | `coverage-reports/<module>/build/test-results/<sourceSet>/TEST-*.xml` |
+| Static-analysis violations | `static-analysis-reports/<module>/build/reports/<tool>/*.xml` for `checkstyle`, `pmd`, `detekt`, `ktlint` |
+
+Read only the **top-level** `<counter>` elements of a JaCoCo report (the direct children of `<report>`);
+the nested per-package and per-class counters must not be summed.
+
+### Perf median
+
+From the `perf-test-report` artifact of the `Performance SLA` run, in `system-err` — not `system-out`, and
+not the job log:
 
 ```bash
 gh run download <PERF_RUN_ID> -R octopusden/octopus-components-registry-service --dir <TMPDIR>
-grep -oE 'getComponents\(\) perf[^&<]{0,200}' \
-  <TMPDIR>/perf-test-report/test-results/perfTest/TEST-*.xml
 ```
-
-Baseline debt counts come from the working tree, not from CI:
 
 ```bash
-for f in $(find . -name detekt-baseline.xml -not -path '*/build/*'); do echo -n "$f "; grep -c '<ID>' $f; done
-for f in $(find . -name ktlint-baseline.xml -not -path '*/build/*'); do echo -n "$f "; grep -c '<error ' $f; done
-wc -l components-registry-service-server/archunit_violation_store/*
+grep -roE "getComponents\(\) perf[^&<]{0,200}" <TMPDIR>/perf-test-report/test-results/perfTest
 ```
 
-Use `--dir <TMPDIR>` outside the repository: `gh run download` unpacks module-shaped directories that
-otherwise land in the working tree.
+### Baseline debt counts
+
+These come from the working tree, not from CI. One command per file — the counts are the burn-down
+numbers in §4:
+
+```bash
+grep -rc "<ID>" --include=detekt-baseline.xml --exclude-dir=build .
+```
+
+```bash
+grep -rc "<error " --include=ktlint-baseline.xml --exclude-dir=build .
+```
+
+```bash
+wc -l components-registry-service-server/archunit_violation_store/3e61e124-fe37-40db-9ea6-91a90f6afc18
+```

--- a/docs/registry/quality-baseline.md
+++ b/docs/registry/quality-baseline.md
@@ -1,0 +1,250 @@
+# Quality Gate Baseline
+
+Snapshot of every automated check and its measured value, taken **before** the planned quality-gate
+work (mutation testing, BRANCH coverage gate, OpenAPI breaking-change diff, TD-017 authorization
+policy test, property-based version-model tests, `src/main`→`src/test` PR gate).
+
+Purpose: a "before / after" reference. Add a new dated section below rather than editing an old one —
+each snapshot must stay reproducible from the recipe in [§7](#7-how-to-re-measure).
+
+## Gate changes since the baseline
+
+Measured values move only when the code changes; this table records when a **gate** changed, so a later
+snapshot can be read against the right contract.
+
+| Date | Change | Gate before | Gate after |
+|---|---|---|---|
+| 2026-07-27 | Aggregate coverage ratchet | LINE ≥ 70%, no BRANCH rule | LINE ≥ 86%, BRANCH ≥ 65% |
+| 2026-07-27 | Per-module coverage ratchet (`jacocoCoverageRatchet`, wired into `qualityCoverage`) | plugin-owned 10% floor only | strict per-module LINE/BRANCH minimums (measured − ~2 p.p.), 10% floor kept underneath |
+
+---
+
+## Snapshot 2026-07-27 (baseline)
+
+**Code under measurement:** `main` @ `1ecab7a2` (`fix(labels): preserve pre-existing
+labels/systems/tools on edit (set-diff sync) [SYS-067] (#454)`) — `origin/main` tip at snapshot time.
+
+**Sources:** TeamCity chain `3.0.9-4407` (2026-07-24, the last `main` chain), GitHub Actions runs on
+`main` @ `1ecab7a2`, and the report artifacts those runs published.
+
+**Tool versions at this snapshot** (they own the thresholds, so a bump can move the numbers):
+`octopus-quality` 2.4.1, shared workflows `octopus-base@v2.4.1`, detekt 1.23.8, ktlint-gradle 14.0.1,
+Gradle 8.6, Java 21. Dependabot PRs proposing `octopus-base` 2.5.1 were open at snapshot time — if the
+plugin-owned per-module coverage floor changes there, re-measure before comparing.
+
+### 1. TeamCity — `main` chain 3.0.9-4407
+
+| Config | Gradle task | Result | Tests | Passed | Ignored | Failed | Duration |
+|---|---|---|---|---|---|---|---|
+| `[1.0] Compile & UT [AUTO]` | `clean build publish dockerPushImage` | SUCCESS | 1893 | 1890 | 3 | 0 | 11m32s |
+| `[2.1] Integration & DB Tests [AUTO]` | `clean :…-server:dbTest :…-client:dbTest :…-light-client:dbTest` | SUCCESS | 1491 | 1485 | 6 | 0 | 8m52s |
+
+Notes:
+
+- TeamCity reports **no** `CodeCoverage*` statistics for either config — coverage is enforced only in
+  the GitHub `quality` job (see §3). Do not expect a coverage delta to show up in TC.
+- `[1.0]` test time is 715s wall across workers vs 692s build duration (parallel execution).
+- `[2.1]` spent 583s in the queue waiting on `[1.0]`; that is queueing, not check cost.
+
+Ignored tests (the baseline set — any change here is a signal):
+
+| Config | Test | Reason class |
+|---|---|---|
+| `[1.0]` | `cli.auth.KeycloakIntegrationTest.deviceFlowLoginAgainstRealKeycloak` | gated on Keycloak device flow |
+| `[1.0]` | `server.service.impl.RealDslUniquenessAcceptanceTest` (§6.0 uniqueness pre-pass) | needs the real production DSL |
+| `[2.1]` | `server.migration.FtDbProfileWriteTest` — SYS-027 POST + PATCH round-trips (2) | H2 `jsonb` column under `ft-db` |
+| `[2.1]` | `server.migration.GitVsDbValidationTest` — VAL-010 bulk canary | full-corpus validation, on demand |
+
+Compat / validation configs do **not** run on `main` — they are PR-triggered. Last runs (chain
+`3.0.9-4413`, 2026-07-27, dependabot branches), recorded here as the reference scale of the gate:
+
+| Config | Result | Assertions | Ignored | Duration |
+|---|---|---|---|---|
+| `[2.2] Compat — Local Stand (baseline + candidate JARs)` | SUCCESS | 21812 | 1 | 30m12s |
+| `[2.3] Compat — Local Stand (git-mode, no DB migration)` | SUCCESS | 21812 | 2 | 25m32s |
+| `[2.0] Validate Git-based Components Registry` | SUCCESS | n/a (`validateConfig`) | — | 2m01s |
+| `[1.5] Compat — HTTP (two pre-deployed URLs)` | last run 2026-05-25 on `v3` (`2.0.84-108`) | — | — | — |
+| `[1.6] Compat — Trace Replay (prod traffic)` | last run 2026-05-25 on `v3` (`2.0.84-86`) | — | — | — |
+
+### 2. GitHub Actions — `main` @ 1ecab7a2
+
+| Workflow / job | Result | Duration |
+|---|---|---|
+| `Gradle Compile & UT` → `run-build-and-deploy / build` | success | 141s |
+| `Quality Gates` → `quality/wrapper-validation` | success | 8s |
+| `Quality Gates` → `quality/tests-coverage` | success | 624s |
+| `Quality Gates` → `quality/static` | success | 142s |
+| `Security Reports` (CodeQL + Trivy; dependency-check disabled) | success | — |
+| `Performance SLA (non-gating)` → `perfTest` | success | 8.09s (single test) |
+
+**Perf SLA measurement** (`GetComponentsListPerformanceTest`, run 2026-07-27):
+
+| Metric | Value |
+|---|---|
+| Median wall time (the asserted metric) | **261 ms** |
+| Ceiling (`MEDIAN_CEILING_MS`) | 2000 ms |
+| Components seeded (`COMPONENT_COUNT`) | 1000 |
+| Iterations | 2 warmup (discarded) + 5 measured |
+| Measured iterations (ms) | 348, 305, 250, 261, 254 |
+| Prepared statements per call | 31 |
+
+The median is emitted through the test's logger, which lands in the **`system-err`** element of
+`build/test-results/perfTest/TEST-*.xml` (published in the `perf-test-report` artifact) — not in the
+job log and not in `system-out`. Read it from the artifact XML, not from the run log.
+
+One observation that is not a quality metric but is true of this snapshot: the `Gradle Release` run on
+`main` (2026-07-24, job `prepare-build-publish-release`) **failed**. Out of scope for this baseline;
+tracked separately.
+
+### 3. Coverage — JaCoCo (`coverage-reports` artifact of the Quality Gates run)
+
+Execution data: `test` + `dbTest`. `integrationTest` boots a separate JVM without the JaCoCo agent
+and is **not** part of the GitHub gate, so these numbers exclude it.
+
+**Aggregate (gate: LINE ≥ 70%, no BRANCH rule):**
+
+| Counter | Covered / total | % | Gate |
+|---|---|---|---|
+| LINE | 12960 / 14701 | **88.2%** | ≥ 70% |
+| BRANCH | 6068 / 9021 | **67.3%** | none |
+| INSTRUCTION | 101192 / 124584 | 81.2% | none |
+| METHOD | 3761 / 4473 | 84.1% | none |
+| CLASS | 746 / 870 | 85.7% | none |
+
+**Per module (plugin-owned floor: 10%):**
+
+| Module | LINE | BRANCH |
+|---|---|---|
+| `components-registry-service-server` | 89.5% (9765/10906) | 70.7% (4505/6368) |
+| `components-registry-service-client` | 96.9% (95/98) | 65.4% (17/26) |
+| `component-resolver-core` | 80.9% (1680/2076) | 62.6% (1182/1889) |
+| `components-registry-dsl` | 81.0% (277/342) | 47.1% (32/68) |
+| `components-registry-service-light-client` | 79.2% (99/125) | 45.0% (27/60) |
+| `component-resolver-api` | 70.2% (351/500) | 30.4% (133/438) |
+| `components-registry-api` | 16.6% (57/343) | 9.6% (10/104) |
+| `components-registry-service-core` | no per-module report | no per-module report |
+
+Two facts to carry into the BRANCH-gate change:
+
+- `components-registry-api` sits at 16.6% LINE — the only module close to the 10% floor, so it sets
+  the ceiling for how far the per-module floor can be raised repo-wide.
+- `components-registry-service-core` (46 main sources) produces no per-module JaCoCo report: it has
+  no tests of its own, so its classes are covered only through the aggregate. A per-module floor
+  cannot be enforced there as-is.
+
+Test counts from the same artifact, by module (source sets `test` = 1069, `dbTest` = 794):
+
+| Module | Tests |
+|---|---|
+| `components-registry-service-server` | 1508 |
+| `components-registry-service-client` | 93 |
+| `component-resolver-core` | 212 |
+| `components-registry-dsl` | 24 |
+| `component-resolver-api` | 20 |
+| `components-registry-service-light-client` | 4 |
+| `components-registry-api` | 2 |
+
+### 4. Static analysis (`static-analysis-reports` artifact of the same run)
+
+**Reported violations (after baselines):**
+
+| Tool | Scope | Blocking | Violations |
+|---|---|---|---|
+| Checkstyle | Java | yes | 0 |
+| PMD | Java | yes | 0 |
+| detekt | Kotlin | yes | 0 |
+| ktlint | Kotlin | yes | 0 |
+| CodeNarc | Groovy | **report-only** | **143** (`component-resolver-core` 138, `component-resolver-api` 5) |
+| SpotBugs | — | disabled by policy | n/a |
+
+**Suppressed as tracked debt (baseline file entries) — this is the burn-down number:**
+
+| Module | detekt | ktlint |
+|---|---|---|
+| `components-registry-service-server` | 111 | 19 |
+| `components-registry-compat-test` | 38 | 5 |
+| `components-registry-cli` | 18 | 3 |
+| `components-registry-service-client` | 8 | — |
+| `components-registry-dsl` | 7 | 1 |
+| `components-registry-api` | 4 | 2 |
+| `components-registry-service-core` | 4 | 3 |
+| `components-registry-automation` | 3 | — |
+| **Total** | **193** | **33** |
+
+### 5. Architecture fitness (ArchUnit)
+
+| Item | Value |
+|---|---|
+| Active rules | 5 (4 package-placement + 1 frozen layering) |
+| Frozen rule | controllers must not use Spring Data repositories directly |
+| Baselined violations in `archunit_violation_store/` | 15 |
+| Store policy | `allowStoreCreation=false`, `allowStoreUpdate=false`, `refreeze=false` |
+| Deferred rules | TD-016 (package cycles), TD-017 (v4 authorization policy), TD-019 (DB-source boundary) |
+
+### 6. Checks with no baseline value (absent today)
+
+| Check | State |
+|---|---|
+| Mutation testing | not present anywhere |
+| BRANCH coverage gate | no rule (measured value 67.3%) |
+| Gherkin / BDD executable specs | not present (0 `.feature` files) |
+| Consumer-driven contracts (Pact / Spring Cloud Contract) | not present; only client compilation + the compat gate |
+| OpenAPI breaking-change diff vs `main` | not present. Spec **drift** *is* gated — `OpenApiV4SpecTest` asserts byte-equality against the committed `v4.json` |
+| `src/main` change requires a `src/test` change | no gate |
+
+### 7. How to re-measure
+
+TeamCity (server host from the team's CI bookmark; personal token from the macOS Keychain — anonymous
+access is disabled):
+
+```bash
+TC="<teamcity-base-url>"
+T=$(security find-generic-password -s tc-rest-token -w)
+B=RnDProcessesAutomation_Octopus_OctopusComponentsRegistryService
+# last main builds of a config
+curl -s -H "Authorization: Bearer $T" -H "Accept: application/json" \
+  "$TC/app/rest/builds?locator=buildType:${B}_10CompileUtAuto,branch:main,count:3&fields=build(id,number,status,revisions(revision(version)))"
+# statistics (TotalTestCount / PassedTestCount / IgnoredTestCount / BuildDuration)
+curl -s -H "Authorization: Bearer $T" -H "Accept: application/json" "$TC/app/rest/builds/id:<ID>/statistics"
+# ignored tests
+curl -s -H "Authorization: Bearer $T" -H "Accept: application/json" \
+  "$TC/app/rest/testOccurrences?locator=build:(id:<ID>),status:UNKNOWN,count:20&fields=testOccurrence(name,status)"
+```
+
+GitHub Actions — coverage and static-analysis numbers come from the Quality Gates artifacts, not
+from the job logs:
+
+```bash
+gh run list --branch main --limit 12 \
+  --json workflowName,conclusion,createdAt,databaseId,headSha
+gh run download <QUALITY_RUN_ID> -R octopusden/octopus-components-registry-service --dir <TMPDIR>
+# aggregate counters:
+#   <TMPDIR>/coverage-reports/build/reports/jacoco/overallCoverage/jacocoOverallCoverageReport.xml
+# per-module counters:
+#   <TMPDIR>/coverage-reports/<module>/build/reports/jacoco/test/jacocoTestReport.xml
+# static analysis:
+#   <TMPDIR>/static-analysis-reports/<module>/build/reports/{checkstyle,pmd,detekt,ktlint}/*.xml
+```
+
+Read only the **top-level** `<counter>` elements of a JaCoCo report (direct children of `<report>`);
+the nested per-package/class counters must not be summed.
+
+The perf median comes from the `perf-test-report` artifact of the `Performance SLA` run, in
+`system-err` (not `system-out`, not the job log):
+
+```bash
+gh run download <PERF_RUN_ID> -R octopusden/octopus-components-registry-service --dir <TMPDIR>
+grep -oE 'getComponents\(\) perf[^&<]{0,200}' \
+  <TMPDIR>/perf-test-report/test-results/perfTest/TEST-*.xml
+```
+
+Baseline debt counts come from the working tree, not from CI:
+
+```bash
+for f in $(find . -name detekt-baseline.xml -not -path '*/build/*'); do echo -n "$f "; grep -c '<ID>' $f; done
+for f in $(find . -name ktlint-baseline.xml -not -path '*/build/*'); do echo -n "$f "; grep -c '<error ' $f; done
+wc -l components-registry-service-server/archunit_violation_store/*
+```
+
+Use `--dir <TMPDIR>` outside the repository: `gh run download` unpacks module-shaped directories that
+otherwise land in the working tree.

--- a/docs/registry/quality-baseline.md
+++ b/docs/registry/quality-baseline.md
@@ -201,11 +201,18 @@ value from one step feeds the next, substitute it by hand into the `<PLACEHOLDER
 
 ### TeamCity
 
-The server host is in the team's CI bookmark; anonymous access is disabled, so requests need the personal
-token. Read it out of the macOS Keychain as its own step and paste the value into `<TOKEN>` below:
+Anonymous access is disabled, so every request needs the personal token from the macOS Keychain. Go through
+[`scripts/quality-baseline/tc-get.sh`](../../scripts/quality-baseline/tc-get.sh) — **never** read the token
+out and paste it into a command. `security find-generic-password -w` prints the secret to stdout, which puts
+it in terminal scrollback, shell history and (in an agent session) the tool output that gets recorded;
+pasting it into a `curl` command then puts it in the command text as well. The helper does the Keychain
+lookup and the request in one process and passes the header to curl on stdin, so the credential never
+reaches argv, a log, or a transcript.
+
+Export the base URL once — it is internal, so it is deliberately not committed anywhere in this repository:
 
 ```bash
-security find-generic-password -s tc-rest-token -w
+export TC_URL=<teamcity-base-url>
 ```
 
 Build-configuration IDs are `<TC_PROJECT_ID>_<CONFIG>`, where `<CONFIG>` is `10CompileUtAuto`,
@@ -215,19 +222,19 @@ Build-configuration IDs are `<TC_PROJECT_ID>_<CONFIG>`, where `<CONFIG>` is `10C
 Last `main` builds of a configuration:
 
 ```bash
-curl -s -H "Authorization: Bearer <TOKEN>" -H "Accept: application/json" "<TC_URL>/app/rest/builds?locator=buildType:<TC_PROJECT_ID>_10CompileUtAuto,branch:main,count:3&fields=build(id,number,status,revisions(revision(version)))"
+scripts/quality-baseline/tc-get.sh "app/rest/builds?locator=buildType:<TC_PROJECT_ID>_10CompileUtAuto,branch:main,count:3&fields=build(id,number,status,revisions(revision(version)))"
 ```
 
 Statistics of one build — `TotalTestCount`, `PassedTestCount`, `IgnoredTestCount`, `BuildDuration`:
 
 ```bash
-curl -s -H "Authorization: Bearer <TOKEN>" -H "Accept: application/json" "<TC_URL>/app/rest/builds/id:<BUILD_ID>/statistics"
+scripts/quality-baseline/tc-get.sh "app/rest/builds/id:<BUILD_ID>/statistics"
 ```
 
 Ignored tests of one build:
 
 ```bash
-curl -s -H "Authorization: Bearer <TOKEN>" -H "Accept: application/json" "<TC_URL>/app/rest/testOccurrences?locator=build:(id:<BUILD_ID>),status:UNKNOWN,count:20&fields=testOccurrence(name,status)"
+scripts/quality-baseline/tc-get.sh "app/rest/testOccurrences?locator=build:(id:<BUILD_ID>),status:UNKNOWN,count:20&fields=testOccurrence(name,status)"
 ```
 
 ### GitHub Actions

--- a/docs/registry/technical-design.md
+++ b/docs/registry/technical-design.md
@@ -557,8 +557,11 @@ The build splits tests by JUnit 5 tag so the heavy DB suite runs off the critica
   GitHub PRs under `qualityCoverage` (the `quality` job), so coverage **and** correctness
   are still gated on every PR.
 
-JaCoCo aggregates `test` + `dbTest` + `integrationTest` exec data, so the 70% coverage gate
-is unchanged. All `Test` tasks set `TESTCONTAINERS_RYUK_DISABLED=true` (the Ryuk reaper
+JaCoCo aggregates `test` + `dbTest` + `integrationTest` exec data, so splitting the suites did
+not cost coverage. The gates on that data are the aggregate LINE/BRANCH thresholds plus the
+per-module ratchet described in [`non-functional-spec.md`](non-functional-spec.md) §5.10.
+
+All `Test` tasks set `TESTCONTAINERS_RYUK_DISABLED=true` (the Ryuk reaper
 can't mount the docker socket on Podman-rootless CI agents). `dockerPushImage` depends on
 the fat-jar `integrationTest` and Maven `publish` is ordered after it, so a broken boot jar
 is never published/pushed.

--- a/scripts/quality-baseline/tc-get.sh
+++ b/scripts/quality-baseline/tc-get.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Read-only TeamCity REST helper for the quality-baseline measurements
+# (docs/registry/quality-baseline.md §7).
+#
+# Its only job is to keep the credential inside ONE process. The personal token lives in the macOS
+# Keychain; a recipe that tells you to print it and paste it into a curl command copies the secret into
+# your terminal scrollback, your shell history, an agent's tool output, and any CI log that captures it.
+# Here the token is read, handed to curl through a config file on stdin (so it never appears in argv or
+# in `ps` output), and discarded when the process exits. It is never printed.
+#
+# Usage:
+#   TC_URL=<teamcity-base-url> scripts/quality-baseline/tc-get.sh "app/rest/server?fields=version"
+#
+# TC_URL is intentionally not baked in: the host is internal and does not belong in this repository.
+# Take it from the team's CI bookmark and export it in your shell.
+#
+# Requires: macOS `security` with a generic password stored under the service name `tc-rest-token`
+# (personal access token; TeamCity guest auth is disabled).
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: TC_URL=<base-url> $0 <rest-path>" >&2
+    echo "example: $0 \"app/rest/builds?locator=buildType:<ID>,branch:main,count:3\"" >&2
+    exit 2
+fi
+
+if [ -z "${TC_URL:-}" ]; then
+    echo "TC_URL is not set — export the TeamCity base URL (see the team's CI bookmark)." >&2
+    exit 2
+fi
+
+rest_path=${1#/}
+base_url=${TC_URL%/}
+
+if ! token=$(security find-generic-password -s tc-rest-token -w 2>/dev/null); then
+    echo "no Keychain entry for service 'tc-rest-token' — create one with your TeamCity token:" >&2
+    echo "  security add-generic-password -s tc-rest-token -a \"\$USER\" -w" >&2
+    exit 3
+fi
+
+# `--config -` reads options from stdin, keeping the Authorization header out of the command line.
+# `--fail-with-body` makes an HTTP error a non-zero exit while still showing TeamCity's error payload.
+printf 'header = "Authorization: Bearer %s"\n' "$token" |
+    curl --config - \
+        --silent --show-error --fail-with-body \
+        --header 'Accept: application/json' \
+        "$base_url/$rest_path"

--- a/scripts/quality-baseline/tc-get.sh
+++ b/scripts/quality-baseline/tc-get.sh
@@ -12,8 +12,11 @@
 # Usage:
 #   TC_URL=<teamcity-base-url> scripts/quality-baseline/tc-get.sh "app/rest/server?fields=version"
 #
+# Pass TC_URL inline on every call. Do not rely on `export`: the documented recipe runs each command as its
+# own invocation, and in an agent session every invocation is a fresh shell, so an earlier export is gone.
+#
 # TC_URL is intentionally not baked in: the host is internal and does not belong in this repository.
-# Take it from the team's CI bookmark and export it in your shell.
+# Take it from the team's CI bookmark.
 #
 # Requires: macOS `security` with a generic password stored under the service name `tc-rest-token`
 # (personal access token; TeamCity guest auth is disabled).
@@ -27,7 +30,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 if [ -z "${TC_URL:-}" ]; then
-    echo "TC_URL is not set — export the TeamCity base URL (see the team's CI bookmark)." >&2
+    echo "TC_URL is not set — pass it inline: TC_URL=<base-url> $0 <rest-path> (see the team's CI bookmark)." >&2
     exit 2
 fi
 


### PR DESCRIPTION
## Why

Coverage was gated by a single rule: aggregate LINE ≥ 70%. Actual LINE coverage is **88.2%** — an 18 p.p. dead zone in which coverage could fall with nothing noticing. **BRANCH was not gated at all**, and BRANCH is the counter LINE cannot substitute for: a conditional taken on only one path still reports 100% LINE.

Neither counter says anything about whether an outcome was *asserted* — that is a different question, addressed separately in #464.

This PR also records the measured baseline the whole quality-gate plan is compared against, so "before / after" has a dated reference instead of a recollection.

## What

**1. Coverage gates** — `build.gradle`

| Gate | Task | Before | After |
|---|---|---|---|
| Aggregate | `jacocoOverallCoverageVerification` | LINE ≥ 70% | LINE ≥ **86%**, BRANCH ≥ **65%** |
| Per module (strict) | `<module>:jacocoCoverageRatchet` *(new)* | — | per-module LINE/BRANCH minimums |
| Per module (floor) | `jacocoTestCoverageVerification` | 10% | 10%, unchanged, kept underneath |

Per-module thresholds are the measured value minus ~2 p.p.:

| Module | Measured LINE / BRANCH | Threshold |
|---|---|---|
| `components-registry-service-server` | 89.5% / 70.7% | 87% / 68% |
| `components-registry-service-client` | 96.9% / 65.4% | 94% / 63% |
| `component-resolver-core` | 80.9% / 62.6% | 78% / 60% |
| `components-registry-dsl` | 81.0% / 47.1% | 79% / 45% |
| `components-registry-service-light-client` | 79.2% / 45.0% | 77% / 43% |
| `component-resolver-api` | 70.2% / 30.4% | 68% / 28% |
| `components-registry-api` | 16.6% / 9.6% | 14% / 7% |

**2. Baseline document** — `docs/registry/quality-baseline.md`

Every automated check and its measured value on `main` @ `1ecab7a2`, from the last `main` TeamCity chain and the GitHub runs on the same commit, with a reproduction recipe per metric. Several numbers exist only inside published artifacts:

- TeamCity publishes **no** `CodeCoverage*` statistics, so coverage can never be compared from a TC build — only from the GitHub `quality` artifacts.
- The perf SLA median (**261 ms** against a 2000 ms ceiling) lands in **`system-err`** of the `perf-test-report` JUnit XML — not in `system-out`, not in the job log.
- detekt/ktlint report zero violations only because **~226** are held in baselines; the burn-down number is the baseline entry count, not the report.

**3. `scripts/quality-baseline/tc-get.sh`** — the recipe's TeamCity access goes through a helper that does the Keychain lookup and the request in one process, passing the header to curl on stdin so the token never reaches argv, a log or a transcript.

## Design notes

**Why a task of our own, not extra rules on the plugin's verification task.** The new task declares the heavy suite it needs (`dependsOn dbTest`), so a standalone run measures the same exec set as CI instead of failing on absent coverage. The plugin-owned task is wired off `test` and must keep working without the heavy suites — hence its lenient 10% floor stays underneath rather than being replaced.

**No effect on TeamCity.** The ratchet is wired into `qualityCoverage` only, never into `check`, so `[1.0]` (`clean build publish dockerPushImage`) is untouched — verified empirically: the full TC chain is green on this branch.

**`integrationTest` is deliberately excluded from the ratchet's `dependsOn`.** Pulling the FatJar boot FT into the GitHub coverage job is what #424 was about: timing-sensitive on shared runners, and a second full-app JVM next to the co-scheduled Postgres containers. Its exec file is still folded in when a TeamCity run leaves one behind — which can only widen the local pass margin, never cause a false failure.

**The map is guarded in both directions, keyed on test SOURCES rather than on the presence of a `test` task.** The Kotlin/Java plugins register `test` even for a module with no test code, and `JacocoCoverageVerification` with empty execution data is **SKIPPED, not failed** — so keying on the task would let a module delete every test and keep a green ratchet, with the ~2 p.p. of aggregate headroom absorbing a small module's loss. Both a new module without an entry and an entry without test sources now fail configuration with the module named. `components-registry-service-core` needs no entry: it has no test sources at all.

## Verification

- `./gradlew qualityCoverage` green locally; per-module and aggregate counters **identical to the recorded GitHub baseline** (88.2% / 67.3%), confirming the measurement is reproducible and the thresholds have the intended headroom.
- **RED demonstrated twice, so the gates are not no-ops:**
  - raising one threshold above its measured value → `Rule violated for bundle components-registry-api: lines covered ratio is 0.16, but expected minimum is 0.20`;
  - mapping a module that has no test sources → `coverage ratchet is configured for components-registry-service-core, which has no test sources — the ratchet task would SKIP on empty JaCoCo execution data and gate nothing`;
  - removing a map entry for a module that has tests → `coverage modules with tests but no ratchet: components-registry-dsl`.
- `tc-get.sh`: returns only the JSON payload; missing `TC_URL` exits 2; missing Keychain entry exits 3.
- Full `./gradlew build qualityStatic` green. GitHub: all checks green, including `quality/tests-coverage` (8m50s). TeamCity: chain `3.0.9-4426` green across `[1.0]`, `[2.1]`, `[2.2]`, `[2.3]`, `[2.0]`, `WL Validation`.

## Review history

Five findings, all accepted and fixed in-branch — three of them regressions introduced while fixing an earlier one, which is recorded in the commit messages:

| Finding | Fix |
|---|---|
| P1 — the recipe printed the personal TeamCity token to stdout and told you to paste it into a command | the helper above; the recipe states why the paste form is forbidden |
| P1 — the helper was not committed at all (`.gitignore` ignores `*.sh` repo-wide) | `!scripts/quality-baseline/*.sh`, following the two existing exceptions |
| P2 — the ratchet could be silenced by deleting a module's tests | guard keyed on test sources, both directions |
| P2 — the recipe used shell forms `AGENTS.md` forbids | one standalone invocation per command, no pipes/substitutions/loops |
| P2 — `TC_URL` exported once cannot survive to the next command | passed inline in every example |
| P3 — BRANCH coverage was described as establishing assertions | restated: it distinguishes "one branch ran" from "both ran"; assertions are a different question |

## Follow-ups (not in this PR)

- `build/reports/quality/index.html` is **tracked in git** although `build/` is ignored, so regenerating it dirties the tree and the committed copy drifts.
- The index's link scheme suggests its links are already dead on TeamCity for every report, not just new ones — unverified against real artifacts.
- Mutation testing, which answers the "was it asserted" question this PR explicitly does not: **#464**, stacked on this branch. Merge this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Strengthened code coverage gates with aggregate and per-module line and branch thresholds.
  * Added checks to detect missing coverage data and prevent silently skipped verification.

* **Documentation**
  * Updated quality, coverage, CI, and test-suite guidance to reflect the new coverage requirements.
  * Added a reproducible quality baseline and measurement instructions.

* **Chores**
  * Added a secure, read-only script for retrieving TeamCity data.
  * Ensured quality-baseline helper scripts are tracked in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->