### PR TITLE
ci: move octopus-base to v2.6.2, carry the guard exception, harden the publication policy check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/infrastructure/components-registry-service-core/_VER_/components-registry-service-core-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
     with:
       java-version: '21'
       flow-type: hybrid
@@ -14,13 +14,13 @@ jobs:
     secrets: inherit
 
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
     with:
       java-version: '21'
     secrets: inherit
 
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
     with:
       java-version: '21'
       enable-codeql: true
@@ -35,6 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.5.2
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,20 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'
       commit-hash: ${{ github.event.client_payload.commit }}
       build-version: ${{ github.event.client_payload.project_version }}
       docker-image: components-registry-service
+      # Exempt from the Maven Central publication guard that v2.6.x adds. Measured on this
+      # branch: of the nine published coordinates, exactly one trips the guard —
+      # components-registry-automation, whose -all.jar is 19.75 MB and carries the shadow
+      # classifier. It must keep publishing because its TeamCity metarunner resolves
+      # ${group}:components-registry-automation:${version}:jar:all from a Maven repository at
+      # build time (components-registry-automation/metarunners/). Every other coordinate is a
+      # thin library well under the 8 MB default, so the threshold is deliberately left alone
+      # rather than raised — raising it would weaken the guard for all of them.
+      fat-jar-publication-allowlist: components-registry-automation
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
     with:
       java-version: '21'
       enable-codeql: true

--- a/build.gradle
+++ b/build.gradle
@@ -39,16 +39,21 @@ plugins {
 // components-registry-automation IS listed even though it is tooling: its TeamCity metarunner
 // resolves `<group>:components-registry-automation:<version>:jar:all` from a Maven repo at build
 // time (see components-registry-automation/metarunners/).
-def centralPublishedModules = [
-        'component-resolver-api',
-        'component-resolver-core',
-        'components-registry-api',
-        'components-registry-dsl',
-        'components-registry-service-client',
-        'components-registry-service-light-client',
-        'components-registry-service-core',
-        'test-common',
-        'components-registry-automation',
+// Allowlist PROJECT PATHS, not names. A Set of names collapses two modules that share a
+// simple name, and the root project's name is a repository-level string rather than a module
+// name, so it cannot sit here meaningfully. `as Set` is load-bearing: in Groovy a Set is never
+// equal to a List even with identical elements, so declaring this as a plain list would fail
+// the check on every publish.
+def centralPublishedProjects = [
+        ':component-resolver-api',
+        ':component-resolver-core',
+        ':components-registry-api',
+        ':components-registry-dsl',
+        ':components-registry-service-client',
+        ':components-registry-service-light-client',
+        ':components-registry-service-core',
+        ':test-common',
+        ':components-registry-automation',
 ] as Set
 
 octopusQuality {
@@ -316,10 +321,10 @@ configure(subprojects) {
         withSourcesJar()
     }
 
-    // Only allowlisted modules get a publication (see centralPublishedModules above); for the
+    // Only allowlisted modules get a publication (see centralPublishedProjects above); for the
     // rest `publishToSonatype` has nothing to upload, while `build`, the docker image and the
     // shadow/boot jars are unaffected.
-    if (project.name in centralPublishedModules) {
+    if (project.path in centralPublishedProjects) {
         publishing {
             publications {
                 mavenJava(MavenPublication) {
@@ -456,12 +461,18 @@ ${sectionsHtml}
 // path, so a drift cannot reach Central: re-adding a publication for an excluded module, or
 // dropping the allowlist check itself, fails before anything is uploaded.
 def centralPublicationPolicyProblems = {
-    def actual = subprojects.findAll { !it.publishing.publications.isEmpty() }*.name as Set
-    if (actual != centralPublishedModules) {
+    // allprojects, NOT subprojects: the root is a publishable project like any other, and a
+    // publication added there would otherwise be invisible to this check. The plugin test comes
+    // first because reading `publishing` throws on a project without maven-publish — the root
+    // does not have it, since it is applied inside `configure(subprojects)`.
+    def actual = allprojects.findAll {
+        it.plugins.hasPlugin('maven-publish') && !it.publishing.publications.isEmpty()
+    }*.path as Set
+    if (actual != centralPublishedProjects) {
         return ["Maven Central publication set drifted.\n" +
-                    "  allowlisted: ${centralPublishedModules.sort()}\n" +
+                    "  allowlisted: ${centralPublishedProjects.sort()}\n" +
                     "  publishing:  ${actual.sort()}\n" +
-                    "Update `centralPublishedModules` in the root build.gradle only if the change is intentional."]
+                    "Update `centralPublishedProjects` in the root build.gradle only if the change is intentional."]
     }
     return []
 }
@@ -474,7 +485,7 @@ def verifyCentralPublicationPolicy = tasks.register('verifyCentralPublicationPol
         if (problems) {
             throw new GradleException(problems.join('\n\n'))
         }
-        logger.lifecycle("Maven Central publication set matches the allowlist (${centralPublishedModules.size()} modules).")
+        logger.lifecycle("Maven Central publication set matches the allowlist (${centralPublishedProjects.size()} projects).")
     }
 }
 
@@ -482,6 +493,13 @@ def verifyCentralPublicationPolicy = tasks.register('verifyCentralPublicationPol
 // the gate attaches wherever it is present without forcing either to be created.
 gradle.projectsEvaluated {
     allprojects { proj ->
+        // Hook the task TYPE first: every concrete publish task extends AbstractPublishToMaven,
+        // so `publishMavenJavaPublicationToSonatypeRepository` and friends are covered too.
+        // Matching only the aggregates by name left the policy bypassable by invoking a leaf
+        // task directly.
+        proj.tasks.withType(AbstractPublishToMaven).configureEach {
+            dependsOn verifyCentralPublicationPolicy
+        }
         proj.tasks.matching { it.name in ['publishToSonatype', 'publish', 'publishToMavenLocal'] }.configureEach {
             dependsOn verifyCentralPublicationPolicy
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
         id 'org.jetbrains.kotlin.plugin.jpa'            version settings['kotlin.version']
         id 'io.gitlab.arturbosch.detekt'                version settings['detekt.version']
         id 'org.jlleitschuh.gradle.ktlint'              version settings['ktlint-gradle.version']
-        id 'org.octopusden.octopus-quality'             version '2.5.2'
+        id 'org.octopusden.octopus-quality'             version '2.6.2'
         id 'com.bmuschko.docker-java-application'       version settings['gradle-docker-plugin.version']
         id 'com.github.johnrengelman.shadow'            version '8.1.1'
         id 'org.octopusden.octopus.oc-template'         version settings['octopus-oc-template.version']


### PR DESCRIPTION
## What

Finishes the Maven Central work in this repository. The publication cleanup itself landed in #456; this PR moves every `octopus-base` reference to **v2.6.2**, carries the guard exception that bump requires, and closes three gaps in the policy check that the newer cleanups in sibling repositories already fix.

Part of the organisation's Maven Central limits work (octopusden/octopus-base#163).

## Measured on this branch

`measure-central-footprint.py --from-gradle` — publishes to a throwaway local repository and reads the real coordinates back, so it covers every groupId including `…components.registry.automation`, which the repository's main group does not reveal:

| | per release | per month (~10 releases) |
|---|---|---|
| coordinates | 9 | — |
| files | 500 | ~5 000 |
| size | 21.39 MB | ~214 MB |

Heaviest by far: `components-registry-automation-3.0.8-all.jar` at 19.75 MB. Everything else is a thin library — the largest is 0.62 MB.

**This PR does not reduce that footprint, and does not claim to.** After #456 the nine remaining coordinates are all genuinely consumed libraries and clients; there is nothing left to drop. What it does is make the repository safe to release under the new guard, and make the existing guard actually guard.

Worth flagging separately, because it changes where the organisation's remaining problem lies: at ~10 releases a month this repository alone accounts for roughly 5 000 published files a month against an organisation-wide limit of 1 000. That is release *frequency* multiplied by the number of consumed coordinates, not unnecessary artifacts — so it cannot be fixed by a cleanup. The options are fewer releases, fewer coordinates, or a raised limit, and picking one is a separate decision.

## The guard exception, and why exactly one

From v2.6.0 the shared release workflow fails a release when a published artifact carries an `-all` classifier, contains `BOOT-INF/`, or exceeds `max-central-artifact-mb` (default 8). `publish-to-nexus` defaults to `true` and this repository does not override it, so the guard runs on every real release here.

Measured against all nine coordinates, exactly one trips it: **`components-registry-automation`**. It keeps publishing because its TeamCity metarunner resolves `${group}:components-registry-automation:${version}:jar:all` from a Maven repository at build time (`components-registry-automation/metarunners/`), so it is named in `fat-jar-publication-allowlist`.

`max-central-artifact-mb` is deliberately left at 8. Raising it to accommodate one artifact would weaken the guard for the other eight.

## Three gaps closed in the policy check

Each was a real hole, not a style preference:

1. **It inspected `subprojects`** — a publication added to the ROOT project was invisible, so the check could pass while an extra coordinate reached Central. Now `allprojects`, with a `plugins.hasPlugin('maven-publish')` test first, because reading `publishing` throws on a project that does not apply it and the root does not (it is applied inside `configure(subprojects)`).
2. **The allowlist compared module NAMES.** Two modules sharing a simple name collapse into one entry in a Set, so one could start or stop publishing without changing the compared value; and the root cannot be expressed as a module name at all. Now project paths.
3. **It attached only to the aggregate tasks by name**, so invoking a concrete publish task directly published without ever running it. Now the `AbstractPublishToMaven` type is hooked as well; the aggregates stay matched by name because `publish` is per-project and `publishToSonatype` only exists with `-Pnexus`, so neither can be forced into existence.

## Guard demonstrated failing, then passing

```
# RED 1 — a publication added to the ROOT project, invisible to the old check
> Maven Central publication set drifted.
    allowlisted: [:component-resolver-api, …, :test-common]
    publishing:  [:, :component-resolver-api, …, :test-common]

# RED 2 — a concrete leaf publish task cannot bypass the guard
./gradlew publishRedDemoPublicationToMavenLocal
> Task :verifyCentralPublicationPolicy FAILED

# unrelated work is unaffected while the violation is present
./gradlew help -> exit 0

# GREEN — after reverting
Maven Central publication set matches the allowlist (9 projects).
```

## An open point, stated rather than left silent

`component-validation` is a module in this build and is **not** in the allowlist, so it does not get a publication. That is deliberate and low-risk: checked against repo1, the coordinate has **never been published** under either groupId, so excluding it is declining to start rather than dropping something consumers have. If it is meant to be published, this PR is where to say so.

## Verified locally

- `./gradlew build verifyCentralPublicationPolicy` — green, with the guard task actually executing. Excluded: `:components-registry-automation:test`, `dockerBuildImage`, `dockerPushImage`, which need infrastructure a developer machine does not have. `AUTH_SERVER_URL` must be set for the build to configure.
- The footprint measurement above, on this branch.
- The red/green demonstration above, reverted afterwards.
- The octopus-quality bump changes no production plugin code between the tags, so existing ktlint/detekt baselines stay valid.
- Every pinned reference enumerated and moved together — six workflow and action refs plus the plugin version pinned inline in `settings.gradle`, not in `gradle.properties`.

## Not verified, and only a real release can

The release path itself: that the guard passes there, that the allowlist entry is honoured, and that the new built-commit tagging behaves. v2.6.2's release-path changes have not been exercised on a real release anywhere yet.

**The TeamCity build is also unverified.** This repository is `flow-type: hybrid`, so a TeamCity build exists and its step runs `clean build publish dockerPushImage` in one invocation — exactly the task graph this PR rewires. Access to check it was unavailable (the REST token is revoked), so this check is outstanding, not passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release**
  * Updated automated build, quality, security, merge-gate, and release processes to the latest shared workflow version.
  * Improved Maven Central publication controls to reliably identify and validate publishable projects.
  * Added an approved exception for the components registry automation artifact during release publication.
  * Updated the quality tooling version used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->