### PR TITLE
feat(meta): add in-use release-manager and security-champion option lists

### DIFF
--- a/components-registry-service-server/ktlint-baseline.xml
+++ b/components-registry-service-server/ktlint-baseline.xml
@@ -9,7 +9,7 @@
         <error line="33" column="5" source="standard:no-consecutive-comments" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt">
-        <error line="363" column="5" source="standard:no-consecutive-comments" />
+        <error line="377" column="5" source="standard:no-consecutive-comments" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/components/registry/server/dto/v4/ComponentFilter.kt">
         <error line="92" column="5" source="standard:no-consecutive-comments" />

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/controller/ComponentControllerV4.kt
@@ -97,6 +97,20 @@ class ComponentControllerV4(
     @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
     fun getDistinctOwners(): List<String> = componentRepository.findDistinctOwners()
 
+    // In-use people option lists backing the Portal's release-manager and
+    // security-champion filter dropdowns. Mirror /meta/owners in shape and
+    // intent, but source the ordered child collections (a component may carry
+    // several of each). Two separate endpoints, not one merged list: the
+    // `?releaseManager=` and `?securityChampion=` filters are separate
+    // dimensions, so a merged list would advertise dead options in both pickers.
+    @GetMapping("/meta/release-managers")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getDistinctReleaseManagers(): List<String> = componentRepository.findDistinctReleaseManagers()
+
+    @GetMapping("/meta/security-champions")
+    @PreAuthorize("@permissionEvaluator.hasPermission('ACCESS_COMPONENTS')")
+    fun getDistinctSecurityChampions(): List<String> = componentRepository.findDistinctSecurityChampions()
+
     // Employee picker lookup (Stage 2). The employee-service client exposes no
     // prefix search, so this is an exact-match probe of `search`: it returns a
     // single `[{username, active}]` when the user exists, or an empty list when

--- a/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentRepository.kt
+++ b/components-registry-service-server/src/main/kotlin/org/octopusden/octopus/components/registry/server/repository/ComponentRepository.kt
@@ -50,6 +50,45 @@ interface ComponentRepository :
     fun findDistinctOwners(): List<String>
 
     /**
+     * Distinct release-manager usernames currently assigned to at least one
+     * component. Source for the `/meta/release-managers` dropdown — parity with
+     * [findDistinctOwners], but joined through the ordered
+     * `component_release_managers` child collection rather than a scalar column,
+     * since a component may carry several release managers.
+     *
+     * Joins from `ComponentEntity` (rather than living on a child-entity
+     * repository) to mirror [findDistinctJiraProjectKeys]; the child entities are
+     * parent-owned and have no repository of their own.
+     *
+     * `username` is a NOT NULL column, so only the non-blank guard is needed —
+     * defence-in-depth against migration drift or a direct DB write leaving a
+     * whitespace-only row, which would otherwise surface as an unselectable
+     * blank chip in the picker.
+     */
+    @Query(
+        "SELECT DISTINCT rm.username FROM ComponentEntity c JOIN c.releaseManagers rm " +
+            "WHERE TRIM(rm.username) <> '' " +
+            "ORDER BY rm.username",
+    )
+    fun findDistinctReleaseManagers(): List<String>
+
+    /**
+     * Distinct security-champion usernames currently assigned to at least one
+     * component. Source for the `/meta/security-champions` dropdown; identical
+     * shape and rationale to [findDistinctReleaseManagers], against the
+     * `component_security_champions` child collection. Kept a separate query (not
+     * a shared one over both collections) because `?releaseManager=` and
+     * `?securityChampion=` are separate filters — a merged list would advertise
+     * dead options in both pickers.
+     */
+    @Query(
+        "SELECT DISTINCT sc.username FROM ComponentEntity c JOIN c.securityChampions sc " +
+            "WHERE TRIM(sc.username) <> '' " +
+            "ORDER BY sc.username",
+    )
+    fun findDistinctSecurityChampions(): List<String>
+
+    /**
      * Distinct client codes currently in use on at least one component. Source for
      * the `/meta/client-codes` dropdown (SYS-046). Scalar `components.client_code`
      * column; same IS NOT NULL + non-blank defence as [findDistinctOwners].

--- a/components-registry-service-server/src/main/resources/openapi/v4.json
+++ b/components-registry-service-server/src/main/resources/openapi/v4.json
@@ -8539,9 +8539,215 @@
         ]
       }
     },
+    "/rest/api/4/components/meta/release-managers" : {
+      "get" : {
+        "operationId" : "getDistinctReleaseManagers",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "413" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Payload Too Large"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
     "/rest/api/4/components/meta/repository-types" : {
       "get" : {
         "operationId" : "getRepositoryTypes",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "items" : {
+                    "type" : "string"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "description" : "OK"
+          },
+          "400" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Found"
+          },
+          "409" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Conflict"
+          },
+          "413" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Payload Too Large"
+          },
+          "425" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Too Early"
+          },
+          "500" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Internal Server Error"
+          },
+          "501" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Not Implemented"
+          },
+          "502" : {
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description" : "Bad Gateway"
+          }
+        },
+        "tags" : [
+          "component-controller-v-4"
+        ]
+      }
+    },
+    "/rest/api/4/components/meta/security-champions" : {
+      "get" : {
+        "operationId" : "getDistinctSecurityChampions",
         "responses" : {
           "200" : {
             "content" : {

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaInUseOptionsEndpointsTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/controller/MetaInUseOptionsEndpointsTest.kt
@@ -28,12 +28,14 @@ import java.nio.file.Paths
 import java.util.UUID
 
 /**
- * SYS-046 — the four in-use meta option-list endpoints that back the extended-search
+ * SYS-046 — the in-use meta option-list endpoints that back the list-page
  * multi-select dropdowns: `/meta/client-codes`, `/meta/jira-project-keys`,
- * `/meta/parent-component-names`, `/meta/group-keys`. Each returns sorted distinct
- * values **actually in use**, null/blank-filtered, 200 + JSON array (never 404) —
- * parity with `/meta/owners` (MetaOptionsEndpointsTest covers the enum/labels/systems
- * family). Focused ft-db test; does NOT extend the global Groovy fixtures.
+ * `/meta/parent-component-names`, `/meta/group-keys`, plus the people pair
+ * `/meta/release-managers` and `/meta/security-champions`. Each returns sorted
+ * distinct values **actually in use**, null/blank-filtered, 200 + JSON array
+ * (never 404) — parity with `/meta/owners` (MetaOptionsEndpointsTest covers the
+ * enum/labels/systems family). Focused ft-db test; does NOT extend the global
+ * Groovy fixtures.
  */
 @AutoConfigureMockMvc
 @SpringBootTest(
@@ -163,7 +165,59 @@ class MetaInUseOptionsEndpointsTest {
     }
 
     @Test
-    @DisplayName("SYS-046: the four in-use meta endpoints always return 200 + a JSON array (never 404)")
+    @DisplayName("GET /meta/release-managers returns sorted distinct in-use release managers")
+    fun `meta release-managers returns sorted distinct in-use values`() {
+        val a = uniqueName("zrm")
+        val b = uniqueName("arm")
+        // A multi-RM component plus a second component reusing `a` — exercises
+        // both the ordered child collection and DISTINCT across components.
+        create(baseBody(uniqueName("rm_one"), ""","releaseManager":["$a","$b"]"""))
+        create(baseBody(uniqueName("rm_two"), ""","releaseManager":["$a"]"""))
+
+        val all = metaList("/rest/api/4/components/meta/release-managers")
+        val seeded = all.filter { it == a || it == b }
+        assert(seeded == listOf(a, b).sorted()) { "expected seeded release managers sorted ascending; got $seeded" }
+        assert(all.size == all.toSet().size) { "expected no duplicates; got $all" }
+        assert(all.none { it.isBlank() }) { "expected no blank entries; got $all" }
+    }
+
+    @Test
+    @DisplayName("GET /meta/security-champions returns sorted distinct in-use security champions")
+    fun `meta security-champions returns sorted distinct in-use values`() {
+        val a = uniqueName("zsc")
+        val b = uniqueName("asc")
+        create(baseBody(uniqueName("sc_one"), ""","securityChampion":["$a","$b"]"""))
+        create(baseBody(uniqueName("sc_two"), ""","securityChampion":["$a"]"""))
+
+        val all = metaList("/rest/api/4/components/meta/security-champions")
+        val seeded = all.filter { it == a || it == b }
+        assert(seeded == listOf(a, b).sorted()) { "expected seeded security champions sorted ascending; got $seeded" }
+        assert(all.size == all.toSet().size) { "expected no duplicates; got $all" }
+        assert(all.none { it.isBlank() }) { "expected no blank entries; got $all" }
+    }
+
+    @Test
+    @DisplayName("the two people option lists stay separate dimensions (RM is not advertised as SC)")
+    fun `meta people option lists do not bleed across roles`() {
+        // Guard against the copy-paste failure mode of wiring both endpoints to
+        // the same child collection: a user who is ONLY an RM must never show up
+        // in /meta/security-champions, and vice versa. `?releaseManager=` and
+        // `?securityChampion=` are separate filters (ListComponentsPeopleFilterTest),
+        // so a bled-through option would be a guaranteed dead entry in the picker.
+        val rmOnly = uniqueName("rmonly")
+        val scOnly = uniqueName("sconly")
+        create(baseBody(uniqueName("people_split"), ""","releaseManager":["$rmOnly"],"securityChampion":["$scOnly"]"""))
+
+        val releaseManagers = metaList("/rest/api/4/components/meta/release-managers")
+        val securityChampions = metaList("/rest/api/4/components/meta/security-champions")
+        assert(releaseManagers.contains(rmOnly)) { "seeded RM $rmOnly must be advertised; got $releaseManagers" }
+        assert(!releaseManagers.contains(scOnly)) { "SC-only $scOnly must NOT appear in release-managers" }
+        assert(securityChampions.contains(scOnly)) { "seeded SC $scOnly must be advertised; got $securityChampions" }
+        assert(!securityChampions.contains(rmOnly)) { "RM-only $rmOnly must NOT appear in security-champions" }
+    }
+
+    @Test
+    @DisplayName("SYS-046: the in-use meta endpoints always return 200 + a JSON array (never 404)")
     fun `SYS-046 meta endpoints always return 200 array`() {
         // AC#7 shape contract: 200 + array regardless of DB state — the Portal's
         // lazy-activation guard is for the transitional pre-deploy window only.
@@ -172,6 +226,8 @@ class MetaInUseOptionsEndpointsTest {
             "/rest/api/4/components/meta/jira-project-keys",
             "/rest/api/4/components/meta/parent-component-names",
             "/rest/api/4/components/meta/group-keys",
+            "/rest/api/4/components/meta/release-managers",
+            "/rest/api/4/components/meta/security-champions",
         ).forEach { path ->
             mvc
                 .perform(get(path).with(viewerJwt()))

--- a/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
+++ b/components-registry-service-server/src/test/kotlin/org/octopusden/octopus/components/registry/server/teamcity/TeamcitySyncServiceTest.kt
@@ -761,6 +761,20 @@ class TeamcitySyncServiceTest {
 
         override fun findDistinctOwners(): List<String> = components.mapNotNull { it.componentOwner }.distinct().sorted()
 
+        override fun findDistinctReleaseManagers(): List<String> =
+            components
+                .flatMap { it.releaseManagerUsernames() }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .sorted()
+
+        override fun findDistinctSecurityChampions(): List<String> =
+            components
+                .flatMap { it.securityChampionUsernames() }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .sorted()
+
         override fun findDistinctClientCodes(): List<String> =
             components
                 .mapNotNull { it.clientCode }


### PR DESCRIPTION
## Why

The `?releaseManager=` / `?securityChampion=` list filters have existed since SYS-056, but nothing enumerated the values they can match. The Portal could only reach them via a personal preset ("components I am RM for") or a Registry Health people deep-link — there was no way to filter by **someone else**.

## What

Two endpoints mirroring `/meta/owners` in shape, permission (`ACCESS_COMPONENTS`) and intent, but joined through the ordered child collections since a component may carry several of each:

- `GET /rest/api/4/components/meta/release-managers`
- `GET /rest/api/4/components/meta/security-champions`

Backed by `findDistinctReleaseManagers()` / `findDistinctSecurityChampions()` on `ComponentRepository`, rooted at `ComponentEntity` like the existing `findDistinctJiraProjectKeys` (the child entities are parent-owned and have no repository of their own).

Values are the **in-use** sets, so every advertised option resolves to a non-empty page — no dead entries in the picker.

## Design note: two endpoints, not one merged list

`?releaseManager=` and `?securityChampion=` are separate dimensions, so a merged list would advertise dead options in both pickers. A test pins that separation: a user who is only an RM must never surface in `/meta/security-champions`.

## Notes for the reviewer

- The ktlint baseline entry for `ComponentControllerV4` is retargeted 363 → 377. The baseline is line-keyed and the new endpoints shifted a pre-existing suppressed `no-consecutive-comments` violation — no new violation was introduced or suppressed.
- `openapi/v4.json` is regenerated via `generateOpenApiDocs`; the diff is purely additive (+206 lines).
- `TeamcitySyncServiceTest`'s `StubComponentRepository` implements the two new methods (it hand-implements the interface).

## Verification

- `dbTest --tests "*MetaInUseOptionsEndpointsTest*"` — 9 tests, 0 failures (3 new). Confirmed via the results XML, not just `BUILD SUCCESSFUL`.
- `ktlintCheck`, `detekt`, `generateOpenApiDocs` — clean.

## Downstream

Portal companion: octopusden/octopus-components-management-portal#210 — inert until this ships (its pickers open empty via the 404 → empty-vocabulary contract). **Merge this first**; the portal then needs its vendored spec refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata endpoints for retrieving distinct, alphabetized release manager and security champion names currently in use.
  * Added OpenAPI documentation for both endpoints.
  * Results exclude blank entries and keep the two role lists separate.

* **Tests**
  * Added coverage for sorting, deduplication, access behavior, and non-empty responses for the new option lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->