### PR TITLE
ci: move octopus-base to v2.7.0, and replace a tautological guard with the shared policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/infrastructure/components-registry-service-core/_VER_/components-registry-service-core-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       java-version: '21'
       flow-type: hybrid
@@ -14,13 +14,13 @@ jobs:
     secrets: inherit
 
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
     with:
       java-version: '21'
     secrets: inherit
 
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
     with:
       java-version: '21'
       enable-codeql: true
@@ -35,6 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
     with:
       java-version: '21'
       enable-codeql: true

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,31 @@ def centralPublishedProjects = [
 ] as Set
 
 octopusQuality {
+    // Regression guard on what this repository publishes to Maven Central, provided by the shared
+    // policy from octopus-base v2.7.0. This repository hand-rolled a task of exactly that name
+    // until this commit; the plugin registers the same name, so the deletion and the version bump
+    // cannot be separated — keeping both fails configuration.
+    //
+    // The declared set is INDEPENDENT of `centralPublishedProjects` above, which stays because it
+    // gates publication creation at `if (project.path in centralPublishedProjects)`. The old guard
+    // compared that same list against the projects that publish, so both sides always moved
+    // together and editing it could never be reported as drift; only a publication arriving by
+    // another route, or a path naming a project that does not exist, was catchable. Declaring the
+    // expected coordinates separately is what makes an edit to that list detectable.
+    publication {
+        enforceCentralPublications.set(true)
+        centralPublications.set([
+            ':component-resolver-api|mavenJava|org.octopusden.octopus.infrastructure:component-resolver-api|[jar, jar:javadoc, jar:sources]',
+            ':component-resolver-core|mavenJava|org.octopusden.octopus.infrastructure:component-resolver-core|[jar, jar:javadoc, jar:sources]',
+            ':components-registry-api|mavenJava|org.octopusden.octopus.infrastructure:components-registry-api|[jar, jar:javadoc, jar:sources]',
+            ':components-registry-automation|mavenJava|org.octopusden.octopus.components.registry.automation:components-registry-automation|[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]',
+            ':components-registry-dsl|mavenJava|org.octopusden.octopus.infrastructure:components-registry-dsl|[jar, jar:javadoc, jar:sources]',
+            ':components-registry-service-client|mavenJava|org.octopusden.octopus.infrastructure:components-registry-service-client|[jar, jar:javadoc, jar:sources, jar:test-fixtures]',
+            ':components-registry-service-core|mavenJava|org.octopusden.octopus.infrastructure:components-registry-service-core|[jar, jar:javadoc, jar:sources]',
+            ':components-registry-service-light-client|mavenJava|org.octopusden.octopus.infrastructure:components-registry-service-light-client|[jar, jar:javadoc, jar:sources, jar:test-fixtures]',
+            ':test-common|mavenJava|org.octopusden.octopus.infrastructure:test-common|[jar, jar:javadoc, jar:sources, jar:test-fixtures]',
+        ] as Set)
+    }
     // NOTE: in octopus-quality 2.5.2 `excludeProjects` maps ONLY to coverage exclusion
     // (coverageExcludedProjects) — it does NOT exclude these modules from qualityStatic, which
     // runs checkstyle/pmd/codenarc/detekt/ktlint over ALL subprojects. These four are excluded
@@ -459,58 +484,6 @@ ${sectionsHtml}
 </html>
 """
 }
-
-// POLICY check, run in a task action rather than at configuration time: a publication-policy
-// problem must fail the release, not every Gradle invocation (`build`, `test`, `dependencies`,
-// IDE sync) — the same reasoning as the coverage-policy checks below. Wired into the publish
-// path, so a drift cannot reach Central: re-adding a publication for an excluded module, or
-// dropping the allowlist check itself, fails before anything is uploaded.
-def centralPublicationPolicyProblems = {
-    // allprojects, NOT subprojects: the root is a publishable project like any other, and a
-    // publication added there would otherwise be invisible to this check. The plugin test comes
-    // first because reading `publishing` throws on a project without maven-publish — the root
-    // does not have it, since it is applied inside `configure(subprojects)`.
-    def actual = allprojects.findAll {
-        it.plugins.hasPlugin('maven-publish') && !it.publishing.publications.isEmpty()
-    }*.path as Set
-    if (actual != centralPublishedProjects) {
-        return ["Maven Central publication set drifted.\n" +
-                    "  allowlisted: ${centralPublishedProjects.sort()}\n" +
-                    "  publishing:  ${actual.sort()}\n" +
-                    "Update `centralPublishedProjects` in the root build.gradle only if the change is intentional."]
-    }
-    return []
-}
-
-def verifyCentralPublicationPolicy = tasks.register('verifyCentralPublicationPolicy') {
-    group = 'verification'
-    description = 'Fails if the set of modules publishing to Maven Central differs from the allowlist.'
-    doLast {
-        def problems = centralPublicationPolicyProblems()
-        if (problems) {
-            throw new GradleException(problems.join('\n\n'))
-        }
-        logger.lifecycle("Maven Central publication set matches the allowlist (${centralPublishedProjects.size()} projects).")
-    }
-}
-
-// `publishToSonatype` only exists with -Pnexus, and `publish` is per-project — match by name so
-// the gate attaches wherever it is present without forcing either to be created.
-gradle.projectsEvaluated {
-    allprojects { proj ->
-        // Hook the task TYPE first: every concrete publish task extends AbstractPublishToMaven,
-        // so `publishMavenJavaPublicationToSonatypeRepository` and friends are covered too.
-        // Matching only the aggregates by name left the policy bypassable by invoking a leaf
-        // task directly.
-        proj.tasks.withType(AbstractPublishToMaven).configureEach {
-            dependsOn verifyCentralPublicationPolicy
-        }
-        proj.tasks.matching { it.name in ['publishToSonatype', 'publish', 'publishToMavenLocal'] }.configureEach {
-            dependsOn verifyCentralPublicationPolicy
-        }
-    }
-}
-
 
 // Aggregate JaCoCo tasks and coverage gate wired in projectsEvaluated (outside any task
 // configuration action) so the task container is still mutable.

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ pluginManagement {
         id 'info.solidsoft.pitest'                      version settings['pitest-plugin.version']
         id 'io.gitlab.arturbosch.detekt'                version settings['detekt.version']
         id 'org.jlleitschuh.gradle.ktlint'              version settings['ktlint-gradle.version']
-        id 'org.octopusden.octopus-quality'             version '2.6.2'
+        id 'org.octopusden.octopus-quality'             version '2.7.0'
         id 'com.bmuschko.docker-java-application'       version settings['gradle-docker-plugin.version']
         id 'com.github.johnrengelman.shadow'            version '8.1.1'
         id 'org.octopusden.octopus.oc-template'         version settings['octopus-oc-template.version']


### PR DESCRIPTION
## What

Three changes that must land in the same commit:

- all **nine** `octopus-base` refs move to **v2.7.0** — six workflow files, four of the refs inside `merge-gate.yml` alone;
- the inline quality-plugin version in `settings.gradle:15` moves to **2.7.0** (this repository pins it there, not in `gradle.properties`);
- the hand-rolled `verifyCentralPublicationPolicy` (`build.gradle` 463–512) is **deleted** and replaced by `octopusQuality { publication { … } }`, which v2.7.0 provides.

## Why the halves cannot be split

The v2.7.0 plugin registers a task named exactly `verifyCentralPublicationPolicy`. Two tasks of one name fail configuration, so bumping first and deleting later would break the build in between.

## `centralPublishedProjects` stays — and that is the point

In this repository that list is not only the guard's expectation: it **gates publication creation**. That is true of one other repository in this rollout — `octopus-external-systems-client` (#144), which has the identical shape and the same tautology — and NOT true of employee-service, reporting-service, vcs-facade, dms-service or teamcity-automation, where each module declares its own unconditional `publishing {}` and the allowlist was only ever the comparison target.

```groovy
if (project.path in centralPublishedProjects) { ... }   // build.gradle:352
```

Which is also why the old guard could not work. It compared that same list against the projects that publish, so both sides always moved together and an edit to it could never be reported as drift. Only two narrower things stayed catchable — a publication created by some other route, and a path naming a project that does not exist, since `actual` can never contain one.

The declared coordinates are now separate data, so editing that list is detectable.

## Where the declared set came from

From the build, not by hand: declare an empty set, run the task, copy what it prints as `publishing:`. Two things a hand derivation would have got wrong, both real here:

- `:components-registry-automation` publishes under **its own group** (`…components.registry.automation`, not the repository's main `…infrastructure`) and carries `jar:all` on top of `zip:metarunners`;
- `:components-registry-service-client`, `:components-registry-service-light-client` and `:test-common` apply `java-test-fixtures` **per module**, so each carries an extra `jar:test-fixtures` that the root `subprojects {}` never mentions.

## Verification

Against the real v2.7.0 plugin resolved from Central:

- **GREEN** with the declared nine coordinates.
- **RED on the signature axis** — dropping `jar:test-fixtures` from `:test-common` fails the task. The old path-only guard could not detect this at all.
- **RED on the axis that matters** — removing `:test-common` from the *creation* list while leaving the declared set untouched **fails**. The same edit **passed** under the old guard, which printed `Maven Central publication set matches the allowlist (8 projects).` — the count silently down from 9, reported as a match. Reproduced on the merge-base `cc5f8e8e`, where the old guard is still present.
- Restored → GREEN again, so it is not red in both states.
- `check --dry-run` schedules the task exactly once, and **`check -x test` actually executes it** — 144 tasks, BUILD SUCCESSFUL — alongside `validatePublications` across every module.

## Not verified locally

Unit tests and a full `build`. This repository cannot be configured at all without `AUTH_SERVER_URL` / `AUTH_SERVER_REALM`, and `assemble` reaches docker-image tasks needing a registry. Both are pre-existing properties of the repository, not consequences of this diff — CI covers them.

`fat-jar-publication-allowlist: components-registry-automation` in `release.yml` is untouched and stays correct: it is the release-pipeline mechanism that lets that module's 19.75 MB `-all.jar` through, orthogonal to this build-time policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build, release, quality, security, and merge checks to the latest shared workflow version.
  * Updated the project’s quality tooling to improve consistency across automated checks.
  * Strengthened validation of published Maven artifacts and removed outdated publication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


