### PR TITLE
fix(coverage): unbreak main — ratchet component-validation, and fail the gate rather than every build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -570,8 +570,6 @@ gradle.projectsEvaluated {
         'components-registry-service-light-client': [line: 0.77, branch: 0.43],
         'component-resolver-api'                  : [line: 0.68, branch: 0.28],
         'components-registry-api'                 : [line: 0.14, branch: 0.07],
-        // Measured 2026-07-28 on main @82d76d26, right after the module landed: LINE 99.7% (343/344),
-        // BRANCH 85.9% (128/149). A pure-Kotlin library with no Spring or IO — dense tests come cheap here.
         'component-validation'                    : [line: 0.97, branch: 0.83],
     ]
     // Escape hatch: a coverage module that OWNS tests but is deliberately left ungated goes here, with the
@@ -588,13 +586,9 @@ gradle.projectsEvaluated {
     // would let a module delete every test and keep a green ratchet, while the ~2 p.p. of aggregate
     // headroom absorbs a small module's loss. Keying on sources makes that state fail loudly.
     //
-    // These are POLICY checks and they run in a TASK ACTION wired into `qualityCoverage`, not at
-    // configuration time. The first version threw during `projectsEvaluated`, which broke EVERY Gradle
-    // invocation — `build`, `test`, `dependencies`, IDE sync — over a coverage-policy problem. That is
-    // exactly what happened when #443 landed straight after #463: it added `component-validation` with
-    // tests, the map had no entry for it, and `main` stopped configuring at all. The gate must fail; the
-    // repository must stay usable. Running in a task action also removes the configuration-on-demand
-    // caveat the first version had to carry.
+    // POLICY checks, run in a task action wired into `qualityCoverage` — deliberately NOT at
+    // configuration time: a coverage-policy problem must fail the coverage gate, not every Gradle
+    // invocation (`build`, `test`, `dependencies`, IDE sync).
     def ratchetPolicyProblems = {
         def problems = []
         def unratcheted = moduleNamesWithTests - moduleCoverageRatchet.keySet() - coverageRatchetExempt.keySet()
@@ -635,6 +629,13 @@ gradle.projectsEvaluated {
     def ratchetTaskPaths = []
     moduleCoverageRatchet.each { moduleName, thresholds ->
         def p = testTargets.find { it.name == moduleName }
+        // A key that resolves to nothing — module removed, renamed, misspelled, or newly excluded from
+        // coverage — is skipped here rather than dereferenced. Reporting it is `verifyCoverageRatchetPolicy`'s
+        // job (`ratchetedWithoutTests` covers it), so a stale key fails the gate with a readable message
+        // instead of aborting configuration with a null-dereference.
+        if (p == null) {
+            return
+        }
         // Only `dbTest` — deliberately NOT `integrationTest`, for the reason spelled out at
         // `heavyTestTaskPaths` above: the FatJar boot FT must not be pulled into the GitHub coverage job
         // (timing-sensitive on shared runners, and it piles a second full-app JVM onto the co-scheduled

--- a/build.gradle
+++ b/build.gradle
@@ -570,6 +570,9 @@ gradle.projectsEvaluated {
         'components-registry-service-light-client': [line: 0.77, branch: 0.43],
         'component-resolver-api'                  : [line: 0.68, branch: 0.28],
         'components-registry-api'                 : [line: 0.14, branch: 0.07],
+        // Measured 2026-07-28 on main @82d76d26, right after the module landed: LINE 99.7% (343/344),
+        // BRANCH 85.9% (128/149). A pure-Kotlin library with no Spring or IO — dense tests come cheap here.
+        'component-validation'                    : [line: 0.97, branch: 0.83],
     ]
     // Escape hatch: a coverage module that OWNS tests but is deliberately left ungated goes here, with the
     // reason. Empty today, and `components-registry-service-core` deliberately does not need an entry — it
@@ -584,34 +587,51 @@ gradle.projectsEvaluated {
     // JacocoCoverageVerification with empty execution data is SKIPPED, not failed, so keying on the task
     // would let a module delete every test and keep a green ratchet, while the ~2 p.p. of aggregate
     // headroom absorbs a small module's loss. Keying on sources makes that state fail loudly.
-    // NOTE: both checks assume `projectsEvaluated` sees the whole project tree, which holds because
-    // configuration-on-demand is off (it is not set in gradle.properties). If it is ever enabled, these
-    // guards must move into a task action — under configure-on-demand a narrow invocation evaluates only
-    // some projects and the checks would fire spuriously.
-    def unratcheted = moduleNamesWithTests - moduleCoverageRatchet.keySet() - coverageRatchetExempt.keySet()
-    if (unratcheted) {
-        throw new GradleException(
-            "coverage modules with tests but no ratchet: ${unratcheted.join(', ')} — measure them (see " +
-                "docs/registry/quality-baseline.md §7) and add entries to moduleCoverageRatchet in build.gradle")
-    }
-    def ratchetedWithoutTests = moduleCoverageRatchet.keySet() - moduleNamesWithTests
-    if (ratchetedWithoutTests) {
-        throw new GradleException(
-            "coverage ratchet is configured for ${ratchetedWithoutTests.join(', ')}, which has no test " +
-                "sources — the ratchet task would SKIP on empty JaCoCo execution data and gate nothing. " +
+    //
+    // These are POLICY checks and they run in a TASK ACTION wired into `qualityCoverage`, not at
+    // configuration time. The first version threw during `projectsEvaluated`, which broke EVERY Gradle
+    // invocation — `build`, `test`, `dependencies`, IDE sync — over a coverage-policy problem. That is
+    // exactly what happened when #443 landed straight after #463: it added `component-validation` with
+    // tests, the map had no entry for it, and `main` stopped configuring at all. The gate must fail; the
+    // repository must stay usable. Running in a task action also removes the configuration-on-demand
+    // caveat the first version had to carry.
+    def ratchetPolicyProblems = {
+        def problems = []
+        def unratcheted = moduleNamesWithTests - moduleCoverageRatchet.keySet() - coverageRatchetExempt.keySet()
+        if (unratcheted) {
+            problems << ("coverage modules with tests but no ratchet: ${unratcheted.join(', ')} — measure them " +
+                "(see docs/registry/quality-baseline.md §7) and add entries to moduleCoverageRatchet in build.gradle")
+        }
+        def ratchetedWithoutTests = moduleCoverageRatchet.keySet() - moduleNamesWithTests
+        if (ratchetedWithoutTests) {
+            problems << ("coverage ratchet is configured for ${ratchetedWithoutTests.join(', ')}, which has no " +
+                "test sources — the ratchet task would SKIP on empty JaCoCo execution data and gate nothing. " +
                 "Restore the tests, or (if the module is intentionally untested) move it to " +
-                "coverageRatchetExempt in build.gradle with the reason")
-    }
-    // A threshold of zero is not a ratchet, it is the absence of one — and it reads as a configured gate,
-    // which is worse than no gate at all. (Sibling repos have both shapes of this: a coverage minimum of
-    // 0.00 with the gate "enabled", and a CVE gate whose fail-on score is above the top of the CVSS scale.)
-    def nonRatchets = moduleCoverageRatchet.findAll { name, t -> t.line <= 0 || t.branch <= 0 }*.key
-    if (nonRatchets) {
-        throw new GradleException(
-            "coverage ratchet thresholds must be > 0 — ${nonRatchets.join(', ')} would be a gate that " +
-                "cannot fail. Measure the module (docs/registry/quality-baseline.md §7) and set a real " +
+                "coverageRatchetExempt with the reason")
+        }
+        // A threshold of zero is not a ratchet, it is the absence of one — and it reads as a configured
+        // gate, which is worse than no gate at all. (Sibling repos have both shapes of this: a coverage
+        // minimum of 0.00 with the gate "enabled", and a CVE gate whose fail-on score sits above the top
+        // of the CVSS scale.)
+        def nonRatchets = moduleCoverageRatchet.findAll { name, t -> t.line <= 0 || t.branch <= 0 }*.key
+        if (nonRatchets) {
+            problems << ("coverage ratchet thresholds must be > 0 — ${nonRatchets.join(', ')} would be a gate " +
+                "that cannot fail. Measure the module (docs/registry/quality-baseline.md §7) and set a real " +
                 "floor, or move it to coverageRatchetExempt with the reason")
+        }
+        problems
     }
+    tasks.register('verifyCoverageRatchetPolicy') {
+        group = 'verification'
+        description = 'Fails when the per-module coverage ratchet map disagrees with the modules that own tests, or carries a zero threshold'
+        doLast {
+            def problems = ratchetPolicyProblems()
+            if (problems) {
+                throw new GradleException(problems.join('\n'))
+            }
+        }
+    }
+
     def ratchetTaskPaths = []
     moduleCoverageRatchet.each { moduleName, thresholds ->
         def p = testTargets.find { it.name == moduleName }
@@ -681,6 +701,7 @@ gradle.projectsEvaluated {
         dependsOn(ratchetTaskPaths)
         // Without this, an empty-exec-data run reports every coverage gate as SKIPPED and passes.
         dependsOn('verifyCoverageDataPresent')
+        dependsOn('verifyCoverageRatchetPolicy')
     }
 
     // Part A.7: gate publish + image push on the server fat-jar FT. dockerPushImage HARD-depends

--- a/docs/registry/quality-baseline.md
+++ b/docs/registry/quality-baseline.md
@@ -16,6 +16,8 @@ snapshot can be read against the right contract.
 |---|---|---|---|
 | 2026-07-27 | Aggregate coverage ratchet | LINE ≥ 70%, no BRANCH rule | LINE ≥ 86%, BRANCH ≥ 65% |
 | 2026-07-27 | Per-module coverage ratchet (`jacocoCoverageRatchet`, wired into `qualityCoverage`) | plugin-owned 10% floor only | strict per-module LINE/BRANCH minimums (measured − ~2 p.p.), 10% floor kept underneath |
+| 2026-07-28 | `component-validation` entered the ratchet (module added by #443, measured on `main` @`82d76d26`: LINE 99.7% = 343/344, BRANCH 85.9% = 128/149) | not gated | LINE ≥ 97%, BRANCH ≥ 83% |
+| 2026-07-28 | Ratchet-map policy checks moved out of configuration into `verifyCoverageRatchetPolicy` | a map problem failed **every** Gradle invocation | it fails the coverage gate only |
 
 ---
 


### PR DESCRIPTION
> **`main` currently does not configure.** `./gradlew help` on `82d76d26` fails, so build, test and IDE sync are all dead — not just the coverage gate. This PR restores it.

## What happened

Merge order, not either change in isolation:

1. **#463** added a guard: every coverage module that owns test sources must carry an entry in `moduleCoverageRatchet`, otherwise fail — so a new module cannot slip in ungated.
2. **#443** then added `component-validation` **with tests** and no entry. Its own CI had run against a base where the guard did not exist yet, so it was green when it merged.

Result on `main`:

```
$ ./gradlew help
coverage modules with tests but no ratchet: component-validation — measure them
(see docs/registry/quality-baseline.md §7) and add entries to moduleCoverageRatchet
```

## Fix, in two parts

**1. The missing entry — measured, not guessed.** `component-validation` on `main`: **LINE 99.7%** (343/344), **BRANCH 85.9%** (128/149). A pure-Kotlin library with no Spring and no IO, so dense tests come cheap. Thresholds follow the existing convention (measured − ~2 p.p.): `line: 0.97, branch: 0.83`.

**2. The guard was in the wrong place.** The entry alone would leave the trap armed for the next module, so the real defect is mine to fix: those three checks — no entry for a tested module, an entry for an untested module, a threshold of zero — are **policy about coverage configuration**, and they threw during `projectsEvaluated`. A coverage-policy problem must fail the coverage gate; it must not stop the repository from configuring.

They now run in `verifyCoverageRatchetPolicy`, a task wired into `qualityCoverage` next to `verifyCoverageDataPresent`. Written this way from the start, #443 would have merged with a red `quality` job and a usable repository, instead of a green PR and a `main` nobody can build. It also drops the configuration-on-demand caveat the first version carried, since a task action sees the evaluated tree by construction.

## Verification

| Scenario | Before this PR | After |
|---|---|---|
| `./gradlew help` with an entry missing | **fails at configuration** | succeeds |
| coverage gate with an entry missing | fails (and breaks everything else too) | **`verifyCoverageRatchetPolicy` fails**, same message |
| both, with the entry present | — | green |

Also green: `./gradlew build qualityStatic`.

**Not verified locally:** `dbTest` and the full `qualityCoverage`. The local Docker VM is down (`colima start` → `error starting vm: exit status 1`), so the heavy suites cannot run on this machine — CI must confirm them here.

## Note for the follow-up

The same class of collision will recur for any new module. Two things worth doing separately: mention the ratchet map in the "adding a module" path of `AGENTS.md`, and re-check the coverage numbers for `component-validation` once its module stops being brand-new (99.7% LINE on a fresh library is easy to hold at first and easy to erode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage thresholds for the component validation module.
  * Added a coverage policy verification task to identify configuration mismatches.

* **Quality Improvements**
  * Coverage policy checks now run as part of the quality coverage workflow.
  * Policy violations are reported during task execution for clearer build feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->