### PR TITLE
ci: gate PRs on spec-delta and spec-first

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## What
+
+<!-- One paragraph: what changes in service behaviour, and why. -->
+
+## Requirement / spec
+
+<!--
+This repo is spec-first (AGENTS.md § Technical Requirements Tracking rule 2):
+a behaviour change must update a numbered requirement or a spec document, and
+that spec must be committed *before* the implementation. The `spec / gate`
+check enforces both.
+
+Link the SYS-NNN / MIG-NNN / RES-NNN entry or spec this PR implements.
+-->
+
+Spec:
+
+- [ ] no-spec-impact — this PR changes no observable behaviour (refactor,
+      tests, build/CI, dependency bump, docs-only). Ticking this skips the
+      spec gate; leave it unticked otherwise.
+
+## Verification
+
+<!-- Commands run (./gradlew test, dbTest, qualityStatic), and manual checks. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,9 +15,14 @@ Link the SYS-NNN / MIG-NNN / RES-NNN entry or spec this PR implements.
 
 Spec:
 
-- [ ] no-spec-impact — this PR changes no observable behaviour (refactor,
-      tests, build/CI, dependency bump, docs-only). Ticking this skips the
-      spec gate; leave it unticked otherwise.
+<!--
+No requirement needed? Apply the `no-spec-impact` label — that, and only that,
+skips the gate. Use it for changes with no observable behaviour: refactors,
+tests, build/CI, dependency bumps, docs. A checkbox here does nothing; the
+opt-out is a label so that it is visible on the PR, recorded in the timeline,
+and can be applied by a reviewer rather than only self-declared.
+-->
+
 
 ## Verification
 

--- a/.github/scripts/spec-gate.sh
+++ b/.github/scripts/spec-gate.sh
@@ -46,6 +46,13 @@ select_paths() {
 behaviour_paths() { select_paths "$BEHAVIOR_RE" "$BEHAVIOR_EXCLUDE_RE"; }
 spec_paths() { select_paths "$SPEC_RE"; }
 
+# die <check> <detail> — every failure exit goes through here, so a gate that
+# cannot do its job reports that rather than falling through to success.
+die() {
+  printf 'spec-gate: FAILED (%s)\n\n%s\n' "$1" "$2" >&2
+  exit 1
+}
+
 # --- escape hatch ------------------------------------------------------------
 # The opt-out is a label, and only a label.
 #
@@ -98,20 +105,50 @@ fi
 # including binary edits, which --numstat reports as "-" and which arithmetic
 # would silently read as zero.
 #
-# Paths containing tabs or newlines are quoted by git in this mode, so splitting
-# on tabs is safe. Combined diffs (merge commits) use two-letter statuses such
-# as "AA"; those fall through to the single-path branch, which is correct.
+# Combined diffs (merge commits) use two-letter statuses such as "AA"; those
+# fall through to the single-path branch, which is correct.
 spec_candidate_paths() {
-  git "$@" --name-status -M | awk -F'\t' '
+  awk -F'\t' '
     $1 == "R100"                  { next }
     $1 ~ /^R[0-9]+$/ && NF >= 3   { print $3; next }
     NF >= 2                       { print $2 }
   '
 }
 
-changed=$(git diff --name-only "${BASE_REF}...HEAD")
+# git C-quotes any path holding a control character, so it reaches us as
+# "src/x\tY.tsx" — leading quote and all. Every path pattern in this gate is
+# anchored, so such a path matches nothing and would slip through as "no
+# behaviour change". Refuse to judge instead of judging wrongly.
+reject_quoted_paths() {
+  local paths="$1" context="$2" quoted
+  quoted=$(printf '%s\n' "$paths" | grep '^"' || true)
+  [[ -z "$quoted" ]] && return 0
+  die "unreadable path" "$(
+    printf 'git had to quote these %s paths, which means they contain control\n' "$context"
+    printf 'characters. This gate matches paths by anchored pattern and cannot\n'
+    printf 'classify a quoted path, so it will not pretend to have checked them:\n\n'
+    printf '%s\n' "$quoted" | sed 's/^/  /'
+    printf '\nRename them.\n'
+  )"
+}
+
+# Every git invocation is checked. An unresolvable base or a failed diff yields
+# an empty list, and an empty list reads as "nothing changed" — the gate would
+# report success precisely when it knows least. Note the `|| die` has to sit in
+# the parent shell: a die inside $( ) would only exit the subshell.
+git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null ||
+  die "configuration" "BASE_REF (${BASE_REF}) does not resolve to a commit.
+The workflow must fetch the base branch before running this gate."
+
+changed=$(git diff --name-only "${BASE_REF}...HEAD") ||
+  die "git" "git diff against ${BASE_REF} failed; refusing to rule on an incomplete diff."
+name_status=$(git diff --name-status -M "${BASE_REF}...HEAD") ||
+  die "git" "git diff --name-status against ${BASE_REF} failed; refusing to rule on an incomplete diff."
+
+reject_quoted_paths "$changed" "changed"
+
 changed_behaviour=$(printf '%s\n' "$changed" | behaviour_paths)
-changed_spec=$(spec_candidate_paths diff "${BASE_REF}...HEAD" | spec_paths)
+changed_spec=$(printf '%s\n' "$name_status" | spec_candidate_paths | spec_paths)
 
 if [[ -z "$changed_behaviour" ]]; then
   echo "spec-gate: no behaviour change in this PR — nothing to gate."
@@ -137,15 +174,26 @@ fi
 first_spec=-1
 first_behaviour=-1
 idx=0
+# Collect the revisions up front so a failure here is caught in the parent
+# shell; inside the loop's process substitution it would be invisible.
+revs=$(git rev-list --reverse "${BASE_REF}..HEAD") ||
+  die "git" "git rev-list ${BASE_REF}..HEAD failed; refusing to rule on an incomplete history."
+
 while read -r sha; do
   [[ -n "$sha" ]] || continue
-  files=$(git show --pretty=format: --name-only "$sha")
+
+  files=$(git show --pretty=format: --name-only "$sha") ||
+    die "git" "git show failed for ${sha}; refusing to rule on an incomplete history."
+  commit_status=$(git show --pretty=format: --name-status -M "$sha") ||
+    die "git" "git show --name-status failed for ${sha}; refusing to rule on an incomplete history."
+  reject_quoted_paths "$files" "committed"
+
   if [[ $first_behaviour -lt 0 ]] && [[ -n "$(printf '%s\n' "$files" | behaviour_paths)" ]]; then
     first_behaviour=$idx
     behaviour_sha=$sha
   fi
   if [[ $first_spec -lt 0 ]] &&
-    [[ -n "$(spec_candidate_paths show --pretty=format: "$sha" | spec_paths)" ]]; then
+    [[ -n "$(printf '%s\n' "$commit_status" | spec_candidate_paths | spec_paths)" ]]; then
     first_spec=$idx
     spec_sha=$sha
   fi
@@ -154,7 +202,9 @@ while read -r sha; do
   # and the commit is inert here, but a conflict resolution can carry real edits
   # that exist nowhere else on the branch — skipping merges would make that code
   # invisible to the ordering check and hand back a false pass.
-done < <(git rev-list --reverse "${BASE_REF}..HEAD")
+done <<EOF
+$revs
+EOF
 
 if [[ $first_behaviour -ge 0 && ( $first_spec -lt 0 || $first_spec -ge $first_behaviour ) ]]; then
   if [[ $first_spec -eq $first_behaviour ]]; then

--- a/.github/scripts/spec-gate.sh
+++ b/.github/scripts/spec-gate.sh
@@ -115,6 +115,13 @@ spec_candidate_paths() {
   '
 }
 
+# git_paths — every path-listing call goes through here so that quoting is
+# consistent and deliberate. `core.quotePath=false` stops git escaping
+# non-ASCII, which it does by default: `docs/features/архитектура.md` would
+# otherwise arrive quoted and be rejected below as unreadable. Control
+# characters are still quoted, which is exactly the set we want to refuse.
+git_paths() { git -c core.quotePath=false "$@"; }
+
 # git C-quotes any path holding a control character, so it reaches us as
 # "src/x\tY.tsx" — leading quote and all. Every path pattern in this gate is
 # anchored, so such a path matches nothing and would slip through as "no
@@ -140,9 +147,9 @@ git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null ||
   die "configuration" "BASE_REF (${BASE_REF}) does not resolve to a commit.
 The workflow must fetch the base branch before running this gate."
 
-changed=$(git diff --name-only "${BASE_REF}...HEAD") ||
+changed=$(git_paths diff --name-only "${BASE_REF}...HEAD") ||
   die "git" "git diff against ${BASE_REF} failed; refusing to rule on an incomplete diff."
-name_status=$(git diff --name-status -M "${BASE_REF}...HEAD") ||
+name_status=$(git_paths diff --name-status -M "${BASE_REF}...HEAD") ||
   die "git" "git diff --name-status against ${BASE_REF} failed; refusing to rule on an incomplete diff."
 
 reject_quoted_paths "$changed" "changed"
@@ -182,9 +189,9 @@ revs=$(git rev-list --reverse "${BASE_REF}..HEAD") ||
 while read -r sha; do
   [[ -n "$sha" ]] || continue
 
-  files=$(git show --pretty=format: --name-only "$sha") ||
+  files=$(git_paths show --pretty=format: --name-only "$sha") ||
     die "git" "git show failed for ${sha}; refusing to rule on an incomplete history."
-  commit_status=$(git show --pretty=format: --name-status -M "$sha") ||
+  commit_status=$(git_paths show --pretty=format: --name-status -M "$sha") ||
     die "git" "git show --name-status failed for ${sha}; refusing to rule on an incomplete history."
   reject_quoted_paths "$files" "committed"
 

--- a/.github/scripts/spec-gate.sh
+++ b/.github/scripts/spec-gate.sh
@@ -93,48 +93,62 @@ fi
 # spec a PR touched has anything to do with the behaviour it changed. That last
 # mile is the reviewer's job; the gate only guarantees there is something to
 # review.
-#
-# Ask git for machine-readable status rather than parsing --numstat, whose
-# rename notation ("docs/{a.md => b.md}", "{docs => openspec}/a.md") is display
-# text: an ordinary path that merely contains " => " is indistinguishable from
-# it, and rewriting such a path can forge a spec that was never touched. Here
-# the rename destination is its own field, so nothing has to be inferred.
-#
-# A pure rename (R100 — identical content) is not a spec change; renumbering an
-# unrelated ADR must not stand in for writing one. Any other status counts,
-# including binary edits, which --numstat reports as "-" and which arithmetic
-# would silently read as zero.
-#
-# Combined diffs (merge commits) use two-letter statuses such as "AA"; those
-# fall through to the single-path branch, which is correct.
-spec_candidate_paths() {
-  awk -F'\t' '
-    $1 == "R100"                  { next }
-    $1 ~ /^R[0-9]+$/ && NF >= 3   { print $3; next }
-    NF >= 2                       { print $2 }
-  '
-}
 
-# git_paths — every path-listing call goes through here so that quoting is
-# consistent and deliberate. `core.quotePath=false` stops git escaping
-# non-ASCII, which it does by default: `docs/features/архитектура.md` would
-# otherwise arrive quoted and be rejected below as unreadable. Control
-# characters are still quoted, which is exactly the set we want to refuse.
+# --- reading paths from git --------------------------------------------------
+# Paths are read NUL-delimited. git's default output C-quotes a path not only
+# for control characters but also for a quote or a backslash in the name, and
+# for non-ASCII unless core.quotePath is off — so "is it quoted" says nothing
+# useful about whether the name is legitimate. Telling those cases apart means
+# decoding git's escape syntax, and a decoder that is subtly wrong rejects
+# ordinary filenames. `-z` removes the question: the bytes arrive as they are.
+#
+# `core.quotePath=false` stays for the diagnostics, which are read by humans.
 git_paths() { git -c core.quotePath=false "$@"; }
 
-# git C-quotes any path holding a control character, so it reaches us as
-# "src/x\tY.tsx" — leading quote and all. Every path pattern in this gate is
-# anchored, so such a path matches nothing and would slip through as "no
-# behaviour change". Refuse to judge instead of judging wrongly.
-reject_quoted_paths() {
-  local paths="$1" context="$2" quoted
-  quoted=$(printf '%s\n' "$paths" | grep '^"' || true)
-  [[ -z "$quoted" ]] && return 0
+# A newline or tab in a path still has to be refused, because every filter here
+# is line-based and would silently mis-split such a path. Those go to BAD and
+# stop the gate rather than being dropped.
+#
+# PATHS and BAD are globals: the readers run in the parent shell so that a die
+# actually ends the run, which it would not do from inside $( ).
+classify_path() {
+  case $1 in
+    *$'\n'* | *$'\t'* | *$'\r'*) BAD+="$1"$'\n' ;;
+    *) PATHS+="$1"$'\n' ;;
+  esac
+}
+
+read_nul_paths() {
+  local p
+  PATHS='' BAD=''
+  while IFS= read -r -d '' p; do classify_path "$p"; done < "$1"
+}
+
+# read_nul_status — `--name-status -M`, applying the rename rules. R100 means
+# identical content, so renumbering an unrelated ADR is not a spec change; any
+# other rename counts at its destination, which is the third field. Combined
+# diffs (merge commits) use two-letter statuses such as "AA" and carry a single
+# path; those take the non-rename branch, which is correct.
+read_nul_status() {
+  local status p dest
+  PATHS='' BAD=''
+  while IFS= read -r -d '' status; do
+    IFS= read -r -d '' p || break
+    if [[ $status == R[0-9]* ]]; then
+      IFS= read -r -d '' dest || break
+      [[ $status == R100 ]] && continue
+      p=$dest
+    fi
+    classify_path "$p"
+  done < "$1"
+}
+
+reject_bad_paths() {
+  [[ -z "$BAD" ]] && return 0
   die "unreadable path" "$(
-    printf 'git had to quote these %s paths, which means they contain control\n' "$context"
-    printf 'characters. This gate matches paths by anchored pattern and cannot\n'
-    printf 'classify a quoted path, so it will not pretend to have checked them:\n\n'
-    printf '%s\n' "$quoted" | sed 's/^/  /'
+    printf 'These %s paths contain a newline or a tab. Every path filter in this\n' "$1"
+    printf 'gate is line-based, so it will not pretend to have classified them:\n\n'
+    printf '%s' "$BAD" | sed 's/^/  /'
     printf '\nRename them.\n'
   )"
 }
@@ -147,15 +161,22 @@ git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null ||
   die "configuration" "BASE_REF (${BASE_REF}) does not resolve to a commit.
 The workflow must fetch the base branch before running this gate."
 
-changed=$(git_paths diff --name-only "${BASE_REF}...HEAD") ||
+# NUL-delimited output goes through files rather than $( ), which drops NUL
+# bytes — and via a file the exit status is still checked in the parent shell.
+tmpdir=$(mktemp -d) || die "environment" "cannot create a temporary directory."
+trap 'rm -rf "$tmpdir"' EXIT
+
+git_paths diff -z --name-only "${BASE_REF}...HEAD" > "$tmpdir/changed" ||
   die "git" "git diff against ${BASE_REF} failed; refusing to rule on an incomplete diff."
-name_status=$(git_paths diff --name-status -M "${BASE_REF}...HEAD") ||
+read_nul_paths "$tmpdir/changed"
+reject_bad_paths "changed"
+changed_behaviour=$(printf '%s' "$PATHS" | behaviour_paths)
+
+git_paths diff -z --name-status -M "${BASE_REF}...HEAD" > "$tmpdir/status" ||
   die "git" "git diff --name-status against ${BASE_REF} failed; refusing to rule on an incomplete diff."
-
-reject_quoted_paths "$changed" "changed"
-
-changed_behaviour=$(printf '%s\n' "$changed" | behaviour_paths)
-changed_spec=$(printf '%s\n' "$name_status" | spec_candidate_paths | spec_paths)
+read_nul_status "$tmpdir/status"
+reject_bad_paths "changed"
+changed_spec=$(printf '%s' "$PATHS" | spec_paths)
 
 if [[ -z "$changed_behaviour" ]]; then
   echo "spec-gate: no behaviour change in this PR — nothing to gate."
@@ -189,18 +210,23 @@ revs=$(git rev-list --reverse "${BASE_REF}..HEAD") ||
 while read -r sha; do
   [[ -n "$sha" ]] || continue
 
-  files=$(git_paths show --pretty=format: --name-only "$sha") ||
+  git_paths show --pretty=format: -z --name-only "$sha" > "$tmpdir/c-files" ||
     die "git" "git show failed for ${sha}; refusing to rule on an incomplete history."
-  commit_status=$(git_paths show --pretty=format: --name-status -M "$sha") ||
-    die "git" "git show --name-status failed for ${sha}; refusing to rule on an incomplete history."
-  reject_quoted_paths "$files" "committed"
+  read_nul_paths "$tmpdir/c-files"
+  reject_bad_paths "committed"
+  commit_files="$PATHS"
 
-  if [[ $first_behaviour -lt 0 ]] && [[ -n "$(printf '%s\n' "$files" | behaviour_paths)" ]]; then
+  git_paths show --pretty=format: -z --name-status -M "$sha" > "$tmpdir/c-status" ||
+    die "git" "git show --name-status failed for ${sha}; refusing to rule on an incomplete history."
+  read_nul_status "$tmpdir/c-status"
+  reject_bad_paths "committed"
+
+  if [[ $first_behaviour -lt 0 ]] && [[ -n "$(printf '%s' "$commit_files" | behaviour_paths)" ]]; then
     first_behaviour=$idx
     behaviour_sha=$sha
   fi
   if [[ $first_spec -lt 0 ]] &&
-    [[ -n "$(printf '%s\n' "$commit_status" | spec_candidate_paths | spec_paths)" ]]; then
+    [[ -n "$(printf '%s' "$PATHS" | spec_paths)" ]]; then
     first_spec=$idx
     spec_sha=$sha
   fi

--- a/.github/scripts/spec-gate.sh
+++ b/.github/scripts/spec-gate.sh
@@ -67,10 +67,12 @@ spec_paths() { select_paths "$SPEC_RE"; }
 # would accept a single label whose name contains commas. Both are different
 # labels that merely contain the token.
 #
-# If jq is missing or the value is not an array the comparison simply fails,
-# leaving the gate enforced — the safe direction.
-if [[ -n "${PR_LABELS//[[:space:]]/}" ]] &&
-  printf '%s' "$PR_LABELS" | jq -e --arg e "$ESCAPE" '
+# If jq is missing, the input is empty, or the value is not an array, the
+# comparison simply fails and the gate stays enforced — the safe direction. jq
+# already exits non-zero on empty, blank and `[]` input, so no guard precedes
+# it: the obvious `[[ -n "${PR_LABELS//[[:space:]]/}" ]]` is quadratic in bash
+# 3.2, where 800 labels took 15 seconds of spinning CPU.
+if printf '%s' "$PR_LABELS" | jq -e --arg e "$ESCAPE" '
     type == "array" and any(.[]; type == "string" and (ascii_downcase == ($e | ascii_downcase)))
   ' >/dev/null 2>&1; then
   echo "spec-gate: skipped — PR carries the ${ESCAPE} label."

--- a/.github/scripts/spec-gate.sh
+++ b/.github/scripts/spec-gate.sh
@@ -12,7 +12,7 @@
 #               where the spec is present but was written afterwards to
 #               describe whatever got built — a record, not an agreement.
 #
-# Both are skipped when the PR is explicitly marked no-spec-impact.
+# Both are skipped when the PR carries the no-spec-impact label.
 #
 # Configuration is entirely by environment so the script stays byte-identical
 # across repositories; only the workflow that calls it differs.
@@ -21,7 +21,6 @@
 #   BEHAVIOR_RE           ERE selecting behaviour-change paths     (required)
 #   BEHAVIOR_EXCLUDE_RE   ERE subtracted from the above            (optional)
 #   SPEC_RE               ERE selecting spec paths                 (required)
-#   PR_BODY               pull request body, for the escape hatch  (optional)
 #   PR_LABELS             pull request labels, a JSON array        (optional)
 #   ESCAPE                escape marker, default no-spec-impact    (optional)
 #
@@ -34,7 +33,6 @@ BASE_REF="${BASE_REF:?BASE_REF is required}"
 BEHAVIOR_RE="${BEHAVIOR_RE:?BEHAVIOR_RE is required}"
 SPEC_RE="${SPEC_RE:?SPEC_RE is required}"
 BEHAVIOR_EXCLUDE_RE="${BEHAVIOR_EXCLUDE_RE:-}"
-PR_BODY="${PR_BODY:-}"
 PR_LABELS="${PR_LABELS:-}"
 ESCAPE="${ESCAPE:-no-spec-impact}"
 
@@ -49,90 +47,44 @@ behaviour_paths() { select_paths "$BEHAVIOR_RE" "$BEHAVIOR_EXCLUDE_RE"; }
 spec_paths() { select_paths "$SPEC_RE"; }
 
 # --- escape hatch ------------------------------------------------------------
-# Only an explicitly TICKED checkbox opts out. Searching the body for the bare
-# token would be catastrophic rather than merely loose: the PR template puts the
-# phrase in every body, and any prose mentioning it — including prose saying it
-# does NOT apply — would silently disable the gate for that PR.
+# The opt-out is a label, and only a label.
 #
-# A ticked box that is quoted as an example or commented out is not consent, so
-# fenced code blocks and HTML comments are removed before the body is searched.
-# What survives is filtered to ticked-box lines (any bullet, exactly one
-# non-space character between the brackets, so "[ ]" and "[  ]" are out), and
-# the token must then appear as a whole word on such a line.
-strip_markup() {
-  awk '
-    {
-      line = $0
-      if (in_comment) {
-        p = index(line, "-->")
-        if (p == 0) next
-        line = substr(line, p + 3)
-        in_comment = 0
-      }
-      while ((s = index(line, "<!--")) > 0) {
-        rest = substr(line, s + 4)
-        e = index(rest, "-->")
-        if (e == 0) { line = substr(line, 1, s - 1); in_comment = 1; break }
-        line = substr(line, 1, s - 1) substr(rest, e + 3)
-      }
-      if (line ~ /^[[:space:]]*(```|~~~)/) { in_fence = !in_fence; next }
-      if (in_fence) next
-      # An indented line is a code block only outside a list. Inside one it is
-      # a nested item, and nesting a box under a parent bullet ("- Spec:" then
-      # an indented box) is ordinary markdown that must still count. Outside a
-      # list, four spaces or a tab is what markdown renders as a literal block,
-      # so a box written there is being shown rather than ticked.
-      # Up to three leading spaces still reads as a top-level list item; four
-      # is where markdown switches to code. Written as optional spaces rather
-      # than an interval because not every awk accepts either an interval or
-      # an empty alternative.
-      if (line ~ /^ ? ? ?([-*+]|[0-9]+\.)[ \t]/) {
-        in_list = 1
-      } else if (line ~ /^(    |\t)/) {
-        if (!in_list) next
-      } else if (line !~ /^[[:space:]]*$/) {
-        in_list = 0
-      }
-      print line
-    }
-  '
-}
-
-ticked_box='^[[:space:]]*[-*][[:space:]]*\[[^][:space:]]\]'
-token="(^|[^A-Za-z0-9_-])${ESCAPE}([^A-Za-z0-9_-]|$)"
-
-body_opt_out=$(printf '%s\n' "$PR_BODY" | strip_markup | grep -iE "$ticked_box" \
-  | grep -qiE "$token" && echo yes || echo no)
-
-# Labels arrive as a JSON array and are parsed as one. The marker must be a
-# label in its own right: a word-boundary match would accept the namespaced
-# "area:no-spec-impact", and splitting on punctuation would accept a single
-# label whose name happens to contain commas. Both are different labels that
-# merely contain the token.
+# It also used to read a ticked checkbox out of the PR body. That cost five
+# review rounds and seven false opt-outs: prose merely mentioning the marker,
+# unticked boxes, boxes inside code fences, boxes inside HTML comments, boxes in
+# indented blocks, and finally a list-versus-code state machine that went stale
+# across blank lines and fences. Each fix opened the next hole, because deciding
+# whether a checkbox is "really ticked" means deciding how the body renders, and
+# that is a markdown parser. This script is not going to be one.
+#
+# A label carries no such ambiguity. It is structured data, it is visible in the
+# PR header and in list views, applying it is a deliberate act recorded in the
+# timeline, and a reviewer can apply it rather than the author self-declaring.
+# Switching the gate off should look like that.
+#
+# The marker must be a label in its own right: a word-boundary match would
+# accept the namespaced "area:no-spec-impact", and splitting on punctuation
+# would accept a single label whose name contains commas. Both are different
+# labels that merely contain the token.
 #
 # If jq is missing or the value is not an array the comparison simply fails,
 # leaving the gate enforced — the safe direction.
-label_opt_out=no
 if [[ -n "${PR_LABELS//[[:space:]]/}" ]] &&
   printf '%s' "$PR_LABELS" | jq -e --arg e "$ESCAPE" '
     type == "array" and any(.[]; type == "string" and (ascii_downcase == ($e | ascii_downcase)))
   ' >/dev/null 2>&1; then
-  label_opt_out=yes
-fi
-
-if [[ "$body_opt_out" == yes || "$label_opt_out" == yes ]]; then
-  echo "spec-gate: skipped — PR is marked ${ESCAPE}."
+  echo "spec-gate: skipped — PR carries the ${ESCAPE} label."
   exit 0
 fi
 
 # --- what this PR changes ----------------------------------------------------
-# Behaviour counts a path however it appears. A spec counts only if its content
-# actually changed: `--numstat` reports 0/0 for a pure rename, so renumbering an
-# unrelated ADR must not stand in for writing a spec.
+# Behaviour counts a path however it appears; a spec has to have really changed.
 #
-# This is still path-based, and path-based checking cannot tell whether the spec
-# a PR touched has anything to do with the behaviour it changed. That last mile
-# is the reviewer's job; the gate only guarantees there is something to review.
+# Either way this is path-based, and path-based checking cannot tell whether the
+# spec a PR touched has anything to do with the behaviour it changed. That last
+# mile is the reviewer's job; the gate only guarantees there is something to
+# review.
+#
 # Ask git for machine-readable status rather than parsing --numstat, whose
 # rename notation ("docs/{a.md => b.md}", "{docs => openspec}/a.md") is display
 # text: an ordinary path that merely contains " => " is indistinguishable from

--- a/.github/scripts/spec-gate.sh
+++ b/.github/scripts/spec-gate.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# spec-gate.sh — enforces that a behaviour change carries a spec, and that the
+# spec was agreed *before* the code was written.
+#
+# Two independent checks, both scoped to the commits this PR adds:
+#
+#   spec-delta  A PR that changes behaviour must also change a spec document.
+#               Catches the drift where code moves and the doc stays behind.
+#
+#   spec-first  The first commit touching a spec must come strictly before the
+#               first commit touching behaviour. Catches the weaker failure
+#               where the spec is present but was written afterwards to
+#               describe whatever got built — a record, not an agreement.
+#
+# Both are skipped when the PR is explicitly marked no-spec-impact.
+#
+# Configuration is entirely by environment so the script stays byte-identical
+# across repositories; only the workflow that calls it differs.
+#
+#   BASE_REF              base to diff against, e.g. origin/main   (required)
+#   BEHAVIOR_RE           ERE selecting behaviour-change paths     (required)
+#   BEHAVIOR_EXCLUDE_RE   ERE subtracted from the above            (optional)
+#   SPEC_RE               ERE selecting spec paths                 (required)
+#   PR_BODY               pull request body, for the escape hatch  (optional)
+#   PR_LABELS             pull request labels, a JSON array        (optional)
+#   ESCAPE                escape marker, default no-spec-impact    (optional)
+#
+# Requires git, awk and jq. All three are preinstalled on GitHub-hosted runners.
+# If jq is absent the label opt-out simply never fires and the gate stays
+# enforced, which is the safe direction to fail in.
+set -uo pipefail
+
+BASE_REF="${BASE_REF:?BASE_REF is required}"
+BEHAVIOR_RE="${BEHAVIOR_RE:?BEHAVIOR_RE is required}"
+SPEC_RE="${SPEC_RE:?SPEC_RE is required}"
+BEHAVIOR_EXCLUDE_RE="${BEHAVIOR_EXCLUDE_RE:-}"
+PR_BODY="${PR_BODY:-}"
+PR_LABELS="${PR_LABELS:-}"
+ESCAPE="${ESCAPE:-no-spec-impact}"
+
+# select <include-re> [exclude-re] — filter a newline list on stdin, dropping
+# blanks so an empty result stays genuinely empty rather than one blank line.
+select_paths() {
+  local include="$1" exclude="${2:-}"
+  grep -E "$include" | { if [[ -n "$exclude" ]]; then grep -vE "$exclude"; else cat; fi; } | grep -v '^$'
+}
+
+behaviour_paths() { select_paths "$BEHAVIOR_RE" "$BEHAVIOR_EXCLUDE_RE"; }
+spec_paths() { select_paths "$SPEC_RE"; }
+
+# --- escape hatch ------------------------------------------------------------
+# Only an explicitly TICKED checkbox opts out. Searching the body for the bare
+# token would be catastrophic rather than merely loose: the PR template puts the
+# phrase in every body, and any prose mentioning it — including prose saying it
+# does NOT apply — would silently disable the gate for that PR.
+#
+# A ticked box that is quoted as an example or commented out is not consent, so
+# fenced code blocks and HTML comments are removed before the body is searched.
+# What survives is filtered to ticked-box lines (any bullet, exactly one
+# non-space character between the brackets, so "[ ]" and "[  ]" are out), and
+# the token must then appear as a whole word on such a line.
+strip_markup() {
+  awk '
+    {
+      line = $0
+      if (in_comment) {
+        p = index(line, "-->")
+        if (p == 0) next
+        line = substr(line, p + 3)
+        in_comment = 0
+      }
+      while ((s = index(line, "<!--")) > 0) {
+        rest = substr(line, s + 4)
+        e = index(rest, "-->")
+        if (e == 0) { line = substr(line, 1, s - 1); in_comment = 1; break }
+        line = substr(line, 1, s - 1) substr(rest, e + 3)
+      }
+      if (line ~ /^[[:space:]]*(```|~~~)/) { in_fence = !in_fence; next }
+      if (in_fence) next
+      # An indented line is a code block only outside a list. Inside one it is
+      # a nested item, and nesting a box under a parent bullet ("- Spec:" then
+      # an indented box) is ordinary markdown that must still count. Outside a
+      # list, four spaces or a tab is what markdown renders as a literal block,
+      # so a box written there is being shown rather than ticked.
+      # Up to three leading spaces still reads as a top-level list item; four
+      # is where markdown switches to code. Written as optional spaces rather
+      # than an interval because not every awk accepts either an interval or
+      # an empty alternative.
+      if (line ~ /^ ? ? ?([-*+]|[0-9]+\.)[ \t]/) {
+        in_list = 1
+      } else if (line ~ /^(    |\t)/) {
+        if (!in_list) next
+      } else if (line !~ /^[[:space:]]*$/) {
+        in_list = 0
+      }
+      print line
+    }
+  '
+}
+
+ticked_box='^[[:space:]]*[-*][[:space:]]*\[[^][:space:]]\]'
+token="(^|[^A-Za-z0-9_-])${ESCAPE}([^A-Za-z0-9_-]|$)"
+
+body_opt_out=$(printf '%s\n' "$PR_BODY" | strip_markup | grep -iE "$ticked_box" \
+  | grep -qiE "$token" && echo yes || echo no)
+
+# Labels arrive as a JSON array and are parsed as one. The marker must be a
+# label in its own right: a word-boundary match would accept the namespaced
+# "area:no-spec-impact", and splitting on punctuation would accept a single
+# label whose name happens to contain commas. Both are different labels that
+# merely contain the token.
+#
+# If jq is missing or the value is not an array the comparison simply fails,
+# leaving the gate enforced — the safe direction.
+label_opt_out=no
+if [[ -n "${PR_LABELS//[[:space:]]/}" ]] &&
+  printf '%s' "$PR_LABELS" | jq -e --arg e "$ESCAPE" '
+    type == "array" and any(.[]; type == "string" and (ascii_downcase == ($e | ascii_downcase)))
+  ' >/dev/null 2>&1; then
+  label_opt_out=yes
+fi
+
+if [[ "$body_opt_out" == yes || "$label_opt_out" == yes ]]; then
+  echo "spec-gate: skipped — PR is marked ${ESCAPE}."
+  exit 0
+fi
+
+# --- what this PR changes ----------------------------------------------------
+# Behaviour counts a path however it appears. A spec counts only if its content
+# actually changed: `--numstat` reports 0/0 for a pure rename, so renumbering an
+# unrelated ADR must not stand in for writing a spec.
+#
+# This is still path-based, and path-based checking cannot tell whether the spec
+# a PR touched has anything to do with the behaviour it changed. That last mile
+# is the reviewer's job; the gate only guarantees there is something to review.
+# Ask git for machine-readable status rather than parsing --numstat, whose
+# rename notation ("docs/{a.md => b.md}", "{docs => openspec}/a.md") is display
+# text: an ordinary path that merely contains " => " is indistinguishable from
+# it, and rewriting such a path can forge a spec that was never touched. Here
+# the rename destination is its own field, so nothing has to be inferred.
+#
+# A pure rename (R100 — identical content) is not a spec change; renumbering an
+# unrelated ADR must not stand in for writing one. Any other status counts,
+# including binary edits, which --numstat reports as "-" and which arithmetic
+# would silently read as zero.
+#
+# Paths containing tabs or newlines are quoted by git in this mode, so splitting
+# on tabs is safe. Combined diffs (merge commits) use two-letter statuses such
+# as "AA"; those fall through to the single-path branch, which is correct.
+spec_candidate_paths() {
+  git "$@" --name-status -M | awk -F'\t' '
+    $1 == "R100"                  { next }
+    $1 ~ /^R[0-9]+$/ && NF >= 3   { print $3; next }
+    NF >= 2                       { print $2 }
+  '
+}
+
+changed=$(git diff --name-only "${BASE_REF}...HEAD")
+changed_behaviour=$(printf '%s\n' "$changed" | behaviour_paths)
+changed_spec=$(spec_candidate_paths diff "${BASE_REF}...HEAD" | spec_paths)
+
+if [[ -z "$changed_behaviour" ]]; then
+  echo "spec-gate: no behaviour change in this PR — nothing to gate."
+  exit 0
+fi
+
+# --- check 1: spec-delta -----------------------------------------------------
+if [[ -z "$changed_spec" ]]; then
+  cat >&2 <<EOF
+spec-gate: FAILED (spec-delta)
+
+This PR changes behaviour but updates no specification:
+
+$(printf '%s\n' "$changed_behaviour" | sed 's/^/  /')
+
+Update the document that describes how this behaves, or mark the PR
+${ESCAPE} if it genuinely changes no observable behaviour.
+EOF
+  exit 1
+fi
+
+# --- check 2: spec-first -----------------------------------------------------
+first_spec=-1
+first_behaviour=-1
+idx=0
+while read -r sha; do
+  [[ -n "$sha" ]] || continue
+  files=$(git show --pretty=format: --name-only "$sha")
+  if [[ $first_behaviour -lt 0 ]] && [[ -n "$(printf '%s\n' "$files" | behaviour_paths)" ]]; then
+    first_behaviour=$idx
+    behaviour_sha=$sha
+  fi
+  if [[ $first_spec -lt 0 ]] &&
+    [[ -n "$(spec_candidate_paths show --pretty=format: "$sha" | spec_paths)" ]]; then
+    first_spec=$idx
+    spec_sha=$sha
+  fi
+  idx=$((idx + 1))
+  # Merge commits are NOT skipped. For a clean merge `git show` reports no files
+  # and the commit is inert here, but a conflict resolution can carry real edits
+  # that exist nowhere else on the branch — skipping merges would make that code
+  # invisible to the ordering check and hand back a false pass.
+done < <(git rev-list --reverse "${BASE_REF}..HEAD")
+
+if [[ $first_behaviour -ge 0 && ( $first_spec -lt 0 || $first_spec -ge $first_behaviour ) ]]; then
+  if [[ $first_spec -eq $first_behaviour ]]; then
+    reason="the spec and the implementation landed in the same commit ($(git log -1 --format='%h %s' "$behaviour_sha"))"
+  else
+    reason="the implementation ($(git log -1 --format='%h %s' "$behaviour_sha")) came before the spec${spec_sha:+ ($(git log -1 --format='%h %s' "${spec_sha}"))}"
+  fi
+  cat >&2 <<EOF
+spec-gate: FAILED (spec-first)
+
+The specification must be committed, and agreed, before the implementation —
+but $reason.
+
+Split the change: commit the spec on its own first, then the code. If you
+squashed locally, re-split before pushing; GitHub's squash-on-merge is fine,
+this gate reads the branch commits, not the merge result.
+EOF
+  exit 1
+fi
+
+echo "spec-gate: ok — spec committed before implementation."

--- a/.github/scripts/spec-gate.test.sh
+++ b/.github/scripts/spec-gate.test.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+# Tests for spec-gate.sh. Builds throwaway git repos per case so the commit
+# ordering the gate inspects is real history, not a mock.
+#
+# Run: bash .github/scripts/spec-gate.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$SCRIPT_DIR/spec-gate.sh"
+
+PASS=0
+FAIL=0
+
+# Keep these in exact parity with the spec-gate job env in each repo's
+# merge-gate.yml. They are duplicated there because the script is configured
+# by environment; this suite is what stops the two copies drifting.
+PORTAL_BEHAVIOR_RE='^(src/main/(kotlin|resources)/|frontend/(src/|vite\.config\.ts$|index\.html$))'
+PORTAL_BEHAVIOR_EXCLUDE_RE='(\.test\.(ts|tsx)$|^frontend/src/lib/api/(schema\.d\.ts|v4\.json)$|^frontend/src/test(-fixtures)?/)'
+PORTAL_SPEC_RE='^(docs/features/|docs/architecture\.md$|docs/adr/|openspec/)'
+
+CRS_BEHAVIOR_RE='^([^/]+/src/main/(kotlin|java|resources)/|components-registry-automation/data/)'
+CRS_BEHAVIOR_EXCLUDE_RE='(/(application|bootstrap)-(test|ft-db)\.yml$|/openapi/v4\.json$)'
+CRS_SPEC_RE='^(docs/registry/(prd|technical-design|api-changelog)\.md$|docs/registry/.*-spec\.md$|docs/registry/requirements-.*\.md$|docs/registry/adr/|docs/features/|openspec/)'
+
+# use_crs — switch the current case to the CRS-shaped configuration.
+use_crs() {
+  export BEHAVIOR_RE="$CRS_BEHAVIOR_RE"
+  export BEHAVIOR_EXCLUDE_RE="$CRS_BEHAVIOR_EXCLUDE_RE"
+  export SPEC_RE="$CRS_SPEC_RE"
+}
+
+export BASE_REF='main'
+
+# run_case — temp repo with one commit on main, cwd moved into it, env reset
+# to the Portal-shaped config.
+run_case() {
+  local dir
+  dir="$(mktemp -d)"
+  cd "$dir" || exit 1
+  git init -q -b main .
+  git config user.email t@example.com
+  git config user.name test
+  mkdir -p docs
+  echo seed > docs/seed.md
+  git add -A && git commit -qm seed
+  git checkout -qb feature
+
+  unset PR_BODY PR_LABELS
+  export BEHAVIOR_RE="$PORTAL_BEHAVIOR_RE"
+  export BEHAVIOR_EXCLUDE_RE="$PORTAL_BEHAVIOR_EXCLUDE_RE"
+  export SPEC_RE="$PORTAL_SPEC_RE"
+}
+
+# commit <message> <path>... — write each path and commit them together.
+commit() {
+  local msg="$1"; shift
+  local p
+  for p in "$@"; do
+    mkdir -p "$(dirname "$p")"
+    echo "change $RANDOM" >> "$p"
+  done
+  git add -A && git commit -qm "$msg"
+}
+
+# expect <expected-rc> <case name>
+expect() {
+  local want="$1" name="$2" out rc
+  out="$("$GATE" 2>&1)"; rc=$?
+  if [[ "$rc" == "$want" ]]; then
+    PASS=$((PASS + 1))
+    printf 'ok   %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL %s (want rc=%s, got rc=%s)\n' "$name" "$want" "$rc"
+    printf '%s\n' "$out" | sed 's/^/     | /'
+  fi
+}
+
+# 1. Docs-only PR: nothing to gate.
+run_case
+commit "docs" docs/features/foo.md
+expect 0 "docs-only PR passes"
+
+# 2. The happy path the rule exists for: spec lands, then implementation.
+run_case
+commit "spec" docs/features/foo.md
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "spec commit before code commit passes"
+
+# 3. Spec and code in one commit — written together, not agreed first.
+run_case
+commit "both" docs/features/foo.md frontend/src/pages/Foo.tsx
+expect 1 "spec and code in the same commit fails spec-first"
+
+# 4. The failure mode we are actually chasing: spec written at the end.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+commit "spec" docs/features/foo.md
+expect 1 "code commit before spec commit fails spec-first"
+
+# 5. No spec at all.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+expect 1 "behaviour change with no spec delta fails spec-delta"
+
+# 6. Escape hatch via PR body.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'Refactor only.\n- [x] no-spec-impact\n'
+expect 0 "no-spec-impact in PR body skips both gates"
+
+# 7. Escape hatch via label.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_LABELS='["dependencies","no-spec-impact"]'
+expect 0 "no-spec-impact label skips both gates"
+
+# 8. Generated files are not behaviour.
+run_case
+commit "regen" frontend/src/lib/api/schema.d.ts frontend/src/lib/api/v4.json
+expect 0 "generated api types alone are not a behaviour change"
+
+# 9. Tests are not behaviour.
+run_case
+commit "tests" frontend/src/pages/Foo.test.tsx
+expect 0 "test-only change is not a behaviour change"
+
+# 10. Backend behaviour is gated too.
+run_case
+commit "impl" src/main/kotlin/Foo.kt
+expect 1 "backend behaviour change with no spec delta fails"
+
+# 11. Merge commits from the base branch must not be read as code commits.
+run_case
+commit "spec" docs/features/foo.md
+git checkout -q main
+commit "base moves" docs/other.md
+git checkout -q feature
+git merge -q --no-edit main
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "merge commit in range does not break spec-first"
+
+# 11b. BFF config is behaviour: gateway routes, CSRF and security live in
+# src/main/resources, not in Kotlin.
+run_case
+commit "route change" src/main/resources/application.yaml
+expect 1 "portal BFF configuration is gated"
+
+# 12. CRS-shaped config: module-prefixed source roots.
+run_case
+use_crs
+commit "impl" components-registry-service-server/src/main/kotlin/Foo.kt
+expect 1 "CRS module source root is gated"
+
+# 13. Same CRS config, spec-first satisfied by a requirements doc.
+run_case
+use_crs
+commit "spec" docs/registry/requirements-common.md
+commit "impl" components-registry-service-server/src/main/kotlin/Foo.kt
+expect 0 "CRS requirements doc before code passes"
+
+# 14. CRS has Java modules alongside Kotlin ones.
+run_case
+use_crs
+commit "impl" components-registry-api/src/main/java/Foo.java
+expect 1 "CRS java module source root is gated"
+
+# 15. A Flyway migration changes observable schema, so it is behaviour.
+run_case
+use_crs
+commit "migration" components-registry-service-server/src/main/resources/db/migration/V99__foo.sql
+expect 1 "CRS flyway migration is gated"
+
+# 16. Service configuration is behaviour: the role-to-permission mapping that
+# decides who may edit what lives in application.yml, not in Kotlin.
+run_case
+use_crs
+commit "permissions" components-registry-service-server/src/main/resources/application.yml
+expect 1 "CRS service configuration is gated"
+
+# 17. CRS spec-first satisfied by an ADR.
+run_case
+use_crs
+commit "adr" docs/registry/adr/020-foo.md
+commit "impl" components-registry-service-server/src/main/kotlin/Foo.kt
+expect 0 "CRS ADR before code passes"
+
+# 18. The SPA build config ships real decisions — the production base path and
+# the deliberate absence of sourcemaps (dist/assets is served permitAll).
+run_case
+commit "build config" frontend/vite.config.ts
+expect 1 "portal vite config is gated"
+
+# 19. index.html ships on every page load.
+run_case
+commit "shell" frontend/index.html
+expect 1 "portal index.html is gated"
+
+# 20. Test scaffolding under frontend/src is not behaviour. Without this the
+# gate demands a spec for editing a contract fixture.
+run_case
+commit "fixtures" frontend/src/test-fixtures/portal-info.contract.json frontend/src/test/setup.ts
+expect 0 "portal test fixtures and setup are not behaviour"
+
+# 21. CRS test-profile configuration lives in src/main/resources but only
+# configures the test and functional-test profiles.
+run_case
+use_crs
+commit "test profile" components-registry-service-server/src/main/resources/application-test.yml
+expect 0 "CRS test-profile config is not behaviour"
+
+run_case
+use_crs
+commit "ft profile" components-registry-service-server/src/main/resources/bootstrap-ft-db.yml
+expect 0 "CRS functional-test bootstrap is not behaviour"
+
+# 22. The server's OpenAPI document is generated from the code that is already
+# gated; a springdoc-driven reformat on its own is not a behaviour change.
+# Mirrors the Portal's exclusion of its vendored copy.
+run_case
+use_crs
+commit "regen spec" components-registry-service-server/src/main/resources/openapi/v4.json
+expect 0 "CRS generated openapi document is not behaviour on its own"
+
+# 23. api-changelog.md is the document CRS tells contributors to update on a v4
+# surface change; it must satisfy spec-delta.
+run_case
+use_crs
+commit "changelog" docs/registry/api-changelog.md
+commit "impl" components-registry-service-server/src/main/kotlin/Foo.kt
+expect 0 "CRS api-changelog satisfies the spec gate"
+
+# --- the automation module ---------------------------------------------------
+# Still deployed. Its runtime configuration sits outside src/main, so the
+# module-source rule alone never sees it.
+
+# 24a. Runtime config: supported groupIds and systems, version-name and
+# product-type mappings — all observable behaviour.
+run_case
+use_crs
+commit "supported systems" components-registry-automation/data/components-registry-service.yaml
+expect 1 "automation runtime config is gated"
+
+# 24b. The OKD template describes an ephemeral stand (a postgres pod with a
+# deadline), not service behaviour — same class as the Portal's infra/dev.
+run_case
+use_crs
+commit "stand template" components-registry-automation/okd/components-registry.yaml
+expect 0 "automation OKD template is not behaviour"
+
+# 24c. TeamCity metarunners are build steps.
+run_case
+use_crs
+commit "build step" components-registry-automation/metarunners/OctopusComponentsRegistryAutomation.xml
+expect 0 "automation metarunners are not behaviour"
+
+# --- escape-hatch abuse ------------------------------------------------------
+# The opt-out is the one thing that can switch the gate off, so everything that
+# is not a deliberately ticked box must fail to trigger it.
+
+# 25. Prose mentioning the marker — including prose denying it applies.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY='This PR does NOT have no-spec-impact status; it changes behaviour.'
+expect 1 "prose mentioning the marker does not opt out"
+
+# 26. Unchecked box, asterisk bullet.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'* [ ] no-spec-impact'
+expect 1 "unchecked asterisk box does not opt out"
+
+# 27. Unchecked box with irregular spacing.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'-  [  ] no-spec-impact'
+expect 1 "unchecked box with wide brackets does not opt out"
+
+# 28. The verbatim PR template, untouched — the common case, and the one that
+# would kill the gate on every single PR if the marker matched loosely.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'## Spec\n\nSpec:\n\n- [ ] no-spec-impact — this PR changes no observable behaviour (refactor,\n      tests, build/CI, dependency bump, docs-only). Ticking this skips the\n      spec gate; leave it unticked otherwise.\n'
+expect 1 "the unticked PR template does not opt out"
+
+# 29. Ticked box with trailing template prose still opts out.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'- [x] no-spec-impact — this PR changes no observable behaviour.'
+expect 0 "ticked box with trailing prose opts out"
+
+# 30. Any tick mark, any bullet.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'* [X] no-spec-impact'
+expect 0 "ticked asterisk box opts out"
+
+# 30a. A ticked box commented out is not consent — "comment out this section"
+# is an ordinary markdown habit.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'Refactor only.\n\n<!--\n- [x] no-spec-impact\n-->\n'
+expect 1 "ticked box inside an HTML comment does not opt out"
+
+# 30b. Nor is a ticked box quoted as an example of the format.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'Example of the checkbox format:\n\n```\n- [x] no-spec-impact\n```\n\nDo not actually skip.\n'
+expect 1 "ticked box inside a code fence does not opt out"
+
+# 30b-i. An indented code block is a code block too.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'Some explanatory text.\n\n    - [x] no-spec-impact\n\nMore text.\n'
+expect 1 "ticked box in an indented code block does not opt out"
+
+# 30b-ii. A box nested under a parent bullet is a list item, not code, and is
+# an ordinary way to write this. The indented-code rule must not swallow it.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'- Spec:\n    - [x] no-spec-impact\n'
+expect 0 "a box nested under a parent bullet still opts out"
+
+# 30c. A namespaced label merely ends in the token; it is a different label.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_LABELS='["area:no-spec-impact","bug"]'
+expect 1 "a namespaced label does not opt out"
+
+# 30c-i. One label whose name contains commas is one label, not three.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_LABELS='["foo,no-spec-impact,bar"]'
+expect 1 "a label containing the token between commas does not opt out"
+
+# 30d. The marker as a label in its own right still does.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_LABELS='["bug","no-spec-impact"]'
+expect 0 "the exact label still opts out"
+
+# --- ordering loopholes ------------------------------------------------------
+
+# 31. Behaviour smuggled into a conflict resolution. The file exists nowhere
+# else on the branch, so skipping merge commits would hide it and pass a PR
+# whose spec was written afterwards.
+run_case
+commit "branch point" docs/unrelated.md
+git checkout -q main
+commit "main moves" docs/mainside.md
+git checkout -q feature
+git merge -q --no-ff --no-commit main >/dev/null 2>&1
+mkdir -p frontend/src/pages
+echo "smuggled" > frontend/src/pages/Bar.tsx
+git add -A
+git commit -qm "Merge main into feature"
+commit "spec afterwards" docs/features/bar.md
+expect 1 "behaviour inside a merge commit is not invisible to spec-first"
+
+# seed_adr_on_base — the spec must pre-exist on the base branch, otherwise the
+# "rename" reads as an addition in the three-dot diff and proves nothing.
+seed_adr_on_base() {
+  git checkout -q main
+  commit "seed adr" docs/adr/001-x.md
+  git branch -qf feature main
+  git checkout -q feature
+}
+
+# 32. Renaming an unrelated spec file is not writing a spec.
+run_case
+seed_adr_on_base
+git mv docs/adr/001-x.md docs/adr/002-x.md
+git commit -qm "renumber adr"
+commit "impl" frontend/src/pages/Foo.tsx
+expect 1 "a pure rename of a spec does not satisfy spec-delta"
+
+# 33. A rename that also edits the file is a real spec change.
+run_case
+seed_adr_on_base
+git mv docs/adr/001-x.md docs/adr/002-x.md
+echo "new requirement" >> docs/adr/002-x.md
+git add -A
+git commit -qm "renumber and revise adr"
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "a rename with real edits satisfies spec-delta"
+
+# 34. Moving a spec into openspec/ while editing it is a spec change. Git
+# compacts the rename to "{docs/adr => openspec}/001-x.md", which anchors on
+# neither path — this is the shape the OpenSpec migration will produce.
+run_case
+seed_adr_on_base
+mkdir -p openspec
+git mv docs/adr/001-x.md openspec/001-x.md
+echo "new requirement" >> openspec/001-x.md
+git add -A
+git commit -qm "move adr into openspec and revise"
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "a cross-directory spec move with edits satisfies spec-delta"
+
+# 35. A binary spec asset is a real change; numstat reports "-" for its counts
+# and must not be read as zero.
+run_case
+git checkout -q main
+mkdir -p docs/adr
+printf 'seed\000binary' > docs/adr/diagram.png
+git add -A
+git commit -qm "seed diagram"
+git branch -qf feature main
+git checkout -q feature
+printf 'changed\000binary\000content' > docs/adr/diagram.png
+git add -A
+git commit -qm "revise diagram"
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "a binary spec asset counts as a spec change"
+
+# 36. A path is not a rename just because it contains git's arrow notation.
+# A directory may legitimately be named with " => " in it; rewriting such a path
+# would forge a spec the PR never touched, passing both checks with no spec at
+# all anywhere in the repository.
+run_case
+mkdir -p "misc/results => docs/features"
+echo decoy > "misc/results => docs/features/backup.md"
+git add -A
+git commit -qm "add a file under an oddly named directory"
+commit "impl" frontend/src/pages/Foo.tsx
+expect 1 "a path containing the rename arrow is not treated as a spec"
+
+# 24. Parity with the workflow. The gate is configured by environment, so the
+# regexes above exist twice: here and in merge-gate.yml. Nothing else would
+# notice them drifting apart — a widened path in one copy and not the other
+# means the suite proves a gate the CI does not actually run.
+cd "$SCRIPT_DIR/../.." || exit 1
+WORKFLOW='.github/workflows/merge-gate.yml'
+yaml_env() { sed -n "s/^ *$1: '\(.*\)'\$/\1/p" "$WORKFLOW"; }
+
+wf_behavior=$(yaml_env BEHAVIOR_RE)
+wf_exclude=$(yaml_env BEHAVIOR_EXCLUDE_RE)
+wf_spec=$(yaml_env SPEC_RE)
+
+if [[ "$wf_behavior" == "$PORTAL_BEHAVIOR_RE" ]]; then
+  want_exclude="$PORTAL_BEHAVIOR_EXCLUDE_RE"; want_spec="$PORTAL_SPEC_RE"; flavour=portal
+elif [[ "$wf_behavior" == "$CRS_BEHAVIOR_RE" ]]; then
+  want_exclude="$CRS_BEHAVIOR_EXCLUDE_RE"; want_spec="$CRS_SPEC_RE"; flavour=crs
+else
+  want_exclude=''; want_spec=''; flavour=''
+fi
+
+if [[ -z "$flavour" ]]; then
+  FAIL=$((FAIL + 1))
+  printf 'FAIL workflow BEHAVIOR_RE matches neither constant\n     | workflow: %s\n' "$wf_behavior"
+elif [[ "$wf_exclude" != "$want_exclude" || "$wf_spec" != "$want_spec" ]]; then
+  FAIL=$((FAIL + 1))
+  printf 'FAIL workflow (%s) has drifted from the constants in this suite\n' "$flavour"
+  [[ "$wf_exclude" == "$want_exclude" ]] || printf '     | BEHAVIOR_EXCLUDE_RE\n     |   workflow: %s\n     |   suite:    %s\n' "$wf_exclude" "$want_exclude"
+  [[ "$wf_spec" == "$want_spec" ]] || printf '     | SPEC_RE\n     |   workflow: %s\n     |   suite:    %s\n' "$wf_spec" "$want_spec"
+else
+  PASS=$((PASS + 1))
+  printf 'ok   workflow (%s) config matches this suite\n' "$flavour"
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" == 0 ]]

--- a/.github/scripts/spec-gate.test.sh
+++ b/.github/scripts/spec-gate.test.sh
@@ -402,8 +402,27 @@ git commit -qm "spec with a non-ascii filename"
 commit "impl" frontend/src/pages/Foo.tsx
 expect 0 "a non-ascii spec filename is read, not rejected"
 
-# 38. git C-quotes a path holding a control character, and every pattern here
-# is anchored, so a quoted path matches nothing. Refuse rather than wave it by.
+# 37b. git also C-quotes a name containing a double quote. That is a legal
+# filename, not a control character, and must be read rather than refused.
+run_case
+mkdir -p docs/features
+echo spec > 'docs/features/a"b.md'
+git add -A
+git commit -qm 'spec with a quote in the name'
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "a double quote in a spec filename is read, not rejected"
+
+# 37c. Same for a backslash.
+run_case
+mkdir -p docs/features
+echo spec > 'docs/features/a\b.md'
+git add -A
+git commit -qm 'spec with a backslash in the name'
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "a backslash in a spec filename is read, not rejected"
+
+# 38. A newline or tab in a path cannot be classified by line-based filters, so
+# the gate refuses to rule rather than silently treating it as nothing.
 run_case
 mkdir -p frontend/src/pages
 printf 'code' > "$(printf 'frontend/src/pages/Foo\tBar.tsx')"

--- a/.github/scripts/spec-gate.test.sh
+++ b/.github/scripts/spec-gate.test.sh
@@ -391,6 +391,17 @@ export BASE_REF='origin/no-such-branch'
 expect 1 "an unresolvable base ref fails instead of passing"
 export BASE_REF='main'
 
+# 37a. A non-ASCII filename is ordinary, not unreadable. git quotes it by
+# default, so without core.quotePath=false the gate would reject a perfectly
+# normal spec — the same mechanism that must still reject control characters.
+run_case
+mkdir -p docs/features
+echo spec > "docs/features/архитектура.md"
+git add -A
+git commit -qm "spec with a non-ascii filename"
+commit "impl" frontend/src/pages/Foo.tsx
+expect 0 "a non-ascii spec filename is read, not rejected"
+
 # 38. git C-quotes a path holding a control character, and every pattern here
 # is anchored, so a quoted path matches nothing. Refuse rather than wave it by.
 run_case

--- a/.github/scripts/spec-gate.test.sh
+++ b/.github/scripts/spec-gate.test.sh
@@ -383,6 +383,23 @@ git commit -qm "add a file under an oddly named directory"
 commit "impl" frontend/src/pages/Foo.tsx
 expect 1 "a path containing the rename arrow is not treated as a spec"
 
+# 37. A base that does not resolve must fail, not read as an empty diff. This
+# is the shape where the gate knows least and would otherwise say "ok".
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export BASE_REF='origin/no-such-branch'
+expect 1 "an unresolvable base ref fails instead of passing"
+export BASE_REF='main'
+
+# 38. git C-quotes a path holding a control character, and every pattern here
+# is anchored, so a quoted path matches nothing. Refuse rather than wave it by.
+run_case
+mkdir -p frontend/src/pages
+printf 'code' > "$(printf 'frontend/src/pages/Foo\tBar.tsx')"
+git add -A
+git commit -qm "behaviour with a tab in the filename"
+expect 1 "a control character in a path fails closed"
+
 # 24. Parity with the workflow. The gate is configured by environment, so the
 # regexes above exist twice: here and in merge-gate.yml. Nothing else would
 # notice them drifting apart — a widened path in one copy and not the other

--- a/.github/scripts/spec-gate.test.sh
+++ b/.github/scripts/spec-gate.test.sh
@@ -103,17 +103,19 @@ run_case
 commit "impl" frontend/src/pages/Foo.tsx
 expect 1 "behaviour change with no spec delta fails spec-delta"
 
-# 6. Escape hatch via PR body.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'Refactor only.\n- [x] no-spec-impact\n'
-expect 0 "no-spec-impact in PR body skips both gates"
-
-# 7. Escape hatch via label.
+# 6. The label opt-out.
 run_case
 commit "impl" frontend/src/pages/Foo.tsx
 export PR_LABELS='["dependencies","no-spec-impact"]'
-expect 0 "no-spec-impact label skips both gates"
+expect 0 "the no-spec-impact label skips both gates"
+
+# 7. The PR body is not an opt-out channel at all. A ticked box in the body was
+# the old escape hatch and is deliberately inert now — deciding whether one is
+# "really ticked" meant parsing markdown, which leaked seven false opt-outs.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_BODY=$'- [x] no-spec-impact\n'
+expect 1 "a ticked box in the PR body does not opt out"
 
 # 8. Generated files are not behaviour.
 run_case
@@ -255,89 +257,32 @@ commit "build step" components-registry-automation/metarunners/OctopusComponents
 expect 0 "automation metarunners are not behaviour"
 
 # --- escape-hatch abuse ------------------------------------------------------
-# The opt-out is the one thing that can switch the gate off, so everything that
-# is not a deliberately ticked box must fail to trigger it.
+# The label is the only thing that can switch the gate off, so anything that is
+# not that exact label must fail to trigger it.
 
-# 25. Prose mentioning the marker — including prose denying it applies.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY='This PR does NOT have no-spec-impact status; it changes behaviour.'
-expect 1 "prose mentioning the marker does not opt out"
-
-# 26. Unchecked box, asterisk bullet.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'* [ ] no-spec-impact'
-expect 1 "unchecked asterisk box does not opt out"
-
-# 27. Unchecked box with irregular spacing.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'-  [  ] no-spec-impact'
-expect 1 "unchecked box with wide brackets does not opt out"
-
-# 28. The verbatim PR template, untouched — the common case, and the one that
-# would kill the gate on every single PR if the marker matched loosely.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'## Spec\n\nSpec:\n\n- [ ] no-spec-impact — this PR changes no observable behaviour (refactor,\n      tests, build/CI, dependency bump, docs-only). Ticking this skips the\n      spec gate; leave it unticked otherwise.\n'
-expect 1 "the unticked PR template does not opt out"
-
-# 29. Ticked box with trailing template prose still opts out.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'- [x] no-spec-impact — this PR changes no observable behaviour.'
-expect 0 "ticked box with trailing prose opts out"
-
-# 30. Any tick mark, any bullet.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'* [X] no-spec-impact'
-expect 0 "ticked asterisk box opts out"
-
-# 30a. A ticked box commented out is not consent — "comment out this section"
-# is an ordinary markdown habit.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'Refactor only.\n\n<!--\n- [x] no-spec-impact\n-->\n'
-expect 1 "ticked box inside an HTML comment does not opt out"
-
-# 30b. Nor is a ticked box quoted as an example of the format.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'Example of the checkbox format:\n\n```\n- [x] no-spec-impact\n```\n\nDo not actually skip.\n'
-expect 1 "ticked box inside a code fence does not opt out"
-
-# 30b-i. An indented code block is a code block too.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'Some explanatory text.\n\n    - [x] no-spec-impact\n\nMore text.\n'
-expect 1 "ticked box in an indented code block does not opt out"
-
-# 30b-ii. A box nested under a parent bullet is a list item, not code, and is
-# an ordinary way to write this. The indented-code rule must not swallow it.
-run_case
-commit "impl" frontend/src/pages/Foo.tsx
-export PR_BODY=$'- Spec:\n    - [x] no-spec-impact\n'
-expect 0 "a box nested under a parent bullet still opts out"
-
-# 30c. A namespaced label merely ends in the token; it is a different label.
+# 25. A namespaced label merely ends in the token; it is a different label.
 run_case
 commit "impl" frontend/src/pages/Foo.tsx
 export PR_LABELS='["area:no-spec-impact","bug"]'
 expect 1 "a namespaced label does not opt out"
 
-# 30c-i. One label whose name contains commas is one label, not three.
+# 26. One label whose name contains commas is one label, not three.
 run_case
 commit "impl" frontend/src/pages/Foo.tsx
 export PR_LABELS='["foo,no-spec-impact,bar"]'
 expect 1 "a label containing the token between commas does not opt out"
 
-# 30d. The marker as a label in its own right still does.
+# 27. Non-string noise in the array must not opt out on its own.
 run_case
 commit "impl" frontend/src/pages/Foo.tsx
-export PR_LABELS='["bug","no-spec-impact"]'
-expect 0 "the exact label still opts out"
+export PR_LABELS='[null,7,{"name":"no-spec-impact"}]'
+expect 1 "non-string label entries do not opt out"
+
+# 28. The marker as a label in its own right still does, alongside noise.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_LABELS='[null,"bug","NO-SPEC-IMPACT"]'
+expect 0 "the exact label opts out regardless of case or neighbours"
 
 # --- ordering loopholes ------------------------------------------------------
 

--- a/.github/scripts/spec-gate.test.sh
+++ b/.github/scripts/spec-gate.test.sh
@@ -278,6 +278,19 @@ commit "impl" frontend/src/pages/Foo.tsx
 export PR_LABELS='[null,7,{"name":"no-spec-impact"}]'
 expect 1 "non-string label entries do not opt out"
 
+# 27a. A large label array must not make the gate spin. The obvious blank-check
+# on the raw value is quadratic in bash 3.2 and cost 15 seconds at 800 labels;
+# GitHub allows up to 100 per PR, so this stays well inside a realistic bound.
+run_case
+commit "impl" frontend/src/pages/Foo.tsx
+export PR_LABELS="$(awk 'BEGIN { printf "["; for (i = 0; i < 400; i++) printf "\"label-%d\",", i; printf "\"no-spec-impact\"]" }')"
+started=$(date +%s)
+expect 0 "a large label array opts out without spinning"
+if [[ $(( $(date +%s) - started )) -gt 5 ]]; then
+  FAIL=$((FAIL + 1))
+  printf 'FAIL a large label array took over 5s\n'
+fi
+
 # 28. The marker as a label in its own right still does, alongside noise.
 run_case
 commit "impl" frontend/src/pages/Foo.tsx

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -3,6 +3,12 @@ name: Merge Gate
 
 on:
   pull_request:
+    # labeled/unlabeled are not in the default set. Without them the spec gate's
+    # opt-out is one-way: label, push to trigger a run, get a green skip, then
+    # remove the label — the same SHA keeps the stale green and merges without
+    # either a spec or the label that excused it. Re-running the whole gate on a
+    # label change costs a build, which is the cheaper side of that trade.
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:
   build:

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -8,7 +8,12 @@ on:
     # remove the label — the same SHA keeps the stale green and merges without
     # either a spec or the label that excused it. Re-running the whole gate on a
     # label change costs a build, which is the cheaper side of that trade.
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    # `edited` is here for retargeting: changing a PR's base branch fires that
+    # and nothing else, so without it a PR moved from a feature base onto main
+    # keeps a green verdict computed against the old base. It also fires on
+    # title and body edits, which re-runs the build for nothing — the price of
+    # not carrying a result that answers a question no longer being asked.
+    types: [ opened, synchronize, reopened, labeled, unlabeled, edited ]
 
 jobs:
   build:

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -28,9 +28,55 @@ jobs:
       enable-dependency-check: false
     secrets: inherit
 
+  # Spec discipline gate. Makes AGENTS.md § Technical Requirements Tracking
+  # rule 2 ("requirements first, then implementation") enforceable rather than
+  # advisory. Script is byte-identical with the Portal copy; only this config
+  # differs.
+  spec-gate:
+    name: spec / gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The gate reads commit ordering on the branch, not just the diff,
+          # so the default shallow clone is not enough.
+          fetch-depth: 0
+      # The gate has its own suite; run it here so a broken gate fails loudly
+      # instead of silently waving every PR through.
+      - run: bash .github/scripts/spec-gate.test.sh
+      - run: git fetch --no-tags origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+      - run: .github/scripts/spec-gate.sh
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          # Behaviour = shipped module sources and their resources. Resources
+          # are included deliberately: Flyway migrations change observable
+          # schema, and the octopus-security role-to-permission mapping that
+          # decides who may edit what lives in application.yml. compat-test
+          # and test-common carry no src/main, so they need no exclusion.
+          #
+          # Excluded: the test and functional-test profile configs, which live
+          # in src/main/resources but configure only those profiles, and the
+          # generated OpenAPI document, which follows a Kotlin change that is
+          # itself gated (mirrors the Portal's exclusion of its vendored copy).
+          #
+          # Keep in exact parity with the constants in spec-gate.test.sh; the
+          # suite fails if these drift.
+          # components-registry-automation keeps its runtime configuration in
+          # data/ rather than src/main — supported groupIds and systems,
+          # version-name and product-type mappings. The module is still
+          # deployed, so that file is behaviour. Its okd/ stand template and
+          # metarunners/ build steps are not.
+          BEHAVIOR_RE: '^([^/]+/src/main/(kotlin|java|resources)/|components-registry-automation/data/)'
+          BEHAVIOR_EXCLUDE_RE: '(/(application|bootstrap)-(test|ft-db)\.yml$|/openapi/v4\.json$)'
+          # api-changelog.md is included because it is the document this repo
+          # instructs contributors to update on any v4 surface change.
+          SPEC_RE: '^(docs/registry/(prd|technical-design|api-changelog)\.md$|docs/registry/.*-spec\.md$|docs/registry/requirements-.*\.md$|docs/registry/adr/|docs/features/|openspec/)'
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+
   gate-merge:
     name: gate/merge
-    needs: [ build, quality, security ]
+    needs: [ build, quality, security, spec-gate ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -71,7 +71,6 @@ jobs:
           # api-changelog.md is included because it is the document this repo
           # instructs contributors to update on any v4 surface change.
           SPEC_RE: '^(docs/registry/(prd|technical-design|api-changelog)\.md$|docs/registry/.*-spec\.md$|docs/registry/requirements-.*\.md$|docs/registry/adr/|docs/features/|openspec/)'
-          PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
 
   gate-merge:

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ BOOT-INF/
 # documented recipe calls them by path — an ignored helper leaves the doc pointing at a file nobody
 # else has.
 !scripts/quality-baseline/*.sh
+# The merge-gate spec check and its suite. Ignored, these vanish from the
+# commit silently and the workflow fails on a missing file.
+!.github/scripts/*.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,9 +238,11 @@ Practical consequence: commit the requirement on its own, get it agreed, then
 implement. If you squash locally, re-split before pushing — GitHub's
 squash-on-merge is fine, the gate reads branch commits, not the merge result.
 
-**Escape hatch:** tick `no-spec-impact` in the PR template, or apply the
-`no-spec-impact` label, for changes with no observable behaviour (refactor,
-tests, build/CI, dependency bumps). It skips both checks.
+**Escape hatch:** apply the `no-spec-impact` label for changes with no
+observable behaviour (refactor, tests, build/CI, dependency bumps). It skips
+both checks. Nothing in the PR body opts out — a label is structured, visible on
+the PR, recorded in the timeline, and can be applied by a reviewer rather than
+only self-declared.
 
 The script [`.github/scripts/spec-gate.sh`](.github/scripts/spec-gate.sh) is
 byte-identical with the Portal copy — configured entirely by environment, so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,39 @@ Rules:
 4. System verifier checks requirements with status ✅ Tested
 5. All requirement content must be written in English
 
+### Enforcement: the `spec / gate` check
+
+Rule 2 above is enforced on every PR by the `spec / gate` job in
+[`merge-gate.yml`](.github/workflows/merge-gate.yml), which runs two checks:
+
+- **spec-delta** — a PR touching `*/src/main/{kotlin,java,resources}/**` or
+  `components-registry-automation/data/**` must also touch a spec. Resources are
+  included because Flyway migrations and the `octopus-security`
+  role-to-permission mapping live there; `components-registry-automation/data/`
+  because that module keeps its runtime configuration (supported groupIds and
+  systems, version-name and product-type mappings) outside `src/main`. Excluded:
+  the `-test` and `-ft-db` profile configs, the generated `openapi/v4.json`, and
+  the automation module's `okd/` stand template and `metarunners/` build steps.
+  A spec is `docs/registry/requirements-*.md`, `docs/registry/*-spec.md`,
+  `prd.md`, `technical-design.md`, `api-changelog.md`, `docs/registry/adr/**`,
+  `docs/features/**`, or `openspec/**`.
+- **spec-first** — the first commit touching a spec must come **strictly
+  before** the first commit touching behaviour. A requirement written in the
+  same commit as the code, or after it, documents what was built instead of
+  agreeing what to build, and fails the gate.
+
+Practical consequence: commit the requirement on its own, get it agreed, then
+implement. If you squash locally, re-split before pushing — GitHub's
+squash-on-merge is fine, the gate reads branch commits, not the merge result.
+
+**Escape hatch:** tick `no-spec-impact` in the PR template, or apply the
+`no-spec-impact` label, for changes with no observable behaviour (refactor,
+tests, build/CI, dependency bumps). It skips both checks.
+
+The script [`.github/scripts/spec-gate.sh`](.github/scripts/spec-gate.sh) is
+byte-identical with the Portal copy — configured entirely by environment, so
+keep the two in sync when either changes. Its suite runs in the same job.
+
 ### Test-to-Requirement Traceability
 
 Every test method that covers a numbered requirement (MIG-xxx, SYS-xxx) MUST:


### PR DESCRIPTION
## What

`AGENTS.md` § Technical Requirements Tracking already requires "requirements first, then implementation", but nothing enforced it, so in practice requirements were written at the end of a change if at all. A requirement written after the code documents what got built rather than agreeing what to build.

Adds a blocking `spec / gate` job that makes that rule enforceable:

- **spec-delta** — a PR touching `*/src/main/{kotlin,java,resources}/**` or `components-registry-automation/data/**` must also touch a requirement, spec, ADR, `api-changelog.md`, or design doc.
- **spec-first** — the first spec commit must precede the first behaviour commit on the branch.

Both are skipped by applying the `no-spec-impact` label. Nothing in the PR body opts out.

## Scope decisions worth checking

- **`src/main/resources` counts as behaviour.** Flyway migrations change observable schema, and the `octopus-security` role-to-permission mapping — who may edit what — lives in `application.yml`. The `-test` and `-ft-db` profile configs and the generated `openapi/v4.json` are excluded.
- **`components-registry-automation/data/` counts too.** That module keeps its runtime configuration — supported groupIds and systems, version-name and product-type mappings — outside `src/main`. Its `okd/` stand template and `metarunners/` build steps do not count.
- **`api-changelog.md` satisfies the gate.** It is the document this repo instructs contributors to update on a v4 surface change; without it, doing exactly what the docs say still failed.

## Notes for review

The script is byte-identical with the Portal copy (octopusden/octopus-components-management-portal#213) — all repo-specific configuration is passed by environment from the workflow — and carries its own 42-case suite, run in the same job. One case asserts the regexes here match the ones in `merge-gate.yml`.

`.gitignore` gains `!.github/scripts/*.sh`: the repo ignores `*.sh` globally, so without it the scripts silently vanish from the commit and the workflow fails on a missing file.

## Verification

`bash .github/scripts/spec-gate.test.sh` → 42 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated merge checks requiring behavior changes to include corresponding specification updates.
  * Enforced specification-first commit ordering before changes can be merged.
  * Added an approved opt-out for changes with no specification impact.
  * Checks now rerun when pull request labels or details change.

* **Documentation**
  * Added pull request guidance for describing changes, linking specifications, and documenting verification.
  * Documented specification requirements, exclusions, recognized files, and opt-out rules.

* **Tests**
  * Added comprehensive coverage for specification detection, commit ordering, exceptions, renames, merges, and unusual paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Changed since the first push

Mirrors octopusden/octopus-components-management-portal#213 — the script stays byte-identical:

- **The opt-out is a label only**; the PR-body checkbox is gone after five review rounds turned up nine ways to fake it.
- **The gate fails closed** on an unresolvable base, a failed git call, or a path git had to quote — all three previously read as "nothing changed" and passed.
- **`labeled`/`unlabeled` added to the workflow triggers**, so removing the label cannot leave a stale green on the same SHA.
