### PR TITLE
Rename step [2.9] to [3.0] on teamcity configuration

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1386,7 +1386,7 @@ object id30DeployToOkdQaDevAuto : BuildType({
 object id29Step2AggregateAuto : BuildType({
     templates(AbsoluteId("RDDepartment_PostGithubStatus"))
     id("29Step2AggregateAuto")
-    name = "[2.9] Step 2 Aggregate [AUTO]"
+    name = "[3.0] Step 2 Aggregate [AUTO]"
 
     // Surface [1.0]'s build number so the whole chain (id10 = id12 = … = id29)
     // shows the same version tag in the TC chain view.

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -65,7 +65,7 @@ project {
     buildType(id18CompatLocalStandGitModeAuto)
     buildType(id20ValidateComponentsRegistryProductionDataAuto)
     buildType(id30DeployToOkdQaDevAuto)
-    buildType(id29Step2AggregateAuto)
+    buildType(id30Step2AggregateAuto)
     buildType(id40ReleaseManual)
     buildType(id50ReleasePostProcessingAuto)
     buildType(id60DeployToOkdQaGhAuto)
@@ -84,7 +84,7 @@ project {
         id17CompatLocalStandManual,
         id18CompatLocalStandGitModeAuto,
         id30DeployToOkdQaDevAuto,
-        id29Step2AggregateAuto,
+        id30Step2AggregateAuto,
         id40ReleaseManual,
         id50ReleasePostProcessingAuto,
         id60DeployToOkdQaGhAuto,
@@ -1383,7 +1383,7 @@ object id30DeployToOkdQaDevAuto : BuildType({
     }
 })
 
-object id29Step2AggregateAuto : BuildType({
+object id30Step2AggregateAuto : BuildType({
     templates(AbsoluteId("RDDepartment_PostGithubStatus"))
     id("30Step2AggregateAuto")
     name = "[3.0] Step 2 Aggregate [AUTO]"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1385,7 +1385,7 @@ object id30DeployToOkdQaDevAuto : BuildType({
 
 object id29Step2AggregateAuto : BuildType({
     templates(AbsoluteId("RDDepartment_PostGithubStatus"))
-    id("29Step2AggregateAuto")
+    id("30Step2AggregateAuto")
     name = "[3.0] Step 2 Aggregate [AUTO]"
 
     // Surface [1.0]'s build number so the whole chain (id10 = id12 = … = id29)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1385,7 +1385,7 @@ object id30DeployToOkdQaDevAuto : BuildType({
 
 object id30Step2AggregateAuto : BuildType({
     templates(AbsoluteId("RDDepartment_PostGithubStatus"))
-    id("30Step2AggregateAuto")
+    id("29Step2AggregateAuto")
     name = "[3.0] Step 2 Aggregate [AUTO]"
 
     // Surface [1.0]'s build number so the whole chain (id10 = id12 = … = id29)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the displayed name of the automated Step 2 Aggregate build from version 2.9 to version 3.0.  
  * Switched the underlying build type to the next version to match the updated label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->